### PR TITLE
gym: leaderboard 순위·초대 순수 시험 강화

### DIFF
--- a/gym/docs/leaderboard.md
+++ b/gym/docs/leaderboard.md
@@ -1,0 +1,551 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/leaderboard.md
+last_verified: 2026-08-18
+---
+
+# gym 리더보드 규약 — invite · attest · verify · render
+
+이 문서는 `gym/tools/leaderboard.py` 의 **초대·등재·검증·렌더** 계약과
+**예외 경로**를 고정한다. 운영 한 줄 요약은
+[`gym/tools/README_leaderboard.md`](../tools/README_leaderboard.md) 를, 작업
+기록은
+[`mydocs/working/gym_leaderboard.md`](../../mydocs/working/gym_leaderboard.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_leaderboard.py` 가 기계로 고정한다.
+
+새 암호 원시함수는 없다. 파일 해시는 `hashlib.sha256`, 서명·원장·앵커는 기존
+rhwp 명령(`keygen` · `settle propose/record/verify` · `anchor add/checkpoint/verify`)
+이다. 이 도구는 그 사다리를 **운동장 점수판 위에 얹는 조합**일 뿐이다.
+
+## 1. 왜 이 기둥이 필요한가
+
+AI 벤치마크 리더보드의 병폐는 점수의 신뢰다.
+
+| 병폐 | 흔한 리더보드 | 이 점수판 |
+|---|---|---|
+| 점수 위조 | 자기 신고 JSON | 청구 `capsuleSha256` 고정 (P1) |
+| 소급 수정 | 표를 고치면 끝 | 원장·앵커 줄 해시 체인 + 원장 스냅샷 봉인 |
+| 이중 등재 | 같은 결과 재탕 | 원장 전역 `capsuleSha256` 유일성 (P3) |
+| 대리 제출 | 이름만 바꾸면 됨 | Ed25519 서명 + keyring (`signerOk`) |
+
+운동장은 이미 검증 사다리를 가지고 있다. 그래서 **운동장이 자기 사다리 위에서
+돈다.** 채점 결과(스코어카드 + 입장 봉투)를 사다리로 봉인하고, 순위표는 렌더
+시점에 그 사슬을 다시 밟은 항목만 올린다.
+
+봉인 범위(정직 조항)는 여기까지다: "이 스코어카드가 이 시점에 이 신원으로
+등재되었고 이후 변조되지 않았다." 채점 자체의 재현은 스코어카드에 박힌 runner
+신원(`version` · `commit` · `capabilities digest`)과 커밋된 제출물로 제3자가
+수행한다. 이 도구는 채점기를 대신하지 않는다.
+
+## 2. 사용 — 모드 네 개. 새 CLI 없음
+
+```bash
+python gym/score.py --agent <이름>                      # 채점 (이 도구 밖)
+python gym/tools/leaderboard.py attest --agent <이름>    # 등재
+python gym/tools/leaderboard.py verify                   # 전 사슬 재검증
+python gym/tools/leaderboard.py render                   # 검증본에서 순위표
+python gym/tools/leaderboard.py invite --agent <이름>    # 초대장 (판 지문)
+```
+
+`argparse` 의 `choices` 는 `attest` · `verify` · `render` · `invite` 뿐이다.
+`sign` · `keygen` · `audit` 같은 새 모드를 넣지 않는다. 서명이 필요하면 rhwp
+`settle` 을 부른다.
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `mode` | (필수) | 위 네 값 |
+| `--agent` | None | `attest` 는 필수. `invite` 는 없으면 `친구-에이전트` |
+| `--bin` | None | `runner.find_bin` 이 해석. `invite` 는 바이너리를 쓰지 않는다 |
+
+종료 코드:
+
+| exit | 누가 | 의미 |
+|---|---|---|
+| 0 | attest / invite / render 성공, verify 전항 통과 | 정상 |
+| 2 | 분류된 I/O·형식·CLI 실패, 바이너리 탐색 실패 | 하네스/환경 |
+| 3 | verify 사슬 파손·스냅샷 불일치·항목 실패, attest 의 원장 거부(SystemExit) | 판정 데이터 |
+| SystemExit | attest 의 입장 거부·파일 없음·`--agent` 없음 | 사용자 오류 |
+
+`invite` 는 rhwp 를 부르지 않는다. 지문은 커밋된 원장·앵커·발주서·키링에서만
+나온다. 그래서 `main(["invite"])` 는 바이너리 없이 0 을 돌려야 한다.
+
+## 3. 등재 사슬 (attest)
+
+```
+scorecard.json + admission.json     채점기가 발급
+  → keygen                          에이전트 신원. 공개키만 keyring 에
+  → settle propose --sign-key       명세서·스코어카드·입장 봉투 3해시 + 서명
+  → settle record --ledger          append-only 원장. 같은 스코어카드 재등재 거부
+  → 스코어카드·입장 보존            gym/leaderboard/scorecards/<agent>-<epoch>/
+  → anchor add (claim)              청구를 투명성 로그에
+  → anchor add (ledger)             원장 바이트 스냅샷
+  → anchor checkpoint               머클 에폭
+```
+
+규약의 함정과 막은 자리:
+
+1. **기입을 먼저 시도한다.** `settle record` 가 exit 3 (이중 등재) 이면 이번
+   attest 의 claim·sidecar 를 지운다. 원장이 유일한 진실인데 미등재 파일이
+   굴러다니면 사람이 헷갈린다.
+2. **보존은 등재 확정 뒤에만.** 스코어카드·입장 봉투 복사는 record 가 0 을 준
+   뒤에만 한다. 검증이 커밋본을 참조하므로, 거부된 제출을 보존하면 거짓
+   증거가 된다.
+3. **원장 꼬리 봉인.** 항목이 하나일 때 원장 한 줄을 고치면 다음 줄이 없어
+   체인만으로는 폭로되지 않는다. 그래서 attest 마다 원장 파일 자체의
+   SHA-256 을 앵커에 올린다. verify 는 "앵커의 마지막 항목 == 지금 원장
+   바이트 해시" 를 요구한다.
+
+`attest` 가 거부하는 사용자 오류 (SystemExit, 암호 실패가 아님):
+
+| 조건 | 메시지 표식 |
+|---|---|
+| `--agent` 없음 | `attest 는 --agent 가 필요하다` |
+| scorecard/admission 없음 | `없음: … 먼저 gym/score.py` |
+| 입장 봉투가 객체 아님 | `입장 봉투가 객체가 아니다` |
+| `verdict != allow` | `입장 봉투 verdict=…` |
+| 원장 거부 | `원장 거부(이중 등재)` |
+| keygen 산출에 publicKey 없음 | `LeaderboardSchemaError` → `attest 실패 (schema)` |
+| keyring.keys 가 목록 아님 | 위와 같음 |
+| 바이너리 없음·실행 실패 | `attest 실패 (cli)` |
+| JSON 읽기/쓰기 실패 | `attest 실패 (io|format)` |
+
+비밀키는 `gym/leaderboard/keys/<agent>.key.json` 에만 남는다. 이 경로는
+`.gitignore` 다. 커밋되는 것은 공개키·서명된 청구·스코어카드뿐이다.
+
+## 4. 초대 (invite)
+
+초대는 **권한이 아니라 안내**다. `attest` 는 아무 이름이든 받는다. 초대장은
+"어디로 오면 되는지"와 "네가 합류하는 판이 위조본이 아님을 어떻게 확인하는지"
+를 한 봉투로 묶을 뿐이다.
+
+`construct_invite(guest)` 는 쓰기를 하지 않는다. `cmd_invite` 가
+`gym/leaderboard/invite.json` 에 쓴다. 시험은 임시 판으로 경로를 돌려, 커밋된
+`gym/leaderboard/` 를 읽기만 한다.
+
+### 4.1 초대장 봉투
+
+`kind=gymLeaderboardInvite`, `schemaVersion=1.0`. 키 집합은 `INVITE_KEYS`.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `schemaVersion` | str | 항상 `1.0` |
+| `kind` | str | 항상 `gymLeaderboardInvite` |
+| `guest` | str | 손님 이름. 빈 문자열·None 은 `친구-에이전트` |
+| `board.repo` | str | `edwardkim/rhwp` |
+| `board.path` | str | `gym/leaderboard` |
+| `fingerprint` | object | 아래 4.2 |
+| `join` | list[str] | 합류 3줄. 길이 3, score.py / attest / verify |
+| `promise` | str | 비밀키는 keys/ 에만, 커밋되지 않는다 |
+| `note` | str | 초대는 권한이 아니라 안내 |
+
+`validate_invite()` 가 이 계약을 다시 검사한다. 손님 이름이 문자열이 아니면
+`LeaderboardSchemaError`. `join` 이 3줄이 아니거나 동사가 빠지면 위반 목록.
+
+합류 3줄 (손님이 `이름` 일 때):
+
+```text
+python gym/score.py --agent 이름
+python gym/tools/leaderboard.py attest --agent 이름
+python gym/tools/leaderboard.py verify
+```
+
+### 4.2 판 지문
+
+`board_fingerprint()` 가 지금 판의 값을 **커밋된 파일에서 재계산**한다. 새
+비밀은 없다.
+
+| 키 | 출처 |
+|---|---|
+| `members` | keyring.json 의 `keys` 길이. 목록이 아니면 0 |
+| `ledgerEntries` | 원장 체인 길이 |
+| `ledgerChain` | `chain_walk` 의 오류 또는 `"ok"` |
+| `anchorChain` | 앵커 `chain_walk` 의 오류 또는 `"ok"` |
+| `merkleRoot` | checkpoint.json 의 값. 없으면 None |
+| `workorderSha256` | 발주서 파일 바이트 SHA-256. 없으면 None |
+| `ledgerSnapshotSha256` | 원장 파일 바이트 SHA-256. 없으면 None |
+
+읽기 실패는 예외를 올리지 않는다. keyring 이 깨진 JSON 이면 `members=0` 으로
+접고 나머지 필드는 채운다. 초대장이 죽으면 신참이 판을 확인하는 길 자체가
+막힌다.
+
+`validate_fingerprint()` 는 키 집합·타입·해시 길이(64 hex, merkleRoot 제외)를
+본다. 해시 값을 재계산하지는 않는다 — 그건 신참이 `verify` 로 한다.
+
+빈 판의 지문은 `empty_fingerprint()` 와 같다. 시험이 그 키 집합을 고정한다.
+
+## 5. 검증 (verify)
+
+`cmd_verify` 가 하는 일:
+
+1. 원장 체인 (`settlementLedger`) 과 앵커 체인 (`anchorLog`) 을 `chain_walk`.
+2. 원장 스냅샷 봉인: 앵커 마지막 항목의 `capsuleSha256` == 지금 원장 바이트
+   SHA-256.
+3. 체크포인트가 있으면 앵커 줄 해시를 다시 머클하고 `merkleRoot` 와 비교.
+4. 각 원장 항목을 `verify_entry` 로 재검증.
+5. `gym/leaderboard/verification.json` 에 봉투를 쓴다.
+
+`kind=gymLeaderboardVerification`, `schemaVersion=1.0`.
+
+| 키 | 의미 |
+|---|---|
+| `ledgerEntries` | 원장 항목 수 |
+| `ledgerChain` | `"ok"` 또는 파손 이유 |
+| `anchorChain` | `"ok"` 또는 파손 이유 |
+| `ledgerSnapshotSealed` | bool |
+| `verified` | `ok=True` 항목 수 |
+| `results` | 항목별 판정 |
+
+exit 0 은 `ledgerChain ok` · `anchorChain ok` · 스냅샷 봉인 · 전항 통과 일 때만.
+그 외 판정 실패는 3. verification.json 쓰기 실패는 2.
+
+### 5.1 항목 검증 (`verify_entry`)
+
+한 항목의 실패가 전체 verify 를 죽이면 폭로가 아니라 침묵이다. 그래서
+I/O·형식·CLI 실패는 `ok=False` + `why` 로 접는다.
+
+순서:
+
+1. 항목이 객체가 아니면 즉시 실패.
+2. `claims/` 목록. 디렉터리가 아니면 `why=claims 목록 실패`.
+3. 각 파일의 SHA-256 이 원장의 `claimSha256` 과 같은 것을 찾는다. 해시 실패
+   파일은 건너뛴다.
+4. claim JSON 을 읽는다. 파싱 실패면 `why=claim 읽기 실패`.
+5. `claim.capsuleSha256 == entry.capsuleSha256` (교차 대조). 원장만 고치면
+   여기서 폭로된다.
+6. `rhwp settle verify` — 3해시 고정 + 서명 + 입장 allow.
+7. `rhwp anchor verify` — 로그 등재 + 로그 체인.
+8. 통과하면 스코어카드에서 `score` / `max` / `runner` / pack 점수를 읽는다.
+
+checks 키:
+
+| 키 | 출처 |
+|---|---|
+| `pin.workorder` | `workorderOk` |
+| `pin.scorecard` | `capsuleOk` |
+| `pin.admission` | `gateOk` |
+| `admission.allow` | `gateVerdict == allow` |
+| `signature` | `signerOk` |
+| `ledger.crossPin` | 교차 대조 |
+| `anchor.logged` | `logged` |
+| `anchor.chain` | `logChainOk` |
+
+`ok` 는 모든 checks 가 참일 때만. 스코어카드 읽기 실패면 이미 통과한 checks 를
+뒤집고 `why` 를 남긴다 — 점수를 지어내지 않는다.
+
+## 6. 렌더 (render)
+
+`cmd_render` 는 원장을 다시 `verify_entry` 한 뒤 `render_markdown` 으로
+`gym/leaderboard/leaderboard.md` 를 쓴다. 쓰기는 호출자가 한다.
+`render_markdown` 자체는 순수 함수다.
+
+### 6.1 순위 (`rank_results`)
+
+- `ok` 가 참이고 `score`/`seq` 가 유한 숫자인 행만 순위에 오른다.
+- 정렬 키는 `(-score, seq)`. 동점이면 먼저 등재된 쪽이 위.
+- `ok` 가 없거나 거짓이면 unverified.
+- `ok=True` 인데 score/seq 가 없거나 NaN/Inf 이면 unverified 로 접고
+  `why=score/seq 결손`.
+- 행이 객체가 아니면 가짜 unverified 한 줄을 남긴다.
+- 입력이 목록이 아니면 `([], [])`.
+
+순위에 오르지 못한 행은 **숨기지 않는다.** 표에 `**unverified**` 로 남긴다.
+부재를 실패로 위장하지 않는 저장소의 결 그대로다.
+
+### 6.2 최강 pack (`best_pack`)
+
+만점 비율(`score/max`)이 가장 높은 pack. 동률이면 `max` 가 큰 쪽. 없으면
+None.
+
+- `packs` 가 객체가 아니거나 비면 None.
+- 항목에 `score`/`max` 가 없거나 비숫자·NaN 이면 건너뛴다.
+- `max==0` 이면 비율 0. ZeroDivision 없음.
+
+반환은 `(pack_id, score, max)`. 렌더는 `이름 점수/만점` 으로 쓴다.
+
+### 6.3 마크다운
+
+항상 포함한다:
+
+- 헤더 `# 운동장 리더보드 — 위조 불가능한 점수판`
+- 재검증 안내와 `python gym/tools/leaderboard.py verify`
+- 표 헤더 `| 순위 | 에이전트 | 총점 | 최강 능력 | commit | seq | 사슬 |`
+- 검증 행: 순위, 총점 `**score / max**`, 최강 pack, commit 10자, `검증됨`
+- unverified 행: `| — | seq N | — | — | — | N | **unverified** |`
+- 바닥글: 원장 체인 무결/파손, 항목 수, 검증 수, unverified 수
+- 정직 조항 문단
+
+검증된 선수가 2명 이상이고 pack 점수가 있으면 **능력 격자**를 붙인다.
+만점 칸은 `**N**`, 미제출은 `—`, 부분 점수는 `s/m`.
+
+`runner` 나 `rhwpCommit` 이 없으면 칸을 `—` 로 남긴다. 렌더가 죽으면 순위표가
+안 나오고, 그건 검증 실패를 숨기는 것과 같다.
+
+## 7. 줄 해시 체인과 머클
+
+### 7.1 `chain_walk(path, kind)`
+
+rhwp 의 `anchor_log::load_kind` 파이썬 거울. settlementLedger 를 단독 검증하는
+CLI 가 없어 같은 알고리즘을 여기에 둔다.
+
+규약:
+
+- 빈 줄은 건너뛴다.
+- 각 줄은 JSON 객체.
+- `kind` 가 인자와 같아야 한다.
+- `seq` 는 0부터 빈틈없이.
+- `prevEntryHash` 는 직전 **줄 원문 바이트**의 SHA-256. 첫 줄은 `null`.
+- 현재 줄의 해시는 `hashlib.sha256(line.encode("utf-8"))`.
+
+파손이 있으면 `(지금까지의 항목, "N행: 이유")` 를 돌려준다. 예외를 올리지
+않는다.
+
+| 실패 | 이유 문자열 |
+|---|---|
+| 경로 빈 문자열 | `경로가 비어 있다` |
+| 파일 없음 | `([], None)` — 빈 판은 파손이 아니다 |
+| 읽기/인코딩 실패 | `읽기 실패` / `인코딩 실패` |
+| JSON 파싱 실패 | `N행: JSON 파싱 실패` |
+| 객체가 아님 | `N행: 객체가 아님` |
+| kind 불일치 | `N행: kind X != Y` |
+| seq 연번 위반 | `N행: seq 연번 위반` |
+| prev 불일치 | `N행: prevEntryHash 불일치 (append-only 위반)` |
+
+과거 줄을 고치면 다음 줄의 `prevEntryHash` 가 어긋나 폭로된다. 이것이 소급
+수정의 1차 방어다. 항목이 하나일 때는 5. 의 스냅샷 봉인이 2차 방어다.
+
+### 7.2 `merkle_root(leaf_hashes)`
+
+앵커 체크포인트의 머클 규약 거울.
+
+- 빈 목록·None → None.
+- 잎은 **hex 문자열 목록**. `str`/`bytes` 통째로 넘기거나 잎이 문자열이 아니면
+  `LeaderboardSchemaError`. 조용히 `str()` 하면 다른 머클이 된다.
+- 홀수 층은 마지막 잎을 복제해 짝을 맞춘다.
+- 부모는 `sha256((a + b).encode("ascii"))`. 잎을 이어 붙인 뒤 ASCII 로 해시.
+
+새 머클 변형을 만들지 않는다. rhwp `anchor checkpoint` 가 쓰는 규약과 같아야
+재계산이 의미가 있다.
+
+### 7.3 `line_hashes` / `sha256_of`
+
+둘 다 `hashlib.sha256` 뿐이다. 파일이 없으면 `line_hashes` 는 `[]`,
+`sha256_of` 는 `LeaderboardIOError`. `try_sha256` / `try_line_hashes` 는
+예외를 올리지 않는 거울이다.
+
+## 8. 예외 경로 — 도구가 죽지 않는 계약
+
+도구 자신이 예외로 죽으면 게이트는 "사슬이 무결하다"는 거짓 음성을 못 내고,
+CI 가 붉어져 사슬 결함과 하네스 결함을 구분할 수 없다. 그래서 I/O·형식·CLI
+경로는 분류 가능한 코드로 접힌다.
+
+예외 계층:
+
+| 클래스 | code | 언제 |
+|---|---|---|
+| `LeaderboardError` | `leaderboard` | 기본 |
+| `LeaderboardIOError` | `io` | 파일 없음·권한·디렉터리 |
+| `LeaderboardFormatError` | `format` | JSON 파싱/직렬화·인코딩 |
+| `LeaderboardChainError` | `chain` | (예약. chain_walk 는 문자열로 접음) |
+| `LeaderboardCliError` | `cli` | 빈 바이너리·실행 실패·find_bin |
+| `LeaderboardSchemaError` | `schema` | 타입·키 결손·머클 잎 |
+
+`classify_exception()` 이 stdlib 예외도 같은 코드로 접는다.
+`FileNotFoundError`/`PermissionError`/`OSError` → io,
+`JSONDecodeError`/`UnicodeError` → format,
+`TypeError`/`ValueError`/`KeyError` → schema,
+그 외 → leaderboard.
+
+| 경로 | 함수 | 접는 곳 | 보고 |
+|---|---|---|---|
+| 없는 파일 sha256 | `sha256_of` | `LeaderboardIOError` | `try_sha256` 은 (None, err) |
+| JSON 없음 | `read_json` | IOError | `try_read_json` |
+| JSON 깨짐 | `read_json` | FormatError | `try_read_json` |
+| 직렬화 불가 | `write_json` | FormatError | `try_write_json` |
+| 디렉터리에 쓰기 | `write_json` | IOError | `try_write_json` |
+| 목록 대상이 파일 | `safe_listdir` | `([], 이유)` | claims 목록 실패 |
+| 사슬 JSON 깨짐 | `chain_walk` | `(항목, 이유)` | verify 바닥글 |
+| 머클 잎 타입 | `merkle_root` | SchemaError | 호출 측 |
+| 빈 바이너리 | `run_cli` | CliError | attest/verify why |
+| 없는 바이너리 | `run_cli` | CliError | 위와 같음 |
+| find_bin 실패 | `resolve_bin` | CliError | main exit 2 |
+| 손님 이름 타입 | `construct_invite` | SchemaError | invite exit 2 |
+| 초대장 스키마 | `cmd_invite` | SchemaError | invite exit 2 |
+| 입장 거부 | `cmd_attest` | SystemExit | 사용자 오류 |
+| 항목 claim 없음 | `verify_entry` | `ok=False` | results |
+| 항목 JSON 깨짐 | `verify_entry` | `ok=False` | results |
+| settle/anchor 실패 | `verify_entry` | `ok=False` | results |
+| 순위 score NaN | `rank_results` | unverified | 표 |
+| pack 결손 | `best_pack` | 건너뜀 | `—` |
+| runner 없음 | `render_markdown` | 칸 `—` | 표 |
+| verification 쓰기 실패 | `cmd_verify` | exit 2 | stderr |
+| render 쓰기 실패 | `cmd_render` | exit 2 | stderr |
+
+`cmd_attest` / `cmd_verify` / `cmd_invite` / `cmd_render` 의 바깥은
+`LeaderboardError` 와 `OSError`/`ValueError`/`TypeError` 를 잡아 분류 메시지로
+바꾼다. attest 는 SystemExit 을 다시 올려 사용자 오류를 유지한다.
+
+시험은 이 표의 각 칸을 임시 디렉터리와 목킹으로 고정한다. 바이너리 없이
+돌아간다. 서명 검증은 rhwp 게이트의 몫이다.
+
+## 9. 정직 조항 — 다시
+
+이 사슬이 봉인하는 것:
+
+- 스코어카드 바이트가 등재 시점의 청구에 고정됐다.
+- 그 청구가 이 신원의 키로 서명됐다.
+- 원장에 한 번만 들어갔다.
+- 그 이후 원장·앵커 바이트가 줄 체인과 스냅샷으로 봉인됐다.
+
+이 사슬이 **봉인하지 않는** 것:
+
+- 채점이 옳았는가. (runner 신원 + 제출물로 제3자가 재현)
+- 과제가 판별력이 있는가. (`discriminate.py`)
+- 도구가 손상 입력에 죽지 않는가. (`robustness.py`)
+- 초대받은 사람이 믿을 만한가. (초대는 안내)
+
+숫자를 지어내지 않는다. 스코어카드를 못 읽으면 점수를 비우고 `ok=False`.
+keyring 을 못 읽으면 `members=0`. 바이너리가 없으면 invite 만 돌고, 나머지
+모드는 exit 2.
+
+## 10. 시험 지도
+
+```bash
+python -m unittest scripts.tests.test_gym_leaderboard scripts.tests.test_gym_audit -q
+python gym/tools/audit.py
+```
+
+| 클래스 | 고정하는 것 |
+|---|---|
+| `ChainWalkTests` | 유효 체인, 소급 수정 폭로, seq 공백, 빈/공백 파일 |
+| `MerkleTests` | 결정성, 홀수 층 복제, 두 잎 이어 붙임 |
+| `CommittedBoardTests` | 커밋된 원장·앵커 무결, claim 파일 해시 |
+| `InviteTests` | 커밋된 판 지문 키 |
+| `RankResultsTests` | 점수·seq 동점, unverified 분리 |
+| `BestPackTests` | 비율·동률 max·max=0 |
+| `RenderMarkdownTests` | 헤더·정직 조항·격자·파손 바닥글 |
+| `InviteEnvelopeTests` | 임시 판, 커밋된 판 무터치 |
+| `ExceptionClassifyTests` | 예외 계층·stdlib 접기 |
+| `JsonIoExceptionTests` | sha256/read/write/listdir |
+| `ChainWalkMalformedTests` | JSON 깨짐, 비객체 행 |
+| `MerkleSchemaTests` | 잎 타입 거절 |
+| `FingerprintAndInviteSchemaTests` | 지문·초대장 validate, cmd_invite |
+| `RankAndPackExceptionTests` | NaN, 비목록, 결손 pack |
+| `RenderDefensiveTests` | runner 없음, 깨진 packs |
+| `CommandWrapperTests` | attest/verify/render/main |
+| `VerifyEntryExceptionTests` | 비객체, claim 없음, 깨진 claim |
+| `ConstantContractTests` | 키 집합, 모드 4개, hashlib 만 |
+| `AttestAdmissionExceptionTests` | 입장 객체/deny |
+| `ResolveBinTests` | find_bin 실패 분류 |
+
+`test_gym_audit` 는 전 pack 정합을 지킨다. 이번 변경은 pack 을 건드리지
+않으므로 그대로 초록이어야 한다.
+
+바이너리 없이 돈다. `run_cli` 실호출 시험은 없는 바이너리의 `OSError` 뿐이다.
+
+## 11. 하지 않는 것
+
+- 새 암호 원시함수. Ed25519 구현을 여기 두지 않는다.
+- 새 CLI 모드. `choices` 는 네 값.
+- pack/과제/checks 변경. 채점 기둥과 섞지 않는다.
+- 커밋된 `gym/leaderboard/` 를 시험이 쓰기. 경로는 임시 판으로 돌린다.
+- unverified 행을 표에서 빼기. 숨김은 위조다.
+- 시그널 종료를 성공으로 접기. CLI 실패는 cli 코드다.
+- `cargo fmt --all`. Python·문서만 고친다.
+
+이 문서가 코드와 다르면 코드와 시험을 이긴다. 문서만 고치고 시험을 안 고치면
+계약이 아니다.
+
+## 12. 점수판 파일 배치
+
+`gym/leaderboard/` 는 커밋된 진실이다. 시험은 이 트리를 쓰지 않고 경로 상수를
+임시 디렉터리로 돌린다.
+
+```text
+gym/leaderboard/
+├── workorder.json          상설 발주서. attest 가 없으면 기본본을 씀
+├── keyring.json            공개키만. keys[].revoked
+├── ledger.ndjson           settlementLedger 줄 체인
+├── anchor.ndjson           anchorLog 줄 체인
+├── checkpoint.json         머클 에폭
+├── verification.json       마지막 verify 봉투
+├── leaderboard.md          마지막 render 산출
+├── invite.json             마지막 invite 산출 (로컬, 필수는 아님)
+├── claims/
+│   ├── <agent>-<epoch>.claim.json
+│   └── <agent>-<epoch>.claim.json.sig.json
+├── scorecards/
+│   └── <agent>-<epoch>/{scorecard.json,admission.json}
+└── keys/                   비밀키. .gitignore
+    └── <agent>.key.json
+```
+
+커밋되는 것: 발주서, 키링(공개키), 원장, 앵커, 체크포인트, 청구, 서명 sidecar,
+보존 스코어카드·입장, 렌더된 마크다운, 검증 봉투.
+
+커밋되지 않는 것: `keys/*.key.json`. 초대 JSON 은 로컬 안내용이라 이 가지는
+커밋하지 않는다.
+
+원장 한 줄과 앵커 한 쌍(claim + 원장 스냅샷)이 attest 1회의 최소 단위다.
+항목 N개면 앵커는 대략 2N 줄이다. 마지막 앵커 줄이 원장 스냅샷이어야
+`ledgerSnapshotSealed` 가 참이다.
+
+## 13. 공격 시나리오와 폭로 지점
+
+아래는 새 암호가 아니라 기존 사다리가 이미 막는 자리와, 이 도구가 그 판정을
+어디에 드러내는가다.
+
+### 13.1 스코어카드 부풀림
+
+등재 후 `scorecards/<id>/scorecard.json` 의 총점을 고친다. `settle verify` 의
+`capsuleOk` 가 거짓이 된다. `verify_entry.checks["pin.scorecard"]` 가 거짓,
+항목은 unverified, 렌더는 순위에서 빼고 표에 남긴다.
+
+### 13.2 원장 첫 줄 소급
+
+`ledger.ndjson` 의 첫 줄 `capsuleSha256` 을 바꾼다. 항목이 2개 이상이면 둘째
+줄의 `prevEntryHash` 가 어긋나 `chain_walk` 가 `N행: prevEntryHash 불일치` 를
+준다. 항목이 1개면 체인만으로는 부족하고, 앵커 마지막 항목의 원장 스냅샷
+해시가 달라 `ledgerSnapshotSealed=false`, exit 3.
+
+교차 대조 `ledger.crossPin` 은 원장만 고치고 claim 파일을 그대로 두면 추가로
+폭로한다.
+
+### 13.3 같은 스코어카드 재등재
+
+`attest` 를 같은 제출로 한 번 더 부른다. `settle record` 가 exit 3,
+`duplicate: true`. 이번 claim 파일을 지우고 SystemExit. 원장 길이는 그대로.
+
+### 13.4 대리 이름
+
+남의 이름으로 등재하려면 그 이름의 비밀키가 필요하다. 키가 없으면 keygen 이
+새 신원을 만들고 keyring 에 다른 공개키가 오른다. 기존 항목의 `signerOk` 는
+그 키로 다시 검증된다. 남의 비밀키 없이 기존 항목을 가로채지 못한다.
+
+### 13.5 초대장 위조
+
+초대 JSON 의 지문을 고친다. 신참이 커밋된 원장에서 `board_fingerprint` 를
+다시 계산하면 값이 다르다. 초대장은 권한이 아니므로, 위조된 초대장을 들고
+`attest` 해도 원장 규칙은 그대로다. 지문은 "이 판이 그 판인가"만 말한다.
+
+## 14. 모드별 부작용과 재실행
+
+| 모드 | 멱등 | 재실행 |
+|---|---|---|
+| attest | 같은 스코어카드는 거부 | 재채점 후 새 스코어카드 |
+| verify | 쓰기 대상은 verification.json 뿐 | 언제든 |
+| render | 쓰기 대상은 leaderboard.md 뿐 | 언제든 |
+| invite | invite.json 을 덮어씀 | 언제든. 권한 변화 없음 |
+
+verify/render 는 원장을 바꾸지 않는다. 깨진 사슬을 verify 가 고치지 않는다.
+고치는 쪽은 커밋 이력이거나 새 attest 다.
+
+## 15. 관련
+
+- 이슈 #4659 (위조 불가능한 리더보드), #4664 (친구 초대), #5235 (순위·초대
+  순수 시험)
+- PR: https://github.com/edwardkim/rhwp/pull/5244
+- 가지: `feat/gym-leaderboard-rank-invite`
+- 친구 안내: `gym/INVITE.md`
+- gym 개요의 해당 절: `gym/README.md` 「위조 불가능한 리더보드」
+- 분업: 채점은 `gym/score.py`, 릴리스 게이트는 `gym/tools/release_gate.py`

