### PR TITLE
feat(gym): text-editing pack 과제 확장 (TE11–TE14)

### DIFF
--- a/gym/packs/text-editing/reference/TE11.json
+++ b/gym/packs/text-editing/reference/TE11.json
@@ -1,0 +1,21 @@
+{
+  "id": "TE11",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "replace-text",
+        "{input}",
+        "--find",
+        "규제",
+        "--replace",
+        "점검",
+        "--occurrence",
+        "0",
+        "-o",
+        "{sub:once.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/text-editing/reference/TE12.json
+++ b/gym/packs/text-editing/reference/TE12.json
@@ -1,0 +1,33 @@
+{
+  "id": "TE12",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "replace-text",
+        "{input}",
+        "--find",
+        "규제",
+        "--replace",
+        "점검",
+        "-o",
+        "{sub:edited.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "answer": {
+        "untouched": {
+          "cmd": [
+            "search",
+            "{sub:edited.hwp}",
+            "--json",
+            "--",
+            "ⅰ"
+          ],
+          "path": "matchCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/text-editing/reference/TE13.json
+++ b/gym/packs/text-editing/reference/TE13.json
@@ -1,0 +1,23 @@
+{
+  "id": "TE13",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "insert-text",
+        "{input}",
+        "--text",
+        "짐표지TE13",
+        "--section",
+        "0",
+        "--para",
+        "0",
+        "--offset",
+        "0",
+        "-o",
+        "{sub:inserted.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/text-editing/reference/TE14.json
+++ b/gym/packs/text-editing/reference/TE14.json
@@ -1,0 +1,33 @@
+{
+  "id": "TE14",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "replace-text",
+        "{input}",
+        "--find",
+        "규제",
+        "--replace",
+        "점검",
+        "-o",
+        "{sub:edited.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "answer": {
+        "para": {
+          "cmd": [
+            "search",
+            "{sub:edited.hwp}",
+            "--json",
+            "--",
+            "점검"
+          ],
+          "path": "matches[0].paragraph"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/text-editing/tasks/TE11.json
+++ b/gym/packs/text-editing/tasks/TE11.json
@@ -1,0 +1,46 @@
+{
+  "id": "TE11",
+  "tier": 2,
+  "title": "k번째만 치환",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "입력의 '규제' 가운데 **0 기준 첫 번째만** '점검' 으로 바꾼 once.hwp 를 제출하라. 전건 치환은 통과하지 못한다 — 옛 문구가 남아 있어야 한다. 힌트: rhwp edit replace-text --occurrence 0.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "once.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "새 문구 실재",
+      "op": "value_ge",
+      "value": 1,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:once.hwp}",
+        "--json",
+        "--",
+        "점검"
+      ]
+    },
+    {
+      "name": "옛 문구 잔여(전건 치환 거부)",
+      "op": "value_ge",
+      "value": 1,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:once.hwp}",
+        "--json",
+        "--",
+        "규제"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "once.hwp"
+    }
+  ]
+}

--- a/gym/packs/text-editing/tasks/TE12.json
+++ b/gym/packs/text-editing/tasks/TE12.json
@@ -1,0 +1,60 @@
+{
+  "id": "TE12",
+  "tier": 2,
+  "title": "치환 후 무관 문구 재검색",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "입력의 '규제' 를 모두 '점검' 으로 바꾼 edited.hwp 를 제출하고, 고치지 않은 문구 'ⅰ' 의 일치 건수를 answer.json 에 {\"untouched\": N} 으로 적어라. 채점기는 산출물을 다시 검색해 네가 적은 건수와 대조한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "edited.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "옛 문구 완전 소거",
+      "op": "value_eq",
+      "value": 0,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:edited.hwp}",
+        "--json",
+        "--",
+        "규제"
+      ]
+    },
+    {
+      "name": "새 문구 실재",
+      "op": "value_ge",
+      "value": 1,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:edited.hwp}",
+        "--json",
+        "--",
+        "점검"
+      ]
+    },
+    {
+      "name": "무관 문구 잔여 건수",
+      "op": "answer_eq",
+      "answer": "untouched",
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:edited.hwp}",
+        "--json",
+        "--",
+        "ⅰ"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "edited.hwp"
+    }
+  ]
+}

--- a/gym/packs/text-editing/tasks/TE13.json
+++ b/gym/packs/text-editing/tasks/TE13.json
@@ -1,0 +1,33 @@
+{
+  "id": "TE13",
+  "tier": 2,
+  "title": "문단 좌표 삽입 후 재검색",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력의 구역 0 · 문단 0 · 오프셋 0 에 '짐표지TE13' 을 넣은 inserted.hwp 를 제출하라. 채점은 그 표지가 정확히 1건인지 재검색한다. 힌트: rhwp edit insert-text --section 0 --para 0 --offset 0.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "inserted.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "삽입 표지 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:inserted.hwp}",
+        "--json",
+        "--",
+        "짐표지TE13"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "inserted.hwp"
+    }
+  ]
+}

--- a/gym/packs/text-editing/tasks/TE14.json
+++ b/gym/packs/text-editing/tasks/TE14.json
@@ -1,0 +1,60 @@
+{
+  "id": "TE14",
+  "tier": 2,
+  "title": "치환 후 첫 일치 문단 좌표",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "입력의 '규제' 를 모두 '점검' 으로 바꾼 edited.hwp 를 제출하고, 산출물에서 '점검' 의 **첫 일치 문단 번호**를 answer.json 에 {\"para\": N} 으로 적어라. 힌트: rhwp search 의 matches[0].paragraph.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "edited.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "옛 문구 완전 소거",
+      "op": "value_eq",
+      "value": 0,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:edited.hwp}",
+        "--json",
+        "--",
+        "규제"
+      ]
+    },
+    {
+      "name": "새 문구 실재",
+      "op": "value_ge",
+      "value": 1,
+      "path": "matchCount",
+      "cmd": [
+        "search",
+        "{file:edited.hwp}",
+        "--json",
+        "--",
+        "점검"
+      ]
+    },
+    {
+      "name": "첫 일치 문단",
+      "op": "answer_eq",
+      "answer": "para",
+      "path": "matches[0].paragraph",
+      "cmd": [
+        "search",
+        "{file:edited.hwp}",
+        "--json",
+        "--",
+        "점검"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "edited.hwp"
+    }
+  ]
+}


### PR DESCRIPTION
## 변경 요약

`gym/packs/text-editing` 에 본문 편집 과제 TE11–TE14 와 기준풀이를 추가한다. T07/fill-fields 를 복제하지 않는다.

- 좌표 치환·재검색·문단 삽입 축만 늘린다.
- 편집 과제에 `deep_contains` 를 쓰지 않는다.
- profiles/README/ci.yml 미수정.

## 관련 이슈

closes #5243

## 테스트

- [x] 과제마다 reference 짝
- [x] `python gym/tools/audit.py` / `test_gym_packs` (로컬에서 pack 스키마 정합)
- [ ] **`cargo fmt --all -- --check` 통과** (JSON pack 만. 생략)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
