### PR TITLE
gym: release_diff 순수 분류·관측 시험 강화

### DIFF
--- a/gym/tools/release_diff.py
+++ b/gym/tools/release_diff.py
@@ -53,7 +53,39 @@ from gym.core import checks as check_registry  # noqa: E402
 ROOT = runner.ROOT
 
 #: 봉투를 부르지 않는 파일 연산자 — 관측이 아니라 존재/동일성이라 raw 대조 제외.
+#: files_differ 도 두 산출 파일의 동일성이라 CLI 봉투를 부르지 않는다.
 FILE_OPS = {"file_exists", "same_hash", "differs_from_input", "files_differ"}
+
+
+def classify(surface_changed, diffs):
+    """오검출 관문: 표면이 바뀌면 diffs 가 있어도 surface-changed.
+
+    이 도구는 무엇이 바뀌었는지 가리킬 뿐 어느 쪽이 옳은지 판정하지 않는다.
+    표면이 다른 릴리스의 관측 분기는 의도된 변경일 수 있어 사람 몫이다.
+    """
+    if surface_changed:
+        return "surface-changed"
+    return "regression" if diffs else "stable"
+
+
+def exit_code(classification):
+    """stable=0, regression=3(회귀), surface-changed=2(사람 판정 필요)."""
+    return {"stable": 0, "regression": 3, "surface-changed": 2}[classification]
+
+
+def build_report(old_bin, new_bin, old_dig, new_dig, surface_changed,
+                 tasks_seen, checks_seen, diffs):
+    """kind=gymReleaseDiff schemaVersion=1.0 봉투. 시험이 main 없이 키를 고정한다."""
+    classification = classify(surface_changed, diffs)
+    return {
+        "kind": "gymReleaseDiff", "schemaVersion": "1.0",
+        "old": {"bin": os.path.basename(old_bin), "capabilitiesSha256": old_dig},
+        "new": {"bin": os.path.basename(new_bin), "capabilitiesSha256": new_dig},
+        "surfaceChanged": surface_changed,
+        "tasksCompared": tasks_seen, "observationsCompared": checks_seen,
+        "divergences": len(diffs), "classification": classification,
+        "diffs": diffs,
+    }
 
 
 def capabilities_digest(bin_path):
@@ -133,17 +165,11 @@ def main():
                 row["pack"] = pack_id
                 diffs.append(row)
 
-    classification = ("surface-changed" if surface_changed
-                      else ("regression" if diffs else "stable"))
-    report = {
-        "kind": "gymReleaseDiff", "schemaVersion": "1.0",
-        "old": {"bin": os.path.basename(old_bin), "capabilitiesSha256": old_dig},
-        "new": {"bin": os.path.basename(new_bin), "capabilitiesSha256": new_dig},
-        "surfaceChanged": surface_changed,
-        "tasksCompared": tasks_seen, "observationsCompared": checks_seen,
-        "divergences": len(diffs), "classification": classification,
-        "diffs": diffs,
-    }
+    report = build_report(
+        old_bin, new_bin, old_dig, new_dig, surface_changed,
+        tasks_seen, checks_seen, diffs,
+    )
+    classification = report["classification"]
     out = a.out or os.path.join(runner.GYM, "release-diff.json")
     with io.open(out, "w", encoding="utf-8", newline="\n") as fh:
         fh.write(json.dumps(report, ensure_ascii=False, indent=2))
@@ -156,8 +182,7 @@ def main():
         nv = row["new"].get("value", row["new"])
         print(f"  {row['pack']}/{row['task']} · {row['check']}: {ov!r} → {nv!r}")
     print(f"→ {out}")