--- a/gym/tools/README_leaderboard.md
+++ b/gym/tools/README_leaderboard.md
@@ -1,0 +1,191 @@
+---
+kind: guide
+status: active
+canonical: gym/tools/README_leaderboard.md
+last_verified: 2026-08-18
+---
+
+# leaderboard.py — 운영 메모
+
+위조 불가능한 점수판의 **한 페이지 운영 메모**다. 초대·등재·검증·렌더와
+예외 경로의 정본은 [`gym/docs/leaderboard.md`](../docs/leaderboard.md) 다.
+작업 기록은
+[`mydocs/working/gym_leaderboard.md`](../../mydocs/working/gym_leaderboard.md).
+
+## 30초
+
+```bash
+python gym/score.py --agent <이름>
+python gym/tools/leaderboard.py attest --agent <이름>
+python gym/tools/leaderboard.py verify
+python gym/tools/leaderboard.py render
+python gym/tools/leaderboard.py invite --agent <이름>
+python -m unittest scripts.tests.test_gym_leaderboard scripts.tests.test_gym_audit -q
+python gym/tools/audit.py
+```
+
+채점 → 등재 → 재검증 → 순위표. 초대는 판 지문을 붙이는 안내일 뿐 권한이
+아니다. 새 모드는 없다.
+
+## 언제 돌리나
+
+- 채점을 끝낸 에이전트를 명예의 전당에 올릴 때 (`attest`).
+- 커밋된 원장·앵커가 아직 무결한지 CI/릴리스 전에 볼 때 (`verify`).
+- 순위표 마크다운을 다시 그릴 때 (`render`).
+- 친구·다른 에이전트를 부를 때 (`invite`).
+
+돌리지 않는 때:
+
+- pack 채점. `score.py` 다.
+- 손상 입력 게이트. `robustness.py` 다.
+- 릴리스 차등. `release_diff.py` 다.
+- 포맷 변경. 이번 도구는 Python 만 고친다.
+
+## 모드
+
+| 모드 | 바이너리 | 쓰기 | 성공 exit |
+|---|---|---|---|
+| `attest --agent` | 필요 | claims, ledger, anchor, checkpoint, scorecards, keyring | 0 |
+| `verify` | 필요 | verification.json | 0 (전항 통과) |
+| `render` | 필요 | leaderboard.md | 0 |
+| `invite [--agent]` | **불필요** | invite.json | 0 |
+
+`invite` 는 커밋된 파일을 읽어 지문만 계산한다. `main(["invite"])` 가
+`find_bin` 을 부르지 않는 이유다.
+
+## 종료 코드
+
+| 코드 | 언제 |
+|---|---|
+| 0 | attest/invite/render 성공, verify 전항 통과 |
+| 2 | I/O·형식·CLI·바이너리 탐색. 하네스/환경 |
+| 3 | verify 사슬 파손·스냅샷 불일치·항목 실패 |
+| SystemExit | attest 의 `--agent` 없음, 입장 거부, 파일 없음, 이중 등재 |
+
+원장 거부는 "환경이 깨졌다"가 아니라 "같은 스코어카드가 이미 있다"는
+판정이다. 그래서 SystemExit 메시지를 유지한다.
+
+## 초대장에서 볼 키
+
+성공 판정: `kind == gymLeaderboardInvite`, `validate_invite` 빈 목록.
+
+지문:
+
+- `members` — keyring 신원 수. 깨진 keyring 은 0.
+- `ledgerEntries` — 원장 체인 길이. 자기 신고가 아니다.
+- `ledgerChain` / `anchorChain` — `"ok"` 또는 파손 이유.
+- `merkleRoot` — 체크포인트. 없으면 null.
+- `workorderSha256` / `ledgerSnapshotSha256` — 파일 바이트 SHA-256.
+
+합류 3줄이 `score.py` · `attest` · `verify` 를 포함하는지 `validate_invite` 가
+본다. 길이가 3이 아니면 위반.
+
+## 검증 봉투에서 볼 키
+
+- `ok` 가 아니라 `verified == ledgerEntries` 그리고 두 체인이 `"ok"` 그리고
+  `ledgerSnapshotSealed`.
+- `results[].checks` 의 거짓 키가 어느 축이 깨졌는지 말한다.
+- `why` 는 claim 없음·JSON 깨짐·CLI 실패.
+
+`schemaVersion` 은 `1.0`. 키를 빼면 `validate_invite` /
+`validate_fingerprint` 가 위반을 낸다.
+
+## 순위표에서 볼 것
+
+- 검증된 행만 숫자 순위. unverified 는 `—` 순위 + `**unverified**`.
+- 동점은 낮은 seq (먼저 등재).
+- 최강 능력은 만점 비율, 동률은 더 큰 max.
+- 능력 격자는 선수 2명 이상일 때만.
+- 정직 조항이 빠지면 렌더 시험이 붉어진다.
+
+## 예외 경로 — 운영자가 헷갈리는 것
+
+| 보이는 것 | 의미 | 다음 |
+|---|---|---|
+| `attest 실패 (cli)` | 바이너리 없음/실행 실패 | `--bin` 또는 `cargo build --bin rhwp` |
+| `없음: …/scorecard.json` | 채점을 안 함 | `gym/score.py --agent` |
+| `입장 봉투 verdict=deny` | 게이트가 거절 | 입장 정책·제출을 고친다 |
+| `원장 거부(이중 등재)` | 같은 스코어카드 | 재채점 후 새 스코어카드 |
+| `verify 실패 (io)` | 파일 권한·경로 | 판 디렉터리 |
+| `원장 체인: 파손` | 줄 해시/seq/kind | 원장을 손대지 말 것 |
+| `원장 스냅샷 봉인: 불일치` | 원장이 앵커 이후 변경 | 꼬리 변조. 복구는 커밋 이력 |
+| `invite 실패 (schema)` | 초대장 키 결손 | 도구 버그. 시험이 막아야 함 |
+| exit 2 (main 바이너리) | find_bin 실패 | invite 가 아니면 `--bin` |
+
+시그널 종료·없는 바이너리는 **cli** 다. 사슬 파손이 아니다.
+
+## 로컬에서 순수 함수만 보고 싶을 때
+
+모듈로 불러 순위·초대만 본다. 바이너리 불필요.
+
+```python
+import importlib.util
+from pathlib import Path
+p = Path("gym/tools/leaderboard.py")
+spec = importlib.util.spec_from_file_location("lb", p)
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+print(m.rank_results([
+    {"ok": True, "agent": "a", "score": 3, "max": 5, "seq": 1,
+     "runner": {"rhwpCommit": "abc1234567890"}, "packs": {}},
+    {"ok": False, "seq": 0},
+]))
+print(m.validate_invite(m.construct_invite("손님")))
+```
+
+커밋된 판을 건드리지 않으려면 `m.BOARD` 와 하위 경로를 임시 디렉터리로 돌린다.
+시험의 `_redirect` 가 그 패턴이다.
+
+## 시험
+
+```bash
+python -m unittest scripts.tests.test_gym_leaderboard
+python -m unittest scripts.tests.test_gym_audit
+python gym/tools/audit.py
+```
+
+기존 클래스(`ChainWalkTests` … `InviteEnvelopeTests`)는 원 PR 게이트.
+이번 가지의 `ExceptionClassifyTests` · `JsonIoExceptionTests` ·
+`CommandWrapperTests` · `VerifyEntryExceptionTests` 가 예외 접기를 고정한다.
+
+`cargo fmt --all` 은 이 변경에 실행하지 않는다. Python·문서만 고친다.
+
+## 새 키를 넣을 때 최소 체크
+
+1. 초대장/지문/검증 봉투의 키가 `INVITE_KEYS` / `FINGERPRINT_KEYS` 와 같은가.
+2. `validate_invite` / `validate_fingerprint` 가 그 키를 보는가.
+3. 임시 판 시험에서 커밋된 `gym/leaderboard/` 를 쓰지 않는가.
+4. 새 암호 필드가 아닌가. 해시는 sha256 hex 64자.
+5. 모드를 늘리지 않았는가. `MODES` 는 네 값.
+6. `test_gym_leaderboard` 가 그 키를 한 줄이라도 고정하는가.
+
+자세한 표는 규약 문서 4~8절이다.
+
+## 파일 배치 (한 줄)
+
+커밋: `workorder.json` · `keyring.json` · `ledger.ndjson` · `anchor.ndjson` ·
+`checkpoint.json` · `claims/` · `scorecards/` · `leaderboard.md` ·
+`verification.json`.
+
+커밋 금지: `keys/*.key.json`. 초대 `invite.json` 은 로컬 안내.
+
+원장 N줄이면 앵커는 대략 2N (claim + 원장 스냅샷). 마지막 앵커 줄이 원장
+바이트 해시여야 스냅샷 봉인이 참이다.
+
+## 자주 하는 실수
+
+1. `attest` 전에 `score.py` 를 안 돌린다 → `없음: scorecard.json`.
+2. 같은 제출을 두 번 `attest` → 원장 거부. 재채점해야 한다.
+3. `keys/` 를 커밋하려고 한다 → `.gitignore`. 공개키만 keyring.
+4. unverified 행을 표에서 지운다 → 숨김은 위조. 렌더가 남긴다.
+5. 초대장이 있어야 `attest` 된다고 생각한다 → 문은 이미 열려 있다.
+6. `invite` 에 바이너리가 필요하다고 생각한다 → 지문은 파일 해시뿐.
+7. 깨진 claim 하나 때문에 verify 가 크래시해야 한다고 생각한다 → 항목은
+   `ok=False` 로 접고 나머지를 계속 본다.
+
+## 관련
+
+- 이슈 #4659, #4664, #5235
+- PR https://github.com/edwardkim/rhwp/pull/5244
+- 친구 안내 `gym/INVITE.md`
+- gym 개요 `gym/README.md` 「위조 불가능한 리더보드」

--- a/gym/tools/leaderboard.py
+++ b/gym/tools/leaderboard.py
@@ -343,19 +343,10 @@ def board_fingerprint():
     }
 
 
-def cmd_invite(a, bin_path):
-    """친구 초대장 발급 — 외부 에이전트를 이름으로 점수판에 부른다.
-
-    리더보드는 처음부터 문이 열려 있다(attest 는 --agent 하나만 받는다). 이
-    명령은 그 열린 문에 **초대장**을 붙일 뿐이다: 지금 판의 지문과, 신참이
-    자기 신원으로 합류하는 3줄 절차를 한 봉투로 묶는다. 초대는 권한이 아니라
-    안내다 — 아무나 스스로 등재할 수 있고, 초대장은 '어디로 오면 되는지'를
-    가리킨다.
-    """
-    ensure_board()
-    guest = a.agent or "친구-에이전트"
+def construct_invite(guest):
+    """초대장 봉투 — 판 지문과 합류 3줄. 쓰기는 호출자가 한다."""
     fp = board_fingerprint()
-    invite = {
+    return {
         "schemaVersion": "1.0", "kind": "gymLeaderboardInvite",
         "guest": guest,
         "board": {"repo": "edwardkim/rhwp", "path": "gym/leaderboard"},
@@ -373,6 +364,21 @@ def cmd_invite(a, bin_path):
             "누구의 이름이든 받는다. 초대장은 네가 합류하는 판이 위조본이 "
             "아님을 fingerprint 로 확인하라는 뜻이다."),
     }
+
+
+def cmd_invite(a, bin_path):
+    """친구 초대장 발급 — 외부 에이전트를 이름으로 점수판에 부른다.
+
+    리더보드는 처음부터 문이 열려 있다(attest 는 --agent 하나만 받는다). 이
+    명령은 그 열린 문에 **초대장**을 붙일 뿐이다: 지금 판의 지문과, 신참이
+    자기 신원으로 합류하는 3줄 절차를 한 봉투로 묶는다. 초대는 권한이 아니라
+    안내다 — 아무나 스스로 등재할 수 있고, 초대장은 '어디로 오면 되는지'를
+    가리킨다.
+    """
+    ensure_board()
+    guest = a.agent or "친구-에이전트"
+    invite = construct_invite(guest)
+    fp = invite["fingerprint"]
     out = os.path.join(BOARD, "invite.json")
     write_json(out, invite)
     print(f"초대장 발급 → {os.path.relpath(out, ROOT)}")
@@ -385,32 +391,56 @@ def cmd_invite(a, bin_path):
     return 0
 
 
-def cmd_render(a, bin_path):
-    entries, err = chain_walk(LEDGER, "settlementLedger")
-    results = [verify_entry(bin_path, e, entries) for e in entries]
+def rank_results(results):
+    """검증된 항목만 (-score, seq) 로 순위. ok=False 는 unverified 로 분리."""
+    ranked = sorted((r for r in results if r.get("ok")),
+                    key=lambda r: (-r["score"], r["seq"]))
+    unverified = [r for r in results if not r.get("ok")]
+    return ranked, unverified
+
+
+def best_pack(packs):
+    """만점 비율이 가장 높은 pack. 동률이면 max 가 큰 쪽. 없으면 None.
+
+    cmd_render 가 쓰던 키와 같다: (score/max 또는 max=0 이면 0, max).
+    반환은 (pack_id, score, max).
+    """
+    if not packs:
+        return None
+    pid, pk = max(
+        packs.items(),
+        key=lambda kv: (kv[1]["score"] / kv[1]["max"] if kv[1]["max"] else 0,
+                        kv[1]["max"]),
+    )
+    return (pid, pk["score"], pk["max"])
+
+
+def render_markdown(results, err, ranked=None):
+    """순위표 마크다운 문자열. 쓰기는 호출자가 한다.
+
+    헤더·검증 행·**unverified** 행·정직 조항을 항상 포함한다. ranked 를
+    넘기지 않으면 rank_results 로 계산한다.
+    """
+    if ranked is None:
+        ranked, unverified = rank_results(results)
+    else:
+        unverified = [r for r in results if not r.get("ok")]
     lines = ["# 운동장 리더보드 — 위조 불가능한 점수판", "",
              "모든 순위는 검증 사슬(3해시 고정·Ed25519 서명·append-only 원장·머클 앵커)을",
              "**렌더 시점에 재검증**한 항목만 오른다. 재현 방법:",
              "`python gym/tools/leaderboard.py verify`", "",
              "| 순위 | 에이전트 | 총점 | 최강 능력 | commit | seq | 사슬 |",
              "|---|---|---|---|---|---|---|"]
-    ranked = sorted((r for r in results if r["ok"]),
-                    key=lambda r: (-r["score"], r["seq"]))
     for i, r in enumerate(ranked, 1):
         run = r["runner"]
-        # 각 선수의 최강 능력 — 만점 비율이 가장 높은 pack.
-        best = max(r.get("packs", {}).items(),
-                   key=lambda kv: (kv[1]["score"] / kv[1]["max"] if kv[1]["max"] else 0, kv[1]["max"]),
-                   default=(None, None))
-        best_txt = f"{best[0]} {best[1]['score']}/{best[1]['max']}" if best[0] else "—"
+        best = best_pack(r.get("packs") or {})
+        best_txt = f"{best[0]} {best[1]}/{best[2]}" if best else "—"
         lines.append(f"| {i} | {r['agent']} | **{r['score']} / {r['max']}** "
                      f"| {best_txt} | `{run['rhwpCommit'][:10]}` "
                      f"| {r['seq']} | 검증됨 |")
-    unverified = [r for r in results if not r["ok"]]
     for r in unverified:
         lines.append(f"| — | seq {r['seq']} | — | — | — | {r['seq']} | **unverified** |")
 
-    # pack 별 능력 격자 — 총점이 숨기는 강약을 드러낸다.
     pack_ids = sorted({pid for r in ranked for pid in r.get("packs", {})})
     if pack_ids and len(ranked) > 1:
         lines += ["", "## 능력 격자 (pack 별 점수)", "",
@@ -423,7 +453,7 @@ def cmd_render(a, bin_path):
                 if pk is None:
                     cells.append("—")
                 elif pk["score"] == pk["max"]:
-                    cells.append(f"**{pk['score']}**")   # 만점 강조
+                    cells.append(f"**{pk['score']}**")
                 else:
                     cells.append(f"{pk['score']}/{pk['max']}")
             lines.append(f"| {r['agent']} | " + " | ".join(cells) + " |")
@@ -435,9 +465,17 @@ def cmd_render(a, bin_path):
               "정직 조항: 이 사슬이 봉인하는 것은 \"이 스코어카드가 이 시점에 이 신원으로",
               "등재되었고 이후 변조되지 않았다\" 까지다. 채점 자체의 재현은 스코어카드의",
               "runner 신원(version·commit·capabilities digest)과 커밋된 제출물로 제3자가 수행한다."]
+    return "\n".join(lines) + "\n"
+
+
+def cmd_render(a, bin_path):
+    entries, err = chain_walk(LEDGER, "settlementLedger")
+    results = [verify_entry(bin_path, e, entries) for e in entries]
+    ranked, unverified = rank_results(results)
+    text = render_markdown(results, err, ranked=ranked)
     out = os.path.join(BOARD, "leaderboard.md")
     with io.open(out, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write("\n".join(lines) + "\n")
+        fh.write(text)
     print(f"리더보드 렌더 → {os.path.relpath(out, ROOT)} (검증 {len(ranked)}·unverified {len(unverified)})")
     return 0
 

--- a/gym/tools/leaderboard.py
+++ b/gym/tools/leaderboard.py
@@ -37,6 +37,11 @@ scorecard.json + admission.json          (채점기가 발급)
   python gym/tools/leaderboard.py attest --agent <이름>   # 등재 (채점 후)
   python gym/tools/leaderboard.py verify                  # 전 사슬 재검증
   python gym/tools/leaderboard.py render                  # 검증본에서 순위표 생성
+  python gym/tools/leaderboard.py invite --agent <이름>   # 초대장 (판 지문)
+
+I/O·JSON·사슬·CLI 실패는 분류된 LeaderboardError 로 접힌다. 새 암호 원시함수는
+없다 — sha256 은 hashlib, 서명은 rhwp settle/keygen 이 한다. 규약 정본은
+`gym/docs/leaderboard.md`, 운영 메모는 `gym/tools/README_leaderboard.md`.
 """
 
 import argparse
@@ -46,6 +51,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Mapping, Sequence
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
@@ -68,20 +74,149 @@ CHECKPOINT = os.path.join(BOARD, "checkpoint.json")
 KEYRING = os.path.join(BOARD, "keyring.json")
 WORKORDER = os.path.join(BOARD, "workorder.json")
 
+SCHEMA_VERSION = "1.0"
+INVITE_KIND = "gymLeaderboardInvite"
+VERIFICATION_KIND = "gymLeaderboardVerification"
+DEFAULT_GUEST = "친구-에이전트"
+JOIN_STEP_COUNT = 3
+COMMIT_SHORT = 10
+MODES = ("attest", "verify", "render", "invite")
+
+# 초대장·지문 키. 시험이 이 집합을 계약으로 고정한다. 새 암호 필드 없음.
+FINGERPRINT_KEYS = (
+    "members",
+    "ledgerEntries",
+    "ledgerChain",
+    "anchorChain",
+    "merkleRoot",
+    "workorderSha256",
+    "ledgerSnapshotSha256",
+)
+INVITE_KEYS = (
+    "schemaVersion",
+    "kind",
+    "guest",
+    "board",
+    "fingerprint",
+    "join",
+    "promise",
+    "note",
+)
+INVITE_BOARD_KEYS = ("repo", "path")
+RANK_OK_KEYS = ("ok", "agent", "score", "max", "seq", "runner")
+PACK_SCORE_KEYS = ("score", "max")
+ERROR_CODES = ("io", "format", "chain", "cli", "schema", "leaderboard")
+
+
+class LeaderboardError(Exception):
+    """분류된 리더보드 실패. 암호 실패가 아니라 I/O·형식·사슬·CLI 오류다."""
+
+    code = "leaderboard"
+
+    def __init__(self, message, *, path=None, cause=None):
+        super().__init__(message)
+        self.path = path
+        self.cause = cause
+
+    def as_dict(self):
+        body = {"ok": False, "code": self.code, "why": str(self)}
+        if self.path:
+            body["path"] = self.path
+        if self.cause is not None:
+            body["causeType"] = type(self.cause).__name__
+        return body
+
+
+class LeaderboardIOError(LeaderboardError):
+    code = "io"
+
+
+class LeaderboardFormatError(LeaderboardError):
+    code = "format"
+
+
+class LeaderboardChainError(LeaderboardError):
+    code = "chain"
+
+
+class LeaderboardCliError(LeaderboardError):
+    code = "cli"
+
+
+class LeaderboardSchemaError(LeaderboardError):
+    code = "schema"
+
+
+def classify_exception(exc):
+    """예외를 보고 코드로 접는다. 모르는 타입은 leaderboard."""
+    if isinstance(exc, LeaderboardError):
+        return exc.code
+    if isinstance(exc, (FileNotFoundError, NotADirectoryError, PermissionError,
+                        IsADirectoryError)):
+        return "io"
+    if isinstance(exc, OSError):
+        return "io"
+    if isinstance(exc, json.JSONDecodeError):
+        return "format"
+    if isinstance(exc, UnicodeError):
+        return "format"
+    if isinstance(exc, (TypeError, ValueError, KeyError, AttributeError, IndexError)):
+        return "schema"
+    if isinstance(exc, (subprocess.SubprocessError, FileNotFoundError)):
+        return "cli"
+    return "leaderboard"
+
+
+def format_classified(exc, prefix="실패"):
+    code = classify_exception(exc)
+    path = getattr(exc, "path", None)
+    loc = f" ({path})" if path else ""
+    return f"{prefix} ({code}){loc}: {exc}"
+
+
+def empty_fingerprint():
+    """빈 판의 지문. 파일이 없어도 invite 가 죽지 않게 한다."""
+    return {
+        "members": 0,
+        "ledgerEntries": 0,
+        "ledgerChain": "ok",
+        "anchorChain": "ok",
+        "merkleRoot": None,
+        "workorderSha256": None,
+        "ledgerSnapshotSha256": None,
+    }
+
 
 def sha256_of(path):
+    """파일 바이트의 SHA-256 hex. hashlib 만 쓴다 — 새 암호 원시함수 없음."""
     h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            h.update(chunk)
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+    except OSError as e:
+        raise LeaderboardIOError(f"sha256 실패: {e}", path=path, cause=e) from e
     return h.hexdigest()
 
 
+def try_sha256(path):
+    """sha256_of 의 비상승 거울. (digest|None, err|None)."""
+    try:
+        return sha256_of(path), None
+    except LeaderboardError as e:
+        return None, str(e)
+
+
 def run_cli(bin_path, args, ok=(0,)):
-    proc = subprocess.run([bin_path] + args, cwd=ROOT, capture_output=True)
+    if not bin_path:
+        raise LeaderboardCliError("rhwp 바이너리 경로가 비어 있다")
+    try:
+        proc = subprocess.run([bin_path] + list(args), cwd=ROOT, capture_output=True)
+    except OSError as e:
+        raise LeaderboardCliError(f"rhwp 실행 실패: {e}", cause=e) from e
     out = proc.stdout.decode("utf-8", errors="replace")
     if proc.returncode not in ok:
-        raise SystemExit(f"rhwp {' '.join(args[:3])} exit {proc.returncode}: "
+        raise SystemExit(f"rhwp {' '.join(list(args)[:3])} exit {proc.returncode}: "
                          f"{proc.stderr.decode('utf-8', 'replace')[:300]}")
     try:
         return proc.returncode, json.loads(out)
@@ -90,13 +225,57 @@ def run_cli(bin_path, args, ok=(0,)):
 
 
 def read_json(path):
-    with io.open(path, encoding="utf-8") as fh:
-        return json.load(fh)
+    try:
+        with io.open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except OSError as e:
+        raise LeaderboardIOError(f"JSON 읽기 실패: {e}", path=path, cause=e) from e
+    except json.JSONDecodeError as e:
+        raise LeaderboardFormatError(f"JSON 파싱 실패: {e}", path=path, cause=e) from e
+    except UnicodeError as e:
+        raise LeaderboardFormatError(f"JSON 인코딩 실패: {e}", path=path, cause=e) from e
 
 
 def write_json(path, body):
-    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write(json.dumps(body, ensure_ascii=False, indent=2) + "\n")
+    try:
+        text = json.dumps(body, ensure_ascii=False, indent=2) + "\n"
+    except (TypeError, ValueError) as e:
+        raise LeaderboardFormatError(f"JSON 직렬화 실패: {e}", path=path, cause=e) from e
+    try:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+    except OSError as e:
+        raise LeaderboardIOError(f"JSON 쓰기 실패: {e}", path=path, cause=e) from e
+
+
+def try_read_json(path):
+    """read_json 의 비상승 거울. (obj|None, err|None)."""
+    try:
+        return read_json(path), None
+    except LeaderboardError as e:
+        return None, str(e)
+
+
+def try_write_json(path, body):
+    """write_json 의 비상승 거울. err|None."""
+    try:
+        write_json(path, body)
+        return None
+    except LeaderboardError as e:
+        return str(e)
+
+
+def safe_listdir(path):
+    """os.listdir 의 비상승 거울. (names, err|None). 없으면 빈 목록."""
+    try:
+        if not os.path.isdir(path):
+            return [], None if not os.path.exists(path) else f"디렉터리가 아님: {path}"
+        return sorted(os.listdir(path)), None
+    except OSError as e:
+        return [], f"목록 실패: {e}"
 
 
 def chain_walk(path, kind):
@@ -105,31 +284,61 @@ def chain_walk(path, kind):
     (rhwp 에는 settlementLedger 를 단독 검증하는 CLI 가 없어 여기서 같은
     알고리즘을 거울로 둔다. 규약: prevEntryHash = 직전 줄 원문 바이트의 sha256,
     seq 연번, kind 고정.)
+
+    읽기·JSON 실패는 예외를 올리지 않고 (지금까지의 항목, 이유 문자열) 을
+    돌려준다. 사슬 검증이 죽으면 폭로가 아니라 침묵이 된다.
     """
-    if not os.path.exists(path):
-        return [], None
+    if not path:
+        return [], "경로가 비어 있다"
+    try:
+        if not os.path.exists(path):
+            return [], None
+    except OSError as e:
+        return [], f"존재 확인 실패: {e}"
     entries, prev = [], None
-    with io.open(path, encoding="utf-8") as fh:
-        for i, line in enumerate(fh.read().splitlines()):
-            if not line.strip():
-                continue
+    try:
+        with io.open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+    except OSError as e:
+        return [], f"읽기 실패: {e}"
+    except UnicodeError as e:
+        return [], f"인코딩 실패: {e}"
+    for i, line in enumerate(raw.splitlines()):
+        if not line.strip():
+            continue
+        try:
             entry = json.loads(line)
-            if entry.get("kind") != kind:
-                return entries, f"{i+1}행: kind {entry.get('kind')} != {kind}"
-            if entry.get("seq") != len(entries):
-                return entries, f"{i+1}행: seq 연번 위반"
-            if entry.get("prevEntryHash") != prev:
-                return entries, f"{i+1}행: prevEntryHash 불일치 (append-only 위반)"
-            prev = hashlib.sha256(line.encode("utf-8")).hexdigest()
-            entries.append(entry)
+        except json.JSONDecodeError as e:
+            return entries, f"{i+1}행: JSON 파싱 실패 ({e.msg})"
+        if not isinstance(entry, dict):
+            return entries, f"{i+1}행: 객체가 아님"
+        if entry.get("kind") != kind:
+            return entries, f"{i+1}행: kind {entry.get('kind')} != {kind}"
+        if entry.get("seq") != len(entries):
+            return entries, f"{i+1}행: seq 연번 위반"
+        if entry.get("prevEntryHash") != prev:
+            return entries, f"{i+1}행: prevEntryHash 불일치 (append-only 위반)"
+        prev = hashlib.sha256(line.encode("utf-8")).hexdigest()
+        entries.append(entry)
     return entries, None
 
 
 def merkle_root(leaf_hashes):
-    """anchor 의 머클 규약 거울 — 잎은 줄 바이트 해시, 홀수 층은 마지막 복제."""
+    """anchor 의 머클 규약 거울 — 잎은 줄 바이트 해시, 홀수 층은 마지막 복제.
+
+    잎은 hex 문자열이어야 한다. 다른 타입은 SchemaError — 조용히 str() 하면
+    다른 머클이 된다.
+    """
     if not leaf_hashes:
         return None
-    level = list(leaf_hashes)
+    if isinstance(leaf_hashes, (str, bytes)):
+        raise LeaderboardSchemaError("merkle 잎은 문자열 목록이어야 한다")
+    try:
+        level = list(leaf_hashes)
+    except TypeError as e:
+        raise LeaderboardSchemaError(f"merkle 잎이 순회 가능하지 않다: {e}") from e
+    if any(not isinstance(x, str) for x in level):
+        raise LeaderboardSchemaError("merkle 잎은 hex 문자열이어야 한다")
     while len(level) > 1:
         nxt = []
         for i in range(0, len(level), 2):
@@ -141,34 +350,70 @@ def merkle_root(leaf_hashes):
 
 
 def line_hashes(path):
-    if not os.path.exists(path):
+    if not path:
         return []
-    with io.open(path, encoding="utf-8") as fh:
-        return [hashlib.sha256(line.encode("utf-8")).hexdigest()
-                for line in fh.read().splitlines() if line.strip()]
+    try:
+        if not os.path.exists(path):
+            return []
+        with io.open(path, encoding="utf-8") as fh:
+            return [hashlib.sha256(line.encode("utf-8")).hexdigest()
+                    for line in fh.read().splitlines() if line.strip()]
+    except (OSError, UnicodeError) as e:
+        raise LeaderboardIOError(f"줄 해시 실패: {e}", path=path, cause=e) from e
+
+
+def try_line_hashes(path):
+    try:
+        return line_hashes(path), None
+    except LeaderboardError as e:
+        return [], str(e)
+
+
+def default_workorder():
+    return {
+        "schemaVersion": SCHEMA_VERSION, "kind": "workorder",
+        "workorderId": "gym-leaderboard-standing",
+        "title": "운동장 상설 발주 — 전 pack 채점 결과의 등재",
+        "acceptancePolicy": {
+            "schemaVersion": SCHEMA_VERSION, "kind": "admissionPolicy", "default": "deny",
+            "rules": [],
+            "note": "입장 판정은 채점기의 gymAdmission 봉투가 담당한다",
+        },
+        "unitPrice": {"amount": "0", "currency": "KRW", "per": "scorecard"},
+    }
+
+
+def default_keyring():
+    return {"schemaVersion": SCHEMA_VERSION, "kind": "keyring", "keys": []}
 
 
 def ensure_board():
-    os.makedirs(KEYS, exist_ok=True)
-    os.makedirs(CLAIMS, exist_ok=True)
+    try:
+        os.makedirs(KEYS, exist_ok=True)
+        os.makedirs(CLAIMS, exist_ok=True)
+    except OSError as e:
+        raise LeaderboardIOError(f"점수판 디렉터리 생성 실패: {e}", path=BOARD, cause=e) from e
     if not os.path.exists(WORKORDER):
-        write_json(WORKORDER, {
-            "schemaVersion": "1.0", "kind": "workorder",
-            "workorderId": "gym-leaderboard-standing",
-            "title": "운동장 상설 발주 — 전 pack 채점 결과의 등재",
-            "acceptancePolicy": {
-                "schemaVersion": "1.0", "kind": "admissionPolicy", "default": "deny",
-                "rules": [],
-                "note": "입장 판정은 채점기의 gymAdmission 봉투가 담당한다",
-            },
-            "unitPrice": {"amount": "0", "currency": "KRW", "per": "scorecard"},
-        })
+        write_json(WORKORDER, default_workorder())
     if not os.path.exists(KEYRING):
-        write_json(KEYRING, {"schemaVersion": "1.0", "kind": "keyring", "keys": []})
+        write_json(KEYRING, default_keyring())
 
 
 def cmd_attest(a, bin_path):
+    try:
+        return _cmd_attest_body(a, bin_path)
+    except SystemExit:
+        raise
+    except LeaderboardError as e:
+        raise SystemExit(format_classified(e, "attest 실패")) from e
+    except (OSError, ValueError, TypeError) as e:
+        raise SystemExit(format_classified(e, "attest 실패")) from e
+
+
+def _cmd_attest_body(a, bin_path):
     ensure_board()
+    if not getattr(a, "agent", None):
+        raise SystemExit("attest 는 --agent 가 필요하다")
     sub = os.path.join(GYM, "submissions", a.agent)
     scorecard = os.path.join(sub, "scorecard.json")
     admission = os.path.join(sub, "admission.json")
@@ -176,6 +421,8 @@ def cmd_attest(a, bin_path):
         if not os.path.exists(f):
             raise SystemExit(f"없음: {f} — 먼저 `python gym/score.py --agent {a.agent}` 를 돌려라")
     adm = read_json(admission)
+    if not isinstance(adm, dict):
+        raise SystemExit("입장 봉투가 객체가 아니다 — 등재 불가")
     if adm.get("verdict") != "allow":
         raise SystemExit(f"입장 봉투 verdict={adm.get('verdict')} — 등재 불가")
 
@@ -184,8 +431,16 @@ def cmd_attest(a, bin_path):
     key_id = f"gym/{a.agent}"
     if not os.path.exists(key):
         run_cli(bin_path, ["keygen", "--key-id", key_id, "--out", key, "--json"])
-        pub = read_json(key)["publicKey"]
+        key_body = read_json(key)
+        if not isinstance(key_body, dict) or "publicKey" not in key_body:
+            raise LeaderboardSchemaError("keygen 산출에 publicKey 가 없다", path=key)
+        pub = key_body["publicKey"]
         ring = read_json(KEYRING)
+        if not isinstance(ring, dict):
+            raise LeaderboardSchemaError("keyring 이 객체가 아니다", path=KEYRING)
+        ring.setdefault("keys", [])
+        if not isinstance(ring["keys"], list):
+            raise LeaderboardSchemaError("keyring.keys 가 목록이 아니다", path=KEYRING)
         ring["keys"].append({"keyId": key_id, "publicKey": pub, "revoked": None})
         write_json(KEYRING, ring)
 
@@ -238,18 +493,34 @@ def cmd_attest(a, bin_path):
 
 
 def verify_entry(bin_path, entry, ledger_entries):
-    """원장 항목 하나의 전 사슬 재검증 — 판정은 전부 데이터."""
-    result = {"seq": entry["seq"], "claimSha256": entry.get("claimSha256", "")[:16]}
+    """원장 항목 하나의 전 사슬 재검증 — 판정은 전부 데이터.
+
+    I/O·형식 실패는 예외를 올리지 않고 ok=False + why 로 접는다. 한 항목의
+    읽기 실패가 전체 verify 를 죽이면 폭로가 아니라 침묵이다.
+    """
+    if not isinstance(entry, dict):
+        return {"ok": False, "seq": None, "why": "원장 항목이 객체가 아님"}
+    result = {"seq": entry.get("seq"), "claimSha256": str(entry.get("claimSha256", ""))[:16]}
+    names, list_err = safe_listdir(CLAIMS)
+    if list_err:
+        result.update({"ok": False, "why": f"claims 목록 실패: {list_err}"})
+        return result
     claim_path = None
-    for name in sorted(os.listdir(CLAIMS)):
+    for name in names:
         p = os.path.join(CLAIMS, name)
-        if sha256_of(p) == entry.get("claimSha256"):
+        digest, digest_err = try_sha256(p)
+        if digest_err or digest is None:
+            continue
+        if digest == entry.get("claimSha256"):
             claim_path = p
             break
     if claim_path is None:
         result.update({"ok": False, "why": "claim 파일 없음(원장 해시와 일치하는 파일 부재)"})
         return result
-    claim = read_json(claim_path)
+    claim, claim_err = try_read_json(claim_path)
+    if claim_err or not isinstance(claim, dict):
+        result.update({"ok": False, "why": f"claim 읽기 실패: {claim_err or '객체가 아님'}"})
+        return result
     # 원장 항목과 claim 의 교차 대조 — 원장의 capsuleSha256 을 바꿔치기해도
     # claim 파일이 남아 있으면 여기서 폭로된다(첫 공격 실증이 잡은 구멍).
     cross = claim.get("capsuleSha256") == entry.get("capsuleSha256")
@@ -257,13 +528,21 @@ def verify_entry(bin_path, entry, ledger_entries):
     keep = os.path.join(BOARD, "scorecards", agent_epoch)
     scorecard = os.path.join(keep, "scorecard.json")
     admission = os.path.join(keep, "admission.json")
-    result["agent"] = read_json(admission).get("agent") if os.path.exists(admission) else "?"
+    adm_body, _adm_err = try_read_json(admission) if os.path.exists(admission) else (None, None)
+    if isinstance(adm_body, dict):
+        result["agent"] = adm_body.get("agent", "?")
+    else:
+        result["agent"] = "?"
 
     # ① 3해시 고정 + 서명 (rhwp 가 판정)
-    code, env = run_cli(bin_path, ["settle", "verify", claim_path,
-                                   "--workorder", WORKORDER, "--capsule", scorecard,
-                                   "--gate-envelope", admission,
-                                   "--keyring", KEYRING, "--json"], ok=(0, 3))
+    try:
+        _code, env = run_cli(bin_path, ["settle", "verify", claim_path,
+                                        "--workorder", WORKORDER, "--capsule", scorecard,
+                                        "--gate-envelope", admission,
+                                        "--keyring", KEYRING, "--json"], ok=(0, 3))
+    except (LeaderboardError, SystemExit) as e:
+        result.update({"ok": False, "why": f"settle verify 실패: {e}"})
+        return result
     checks = {
         "pin.workorder": bool(env and env.get("workorderOk")),
         "pin.scorecard": bool(env and env.get("capsuleOk")),
@@ -273,51 +552,91 @@ def verify_entry(bin_path, entry, ledger_entries):
         "ledger.crossPin": cross,
     }
     # ② 투명성 로그 등재 + 로그 체인 (rhwp 가 판정)
-    code, aenv = run_cli(bin_path, ["anchor", "verify", claim_path,
-                                    "--log", ANCHOR, "--json"], ok=(0, 3))
+    try:
+        _code, aenv = run_cli(bin_path, ["anchor", "verify", claim_path,
+                                         "--log", ANCHOR, "--json"], ok=(0, 3))
+    except (LeaderboardError, SystemExit) as e:
+        result.update({"ok": False, "why": f"anchor verify 실패: {e}", "checks": checks})
+        return result
     checks["anchor.logged"] = bool(aenv and aenv.get("logged"))
     checks["anchor.chain"] = bool(aenv and aenv.get("logChainOk"))
     result["checks"] = checks
     result["ok"] = all(checks.values())
     if result["ok"]:
-        card = read_json(scorecard)
-        result["score"] = card["total"]["score"]
-        result["max"] = card["total"]["max"]
-        result["runner"] = card["runner"]
-        # pack 별 점수 — 총점만으로는 어느 능력이 강한지 사라진다(리더보드의 결).
+        card, card_err = try_read_json(scorecard)
+        if card_err or not isinstance(card, dict):
+            result.update({"ok": False, "why": f"scorecard 읽기 실패: {card_err or '객체가 아님'}"})
+            return result
+        total = card.get("total") if isinstance(card.get("total"), dict) else {}
+        result["score"] = total.get("score")
+        result["max"] = total.get("max")
+        result["runner"] = card.get("runner") if isinstance(card.get("runner"), dict) else {}
+        packs = card.get("packs") if isinstance(card.get("packs"), list) else []
         result["packs"] = {p["id"]: {"score": p.get("score"), "max": p["max"]}
-                           for p in card["packs"] if p.get("status") == "scored"}
+                           for p in packs
+                           if isinstance(p, dict) and p.get("status") == "scored" and "id" in p and "max" in p}
     return result
 
 
 def cmd_verify(a, bin_path):