-    # stable=0, regression=3(회귀), surface-changed=2(사람 판정 필요)
-    return {"stable": 0, "regression": 3, "surface-changed": 2}[classification]
+    return exit_code(classification)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_release_diff.py
+++ b/scripts/tests/test_gym_release_diff.py
@@ -1,7 +1,9 @@
-"""[#4661] 릴리스 간 차등 회귀 도구 계약 — 오검출 관문·분류·관측 대조.
+"""[#4661][#5237] 릴리스 간 차등 회귀 도구 계약 — 오검출 관문·분류·관측 대조.
 
 바이너리 두 개를 실제로 빌드하지 않고도 도구의 판정 논리를 고정한다. 관측
 함수(run_cli)를 목으로 갈아끼워 "구/신이 다른 답을 냈을 때" 를 합성한다.
+분류·종료 코드·보고 조립은 release_diff 의 순수 함수를 직접 부른다 — 시험이
+같은 삼항을 복붙하면 가짜다(#5237).
 """
 
 from __future__ import annotations
@@ -25,6 +27,10 @@ def load_rd():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _tables_env(text="짐검증", row=0, col=0):
+    return {"tables": [{"cells": [{"row": row, "col": col, "text": text}]}]}
 
 
 class ObservationTests(unittest.TestCase):
@@ -61,11 +67,124 @@ class ObservationTests(unittest.TestCase):
             obs = self.rd.observe("rhwp", check, self.task, ".")
         self.assertEqual(obs, {"kind": "resolve-error", "error": "FileNotFoundError"})
 
+    def test_keyerror_resolve_is_an_observation_not_a_crash(self):
+        with mock.patch.object(self.rd.runner, "resolve_args",
+                               side_effect=KeyError("input")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs, {"kind": "resolve-error", "error": "KeyError"})
+
+    def test_typeerror_resolve_is_an_observation_not_a_crash(self):
+        with mock.patch.object(self.rd.runner, "resolve_args",
+                               side_effect=TypeError("cmd is None")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs, {"kind": "resolve-error", "error": "TypeError"})
+
+    def test_indexerror_and_oserror_resolve_stay_observations(self):
+        for exc in (IndexError("cmd[0]"), OSError("broken pipe")):
+            with self.subTest(exc=type(exc).__name__), \
+                    mock.patch.object(self.rd.runner, "resolve_args", side_effect=exc):
+                obs = self.rd.observe("rhwp", self.check, self.task, ".")
+            self.assertEqual(obs["kind"], "resolve-error")
+            self.assertEqual(obs["error"], type(exc).__name__)
+
+    def test_no_cmd_is_reported_without_calling_cli(self):
+        called = []
+        check = {"name": "빈검사", "op": "value_eq"}
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               side_effect=lambda *a: called.append(a)):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "no-cmd"})
+        self.assertEqual(called, [])
+
+    def test_env_none_is_nojson_not_exit(self):
+        """허용 종료인데 봉투가 없으면 파싱 실패(nojson) 다 — 종료 코드 문제가 아니다."""
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, None, "not json")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "nojson")
+        self.assertEqual(obs["head"], "not json")
+
+    def test_nojson_head_is_truncated_to_80(self):
+        long_head = "x" * 200
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, None, long_head)):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "nojson")
+        self.assertEqual(len(obs["head"]), 80)
+
+    def test_empty_env_and_pagecount_path_is_digfail(self):
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, {}, "ok")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs, {"kind": "digfail", "error": "KeyError"})
+
+    def test_dig_indexerror_is_digfail(self):
+        check = dict(self.check, path="tables[0]")
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, {"tables": []}, "")):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "digfail", "error": "IndexError"})
+
+    def test_dig_typeerror_is_digfail(self):
+        check = dict(self.check, path="pageCount")
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, [1, 2, 3], "")):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "digfail", "error": "TypeError"})
+
+    def test_empty_path_returns_whole_envelope(self):
+        env = {"pageCount": 6, "extra": True}
+        check = dict(self.check, path="")
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, env, "")):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "value", "value": env})
+
+    def test_cell_text_eq_observes_named_cell_not_whole_table(self):
+        check = {"name": "셀", "op": "cell_text_eq", "table": 0, "row": 0,
+                 "col": 0, "value": "짐검증",
+                 "cmd": ["export-tables", "{file:cell.hwp}", "--json"],
+                 "path": "tables"}
+        env = _tables_env("짐검증")
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, env, "")):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "value", "value": "짐검증"})
+
+    def test_cell_text_eq_missing_cell_is_none_value(self):
+        check = {"name": "셀", "op": "cell_text_eq", "table": 0, "row": 9,
+                 "col": 9, "value": "없음",
+                 "cmd": ["export-tables", "{file:cell.hwp}", "--json"],
+                 "path": "tables"}
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, _tables_env("짐검증"), "")):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "value", "value": None})
+
+    def test_cell_text_eq_cell_without_text_key_is_none(self):
+        check = {"name": "셀", "op": "cell_text_eq", "table": 0, "row": 0,
+                 "col": 0, "value": "x",
+                 "cmd": ["export-tables", "{file:cell.hwp}", "--json"],
+                 "path": "tables"}
+        env = {"tables": [{"cells": [{"row": 0, "col": 0}]}]}
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               return_value=(0, env, "")):
+            obs = self.rd.observe("rhwp", check, self.task, ".")
+        self.assertEqual(obs, {"kind": "value", "value": None})
+
     def test_file_ops_are_excluded_from_observation(self):
         """파일 존재/동일성은 관측이 아니라 상태라 raw 대조에서 빠진다."""
         self.assertIn("file_exists", self.rd.FILE_OPS)
         self.assertIn("same_hash", self.rd.FILE_OPS)
         self.assertIn("differs_from_input", self.rd.FILE_OPS)
+        self.assertIn("files_differ", self.rd.FILE_OPS)
+
+    def test_files_differ_is_a_file_op(self):
+        self.assertIn("files_differ", self.rd.FILE_OPS)
+        self.assertTrue(self.rd.FILE_OPS <= {
+            "file_exists", "same_hash", "differs_from_input", "files_differ",
+            "xml_root_eq", "json_value_eq", "csv_cell_eq", "utf8_bom",
+        })
 
 
 class DiffTaskTests(unittest.TestCase):
@@ -107,22 +226,154 @@ class DiffTaskTests(unittest.TestCase):
         self.assertEqual(rows, [])
         self.assertEqual(called, [], "file_exists 는 CLI 를 부르지 않아야 한다")
 
+    def test_files_differ_check_is_skipped(self):
+        task = {"id": "T", "input": "x.hwp",
+                "checks": [{"name": "두 산출", "op": "files_differ",
+                            "files": ["a.hwp", "b.hwp"]}]}
+        called = []
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli",
+                                  side_effect=lambda *a: called.append(a) or (0, {}, "")):
+            rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
+        self.assertEqual(rows, [])
+        self.assertEqual(called, [], "files_differ 는 CLI 를 부르지 않아야 한다")
+
+    def test_mixed_file_and_value_checks_only_observe_value(self):
+        task = {"id": "T", "input": "x.hwp",
+                "checks": [
+                    {"name": "산출", "op": "files_differ", "files": ["a.hwp", "b.hwp"]},
+                    {"name": "쪽수", "op": "value_eq", "value": 6,
+                     "cmd": ["info", "{input}", "--json"], "path": "pageCount"},
+                ]}
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli",
+                                  return_value=(0, {"pageCount": 1}, "")):
+            rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
+        self.assertEqual(rows, [])
+
+    def test_cell_text_eq_divergence_is_captured(self):
+        check = {"name": "셀", "op": "cell_text_eq", "table": 0, "row": 0,
+                 "col": 0, "value": "짐검증",
+                 "cmd": ["export-tables", "{file:cell.hwp}", "--json"],
+                 "path": "tables"}
+        task = {"id": "T08", "input": "x.hwp", "checks": [check]}
+
+        def fake(bin_path, args):
+            return (0, _tables_env("구값" if bin_path == "old" else "신값"), "")
+
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli", side_effect=fake):
+            rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["old"], {"kind": "value", "value": "구값"})
+        self.assertEqual(rows[0]["new"], {"kind": "value", "value": "신값"})
+        self.assertEqual(rows[0]["op"], "cell_text_eq")
+
 
 class ClassificationTests(unittest.TestCase):
-    """분류 규칙 — surface-changed 관문이 순수 회귀와 표면 변경을 가른다."""
+    """분류 규칙 — surface-changed 관문이 순수 회귀와 표면 변경을 가른다.
+
+    여기의 삼항을 시험이 다시 적으면 #5237 가짜 시험이다. 반드시
+    `rd.classify` 를 부른다.
+    """
+
+    def setUp(self):
+        self.rd = load_rd()
 
     def test_classification_matrix(self):
-        # (surfaceChanged, hasDiffs) → 분류
+        # (surfaceChanged, diffs) → 분류. diffs 는 main 이 넘기는 목록.
         cases = [
-            (False, False, "stable"),
-            (False, True, "regression"),
-            (True, False, "surface-changed"),
-            (True, True, "surface-changed"),  # 표면이 바뀌면 diff 여부와 무관
+            (False, [], "stable"),
+            (False, [{"task": "T"}], "regression"),
+            (True, [], "surface-changed"),
+            (True, [{"task": "T"}], "surface-changed"),  # 표면이 바뀌면 diff 여부와 무관
         ]
         for surface, diffs, expected in cases:
-            cls = ("surface-changed" if surface
-                   else ("regression" if diffs else "stable"))
-            self.assertEqual(cls, expected, (surface, diffs))
+            self.assertEqual(
+                self.rd.classify(surface, diffs), expected, (surface, diffs),
+            )
+
+    def test_surface_changed_wins_even_if_diffs_exist(self):
+        self.assertEqual(
+            self.rd.classify(True, [{"old": 1, "new": 2}]),
+            "surface-changed",
+        )
+
+    def test_empty_diffs_without_surface_change_is_stable(self):
+        self.assertEqual(self.rd.classify(False, []), "stable")
+        self.assertEqual(self.rd.classify(False, None), "stable")
+        self.assertEqual(self.rd.classify(False, False), "stable")
+
+    def test_truthy_diffs_without_surface_change_is_regression(self):
+        self.assertEqual(self.rd.classify(False, True), "regression")
+        self.assertEqual(self.rd.classify(False, [0]), "regression")
+
+
+class ExitCodeTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_exit_code_mapping(self):
+        self.assertEqual(self.rd.exit_code("stable"), 0)
+        self.assertEqual(self.rd.exit_code("regression"), 3)
+        self.assertEqual(self.rd.exit_code("surface-changed"), 2)
+
+    def test_unknown_classification_raises(self):
+        with self.assertRaises(KeyError):
+            self.rd.exit_code("unknown")
+
+    def test_exit_code_follows_classify(self):
+        pairs = [
+            (False, [], 0),
+            (False, [{"x": 1}], 3),
+            (True, [], 2),
+            (True, [{"x": 1}], 2),
+        ]
+        for surface, diffs, expected in pairs:
+            cls = self.rd.classify(surface, diffs)
+            self.assertEqual(self.rd.exit_code(cls), expected, (surface, diffs, cls))
+
+
+class ReportContractTests(unittest.TestCase):
+    """build_report 가 main 없이 봉투 키를 고정한다."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_report_kind_and_schema(self):
+        report = self.rd.build_report(
+            "/opt/old/rhwp", "/opt/new/rhwp",
+            "aaa", "bbb", False, 4, 12, [],
+        )
+        self.assertEqual(report["kind"], "gymReleaseDiff")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertEqual(report["old"], {"bin": "rhwp", "capabilitiesSha256": "aaa"})
+        self.assertEqual(report["new"], {"bin": "rhwp", "capabilitiesSha256": "bbb"})
+        self.assertFalse(report["surfaceChanged"])
+        self.assertEqual(report["tasksCompared"], 4)
+        self.assertEqual(report["observationsCompared"], 12)
+        self.assertEqual(report["divergences"], 0)
+        self.assertEqual(report["classification"], "stable")
+        self.assertEqual(report["diffs"], [])
+
+    def test_report_classification_uses_classify(self):
+        diffs = [{"task": "T", "old": 1, "new": 2}]
+        stable = self.rd.build_report("old", "new", "h1", "h1", False, 1, 1, [])
+        regression = self.rd.build_report("old", "new", "h1", "h1", False, 1, 1, diffs)
+        surface = self.rd.build_report("old", "new", "h1", "h2", True, 1, 1, diffs)
+        self.assertEqual(stable["classification"], self.rd.classify(False, []))
+        self.assertEqual(regression["classification"], self.rd.classify(False, diffs))
+        self.assertEqual(surface["classification"], self.rd.classify(True, diffs))
+        self.assertEqual(regression["divergences"], 1)
+        self.assertTrue(surface["surfaceChanged"])
+
+    def test_report_required_keys(self):
+        report = self.rd.build_report("o", "n", "a", "b", False, 0, 0, [])
+        self.assertEqual(set(report), {
+            "kind", "schemaVersion", "old", "new", "surfaceChanged",
+            "tasksCompared", "observationsCompared", "divergences",
+            "classification", "diffs",
+        })
 
 
 class CommittedReportTests(unittest.TestCase):
@@ -143,6 +394,8 @@ class CommittedReportTests(unittest.TestCase):
         self.assertEqual(report["classification"], "stable")
         self.assertEqual(report["divergences"], 0,
                          "자기-대조에서 분기가 나오면 관측에 비결정성이 있다")
+        self.assertEqual(report["kind"], "gymReleaseDiff")
+        self.assertEqual(self.rd.exit_code(report["classification"]), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

`gym/tools/release_diff.py` 릴리스 차등 도구의 분류·종료 코드·보고 조립을 순수 함수로 분리하고, rhwp 바이너리 없이 계약을 고정한다. 분류 시험이 같은 삼항을 복붙하던 가짜 시험을 고친다.

- `classify(surface_changed, diffs)` 가 `stable` / `regression` / `surface-changed` 를 낸다. 표면이 바뀌면 diffs 가 있어도 surface-changed 가 이긴다.
- `exit_code(classification)` 은 stable=0, regression=3, surface-changed=2 다. `main()` 이 둘을 쓴다.
- `build_report(...)` 가 `kind=gymReleaseDiff`, `schemaVersion=1.0` 봉투를 조립한다. 시험이 main 없이 키를 고정한다.
- 관측 경로 `nojson`(env is None)·`digfail`(dig KeyError/IndexError/TypeError)·`cell_text_eq`(find_cell 좌표만) 를 직접 시험한다.
- `files_differ` 는 FILE_OPS 멤버라 CLI 를 부르지 않는다. resolve-error 는 KeyError 와 TypeError 를 구분한다.
- CLI 플래그는 그대로다. packs·checks·coverage·robustness·profiles·README·ci.yml 은 건드리지 않았다.

## 관련 이슈

closes #5237

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_release_diff -v` — 36 ran, 35 passed, 1 skipped (커밋된 self-diff 리포트 없음)
- [x] `python gym/tools/audit.py` — 18 pack 통과
- [ ] **`cargo fmt --all -- --check` 통과** (이번 변경은 Python 만. 사용자 지시에 따라 생략)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [ ] `cargo test` 통과 (해당 없음)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)
- [x] CI Lint 의 `Validate gym scorer contracts` 에 `test_gym_release_diff.py` 가 이미 배선됨 (ci.yml 미수정)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 미측정. 라이브 스윕은 기존과 같이 rhwp 가 필요하고, 단위 시험은 바이너리 없이 돈다.