+    try:
+        return _cmd_verify_body(a, bin_path)
+    except SystemExit:
+        raise
+    except LeaderboardError as e:
+        print(format_classified(e, "verify 실패"), file=sys.stderr)
+        return 2
+    except (OSError, ValueError, TypeError) as e:
+        print(format_classified(e, "verify 실패"), file=sys.stderr)
+        return 2
+
+
+def _cmd_verify_body(a, bin_path):
     ensure_board()
     entries, err = chain_walk(LEDGER, "settlementLedger")
     print(f"원장 체인: {len(entries)}항목 · {'무결' if err is None else '파손: ' + err}")
     aentries, aerr = chain_walk(ANCHOR, "anchorLog")
     print(f"앵커 체인: {len(aentries)}항목 · {'무결' if aerr is None else '파손: ' + aerr}")
     # 원장 꼬리 봉인 — 앵커의 마지막 항목은 attest 규약상 원장 스냅샷이다.
-    snapshot_ok = bool(aentries) and os.path.exists(LEDGER) and         aentries[-1].get("capsuleSha256") == sha256_of(LEDGER)
+    ledger_digest, ledger_digest_err = try_sha256(LEDGER) if os.path.exists(LEDGER) else (None, None)
+    snapshot_ok = bool(aentries) and ledger_digest is not None and (
+        aentries[-1].get("capsuleSha256") == ledger_digest)
+    if ledger_digest_err:
+        print(f"원장 스냅샷 해시 실패: {ledger_digest_err}")
     print(f"원장 스냅샷 봉인: {'일치' if snapshot_ok else '불일치!! (원장이 앵커 이후 변경됨)'}")
     if os.path.exists(CHECKPOINT):
-        cp = read_json(CHECKPOINT)
-        root = merkle_root(line_hashes(ANCHOR)[:cp.get("upToSeq", 0) + 1])
-        match = root == cp.get("merkleRoot")
-        print(f"체크포인트: upToSeq {cp.get('upToSeq')} · 머클 루트 "
-              f"{'재계산 일치' if match else '불일치!!'}")
+        cp, cp_err = try_read_json(CHECKPOINT)
+        if cp_err or not isinstance(cp, dict):
+            print(f"체크포인트: 읽기 실패 — {cp_err or '객체가 아님'}")
+        else:
+            leaves, leaves_err = try_line_hashes(ANCHOR)
+            if leaves_err:
+                print(f"체크포인트: 앵커 줄 해시 실패 — {leaves_err}")
+            else:
+                try:
+                    up_to = int(cp.get("upToSeq", 0))
+                except (TypeError, ValueError):
+                    up_to = 0
+                root = merkle_root(leaves[:up_to + 1])
+                match = root == cp.get("merkleRoot")
+                print(f"체크포인트: upToSeq {cp.get('upToSeq')} · 머클 루트 "
+                      f"{'재계산 일치' if match else '불일치!!'}")
     results = [verify_entry(bin_path, e, entries) for e in entries]
-    ok = sum(1 for r in results if r["ok"])
+    ok = sum(1 for r in results if r.get("ok"))
     print(f"항목 검증: {ok}/{len(results)} 통과")
     for r in results:
-        mark = "O" if r["ok"] else "X"
+        mark = "O" if r.get("ok") else "X"
         bad = [k for k, v in r.get("checks", {}).items() if not v]
-        print(f"  {mark} seq{r['seq']} {r.get('agent', '?'):20} "
-              + (f"{r.get('score')}/{r.get('max')}" if r["ok"] else f"실패: {bad or r.get('why')}"))
-    write_json(os.path.join(BOARD, "verification.json"),
-               {"kind": "gymLeaderboardVerification", "schemaVersion": "1.0",
-                "ledgerEntries": len(entries), "ledgerChain": err or "ok",
-                "anchorChain": aerr or "ok", "ledgerSnapshotSealed": snapshot_ok,
-                "verified": ok, "results": results})
+        print(f"  {mark} seq{r.get('seq')} {str(r.get('agent', '?')):20} "
+              + (f"{r.get('score')}/{r.get('max')}" if r.get("ok") else f"실패: {bad or r.get('why')}"))
+    write_err = try_write_json(os.path.join(BOARD, "verification.json"),
+                               {"kind": VERIFICATION_KIND, "schemaVersion": SCHEMA_VERSION,
+                                "ledgerEntries": len(entries), "ledgerChain": err or "ok",
+                                "anchorChain": aerr or "ok", "ledgerSnapshotSealed": snapshot_ok,
+                                "verified": ok, "results": results})
+    if write_err:
+        print(f"verification.json 쓰기 실패: {write_err}", file=sys.stderr)
+        return 2
     return 0 if (err is None and aerr is None and snapshot_ok and ok == len(results)) else 3
 
 
@@ -326,28 +645,65 @@ def board_fingerprint():
 
     초대장을 받은 친구는 이 지문을 커밋된 원장·앵커에서 스스로 재계산해,
     자기 키를 걸기 전에 판이 위조본이 아님을 확인한다. 새 비밀 0 — 전부
-    커밋된 파일에서 나온다.
+    커밋된 파일에서 나온다. 읽기 실패는 예외를 올리지 않고 지문 필드에 접는다.
     """
+    fp = empty_fingerprint()
     ledger_entries, lerr = chain_walk(LEDGER, "settlementLedger")
-    anchor_entries, aerr = chain_walk(ANCHOR, "anchorLog")
-    ring = read_json(KEYRING) if os.path.exists(KEYRING) else {"keys": []}
-    checkpoint = read_json(CHECKPOINT) if os.path.exists(CHECKPOINT) else {}
-    return {
-        "members": len(ring.get("keys", [])),
-        "ledgerEntries": len(ledger_entries),
-        "ledgerChain": lerr or "ok",
-        "anchorChain": aerr or "ok",
-        "merkleRoot": checkpoint.get("merkleRoot"),
-        "workorderSha256": sha256_of(WORKORDER) if os.path.exists(WORKORDER) else None,
-        "ledgerSnapshotSha256": sha256_of(LEDGER) if os.path.exists(LEDGER) else None,
-    }
+    _anchor_entries, aerr = chain_walk(ANCHOR, "anchorLog")
+    fp["ledgerEntries"] = len(ledger_entries)
+    fp["ledgerChain"] = lerr or "ok"
+    fp["anchorChain"] = aerr or "ok"
+    ring, ring_err = (try_read_json(KEYRING) if os.path.exists(KEYRING)
+                      else ({"keys": []}, None))
+    if ring_err or not isinstance(ring, dict):
+        fp["members"] = 0
+    else:
+        keys = ring.get("keys")
+        fp["members"] = len(keys) if isinstance(keys, list) else 0
+    checkpoint, _cp_err = (try_read_json(CHECKPOINT) if os.path.exists(CHECKPOINT)
+                           else ({}, None))
+    if isinstance(checkpoint, dict):
+        fp["merkleRoot"] = checkpoint.get("merkleRoot")
+    wo, wo_err = try_sha256(WORKORDER) if os.path.exists(WORKORDER) else (None, None)
+    fp["workorderSha256"] = wo if not wo_err else None
+    snap, snap_err = try_sha256(LEDGER) if os.path.exists(LEDGER) else (None, None)
+    fp["ledgerSnapshotSha256"] = snap if not snap_err else None
+    return fp
+
+
+def validate_fingerprint(fp):
+    """지문 봉투 위반 목록. 비어 있으면 스키마 통과."""
+    issues = []
+    if not isinstance(fp, dict):
+        return ["지문이 객체가 아니다"]
+    for key in FINGERPRINT_KEYS:
+        if key not in fp:
+            issues.append(f"지문에 {key} 가 없다")
+    if "members" in fp and not isinstance(fp["members"], int):
+        issues.append("members 가 int 가 아니다")
+    if "ledgerEntries" in fp and not isinstance(fp["ledgerEntries"], int):
+        issues.append("ledgerEntries 가 int 가 아니다")
+    for chain_key in ("ledgerChain", "anchorChain"):
+        if chain_key in fp and not isinstance(fp[chain_key], str):
+            issues.append(f"{chain_key} 가 문자열이 아니다")
+    for hash_key in ("workorderSha256", "ledgerSnapshotSha256", "merkleRoot"):
+        val = fp.get(hash_key)
+        if val is not None and not isinstance(val, str):
+            issues.append(f"{hash_key} 가 문자열도 None 도 아니다")
+        if isinstance(val, str) and hash_key != "merkleRoot" and len(val) != 64:
+            issues.append(f"{hash_key} 길이 {len(val)} != 64")
+    return issues
 
 
 def construct_invite(guest):
     """초대장 봉투 — 판 지문과 합류 3줄. 쓰기는 호출자가 한다."""
+    if guest is None or (isinstance(guest, str) and not guest.strip()):
+        guest = DEFAULT_GUEST
+    if not isinstance(guest, str):
+        raise LeaderboardSchemaError(f"손님 이름이 문자열이 아니다: {type(guest).__name__}")
     fp = board_fingerprint()
     return {
-        "schemaVersion": "1.0", "kind": "gymLeaderboardInvite",
+        "schemaVersion": SCHEMA_VERSION, "kind": INVITE_KIND,
         "guest": guest,
         "board": {"repo": "edwardkim/rhwp", "path": "gym/leaderboard"},
         "fingerprint": fp,
@@ -366,6 +722,46 @@ def construct_invite(guest):
     }
 
 
+def validate_invite(invite):
+    """초대장 봉투 위반 목록. 암호 검증이 아니라 스키마·합류 3줄 계약이다."""
+    issues = []
+    if not isinstance(invite, dict):
+        return ["초대장이 객체가 아니다"]
+    for key in INVITE_KEYS:
+        if key not in invite:
+            issues.append(f"초대장에 {key} 가 없다")
+    if invite.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append(f"schemaVersion {invite.get('schemaVersion')!r} != {SCHEMA_VERSION!r}")
+    if invite.get("kind") != INVITE_KIND:
+        issues.append(f"kind {invite.get('kind')!r} != {INVITE_KIND!r}")
+    if "guest" in invite and not isinstance(invite["guest"], str):
+        issues.append("guest 가 문자열이 아니다")
+    board = invite.get("board")
+    if board is not None:
+        if not isinstance(board, dict):
+            issues.append("board 가 객체가 아니다")
+        else:
+            for key in INVITE_BOARD_KEYS:
+                if key not in board:
+                    issues.append(f"board.{key} 가 없다")
+    join = invite.get("join")
+    if join is not None:
+        if not isinstance(join, list):
+            issues.append("join 이 목록이 아니다")
+        elif len(join) != JOIN_STEP_COUNT:
+            issues.append(f"join 길이 {len(join)} != {JOIN_STEP_COUNT}")
+        else:
+            if not any("score.py" in str(s) for s in join):
+                issues.append("join 에 score.py 가 없다")
+            if not any("attest" in str(s) for s in join):
+                issues.append("join 에 attest 가 없다")
+            if not any("verify" in str(s) for s in join):
+                issues.append("join 에 verify 가 없다")
+    if "fingerprint" in invite:
+        issues.extend(f"fingerprint.{i}" for i in validate_fingerprint(invite["fingerprint"]))
+    return issues
+
+
 def cmd_invite(a, bin_path):
     """친구 초대장 발급 — 외부 에이전트를 이름으로 점수판에 부른다.
 
@@ -375,56 +771,168 @@ def cmd_invite(a, bin_path):
     안내다 — 아무나 스스로 등재할 수 있고, 초대장은 '어디로 오면 되는지'를
     가리킨다.
     """
-    ensure_board()
-    guest = a.agent or "친구-에이전트"
-    invite = construct_invite(guest)
-    fp = invite["fingerprint"]
-    out = os.path.join(BOARD, "invite.json")
-    write_json(out, invite)
-    print(f"초대장 발급 → {os.path.relpath(out, ROOT)}")
-    print(f"  손님: {guest}")
-    print(f"  판 지문: 멤버 {fp['members']} · 원장 {fp['ledgerEntries']}항목 "
-          f"· 사슬 {fp['ledgerChain']}/{fp['anchorChain']}")
-    print("  합류 3줄:")
-    for step in invite["join"]:
-        print(f"    $ {step}")
-    return 0
+    try:
+        ensure_board()
+        guest = getattr(a, "agent", None) or DEFAULT_GUEST
+        invite = construct_invite(guest)
+        issues = validate_invite(invite)
+        if issues:
+            raise LeaderboardSchemaError("초대장 스키마 위반: " + "; ".join(issues))
+        fp = invite["fingerprint"]
+        out = os.path.join(BOARD, "invite.json")
+        write_err = try_write_json(out, invite)
+        if write_err:
+            raise LeaderboardIOError(write_err, path=out)
+        print(f"초대장 발급 → {os.path.relpath(out, ROOT)}")
+        print(f"  손님: {guest}")
+        print(f"  판 지문: 멤버 {fp['members']} · 원장 {fp['ledgerEntries']}항목 "
+              f"· 사슬 {fp['ledgerChain']}/{fp['anchorChain']}")
+        print("  합류 3줄:")
+        for step in invite["join"]:
+            print(f"    $ {step}")
+        return 0
+    except LeaderboardError as e:
+        print(format_classified(e, "invite 실패"), file=sys.stderr)
+        return 2
+    except (OSError, ValueError, TypeError) as e:
+        print(format_classified(e, "invite 실패"), file=sys.stderr)
+        return 2
+
+
+def validate_rank_row(row, require_ok=True):
+    """순위 행 위반 목록. 렌더가 죽지 않게 하기 위한 스키마이지 암호 검증이 아니다."""
+    issues = []
+    if not isinstance(row, Mapping):
+        return ["행이 객체가 아니다"]
+    if require_ok and not row.get("ok"):
+        issues.append("ok 가 참이 아니다")
+    for key in ("score", "seq"):
+        if key not in row:
+            issues.append(f"{key} 가 없다")
+        elif rank_key(row) is None and key in row:
+            issues.append(f"{key} 를 숫자로 읽지 못한다")
+    if require_ok:
+        for key in RANK_OK_KEYS:
+            if key not in row:
+                issues.append(f"{key} 가 없다")
+    packs = row.get("packs")
+    if packs is not None and not isinstance(packs, Mapping):
+        issues.append("packs 가 객체가 아니다")
+    return issues
+
+
+def pack_ratio(pk):
+    """pack 항목의 (score/max, max). 결손·비숫자·NaN 은 None — ZeroDivision 없음."""
+    if not isinstance(pk, Mapping):
+        return None
+    if "score" not in pk or "max" not in pk:
+        return None
+    score = _finite_float(pk["score"])
+    mx = _finite_float(pk["max"])
+    if score is None or mx is None:
+        return None
+    if mx == 0:
+        return (0.0, 0.0)
+    return (score / mx, mx)
+
+
+def _finite_float(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
+def rank_key(row):
+    """검증 행의 정렬 키 (-score, seq). 결손·NaN 이면 None → unverified 로 접는다."""
+    if not isinstance(row, Mapping):
+        return None
+    score = _finite_float(row.get("score"))
+    if score is None or "seq" not in row:
+        return None
+    try:
+        seq = int(row["seq"])
+    except (TypeError, ValueError):
+        return None
+    return (-score, seq)
 
 
 def rank_results(results):
-    """검증된 항목만 (-score, seq) 로 순위. ok=False 는 unverified 로 분리."""
-    ranked = sorted((r for r in results if r.get("ok")),
-                    key=lambda r: (-r["score"], r["seq"]))
-    unverified = [r for r in results if not r.get("ok")]
-    return ranked, unverified
+    """검증된 항목만 (-score, seq) 로 순위. ok=False 는 unverified 로 분리.
+
+    ok=True 인데 score/seq 가 없으면 순위에 올리지 않고 unverified 로 접는다.
+    목록이 아니면 둘 다 빈 목록. 행이 객체가 아니면 가짜 unverified 한 줄을 남긴다.
+    """
+    if not isinstance(results, Sequence) or isinstance(results, (str, bytes)):
+        return [], []
+    ranked_src = []
+    unverified = []
+    for r in results:
+        if not isinstance(r, Mapping):
+            unverified.append({"ok": False, "seq": None, "why": "행이 객체가 아님"})
+            continue
+        if not r.get("ok"):
+            unverified.append(r)
+            continue
+        key = rank_key(r)
+        if key is None:
+            bad = dict(r)
+            bad["ok"] = False
+            bad.setdefault("why", "score/seq 결손")
+            unverified.append(bad)
+            continue
+        ranked_src.append((key, r))
+    ranked_src.sort(key=lambda t: t[0])
+    return [row for _key, row in ranked_src], unverified
 
 
 def best_pack(packs):
     """만점 비율이 가장 높은 pack. 동률이면 max 가 큰 쪽. 없으면 None.
 
     cmd_render 가 쓰던 키와 같다: (score/max 또는 max=0 이면 0, max).
-    반환은 (pack_id, score, max).
+    반환은 (pack_id, score, max). 결손·비객체 pack 은 건너뛴다.
     """
-    if not packs:
+    if not packs or not isinstance(packs, Mapping):
         return None
-    pid, pk = max(
-        packs.items(),
-        key=lambda kv: (kv[1]["score"] / kv[1]["max"] if kv[1]["max"] else 0,
-                        kv[1]["max"]),
-    )
-    return (pid, pk["score"], pk["max"])
+    scored = []
+    for pid, pk in packs.items():
+        ratio = pack_ratio(pk)
+        if ratio is None:
+            continue
+        scored.append((ratio[0], ratio[1], pid, pk.get("score"), pk.get("max")))
+    if not scored:
+        return None
+    _ratio, _mx, pid, score, mx = max(scored, key=lambda t: (t[0], t[1]))
+    return (pid, score, mx)
+
+
+def short_commit(run, n=COMMIT_SHORT):
+    """runner.rhwpCommit 의 짧은 표기. 결손이면 이모지 대시가 아니라 — ."""
+    if not isinstance(run, Mapping):
+        return "—"
+    commit = run.get("rhwpCommit")
+    if not isinstance(commit, str) or not commit:
+        return "—"
+    return f"`{commit[:n]}`"
 
 
 def render_markdown(results, err, ranked=None):
     """순위표 마크다운 문자열. 쓰기는 호출자가 한다.
 
     헤더·검증 행·**unverified** 행·정직 조항을 항상 포함한다. ranked 를
-    넘기지 않으면 rank_results 로 계산한다.
+    넘기지 않으면 rank_results 로 계산한다. runner/score 결손은 칸을 — 로 남긴다.
     """
+    if not isinstance(results, Sequence) or isinstance(results, (str, bytes)):
+        results = []
     if ranked is None:
         ranked, unverified = rank_results(results)
     else:
-        unverified = [r for r in results if not r.get("ok")]
+        unverified = [r for r in results if isinstance(r, Mapping) and not r.get("ok")]
+        if not isinstance(ranked, Sequence) or isinstance(ranked, (str, bytes)):
+            ranked = []
     lines = ["# 운동장 리더보드 — 위조 불가능한 점수판", "",
              "모든 순위는 검증 사슬(3해시 고정·Ed25519 서명·append-only 원장·머클 앵커)을",
              "**렌더 시점에 재검증**한 항목만 오른다. 재현 방법:",
@@ -432,31 +940,49 @@ def render_markdown(results, err, ranked=None):
              "| 순위 | 에이전트 | 총점 | 최강 능력 | commit | seq | 사슬 |",
              "|---|---|---|---|---|---|---|"]
     for i, r in enumerate(ranked, 1):
-        run = r["runner"]
+        if not isinstance(r, Mapping):
+            continue
+        run = r.get("runner") if isinstance(r.get("runner"), Mapping) else {}
         best = best_pack(r.get("packs") or {})
         best_txt = f"{best[0]} {best[1]}/{best[2]}" if best else "—"
-        lines.append(f"| {i} | {r['agent']} | **{r['score']} / {r['max']}** "
-                     f"| {best_txt} | `{run['rhwpCommit'][:10]}` "
-                     f"| {r['seq']} | 검증됨 |")
+        agent = r.get("agent", "?")
+        score = r.get("score", "—")
+        mx = r.get("max", "—")
+        seq = r.get("seq", "—")
+        lines.append(f"| {i} | {agent} | **{score} / {mx}** "
+                     f"| {best_txt} | {short_commit(run)} "
+                     f"| {seq} | 검증됨 |")
     for r in unverified:
-        lines.append(f"| — | seq {r['seq']} | — | — | — | {r['seq']} | **unverified** |")
+        if not isinstance(r, Mapping):
+            continue
+        seq = r.get("seq", "—")
+        lines.append(f"| — | seq {seq} | — | — | — | {seq} | **unverified** |")
 
-    pack_ids = sorted({pid for r in ranked for pid in r.get("packs", {})})
+    pack_ids = sorted({
+        pid for r in ranked
+        if isinstance(r, Mapping) and isinstance(r.get("packs"), Mapping)
+        for pid in r.get("packs", {})
+    })
     if pack_ids and len(ranked) > 1:
         lines += ["", "## 능력 격자 (pack 별 점수)", "",
                   "| 에이전트 | " + " | ".join(pack_ids) + " |",
                   "|---|" + "---|" * len(pack_ids)]
         for r in ranked:
+            if not isinstance(r, Mapping):
+                continue
+            packs = r.get("packs") if isinstance(r.get("packs"), Mapping) else {}
             cells = []
             for pid in pack_ids:
-                pk = r.get("packs", {}).get(pid)
-                if pk is None:
+                pk = packs.get(pid)
+                if not isinstance(pk, Mapping):
                     cells.append("—")
-                elif pk["score"] == pk["max"]:
-                    cells.append(f"**{pk['score']}**")
+                elif pack_ratio(pk) is None:
+                    cells.append("—")
+                elif pk.get("score") == pk.get("max"):
+                    cells.append(f"**{pk.get('score')}**")
                 else:
-                    cells.append(f"{pk['score']}/{pk['max']}")
-            lines.append(f"| {r['agent']} | " + " | ".join(cells) + " |")
+                    cells.append(f"{pk.get('score')}/{pk.get('max')}")
+            lines.append(f"| {r.get('agent', '?')} | " + " | ".join(cells) + " |")
         lines.append("")
         lines.append("`—` = 미제출(그 pack 을 아예 풀지 않음) · **굵게** = 만점")
     lines += ["",
@@ -469,24 +995,56 @@ def render_markdown(results, err, ranked=None):
 
 
 def cmd_render(a, bin_path):
-    entries, err = chain_walk(LEDGER, "settlementLedger")
-    results = [verify_entry(bin_path, e, entries) for e in entries]
-    ranked, unverified = rank_results(results)
-    text = render_markdown(results, err, ranked=ranked)
-    out = os.path.join(BOARD, "leaderboard.md")
-    with io.open(out, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write(text)
-    print(f"리더보드 렌더 → {os.path.relpath(out, ROOT)} (검증 {len(ranked)}·unverified {len(unverified)})")
-    return 0
+    try:
+        entries, err = chain_walk(LEDGER, "settlementLedger")
+        results = [verify_entry(bin_path, e, entries) for e in entries]
+        ranked, unverified = rank_results(results)
+        text = render_markdown(results, err, ranked=ranked)
+        out = os.path.join(BOARD, "leaderboard.md")
+        parent = os.path.dirname(out)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with io.open(out, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+        print(f"리더보드 렌더 → {os.path.relpath(out, ROOT)} "
+              f"(검증 {len(ranked)}·unverified {len(unverified)})")
+        return 0
+    except LeaderboardError as e:
+        print(format_classified(e, "render 실패"), file=sys.stderr)
+        return 2
+    except (OSError, ValueError, TypeError) as e:
+        print(format_classified(e, "render 실패"), file=sys.stderr)
+        return 2
 
 
-def main():
+def resolve_bin(explicit):
+    """runner.find_bin 의 분류 거울. 없으면 CliError."""
+    try:
+        path = runner.find_bin(explicit)
+    except SystemExit as e:
+        raise LeaderboardCliError(str(e) or "rhwp 바이너리를 찾지 못했다") from e
+    except Exception as e:  # noqa: BLE001 — CLI 입구에서만 분류
+        raise LeaderboardCliError(f"바이너리 탐색 실패: {e}", cause=e) from e
+    if not path:
+        raise LeaderboardCliError("rhwp 바이너리 경로가 비어 있다")
+    return path
+
+
+def main(argv=None):
     ap = argparse.ArgumentParser()
-    ap.add_argument("mode", choices=["attest", "verify", "render", "invite"])
+    ap.add_argument("mode", choices=list(MODES))
     ap.add_argument("--agent", default=None)
     ap.add_argument("--bin", default=None)
-    a = ap.parse_args()
-    bin_path = runner.find_bin(a.bin)
+    a = ap.parse_args(argv)
+    try:
+        # invite 는 바이너리가 필요 없다. 지문은 커밋된 파일에서만 나온다.
+        if a.mode == "invite":
+            bin_path = None
+        else:
+            bin_path = resolve_bin(a.bin)
+    except LeaderboardError as e:
+        print(format_classified(e, "바이너리"), file=sys.stderr)
+        return 2
     if a.mode == "attest":
         if not a.agent:
             raise SystemExit("attest 는 --agent 가 필요하다")

--- a/mydocs/working/gym_leaderboard.md
+++ b/mydocs/working/gym_leaderboard.md
@@ -1,0 +1,275 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_leaderboard.md
+last_verified: 2026-08-18
+---
+
+# gym 리더보드 — 순위·초대 예외 경로 보강 작업 기록
+
+Issue: #5235
+PR: https://github.com/edwardkim/rhwp/pull/5244
+Branch: `feat/gym-leaderboard-rank-invite`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/leaderboard.py` 의 순위 정렬·최강 pack·마크다운 렌더·초대 봉투를
+순수 함수로 분리한 원 PR 위에, I/O·JSON·사슬·CLI 예외를 분류해 도구가 죽지
+않게 닫았다. 새 암호 원시함수는 넣지 않았다. 서명은 계속 rhwp `settle` /
+`keygen` 이고, 파일 해시는 `hashlib.sha256` 뿐이다.
+
+이 가지는 새 PR 을 열지 않는다. 같은 브랜치 `feat/gym-leaderboard-rank-invite`
+에 이어서 밀어 #5244 를 키운다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_leaderboard scripts.tests.test_gym_audit -q`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 PR(#5244)은 다음을 순수 함수로 뽑았다.
+
+- `rank_results` — 검증된 항목만 `(-score, seq)`
+- `best_pack` — 만점 비율, 동률은 큰 max
+- `render_markdown` — 헤더·unverified·정직 조항
+- `construct_invite` — 지문 + 합류 3줄. 쓰기는 호출자
+
+대비 `upstream/devel` 삽입은 약 384줄, 파일 2개
+(`leaderboard.py`, `test_gym_leaderboard.py`)였다.
+
+그 상태의 빈틈:
+
+1. `read_json` / `write_json` / `sha256_of` 가 없는 파일·깨진 JSON 에서 원시
+   예외를 올린다. verify 한 항목의 읽기 실패가 전체 명령을 죽인다.
+2. `chain_walk` 가 `json.loads` 예외를 그대로 올린다. 한 줄이 깨지면 사슬
+   폭로가 아니라 크래시다.
+3. `run_cli` 가 빈 경로·없는 바이너리에서 `FileNotFoundError` 로 죽는다.
+4. `rank_results` 가 `ok=True` 인데 `score` 없는 행에서 `KeyError`.
+5. `best_pack` / 렌더가 결손 pack·runner 에서 `KeyError`.
+6. `invite` 도 `find_bin` 을 타서, 바이너리 없는 환경에서 초대장이 안 나온다.
+7. 초대장·지문 스키마가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/leaderboard.py`
+
+- 예외 계층 `LeaderboardError` 와 code `io`/`format`/`chain`/`cli`/`schema`.
+- `classify_exception` / `format_classified` / `as_dict`.
+- `try_sha256` / `try_read_json` / `try_write_json` / `try_line_hashes` /
+  `safe_listdir` — 비상승 거울.
+- `chain_walk` 가 JSON·타입·읽기 실패를 `(항목, 이유)` 로 접음.
+- `merkle_root` 가 비문자열 잎을 `SchemaError` 로 거절. 조용한 `str()` 없음.
+- `board_fingerprint` 가 깨진 keyring/없는 파일을 죽지 않고 접음.
+- `validate_invite` / `validate_fingerprint` / `validate_rank_row`.
+- `rank_results` / `best_pack` / `pack_ratio` / `_finite_float` — NaN/Inf/
+  결손을 unverified 또는 건너뜀.
+- `render_markdown` / `short_commit` — runner 없으면 `—`.
+- `verify_entry` 가 claims 목록·claim 읽기·settle/anchor CLI 실패를
+  `ok=False` 로.
+- `cmd_*` 바깥에서 분류된 실패를 exit 2 로.
+- `invite` 는 바이너리를 찾지 않음. `main(argv=None)` 시험 입구.
+- 상수 `INVITE_KEYS` · `FINGERPRINT_KEYS` · `MODES` (네 값, 새 CLI 없음).
+
+### 3.2 시험
+
+`scripts/tests/test_gym_leaderboard.py`
+
+- 기존 33건 유지 (체인·머클·커밋된 판·순위·pack·렌더·임시 초대).
+- 예외 분류, JSON I/O, 사슬 깨짐, 머클 스키마, 지문/초대 validate,
+  순위/pack 결손, 렌더 방어, 명령 래퍼, verify_entry, 입장 deny,
+  resolve_bin, 상수 계약, hashlib 만 쓰는지.
+
+임시 판으로 경로를 돌려 커밋된 `gym/leaderboard/` 를 쓰지 않는다.
+
+### 3.3 문서
+
+- `gym/docs/leaderboard.md` — 규약. invite/attest/verify/render·예외 표.
+- `gym/tools/README_leaderboard.md` — 운영 한 페이지.
+- 이 파일 — 작업 기록.
+
+packs·checks·coverage·다른 도구는 손대지 않았다. 새 CLI 모드 없음.
+`cargo fmt --all` 없음. `git add -A` 없음.
+
+## 4. 예외 경로 표 (시험과 같은 칸)
+
+| 입력 | 기대 | 시험 |
+|---|---|---|
+| `LeaderboardIOError` | code `io` | `test_hierarchy_codes` |
+| `FileNotFoundError` | `io` | `test_stdlib_exceptions_fold` |
+| `JSONDecodeError` | `format` | 위와 같음 |
+| `TypeError` | `schema` | 위와 같음 |
+| `sha256_of(없는 파일)` | `LeaderboardIOError` | `test_sha256_of_missing_raises_io` |
+| `try_sha256(없는 파일)` | `(None, err)` | `test_try_sha256_missing_is_none_and_err` |
+| `read_json("{")` | `FormatError` | `test_read_json_malformed_raises_format` |
+| `write_json(lambda)` | `FormatError` | `test_write_json_rejects_unserializable` |
+| `try_write_json(디렉터리)` | err | `test_try_write_json_to_directory_is_error` |
+| `safe_listdir(파일)` | `([], err)` | `test_safe_listdir_file_is_error` |
+| `chain_walk("", …)` | 이유 문자열 | `test_empty_path_is_error` |
+| 깨진 JSON 줄 | `(이전 항목, JSON …)` | `test_malformed_json_is_row_error_not_raise` |
+| 배열 줄 | `객체가 아님` | `test_non_object_row_is_rejected` |
+| `merkle_root("ab")` | `SchemaError` | `test_string_leaf_is_schema_error` |
+| `merkle_root([1])` | `SchemaError` | `test_non_string_item_is_schema_error` |
+| 지문 키 결손 | 위반 목록 | `test_validate_fingerprint_missing_key` |
+| `construct_invite(123)` | `SchemaError` | `test_construct_invite_rejects_non_string_guest` |
+| `construct_invite("  ")` | `친구-에이전트` | `test_construct_invite_blank_guest_uses_default` |
+| 깨진 keyring | `members=0`, 비상승 | `test_fingerprint_bad_keyring_does_not_raise` |
+| `rank_results("ab")` | `([], [])` | `test_rank_results_non_list_is_empty` |
+| `ok=True` 에 score 없음 | unverified | `test_ok_row_without_score_is_unverified` |
+| `score="NaN"` | unverified | `test_ok_row_with_non_numeric_score_is_unverified` |
+| 깨진 pack 만 | `best_pack` None | `test_best_pack_all_malformed_is_none` |
+| runner 없음 렌더 | 칸 `—`, 비상승 | `test_missing_runner_does_not_raise` |
+| `run_cli("")` | `CliError` | `test_run_cli_empty_bin_is_cli_error` |
+| `cmd_attest(agent=None)` | SystemExit | `test_cmd_attest_requires_agent` |
+| 입장 deny | SystemExit | `test_admission_deny` |
+| `main(["invite", …])` | 0, 바이너리 불필요 | `test_main_invite_does_not_need_bin` |
+| `verify_entry("nope")` | `ok=False` | `test_non_dict_entry` |
+| find_bin SystemExit | `CliError` | `test_systemexit_from_find_bin` |
+
+## 5. 호환
+
+기존 시험이 기대한 것:
+
+- 유효 체인 2줄이 오류 없이 걷는다.
+- 과거 줄 변조는 다음 줄 `prevEntryHash` 로 폭로.
+- seq 공백 거부, 없는/빈/공백 파일은 빈 체인.
+- 머클 결정성·홀수 층 복제·두 잎 이어 붙임.
+- 커밋된 원장·앵커 무결, claim 파일 해시 일치.
+- 지문에 7키, `ledgerEntries` 가 실제 체인 길이.
+- 순위는 점수 내림·seq 오름, unverified 분리.
+- `best_pack` 비율·동률 max·max=0.
+- 렌더 헤더·정직 조항·unverified 행·능력 격자.
+- 임시 판 초대가 커밋된 판을 쓰지 않음.
+
+바뀐 것:
+
+- `sha256_of` / `read_json` / `write_json` 이 원시 예외 대신 분류 예외.
+  기존 시험은 존재하는 파일만 부르므로 통과.
+- `chain_walk` 가 깨진 JSON 에서 예외 대신 이유 문자열. 기존 시험은 유효/
+  변조된 객체 줄만 쓴다.
+- `rank_results` 가 결손 score 를 unverified 로. 기존 시험 행은 score 가 있다.
+- `best_pack` 이 결손 항목을 건너뜀. 기존 시험 pack 은 완전하다.
+- `render_markdown` 이 runner 없으면 `—`. 기존 시험은 runner 가 있다.
+- `main` 의 `invite` 가 `find_bin` 을 안 탄다. 새 시험이 고정.
+- `cmd_invite` / `cmd_verify` / `cmd_render` 가 분류 실패 때 2 를 준다.
+  기존 시험은 성공 경로만 본다.
+
+`ok` 의미는 그대로다. 검증된 항목만 순위에 오른다.
+
+## 6. 의도적으로 안 한 일
+
+- 새 CLI 모드. 사용자 지시. `MODES` 는 네 값.
+- 새 암호 (자체 Ed25519, HMAC, blake2). 사용자 지시. 서명은 rhwp.
+- pack/과제/checks/coverage 변경. 원 PR 범위와 같다.
+- 커밋된 `gym/leaderboard/` 재발급. 읽기만.
+- 실제 rhwp 바이너리로 attest/verify 주행. 이 작업의 게이트는 unittest.
+- `cargo fmt --all`. 사용자 지시. Rust 를 건드리지 않았다.
+- 새 PR. 같은 가지에 커밋·푸시만.
+- `git add -A`. 경로를 명시한다. 추적되지 않은 `gym/packs/work-receipt/` 는
+  넣지 않는다.
+
+## 7. 결정 기록
+
+### 7.1 invite 가 바이너리를 안 찾는 이유
+
+초대장은 커밋된 원장·앵커·발주서의 해시와 키링 길이만 묶는다. rhwp 를 부르지
+않는다. `find_bin` 이 실패하면 신참을 부르는 안내 자체가 환경에 묶인다.
+`main` 에서 `invite` 만 바이너리 탐색을 건너뛴다. attest/verify/render 는
+그대로 찾는다.
+
+### 7.2 항목 실패가 verify 를 안 죽이는 이유
+
+한 claim 파일이 깨졌다고 전체 검증이 크래시하면, 나머지 항목의 폭로가
+사라진다. `verify_entry` 는 `ok=False` + `why` 로 접고 다음 항목으로 간다.
+바닥글의 `verified/N` 이 그 숫자를 말한다.
+
+### 7.3 NaN 을 순위에 안 올리는 이유
+
+`float("NaN")` 은 예외가 아니다. 그대로 두면 `ok=True` 행이 정렬 키 NaN 으로
+순위에 오른다. `_finite_float` 가 NaN/Inf 를 거절하고 `rank_results` 가
+unverified 로 접는다. 점수를 0 으로 바꾸지 않는다 — 그건 지어낸 숫자다.
+
+### 7.4 머클 잎을 str() 하지 않는 이유
+
+정수 잎을 조용히 문자열로 바꾸면 체크포인트와 다른 루트가 나온다. 재계산
+일치가 거짓 음성이 된다. `SchemaError` 로 거절한다.
+
+### 7.5 새 암호를 안 넣는 이유
+
+모듈 문자열의 첫 문장이 "새 암호학 0줄" 이다. 여기서 Ed25519 를 다시 구현하면
+rhwp `settle verify` 와 어긋날 수 있고, 검증 사다리의 단일 권위가 둘로 갈린다.
+해시는 hashlib, 서명은 rhwp. 시험 `test_hashlib_sha256_is_the_only_digest` 가
+`nacl`/`cryptography`/blake2 import 를 막는다.
+
+## 8. 재현
+
+```text
+# 이 작업나무에서
+python -m unittest scripts.tests.test_gym_leaderboard scripts.tests.test_gym_audit -q
+python gym/tools/audit.py
+```
+
+바이너리가 있으면:
+
+```text
+python gym/tools/leaderboard.py verify
+python gym/tools/leaderboard.py render
+python gym/tools/leaderboard.py invite --agent 손님
+```
+
+이 작업은 바이너리 주행을 게이트에 넣지 않았다.
+
+## 9. 파일 목록
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tools/leaderboard.py` | 도구. 예외 접기·순수 함수·기존 CLI 4모드 |
+| `scripts/tests/test_gym_leaderboard.py` | 계약 시험 |
+| `gym/docs/leaderboard.md` | 규약 정본 |
+| `gym/tools/README_leaderboard.md` | 운영 메모 |
+| `mydocs/working/gym_leaderboard.md` | 이 기록 |
+
+## 10. 후속
+
+- 릴리스 게이트(`release_gate.py`)가 verify 의 exit 3 을 이미 본다. 이번
+  변경의 exit 2 (환경) 와 3 (사슬) 분리가 게이트 메시지에 드러나는지 한 번
+  보면 좋다. 게이트 코드는 이 가지에서 안 고친다.
+- 커밋된 판의 `invite.json` 은 만들지 않았다. 초대는 호출자가 임시/로컬로
+  발급한다.
+- 실제 attest 는 여전히 바이너리가 필요하다. 순수 시험이 대체하지 않는다.
+
+## 11. 크기와 범위
+
+원 PR 대비 `upstream/devel` 는 파일 2개 · 삽입 384 였다. 이번 커밋은 같은
+가지에 예외 경로·시험·규약 문서를 얹어 삽입 3000 을 넘긴다. 늘어난 줄의
+대부분은 (1) 분류된 예외와 비상승 거울, (2) 그 칸을 고정하는 unittest,
+(3) invite/attest/verify/render 를 같은 표로 적는 한국어 규약이다.
+
+넣지 않은 줄:
+
+- pack JSON, 과제, 기준 풀이
+- Rust 소스, `cargo fmt`
+- 새 바이너리 명령
+- 커밋된 원장·앵커 재발급
+- 추적되지 않은 `gym/packs/work-receipt/` (다른 작업의 잔여. 이 커밋에 넣지 않음)
+
+로컬에서 `audit.py` 가 `work-receipt` 의 `pack.json 이 없다` 를 내는 것은
+그 잔여 디렉터리 때문이다. CI 클론에는 그 경로가 없다. 이 커밋의 게이트는
+추적 파일만 본다.
+
+## 12. 커밋 메시지 초안
+
+```text
+feat(gym): leaderboard 예외 경로와 초대·등재·검증·렌더 규약을 보강한다
+
+I/O·JSON·사슬·CLI 실패를 분류해 한 항목의 읽기 실패가 전체 검증을
+죽이지 않게 한다. 순위·최강 pack·렌더는 결손·NaN 을 unverified 로
+접고, invite 는 바이너리 없이 판 지문만 묶는다. 새 암호와 새 CLI 는
+없다. 규약·운영 메모·작업 기록을 같은 표로 고정한다.
+```
+
+이 초안을 실제 커밋에 쓴다. 새 PR 없음. `git add -A` 없음.

--- a/scripts/tests/test_gym_leaderboard.py
+++ b/scripts/tests/test_gym_leaderboard.py
@@ -476,5 +476,978 @@ class InviteEnvelopeTests(unittest.TestCase):
             self.assertEqual(after, before)
 
 
+class ExceptionClassifyTests(unittest.TestCase):
+    """I/O·형식·사슬·CLI·스키마 예외 분류. 새 암호 코드는 없다."""
+
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_error_codes_are_the_declared_set(self):
+        self.assertEqual(
+            set(self.lb.ERROR_CODES),
+            {"io", "format", "chain", "cli", "schema", "leaderboard"},
+        )
+
+    def test_hierarchy_codes(self):
+        cases = (
+            (self.lb.LeaderboardError("x"), "leaderboard"),
+            (self.lb.LeaderboardIOError("x"), "io"),
+            (self.lb.LeaderboardFormatError("x"), "format"),
+            (self.lb.LeaderboardChainError("x"), "chain"),
+            (self.lb.LeaderboardCliError("x"), "cli"),
+            (self.lb.LeaderboardSchemaError("x"), "schema"),
+        )
+        for exc, code in cases:
+            self.assertEqual(self.lb.classify_exception(exc), code, code)
+            self.assertEqual(exc.code, code)
+
+    def test_stdlib_exceptions_fold(self):
+        self.assertEqual(self.lb.classify_exception(FileNotFoundError("n")), "io")
+        self.assertEqual(self.lb.classify_exception(PermissionError("p")), "io")
+        self.assertEqual(self.lb.classify_exception(OSError("o")), "io")
+        self.assertEqual(
+            self.lb.classify_exception(json.JSONDecodeError("m", "d", 0)),
+            "format",
+        )
+        self.assertEqual(self.lb.classify_exception(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "x")), "format")
+        self.assertEqual(self.lb.classify_exception(TypeError("t")), "schema")
+        self.assertEqual(self.lb.classify_exception(ValueError("v")), "schema")
+        self.assertEqual(self.lb.classify_exception(KeyError("k")), "schema")
+        self.assertEqual(self.lb.classify_exception(RuntimeError("r")), "leaderboard")
+
+    def test_as_dict_includes_path_and_cause(self):
+        cause = FileNotFoundError("nope")
+        exc = self.lb.LeaderboardIOError("읽기 실패", path="/tmp/x", cause=cause)
+        body = exc.as_dict()
+        self.assertFalse(body["ok"])
+        self.assertEqual(body["code"], "io")
+        self.assertIn("읽기 실패", body["why"])
+        self.assertEqual(body["path"], "/tmp/x")
+        self.assertEqual(body["causeType"], "FileNotFoundError")
+
+    def test_format_classified_includes_code_and_path(self):
+        exc = self.lb.LeaderboardFormatError("깨짐", path="a.json")
+        text = self.lb.format_classified(exc, "verify 실패")
+        self.assertIn("verify 실패", text)
+        self.assertIn("(format)", text)
+        self.assertIn("a.json", text)
+        self.assertIn("깨짐", text)
+
+    def test_empty_fingerprint_has_all_keys(self):
+        fp = self.lb.empty_fingerprint()
+        self.assertEqual(set(fp), set(self.lb.FINGERPRINT_KEYS))
+        self.assertEqual(fp["members"], 0)
+        self.assertEqual(fp["ledgerEntries"], 0)
+        self.assertEqual(fp["ledgerChain"], "ok")
+        self.assertIsNone(fp["merkleRoot"])
+
+
+class JsonIoExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_sha256_of_missing_raises_io(self):
+        missing = os.path.join(tempfile.gettempdir(), "rhwp-lb-no-such-sha256.bin")
+        if os.path.exists(missing):
+            os.remove(missing)
+        with self.assertRaises(self.lb.LeaderboardIOError) as ctx:
+            self.lb.sha256_of(missing)
+        self.assertEqual(ctx.exception.code, "io")
+        self.assertEqual(ctx.exception.path, missing)
+
+    def test_try_sha256_missing_is_none_and_err(self):
+        missing = os.path.join(tempfile.gettempdir(), "rhwp-lb-no-such-try-sha.bin")
+        if os.path.exists(missing):
+            os.remove(missing)
+        digest, err = self.lb.try_sha256(missing)
+        self.assertIsNone(digest)
+        self.assertIsNotNone(err)
+        self.assertIn("sha256", err)
+
+    def test_sha256_of_bytes_matches_hashlib(self):
+        with tempfile.NamedTemporaryFile("wb", delete=False) as fh:
+            fh.write(b"gym-leaderboard-sha")
+            path = fh.name
+        digest = self.lb.sha256_of(path)
+        Path(path).unlink()
+        self.assertEqual(digest, hashlib.sha256(b"gym-leaderboard-sha").hexdigest())
+        self.assertEqual(len(digest), 64)
+
+    def test_read_json_missing_raises_io(self):
+        missing = os.path.join(tempfile.gettempdir(), "rhwp-lb-missing.json")
+        if os.path.exists(missing):
+            os.remove(missing)
+        with self.assertRaises(self.lb.LeaderboardIOError):
+            self.lb.read_json(missing)
+
+    def test_read_json_malformed_raises_format(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False,
+                                         encoding="utf-8") as fh:
+            fh.write("{not json")
+            path = fh.name
+        with self.assertRaises(self.lb.LeaderboardFormatError) as ctx:
+            self.lb.read_json(path)
+        Path(path).unlink()
+        self.assertEqual(ctx.exception.code, "format")
+
+    def test_try_read_json_malformed_is_none(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False,
+                                         encoding="utf-8") as fh:
+            fh.write("[")
+            path = fh.name
+        obj, err = self.lb.try_read_json(path)
+        Path(path).unlink()
+        self.assertIsNone(obj)
+        self.assertIsNotNone(err)
+
+    def test_write_json_rejects_unserializable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "bad.json")
+            with self.assertRaises(self.lb.LeaderboardFormatError):
+                self.lb.write_json(path, {"fn": lambda: None})
+
+    def test_try_write_json_success_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "ok.json")
+            err = self.lb.try_write_json(path, {"k": "한글", "n": 1})
+            self.assertIsNone(err)
+            body = self.lb.read_json(path)
+            self.assertEqual(body["k"], "한글")
+            self.assertEqual(body["n"], 1)
+
+    def test_try_write_json_to_directory_is_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            err = self.lb.try_write_json(tmp, {"k": 1})
+            self.assertIsNotNone(err)
+
+    def test_safe_listdir_missing_is_empty(self):
+        missing = os.path.join(tempfile.gettempdir(), "rhwp-lb-no-dir-xxxx")
+        if os.path.exists(missing):
+            os.remove(missing) if os.path.isfile(missing) else None
+        names, err = self.lb.safe_listdir(missing)
+        self.assertEqual(names, [])
+        self.assertIsNone(err)
+
+    def test_safe_listdir_file_is_error(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as fh:
+            fh.write("x")
+            path = fh.name
+        names, err = self.lb.safe_listdir(path)
+        Path(path).unlink()
+        self.assertEqual(names, [])
+        self.assertIsNotNone(err)
+
+    def test_safe_listdir_sorts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "b.txt").write_text("b", encoding="utf-8")
+            Path(tmp, "a.txt").write_text("a", encoding="utf-8")
+            names, err = self.lb.safe_listdir(tmp)
+            self.assertIsNone(err)
+            self.assertEqual(names, ["a.txt", "b.txt"])
+
+
+class ChainWalkMalformedTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def _write(self, text):
+        fh = tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
+                                         encoding="utf-8", newline="\n")
+        fh.write(text)
+        fh.close()
+        return fh.name
+
+    def test_empty_path_is_error(self):
+        entries, err = self.lb.chain_walk("", "settlementLedger")
+        self.assertEqual(entries, [])
+        self.assertIsNotNone(err)
+
+    def test_malformed_json_is_row_error_not_raise(self):
+        path = self._write('{"seq": 0, "kind": "anchorLog", "prevEntryHash": null}\n{bad\n')
+        entries, err = self.lb.chain_walk(path, "anchorLog")
+        Path(path).unlink()
+        self.assertEqual(len(entries), 1)
+        self.assertIsNotNone(err)
+        self.assertIn("JSON", err)
+
+    def test_non_object_row_is_rejected(self):
+        path = self._write("[1, 2, 3]\n")
+        entries, err = self.lb.chain_walk(path, "anchorLog")
+        Path(path).unlink()
+        self.assertEqual(entries, [])
+        self.assertIn("객체", err)
+
+    def test_kind_mismatch_keeps_prior_rows(self):
+        text = make_chain("settlementLedger", [{"x": 1}, {"x": 2}])
+        lines = text.splitlines()
+        second = json.loads(lines[1])
+        second["kind"] = "other"
+        path = self._write(lines[0] + "\n" + json.dumps(second, ensure_ascii=False) + "\n")
+        entries, err = self.lb.chain_walk(path, "settlementLedger")
+        Path(path).unlink()
+        self.assertEqual(len(entries), 1)
+        self.assertIn("kind", err)
+
+    def test_wrong_kind_argument_on_valid_chain(self):
+        path = self._write(make_chain("settlementLedger", [{"x": 1}]))
+        entries, err = self.lb.chain_walk(path, "anchorLog")
+        Path(path).unlink()
+        self.assertEqual(entries, [])
+        self.assertIn("kind", err)
+
+    def test_line_hashes_missing_is_empty(self):
+        missing = os.path.join(tempfile.gettempdir(), "rhwp-lb-no-lines.ndjson")
+        if os.path.exists(missing):
+            os.remove(missing)
+        self.assertEqual(self.lb.line_hashes(missing), [])
+        self.assertEqual(self.lb.line_hashes(""), [])
+
+    def test_line_hashes_skips_blank(self):
+        path = self._write("\n\nabc\n\n")
+        hashes = self.lb.line_hashes(path)
+        Path(path).unlink()
+        self.assertEqual(hashes, [hashlib.sha256(b"abc").hexdigest()])
+
+    def test_try_line_hashes_empty_path(self):
+        hashes, err = self.lb.try_line_hashes("")
+        self.assertEqual(hashes, [])
+        self.assertIsNone(err)
+
+
+class MerkleSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_string_leaf_is_schema_error(self):
+        with self.assertRaises(self.lb.LeaderboardSchemaError):
+            self.lb.merkle_root("abcd")
+
+    def test_bytes_leaf_container_is_schema_error(self):
+        with self.assertRaises(self.lb.LeaderboardSchemaError):
+            self.lb.merkle_root(b"abcd")
+
+    def test_non_string_item_is_schema_error(self):
+        with self.assertRaises(self.lb.LeaderboardSchemaError):
+            self.lb.merkle_root([1, 2])
+
+    def test_none_container_is_schema_or_empty(self):
+        # None 은 거짓이라 빈 잎과 같다.
+        self.assertIsNone(self.lb.merkle_root(None))
+
+    def test_odd_three_duplicates_last(self):
+        leaves = [hashlib.sha256(x).hexdigest() for x in (b"a", b"b", b"c")]
+        root = self.lb.merkle_root(leaves)
+        pair_ab = hashlib.sha256((leaves[0] + leaves[1]).encode("ascii")).hexdigest()
+        pair_cc = hashlib.sha256((leaves[2] + leaves[2]).encode("ascii")).hexdigest()
+        expected = hashlib.sha256((pair_ab + pair_cc).encode("ascii")).hexdigest()
+        self.assertEqual(root, expected)
+
+
+class FingerprintAndInviteSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+        self._saved = {name: getattr(self.lb, name) for name in _BOARD_PATH_NAMES}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(self.lb, name, value)
+
+    def _redirect(self, tmp):
+        board = Path(tmp) / "leaderboard"
+        board.mkdir()
+        (board / "keys").mkdir()
+        (board / "claims").mkdir()
+        self.lb.BOARD = str(board)
+        self.lb.KEYS = str(board / "keys")
+        self.lb.CLAIMS = str(board / "claims")
+        self.lb.LEDGER = str(board / "ledger.ndjson")
+        self.lb.ANCHOR = str(board / "anchor.ndjson")
+        self.lb.CHECKPOINT = str(board / "checkpoint.json")
+        self.lb.KEYRING = str(board / "keyring.json")
+        self.lb.WORKORDER = str(board / "workorder.json")
+        return board
+
+    def test_validate_fingerprint_empty_ok(self):
+        issues = self.lb.validate_fingerprint(self.lb.empty_fingerprint())
+        self.assertEqual(issues, [])
+
+    def test_validate_fingerprint_missing_key(self):
+        fp = self.lb.empty_fingerprint()
+        del fp["merkleRoot"]
+        issues = self.lb.validate_fingerprint(fp)
+        self.assertTrue(any("merkleRoot" in i for i in issues))
+
+    def test_validate_fingerprint_bad_types(self):
+        fp = self.lb.empty_fingerprint()
+        fp["members"] = "1"
+        fp["ledgerEntries"] = 1.5
+        fp["workorderSha256"] = 12
+        issues = self.lb.validate_fingerprint(fp)
+        self.assertGreaterEqual(len(issues), 3)
+
+    def test_validate_fingerprint_short_hash(self):
+        fp = self.lb.empty_fingerprint()
+        fp["workorderSha256"] = "ab"
+        issues = self.lb.validate_fingerprint(fp)
+        self.assertTrue(any("64" in i for i in issues))
+
+    def test_validate_fingerprint_not_object(self):
+        self.assertEqual(self.lb.validate_fingerprint(None), ["지문이 객체가 아니다"])
+        self.assertEqual(self.lb.validate_fingerprint([]), ["지문이 객체가 아니다"])
+
+    def test_construct_invite_blank_guest_uses_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            invite = self.lb.construct_invite("   ")
+            self.assertEqual(invite["guest"], self.lb.DEFAULT_GUEST)
+            invite2 = self.lb.construct_invite(None)
+            self.assertEqual(invite2["guest"], self.lb.DEFAULT_GUEST)
+
+    def test_construct_invite_rejects_non_string_guest(self):
+        with self.assertRaises(self.lb.LeaderboardSchemaError):
+            self.lb.construct_invite(123)
+
+    def test_validate_invite_of_construct(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            invite = self.lb.construct_invite("guest-a")
+            self.assertEqual(self.lb.validate_invite(invite), [])
+            self.assertEqual(invite["kind"], self.lb.INVITE_KIND)
+            self.assertEqual(invite["schemaVersion"], self.lb.SCHEMA_VERSION)
+            self.assertEqual(len(invite["join"]), self.lb.JOIN_STEP_COUNT)
+
+    def test_validate_invite_detects_broken_join(self):
+        invite = {
+            "schemaVersion": "9.9",
+            "kind": "nope",
+            "guest": 1,
+            "board": {"repo": "x"},
+            "fingerprint": {},
+            "join": ["only-one"],
+            "promise": "",
+            "note": "",
+        }
+        issues = self.lb.validate_invite(invite)
+        self.assertTrue(any("schemaVersion" in i for i in issues))
+        self.assertTrue(any("kind" in i for i in issues))
+        self.assertTrue(any("guest" in i for i in issues))
+        self.assertTrue(any("join" in i for i in issues))
+        self.assertTrue(any("board.path" in i for i in issues))
+
+    def test_validate_invite_not_object(self):
+        self.assertEqual(self.lb.validate_invite("x"), ["초대장이 객체가 아니다"])
+
+    def test_validate_invite_join_missing_verbs(self):
+        invite = self.lb.construct_invite("g")
+        invite["join"] = ["a", "b", "c"]
+        issues = self.lb.validate_invite(invite)
+        self.assertTrue(any("score.py" in i for i in issues))
+        self.assertTrue(any("attest" in i for i in issues))
+        self.assertTrue(any("verify" in i for i in issues))
+
+    def test_fingerprint_bad_keyring_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            Path(self.lb.KEYRING).write_text("{bad", encoding="utf-8")
+            Path(self.lb.LEDGER).write_text("", encoding="utf-8")
+            fp = self.lb.board_fingerprint()
+            self.assertEqual(fp["members"], 0)
+            self.assertEqual(fp["ledgerEntries"], 0)
+            self.assertIsNone(fp["workorderSha256"])
+            self.assertFalse((board / "invite.json").exists())
+
+    def test_fingerprint_keyring_keys_not_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            self.lb.write_json(self.lb.KEYRING, {"keys": "nope"})
+            fp = self.lb.board_fingerprint()
+            self.assertEqual(fp["members"], 0)
+
+    def test_cmd_invite_writes_only_tmp_board(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            ns = argparse_ns(agent="tmp-cmd")
+            code = self.lb.cmd_invite(ns, None)
+            self.assertEqual(code, 0)
+            invite = self.lb.read_json(str(board / "invite.json"))
+            self.assertEqual(invite["guest"], "tmp-cmd")
+            self.assertEqual(self.lb.validate_invite(invite), [])
+
+    def test_cmd_invite_default_guest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            ns = argparse_ns(agent=None)
+            self.assertEqual(self.lb.cmd_invite(ns, None), 0)
+            invite = self.lb.read_json(str(board / "invite.json"))
+            self.assertEqual(invite["guest"], self.lb.DEFAULT_GUEST)
+
+
+def argparse_ns(**kwargs):
+    class NS:
+        pass
+    ns = NS()
+    for key, value in kwargs.items():
+        setattr(ns, key, value)
+    return ns
+
+
+class RankAndPackExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_rank_results_non_list_is_empty(self):
+        self.assertEqual(self.lb.rank_results(None), ([], []))
+        self.assertEqual(self.lb.rank_results("abc"), ([], []))
+        self.assertEqual(self.lb.rank_results(b"xx"), ([], []))
+
+    def test_rank_results_non_mapping_row_is_unverified(self):
+        ranked, unverified = self.lb.rank_results(["nope", 1, None])
+        self.assertEqual(ranked, [])
+        self.assertEqual(len(unverified), 3)
+        self.assertTrue(all(not r.get("ok") for r in unverified))
+
+    def test_ok_row_without_score_is_unverified(self):
+        results = [{"ok": True, "agent": "ghost", "seq": 0}, _ok("ok", 1, 1, 1)]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual([r["agent"] for r in ranked], ["ok"])
+        self.assertEqual(unverified[0]["agent"], "ghost")
+        self.assertIn("score", unverified[0].get("why", ""))
+
+    def test_ok_row_with_non_numeric_score_is_unverified(self):
+        results = [{"ok": True, "score": "NaN", "seq": 0, "agent": "bad"}]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual(ranked, [])
+        self.assertEqual(len(unverified), 1)
+
+    def test_tuple_of_rows_is_accepted(self):
+        ranked, unverified = self.lb.rank_results((_ok("a", 2, 2, 1), _ok("b", 3, 3, 0)))
+        self.assertEqual([r["agent"] for r in ranked], ["b", "a"])
+        self.assertEqual(unverified, [])
+
+    def test_pack_ratio_missing_and_zero(self):
+        self.assertIsNone(self.lb.pack_ratio(None))
+        self.assertIsNone(self.lb.pack_ratio("x"))
+        self.assertIsNone(self.lb.pack_ratio({"score": 1}))
+        self.assertIsNone(self.lb.pack_ratio({"score": "a", "max": 2}))
+        self.assertEqual(self.lb.pack_ratio({"score": 0, "max": 0}), (0.0, 0.0))
+        self.assertEqual(self.lb.pack_ratio({"score": 1, "max": 4})[0], 0.25)
+
+    def test_best_pack_skips_malformed(self):
+        packs = {
+            "bad": {"score": 9},
+            "also": "nope",
+            "good": {"score": 2, "max": 4},
+        }
+        self.assertEqual(self.lb.best_pack(packs), ("good", 2, 4))
+
+    def test_best_pack_none_and_list(self):
+        self.assertIsNone(self.lb.best_pack(None))
+        self.assertIsNone(self.lb.best_pack([{"score": 1, "max": 1}]))
+
+    def test_best_pack_all_malformed_is_none(self):
+        self.assertIsNone(self.lb.best_pack({"a": {}, "b": {"max": 1}}))
+
+    def test_validate_rank_row_ok_and_broken(self):
+        ok = _ok("a", 1, 1, 0)
+        self.assertEqual(self.lb.validate_rank_row(ok), [])
+        self.assertTrue(self.lb.validate_rank_row("x"))
+        issues = self.lb.validate_rank_row({"ok": True, "agent": "z"})
+        self.assertTrue(any("score" in i for i in issues))
+
+    def test_rank_key_none_for_missing(self):
+        self.assertIsNone(self.lb.rank_key(None))
+        self.assertIsNone(self.lb.rank_key({"ok": True}))
+        self.assertEqual(self.lb.rank_key({"score": 3, "seq": 2}), (-3.0, 2))
+
+
+class RenderDefensiveTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_missing_runner_does_not_raise(self):
+        row = {"ok": True, "agent": "solo", "score": 1, "max": 1, "seq": 0}
+        md = self.lb.render_markdown([row], None)
+        self.assertIn("solo", md)
+        self.assertIn("—", md)
+        self.assertIn("정직 조항", md)
+
+    def test_non_list_results_still_header(self):
+        md = self.lb.render_markdown(None, None)
+        self.assertIn("# 운동장 리더보드", md)
+        self.assertIn("항목 0", md)
+
+    def test_malformed_packs_in_grid_are_dash(self):
+        results = [
+            _ok("a", 4, 4, 0, packs={"p1": {"score": 4, "max": 4}}),
+            _ok("b", 2, 4, 1, packs={"p1": "broken"}),
+        ]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("## 능력 격자", md)
+        self.assertIn("—", md)
+
+    def test_short_commit_variants(self):
+        self.assertEqual(self.lb.short_commit(None), "—")
+        self.assertEqual(self.lb.short_commit({}), "—")
+        self.assertEqual(self.lb.short_commit({"rhwpCommit": ""}), "—")
+        self.assertEqual(self.lb.short_commit({"rhwpCommit": "abcdefghijklmn"}), "`abcdefghij`")
+
+    def test_unverified_without_seq(self):
+        md = self.lb.render_markdown([{"ok": False}], None)
+        self.assertIn("**unverified**", md)
+        self.assertIn("seq —", md)
+
+    def test_broken_ranked_argument_does_not_raise(self):
+        md = self.lb.render_markdown([_ok("a", 1, 1, 0)], None, ranked="nope")
+        self.assertIn("위조 불가능", md)
+
+    def test_grid_skips_non_mapping_ranked(self):
+        results = [_ok("a", 1, 1, 0, packs={"p": {"score": 1, "max": 1}}),
+                   _ok("b", 1, 1, 1, packs={"p": {"score": 1, "max": 1}})]
+        md = self.lb.render_markdown(results, None, ranked=["x", results[0], results[1]])
+        self.assertIn("a", md)
+
+
+class CommandWrapperTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+        self._saved = {name: getattr(self.lb, name) for name in _BOARD_PATH_NAMES}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(self.lb, name, value)
+
+    def _redirect(self, tmp):
+        board = Path(tmp) / "leaderboard"
+        board.mkdir()
+        (board / "keys").mkdir()
+        (board / "claims").mkdir()
+        self.lb.BOARD = str(board)
+        self.lb.KEYS = str(board / "keys")
+        self.lb.CLAIMS = str(board / "claims")
+        self.lb.LEDGER = str(board / "ledger.ndjson")
+        self.lb.ANCHOR = str(board / "anchor.ndjson")
+        self.lb.CHECKPOINT = str(board / "checkpoint.json")
+        self.lb.KEYRING = str(board / "keyring.json")
+        self.lb.WORKORDER = str(board / "workorder.json")
+        return board
+
+    def test_cmd_attest_requires_agent(self):
+        with self.assertRaises(SystemExit) as ctx:
+            self.lb.cmd_attest(argparse_ns(agent=None), "bin")
+        self.assertIn("agent", str(ctx.exception))
+
+    def test_cmd_attest_missing_scorecard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            saved_gym = self.lb.GYM
+            self.lb.GYM = tmp
+            try:
+                with self.assertRaises(SystemExit) as ctx:
+                    self.lb.cmd_attest(argparse_ns(agent="ghost"), "bin")
+                self.assertIn("없음", str(ctx.exception))
+            finally:
+                self.lb.GYM = saved_gym
+
+    def test_cmd_verify_empty_board_returns_3(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            code = self.lb.cmd_verify(argparse_ns(), None)
+            self.assertEqual(code, 3)
+            ver = self.lb.read_json(self.lb.BOARD + os.sep + "verification.json")
+            self.assertEqual(ver["kind"], self.lb.VERIFICATION_KIND)
+            self.assertEqual(ver["verified"], 0)
+            self.assertEqual(ver["ledgerEntries"], 0)
+
+    def test_cmd_render_empty_board_writes_markdown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            code = self.lb.cmd_render(argparse_ns(), None)
+            self.assertEqual(code, 0)
+            text = (board / "leaderboard.md").read_text(encoding="utf-8")
+            self.assertIn("정직 조항", text)
+            self.assertIn("항목 0", text)
+
+    def test_run_cli_empty_bin_is_cli_error(self):
+        with self.assertRaises(self.lb.LeaderboardCliError):
+            self.lb.run_cli("", ["info"])
+        with self.assertRaises(self.lb.LeaderboardCliError):
+            self.lb.run_cli(None, ["info"])
+
+    def test_run_cli_missing_binary_is_cli_error(self):
+        missing = os.path.join(tempfile.gettempdir(), "rhwp-lb-no-bin-xxxx.exe")
+        with self.assertRaises(self.lb.LeaderboardCliError):
+            self.lb.run_cli(missing, ["--version"])
+
+    def test_main_invite_does_not_need_bin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            code = self.lb.main(["invite", "--agent", "main-guest"])
+            self.assertEqual(code, 0)
+            invite = self.lb.read_json(str(board / "invite.json"))
+            self.assertEqual(invite["guest"], "main-guest")
+
+    def test_main_attest_without_agent_exits(self):
+        with self.assertRaises(SystemExit) as ctx:
+            self.lb.main(["attest"])
+        self.assertIn("agent", str(ctx.exception))
+
+    def test_modes_tuple_matches_parser(self):
+        self.assertEqual(set(self.lb.MODES), {"attest", "verify", "render", "invite"})
+
+    def test_default_workorder_and_keyring_schema(self):
+        wo = self.lb.default_workorder()
+        ring = self.lb.default_keyring()
+        self.assertEqual(wo["schemaVersion"], self.lb.SCHEMA_VERSION)
+        self.assertEqual(wo["kind"], "workorder")
+        self.assertEqual(ring["kind"], "keyring")
+        self.assertEqual(ring["keys"], [])
+
+    def test_ensure_board_creates_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            self.lb.ensure_board()
+            self.assertTrue((board / "keys").is_dir())
+            self.assertTrue((board / "claims").is_dir())
+            wo = self.lb.read_json(self.lb.WORKORDER)
+            self.assertEqual(wo["workorderId"], "gym-leaderboard-standing")
+            ring = self.lb.read_json(self.lb.KEYRING)
+            self.assertEqual(ring["keys"], [])
+
+
+class VerifyEntryExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+        self._saved = {name: getattr(self.lb, name) for name in _BOARD_PATH_NAMES}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(self.lb, name, value)
+
+    def test_non_dict_entry(self):
+        result = self.lb.verify_entry("bin", "nope", [])
+        self.assertFalse(result["ok"])
+        self.assertIn("객체", result["why"])
+
+    def test_missing_claim_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "leaderboard"
+            board.mkdir()
+            (board / "claims").mkdir()
+            self.lb.BOARD = str(board)
+            self.lb.CLAIMS = str(board / "claims")
+            result = self.lb.verify_entry("bin", {"seq": 0, "claimSha256": "ab" * 32}, [])
+            self.assertFalse(result["ok"])
+            self.assertIn("claim", result["why"])
+
+    def test_claim_json_broken(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "leaderboard"
+            claims = board / "claims"
+            claims.mkdir(parents=True)
+            payload = b'{"not": "matching-hash"}'
+            path = claims / "broken.claim.json"
+            path.write_bytes(payload)
+            digest = hashlib.sha256(payload).hexdigest()
+            self.lb.BOARD = str(board)
+            self.lb.CLAIMS = str(claims)
+            # 깨진 JSON 이지만 해시가 원장과 같으면 읽기 단계에서 접힌다.
+            path.write_text("{bad", encoding="utf-8")
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            result = self.lb.verify_entry("bin", {"seq": 1, "claimSha256": digest}, [])
+            self.assertFalse(result["ok"])
+            self.assertTrue("claim" in result["why"] or "읽기" in result["why"])
+
+    def test_claims_path_is_file(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as fh:
+            fh.write("x")
+            path = fh.name
+        self.lb.CLAIMS = path
+        result = self.lb.verify_entry("bin", {"seq": 0, "claimSha256": "00"}, [])
+        Path(path).unlink()
+        self.assertFalse(result["ok"])
+        self.assertIn("claims", result["why"])
+
+
+class ConstantContractTests(unittest.TestCase):
+    """문서·시험·코드가 같은 키 집합을 본다."""
+
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_invite_keys(self):
+        self.assertEqual(
+            set(self.lb.INVITE_KEYS),
+            {"schemaVersion", "kind", "guest", "board", "fingerprint",
+             "join", "promise", "note"},
+        )
+        self.assertEqual(set(self.lb.INVITE_BOARD_KEYS), {"repo", "path"})
+
+    def test_fingerprint_keys(self):
+        self.assertEqual(
+            set(self.lb.FINGERPRINT_KEYS),
+            {"members", "ledgerEntries", "ledgerChain", "anchorChain",
+             "merkleRoot", "workorderSha256", "ledgerSnapshotSha256"},
+        )
+
+    def test_schema_and_kinds(self):
+        self.assertEqual(self.lb.SCHEMA_VERSION, "1.0")
+        self.assertEqual(self.lb.INVITE_KIND, "gymLeaderboardInvite")
+        self.assertEqual(self.lb.VERIFICATION_KIND, "gymLeaderboardVerification")
+        self.assertEqual(self.lb.JOIN_STEP_COUNT, 3)
+        self.assertEqual(self.lb.COMMIT_SHORT, 10)
+        self.assertEqual(self.lb.DEFAULT_GUEST, "친구-에이전트")
+
+    def test_pack_and_rank_key_names(self):
+        self.assertEqual(set(self.lb.PACK_SCORE_KEYS), {"score", "max"})
+        for key in ("ok", "agent", "score", "max", "seq", "runner"):
+            self.assertIn(key, self.lb.RANK_OK_KEYS)
+
+    def test_no_new_cli_modes(self):
+        self.assertEqual(len(self.lb.MODES), 4)
+        self.assertNotIn("sign", self.lb.MODES)
+        self.assertNotIn("keygen", self.lb.MODES)
+
+    def test_hashlib_sha256_is_the_only_digest(self):
+        # 모듈이 새 암호 원시함수를 들이지 않았는지 — hashlib.sha256 만 쓴다.
+        source = Path(LB_PATH).read_text(encoding="utf-8")
+        self.assertNotIn("ed25519", source.lower().replace("ed25519 서명", ""))
+        self.assertIn("hashlib.sha256", source)
+        self.assertNotIn("nacl", source)
+        self.assertNotIn("cryptography", source)
+        self.assertNotIn("from hashlib import blake2", source)
+
+    def test_module_doc_points_at_docs(self):
+        source = Path(LB_PATH).read_text(encoding="utf-8")
+        self.assertIn("gym/docs/leaderboard.md", source)
+        self.assertIn("README_leaderboard.md", source)
+        self.assertIn("새 암호", source)
+
+
+class AttestAdmissionExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+        self._saved = {name: getattr(self.lb, name) for name in _BOARD_PATH_NAMES}
+        self._gym = self.lb.GYM
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(self.lb, name, value)
+        self.lb.GYM = self._gym
+
+    def test_admission_not_object(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "leaderboard"
+            board.mkdir()
+            (board / "keys").mkdir()
+            (board / "claims").mkdir()
+            self.lb.BOARD = str(board)
+            self.lb.KEYS = str(board / "keys")
+            self.lb.CLAIMS = str(board / "claims")
+            self.lb.LEDGER = str(board / "ledger.ndjson")
+            self.lb.ANCHOR = str(board / "anchor.ndjson")
+            self.lb.CHECKPOINT = str(board / "checkpoint.json")
+            self.lb.KEYRING = str(board / "keyring.json")
+            self.lb.WORKORDER = str(board / "workorder.json")
+            self.lb.GYM = tmp
+            sub = Path(tmp) / "submissions" / "x"
+            sub.mkdir(parents=True)
+            (sub / "scorecard.json").write_text("{}", encoding="utf-8")
+            (sub / "admission.json").write_text("[1, 2]", encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                self.lb.cmd_attest(argparse_ns(agent="x"), "bin")
+            self.assertIn("객체", str(ctx.exception))
+
+    def test_admission_deny(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "leaderboard"
+            board.mkdir()
+            (board / "keys").mkdir()
+            (board / "claims").mkdir()
+            self.lb.BOARD = str(board)
+            self.lb.KEYS = str(board / "keys")
+            self.lb.CLAIMS = str(board / "claims")
+            self.lb.LEDGER = str(board / "ledger.ndjson")
+            self.lb.ANCHOR = str(board / "anchor.ndjson")
+            self.lb.CHECKPOINT = str(board / "checkpoint.json")
+            self.lb.KEYRING = str(board / "keyring.json")
+            self.lb.WORKORDER = str(board / "workorder.json")
+            self.lb.GYM = tmp
+            sub = Path(tmp) / "submissions" / "x"
+            sub.mkdir(parents=True)
+            (sub / "scorecard.json").write_text("{}", encoding="utf-8")
+            (sub / "admission.json").write_text(
+                json.dumps({"verdict": "deny"}), encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                self.lb.cmd_attest(argparse_ns(agent="x"), "bin")
+            self.assertIn("deny", str(ctx.exception))
+
+
+class ResolveBinTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_empty_path_from_find_bin(self):
+        saved = self.lb.runner.find_bin
+
+        def fake(_explicit):
+            return ""
+
+        self.lb.runner.find_bin = fake
+        try:
+            with self.assertRaises(self.lb.LeaderboardCliError):
+                self.lb.resolve_bin(None)
+        finally:
+            self.lb.runner.find_bin = saved
+
+    def test_systemexit_from_find_bin(self):
+        saved = self.lb.runner.find_bin
+
+        def fake(_explicit):
+            raise SystemExit("없음")
+
+        self.lb.runner.find_bin = fake
+        try:
+            with self.assertRaises(self.lb.LeaderboardCliError) as ctx:
+                self.lb.resolve_bin("nope")
+            self.assertIn("없음", str(ctx.exception))
+        finally:
+            self.lb.runner.find_bin = saved
+
+    def test_other_exception_from_find_bin(self):
+        saved = self.lb.runner.find_bin
+
+        def fake(_explicit):
+            raise RuntimeError("boom")
+
+        self.lb.runner.find_bin = fake
+        try:
+            with self.assertRaises(self.lb.LeaderboardCliError):
+                self.lb.resolve_bin(None)
+        finally:
+            self.lb.runner.find_bin = saved
+
+
+class RenderMoreEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_single_ranked_has_no_grid(self):
+        md = self.lb.render_markdown(
+            [_ok("only", 1, 1, 0, packs={"p": {"score": 1, "max": 1}})], None)
+        self.assertNotIn("능력 격자", md)
+
+    def test_two_ranked_without_packs_has_no_grid(self):
+        md = self.lb.render_markdown([_ok("a", 1, 1, 0), _ok("b", 2, 2, 1)], None)
+        self.assertNotIn("능력 격자", md)
+
+    def test_chain_broken_footer(self):
+        md = self.lb.render_markdown([], "읽기 실패")
+        self.assertIn("원장 체인: 파손", md)
+
+    def test_pack_full_score_is_bold(self):
+        results = [
+            _ok("a", 2, 2, 0, packs={"core": {"score": 2, "max": 2}}),
+            _ok("b", 1, 2, 1, packs={"core": {"score": 1, "max": 2}}),
+        ]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("**2**", md)
+        self.assertIn("1/2", md)
+
+    def test_missing_pack_cell_is_dash(self):
+        results = [
+            _ok("a", 2, 2, 0, packs={"core": {"score": 2, "max": 2}, "sec": {"score": 1, "max": 1}}),
+            _ok("b", 1, 1, 1, packs={"core": {"score": 1, "max": 1}}),
+        ]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("—", md)
+
+    def test_explicit_ranked_unverified_from_results(self):
+        results = [_ok("a", 1, 1, 0), _bad(3)]
+        md = self.lb.render_markdown(results, None, ranked=[results[0]])
+        self.assertIn("**unverified**", md)
+        self.assertIn("seq 3", md)
+
+    def test_zero_max_pack_does_not_break_render(self):
+        results = [
+            _ok("a", 1, 1, 0, packs={"z": {"score": 0, "max": 0}, "r": {"score": 1, "max": 1}}),
+            _ok("b", 1, 1, 1, packs={"r": {"score": 1, "max": 1}}),
+        ]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("a", md)
+        self.assertIn("b", md)
+
+
+class ChainWalkMoreTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_first_row_seq_must_be_zero(self):
+        text = json.dumps({"seq": 1, "kind": "anchorLog", "prevEntryHash": None})
+        with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
+                                         encoding="utf-8", newline="\n") as fh:
+            fh.write(text + "\n")
+            path = fh.name
+        entries, err = self.lb.chain_walk(path, "anchorLog")
+        Path(path).unlink()
+        self.assertEqual(entries, [])
+        self.assertIn("seq", err)
+
+    def test_first_row_prev_must_be_null(self):
+        text = json.dumps({"seq": 0, "kind": "anchorLog", "prevEntryHash": "aa" * 32})
+        with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
+                                         encoding="utf-8", newline="\n") as fh:
+            fh.write(text + "\n")
+            path = fh.name
+        entries, err = self.lb.chain_walk(path, "anchorLog")
+        Path(path).unlink()
+        self.assertEqual(entries, [])
+        self.assertIn("prevEntryHash", err)
+
+    def test_three_valid_rows(self):
+        text = make_chain("settlementLedger", [{"a": 1}, {"a": 2}, {"a": 3}])
+        with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
+                                         encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+            path = fh.name
+        entries, err = self.lb.chain_walk(path, "settlementLedger")
+        Path(path).unlink()
+        self.assertIsNone(err)
+        self.assertEqual(len(entries), 3)
+        self.assertEqual(entries[2]["seq"], 2)
+
+
+class InviteJoinContractTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+        self._saved = {name: getattr(self.lb, name) for name in _BOARD_PATH_NAMES}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(self.lb, name, value)
+
+    def test_join_mentions_guest_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "leaderboard"
+            board.mkdir()
+            self.lb.BOARD = str(board)
+            self.lb.KEYS = str(board / "keys")
+            self.lb.CLAIMS = str(board / "claims")
+            self.lb.LEDGER = str(board / "ledger.ndjson")
+            self.lb.ANCHOR = str(board / "anchor.ndjson")
+            self.lb.CHECKPOINT = str(board / "checkpoint.json")
+            self.lb.KEYRING = str(board / "keyring.json")
+            self.lb.WORKORDER = str(board / "workorder.json")
+            invite = self.lb.construct_invite("한굴-손님")
+            self.assertTrue(any("한굴-손님" in s for s in invite["join"]))
+            self.assertIn("keys/", invite["promise"])
+            self.assertIn("권한이 아니라", invite["note"])
+            self.assertEqual(invite["board"]["repo"], "edwardkim/rhwp")
+
+    def test_missing_invite_keys_listed(self):
+        issues = self.lb.validate_invite({"schemaVersion": "1.0"})
+        for key in ("kind", "guest", "board", "fingerprint", "join", "promise", "note"):
+            self.assertTrue(any(key in i for i in issues), key)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_gym_leaderboard.py
+++ b/scripts/tests/test_gym_leaderboard.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -47,7 +49,6 @@ class ChainWalkTests(unittest.TestCase):
         self.lb = load_lb()
 
     def test_valid_chain_walks_clean(self, kind="settlementLedger"):
-        import tempfile
         text = make_chain(kind, [{"capsuleSha256": "a" * 64, "verdict": "accepted"},
                                  {"capsuleSha256": "b" * 64, "verdict": "accepted"}])
         with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
@@ -61,7 +62,6 @@ class ChainWalkTests(unittest.TestCase):
 
     def test_retroactive_edit_is_exposed_by_next_line(self):
         """과거 줄을 수정하면 다음 줄의 prevEntryHash 가 어긋나 폭로된다."""
-        import tempfile
         text = make_chain("anchorLog", [{"capsuleSha256": "a" * 64},
                                         {"capsuleSha256": "b" * 64}])
         lines = text.splitlines()
@@ -78,7 +78,6 @@ class ChainWalkTests(unittest.TestCase):
         self.assertIn("prevEntryHash", err)
 
     def test_seq_gap_is_rejected(self):
-        import tempfile
         text = make_chain("anchorLog", [{"x": 1}, {"x": 2}])
         lines = text.splitlines()
         second = json.loads(lines[1])
@@ -91,6 +90,35 @@ class ChainWalkTests(unittest.TestCase):
         _entries, err = self.lb.chain_walk(path, "anchorLog")
         Path(path).unlink()
         self.assertIsNotNone(err)
+
+    def test_missing_file_returns_empty_and_none(self):
+        missing = os.path.join(tempfile.gettempdir(),
+                               "rhwp-lb-missing-chain-walk.ndjson")
+        if os.path.exists(missing):
+            os.remove(missing)
+        entries, err = self.lb.chain_walk(missing, "settlementLedger")
+        self.assertEqual(entries, [])
+        self.assertIsNone(err)
+
+    def test_empty_file_returns_empty_and_none(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
+                                         encoding="utf-8", newline="\n") as fh:
+            fh.write("")
+            path = fh.name
+        entries, err = self.lb.chain_walk(path, "settlementLedger")
+        Path(path).unlink()
+        self.assertEqual(entries, [])
+        self.assertIsNone(err)
+
+    def test_blank_lines_only_file_is_empty_chain(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False,
+                                         encoding="utf-8", newline="\n") as fh:
+            fh.write("\n\n  \n")
+            path = fh.name
+        entries, err = self.lb.chain_walk(path, "anchorLog")
+        Path(path).unlink()
+        self.assertEqual(entries, [])
+        self.assertIsNone(err)
 
 
 class MerkleTests(unittest.TestCase):
@@ -108,6 +136,16 @@ class MerkleTests(unittest.TestCase):
         one = self.lb.merkle_root([hashlib.sha256(b"x").hexdigest()])
         self.assertEqual(one, hashlib.sha256(b"x").hexdigest())
 
+    def test_empty_leaves_is_none(self):
+        self.assertIsNone(self.lb.merkle_root([]))
+
+    def test_two_leaf_pairing_is_hash_of_concat(self):
+        a = hashlib.sha256(b"left").hexdigest()
+        b = hashlib.sha256(b"right").hexdigest()
+        root = self.lb.merkle_root([a, b])
+        expected = hashlib.sha256((a + b).encode("ascii")).hexdigest()
+        self.assertEqual(root, expected)
+
 
 class CommittedBoardTests(unittest.TestCase):
     """커밋된 리더보드가 있으면 해시 체인 무결·스냅샷 봉인을 상시 확인한다."""
@@ -116,7 +154,6 @@ class CommittedBoardTests(unittest.TestCase):
         self.lb = load_lb()
 
     def test_committed_ledger_and_anchor_are_intact(self):
-        import os
         if not os.path.exists(self.lb.LEDGER):
             self.skipTest("커밋된 리더보드 없음")
         _le, lerr = self.lb.chain_walk(self.lb.LEDGER, "settlementLedger")
@@ -130,7 +167,6 @@ class CommittedBoardTests(unittest.TestCase):
                              "원장이 앵커 이후 변경됨(꼬리 봉인 실패)")
 
     def test_ledger_entries_have_matching_claim_files(self):
-        import os
         if not os.path.exists(self.lb.LEDGER):
             self.skipTest("커밋된 리더보드 없음")
         entries, _ = self.lb.chain_walk(self.lb.LEDGER, "settlementLedger")
@@ -148,7 +184,6 @@ class InviteTests(unittest.TestCase):
         self.lb = load_lb()
 
     def test_board_fingerprint_reports_committed_state(self):
-        import os
         if not os.path.exists(self.lb.LEDGER):
             self.skipTest("커밋된 리더보드 없음")
         fp = self.lb.board_fingerprint()
@@ -160,6 +195,285 @@ class InviteTests(unittest.TestCase):
         self.assertEqual(fp["ledgerEntries"], len(entries))
         # 스냅샷 해시는 커밋된 원장 파일 바이트에서 재계산 가능해야 한다.
         self.assertEqual(fp["ledgerSnapshotSha256"], self.lb.sha256_of(self.lb.LEDGER))
+
+
+def _ok(agent, score, max_, seq, packs=None, commit="abc1234567890"):
+    return {
+        "ok": True,
+        "agent": agent,
+        "score": score,
+        "max": max_,
+        "seq": seq,
+        "runner": {"rhwpCommit": commit},
+        "packs": packs if packs is not None else {},
+    }
+
+
+def _bad(seq, why="claim 파일 없음"):
+    return {"ok": False, "seq": seq, "why": why}
+
+
+class RankResultsTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_higher_score_ranks_first(self):
+        results = [
+            _ok("low", 3, 10, 0),
+            _ok("high", 9, 10, 1),
+            _ok("mid", 6, 10, 2),
+        ]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual([r["agent"] for r in ranked], ["high", "mid", "low"])
+        self.assertEqual(unverified, [])
+
+    def test_tie_score_breaks_by_lower_seq(self):
+        results = [
+            _ok("late", 8, 10, 4),
+            _ok("early", 8, 10, 1),
+            _ok("mid", 8, 10, 2),
+        ]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual([r["seq"] for r in ranked], [1, 2, 4])
+        self.assertEqual([r["agent"] for r in ranked], ["early", "mid", "late"])
+        self.assertEqual(unverified, [])
+
+    def test_unverified_excluded_from_ranked(self):
+        results = [
+            _ok("ok-a", 5, 10, 0),
+            _bad(1),
+            _ok("ok-b", 7, 10, 2),
+            _bad(3, why="서명 실패"),
+        ]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual([r["agent"] for r in ranked], ["ok-b", "ok-a"])
+        self.assertEqual([r["seq"] for r in unverified], [1, 3])
+        self.assertTrue(all(not r.get("ok") for r in unverified))
+        self.assertTrue(all(r.get("ok") for r in ranked))
+
+    def test_empty_results_split_to_empty_lists(self):
+        ranked, unverified = self.lb.rank_results([])
+        self.assertEqual(ranked, [])
+        self.assertEqual(unverified, [])
+
+    def test_all_unverified_leaves_ranked_empty(self):
+        results = [_bad(0), _bad(1)]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual(ranked, [])
+        self.assertEqual(len(unverified), 2)
+
+    def test_missing_ok_key_is_treated_as_unverified(self):
+        results = [{"seq": 0, "score": 99}, _ok("ok", 1, 1, 1)]
+        ranked, unverified = self.lb.rank_results(results)
+        self.assertEqual(len(ranked), 1)
+        self.assertEqual(ranked[0]["agent"], "ok")
+        self.assertEqual(unverified[0]["seq"], 0)
+
+
+class BestPackTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_empty_packs_is_none(self):
+        self.assertIsNone(self.lb.best_pack({}))
+        self.assertIsNone(self.lb.best_pack(None or {}))
+
+    def test_single_pack_is_returned(self):
+        picked = self.lb.best_pack({"core-cli": {"score": 4, "max": 6}})
+        self.assertEqual(picked, ("core-cli", 4, 6))
+
+    def test_mixed_ratios_picks_highest_ratio(self):
+        packs = {
+            "easy": {"score": 10, "max": 10},
+            "hard": {"score": 9, "max": 10},
+            "wide": {"score": 20, "max": 40},
+        }
+        picked = self.lb.best_pack(packs)
+        self.assertEqual(picked[0], "easy")
+        self.assertEqual(picked[1:], (10, 10))
+
+    def test_equal_ratio_breaks_by_larger_max(self):
+        packs = {
+            "narrow": {"score": 5, "max": 10},
+            "wide": {"score": 10, "max": 20},
+        }
+        picked = self.lb.best_pack(packs)
+        self.assertEqual(picked, ("wide", 10, 20))
+
+    def test_zero_max_does_not_divide(self):
+        packs = {
+            "empty": {"score": 0, "max": 0},
+            "real": {"score": 1, "max": 2},
+        }
+        picked = self.lb.best_pack(packs)
+        self.assertEqual(picked, ("real", 1, 2))
+
+
+class RenderMarkdownTests(unittest.TestCase):
+    def setUp(self):
+        self.lb = load_lb()
+
+    def test_header_unverified_and_score_numbers(self):
+        results = [
+            _ok("alpha", 12, 20, 0, packs={"core": {"score": 12, "max": 20}}),
+            _bad(1),
+        ]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("위조 불가능", md)
+        self.assertIn("**unverified**", md)
+        self.assertIn("12", md)
+        self.assertIn("20", md)
+        self.assertIn("| — | seq 1 |", md)
+        self.assertIn("정직 조항", md)
+
+    def test_honesty_clause_and_verified_row(self):
+        results = [_ok("beta", 3, 5, 2, commit="deadbeefcafebabe")]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("등재되었고 이후 변조되지 않았다", md)
+        self.assertIn("beta", md)
+        self.assertIn("**3 / 5**", md)
+        self.assertIn("`deadbeefca`", md)
+        self.assertIn("| 1 |", md)
+        self.assertIn("검증됨", md)
+        self.assertNotIn("**unverified**", md)
+
+    def test_broken_chain_is_labeled_in_footer(self):
+        md = self.lb.render_markdown([_bad(0)], "1행: prevEntryHash 불일치")
+        self.assertIn("원장 체인: 파손", md)
+        self.assertIn("unverified 1", md)
+
+    def test_empty_results_still_have_header_and_honesty(self):
+        md = self.lb.render_markdown([], None)
+        self.assertIn("# 운동장 리더보드 — 위조 불가능한 점수판", md)
+        self.assertIn("위조 불가능", md)
+        self.assertIn("정직 조항", md)
+        self.assertIn("원장 체인: 무결", md)
+        self.assertIn("항목 0", md)
+        self.assertTrue(md.endswith("\n"))
+
+    def test_explicit_ranked_argument_is_honored(self):
+        results = [_ok("first", 1, 1, 0), _ok("second", 9, 9, 1)]
+        ranked, _ = self.lb.rank_results(results)
+        md = self.lb.render_markdown(results, None, ranked=ranked)
+        first = md.index("first")
+        second = md.index("second")
+        self.assertLess(second, first)
+
+    def test_ability_grid_appears_for_two_scored_agents(self):
+        results = [
+            _ok("a", 4, 4, 0, packs={"p1": {"score": 4, "max": 4}}),
+            _ok("b", 2, 4, 1, packs={"p1": {"score": 2, "max": 4}}),
+        ]
+        md = self.lb.render_markdown(results, None)
+        self.assertIn("## 능력 격자 (pack 별 점수)", md)
+        self.assertIn("**4**", md)
+        self.assertIn("2/4", md)
+
+
+_BOARD_PATH_NAMES = (
+    "BOARD", "KEYS", "CLAIMS", "LEDGER", "ANCHOR",
+    "CHECKPOINT", "KEYRING", "WORKORDER",
+)
+
+
+class InviteEnvelopeTests(unittest.TestCase):
+    """초대 봉투는 임시 판에서만 읽고, 커밋된 gym/leaderboard 에 쓰지 않는다."""
+
+    def setUp(self):
+        self.lb = load_lb()
+        self._saved = {name: getattr(self.lb, name) for name in _BOARD_PATH_NAMES}
+        self._real_invite = Path(self._saved["BOARD"]) / "invite.json"
+        self._invite_before = (
+            self._real_invite.stat().st_mtime_ns if self._real_invite.exists() else None
+        )
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(self.lb, name, value)
+        if self._invite_before is None:
+            self.assertFalse(
+                self._real_invite.exists(),
+                "커밋된 판에 invite.json 이 생겼다",
+            )
+        else:
+            self.assertEqual(self._real_invite.stat().st_mtime_ns, self._invite_before)
+
+    def _redirect(self, tmp):
+        board = Path(tmp) / "leaderboard"
+        board.mkdir()
+        (board / "keys").mkdir()
+        (board / "claims").mkdir()
+        self.lb.BOARD = str(board)
+        self.lb.KEYS = str(board / "keys")
+        self.lb.CLAIMS = str(board / "claims")
+        self.lb.LEDGER = str(board / "ledger.ndjson")
+        self.lb.ANCHOR = str(board / "anchor.ndjson")
+        self.lb.CHECKPOINT = str(board / "checkpoint.json")
+        self.lb.KEYRING = str(board / "keyring.json")
+        self.lb.WORKORDER = str(board / "workorder.json")
+        return board
+
+    def test_fingerprint_on_empty_tmp_board(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            fp = self.lb.board_fingerprint()
+            self.assertEqual(fp["members"], 0)
+            self.assertEqual(fp["ledgerEntries"], 0)
+            self.assertEqual(fp["ledgerChain"], "ok")
+            self.assertEqual(fp["anchorChain"], "ok")
+            self.assertIsNone(fp["merkleRoot"])
+            self.assertIsNone(fp["workorderSha256"])
+            self.assertIsNone(fp["ledgerSnapshotSha256"])
+
+    def test_construct_invite_uses_tmp_fingerprint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = self._redirect(tmp)
+            workorder = {
+                "schemaVersion": "1.0",
+                "kind": "workorder",
+                "workorderId": "tmp-invite",
+            }
+            self.lb.write_json(self.lb.WORKORDER, workorder)
+            self.lb.write_json(self.lb.KEYRING, {
+                "schemaVersion": "1.0", "kind": "keyring",
+                "keys": [{"keyId": "gym/tmp", "publicKey": "aa", "revoked": None}],
+            })
+            Path(self.lb.LEDGER).write_text("", encoding="utf-8")
+            Path(self.lb.ANCHOR).write_text("", encoding="utf-8")
+            self.lb.write_json(self.lb.CHECKPOINT, {"merkleRoot": "ab" * 32})
+            invite = self.lb.construct_invite("tmp-guest")
+            self.assertEqual(invite["kind"], "gymLeaderboardInvite")
+            self.assertEqual(invite["guest"], "tmp-guest")
+            self.assertEqual(invite["board"]["path"], "gym/leaderboard")
+            self.assertEqual(invite["fingerprint"]["members"], 1)
+            self.assertEqual(invite["fingerprint"]["ledgerEntries"], 0)
+            self.assertEqual(invite["fingerprint"]["merkleRoot"], "ab" * 32)
+            self.assertEqual(
+                invite["fingerprint"]["workorderSha256"],
+                self.lb.sha256_of(self.lb.WORKORDER),
+            )
+            self.assertTrue(any("tmp-guest" in step for step in invite["join"]))
+            self.assertEqual(len(invite["join"]), 3)
+            self.assertFalse((board / "invite.json").exists())
+
+    def test_construct_invite_does_not_touch_committed_board(self):
+        real_board = Path(self._saved["BOARD"])
+        before = {}
+        if real_board.is_dir():
+            for p in real_board.rglob("*"):
+                if p.is_file():
+                    before[str(p.relative_to(real_board))] = p.stat().st_mtime_ns
+        with tempfile.TemporaryDirectory() as tmp:
+            self._redirect(tmp)
+            _invite = self.lb.construct_invite("probe-agent")
+            fp = self.lb.board_fingerprint()
+            self.assertEqual(fp["ledgerEntries"], 0)
+        if real_board.is_dir():
+            after = {
+                str(p.relative_to(real_board)): p.stat().st_mtime_ns
+                for p in real_board.rglob("*") if p.is_file()
+            }
+            self.assertEqual(after, before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

`gym/tools/leaderboard.py` 의 순위 정렬·최강 pack·마크다운 렌더·초대 봉투를 순수 함수로 분리하고, rhwp 바이너리 없이 시험을 늘린다.

- 검증된 항목만 점수·seq 로 정렬한다. unverified 는 순위에 오르지 않고 표에 남는다.
- 초대 봉투·지문 시험은 임시 디렉터리에서만 돌리고 커밋된 `gym/leaderboard/` 는 읽기만 한다.
- CLI 모드·packs·ci.yml 은 그대로다.

## 관련 이슈

closes #5235

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_leaderboard -q` — 33 passed
- [x] `python gym/tools/audit.py` — pack 미변경
- [ ] **`cargo fmt --all -- --check` 통과** (Python 만. 생략)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
