### PR TITLE
feat(gym): table-editing pack에 TB09–TB12 표 좌표 과제를 추가한다

### DIFF
--- a/gym/packs/table-editing/reference/TB09.json
+++ b/gym/packs/table-editing/reference/TB09.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB09",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "병합앵커",
+        "-o",
+        "{sub:merge.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB10.json
+++ b/gym/packs/table-editing/reference/TB10.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB10",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "HWPX칸",
+        "-o",
+        "{sub:cell.hwpx}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB11.json
+++ b/gym/packs/table-editing/reference/TB11.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB11",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "1",
+        "--text",
+        "가상공과대학",
+        "-o",
+        "{sub:form.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB12.json
+++ b/gym/packs/table-editing/reference/TB12.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB12",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "바깥칸",
+        "-o",
+        "{sub:outer.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB09.json
+++ b/gym/packs/table-editing/tasks/TB09.json
@@ -1,0 +1,40 @@
+{
+  "id": "TB09",
+  "tier": 3,
+  "title": "병합 표 앵커 셀 교정",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,1열) 을 '병합앵커' 로 바꾼 merge.hwp 를 제출하라. (0,2) 는 병합으로 덮인 칸이므로 앵커 (0,1) 만 유효하다. 힌트: rhwp edit set-cell --table 0 --row 0 --col 1.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "merge.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "산출물 존재",
+      "op": "file_exists",
+      "file": "merge.hwp",
+      "minBytes": 1024
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부)",
+      "op": "differs_from_input",
+      "file": "merge.hwp"
+    },
+    {
+      "name": "(0,1) == 병합앵커",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "병합앵커",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:merge.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB10.json
+++ b/gym/packs/table-editing/tasks/TB10.json
@@ -1,0 +1,40 @@
+{
+  "id": "TB10",
+  "tier": 2,
+  "title": "HWPX 격자 셀 교정",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "HWPX 입력의 첫 번째 표 (0행,0열) 을 'HWPX칸' 으로 바꾼 cell.hwpx 를 제출하라. 형식은 HWPX 로 유지한다. 힌트: rhwp edit set-cell --table 0 --row 0 --col 0 -o cell.hwpx.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "cell.hwpx"
+    ]
+  },
+  "checks": [
+    {
+      "name": "산출물 존재",
+      "op": "file_exists",
+      "file": "cell.hwpx",
+      "minBytes": 1024
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부)",
+      "op": "differs_from_input",
+      "file": "cell.hwpx"
+    },
+    {
+      "name": "(0,0) == HWPX칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "HWPX칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:cell.hwpx}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB11.json
+++ b/gym/packs/table-editing/tasks/TB11.json
@@ -1,0 +1,40 @@
+{
+  "id": "TB11",
+  "tier": 3,
+  "title": "실문서 표 칸 채움",
+  "input": "samples/복학원서.hwp",
+  "instructions": "누름틀이 없는 실문서다. 첫 번째 표의 (1행,1열) 대학 칸을 '가상공과대학' 으로 바꾼 form.hwp 를 제출하라. fill-fields 가 아니라 표 좌표 set-cell 이다. 힌트: rhwp edit set-cell --table 0 --row 1 --col 1.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "form.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "산출물 존재",
+      "op": "file_exists",
+      "file": "form.hwp",
+      "minBytes": 1024
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부)",
+      "op": "differs_from_input",
+      "file": "form.hwp"
+    },
+    {
+      "name": "(1,1) == 가상공과대학",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 1,
+      "value": "가상공과대학",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:form.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB12.json
+++ b/gym/packs/table-editing/tasks/TB12.json
@@ -1,0 +1,40 @@
+{
+  "id": "TB12",
+  "tier": 2,
+  "title": "중첩 표 문서의 바깥 셀 교정",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "최상위 표의 (0행,0열) 을 '바깥칸' 으로 바꾼 outer.hwp 를 제출하라. 셀 안 중첩 표는 v1 범위 밖이므로 건드리지 않는다. 힌트: rhwp edit set-cell --table 0 --row 0 --col 0.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "outer.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "산출물 존재",
+      "op": "file_exists",
+      "file": "outer.hwp",
+      "minBytes": 1024
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부)",
+      "op": "differs_from_input",
+      "file": "outer.hwp"
+    },
+    {
+      "name": "(0,0) == 바깥칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "바깥칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:outer.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 변경 요약

table-editing pack이 표 좌표 편집 축인데 과제가 TB01–TB08에 머문다. 기존 CLI(`edit set-cell`)와 `samples/`만으로 TB09–TB12를 추가한다. 새 pack·새 CLI·T07/fill-fields 복제는 없다. profiles/README/PARK/checks.py/다른 pack은 건드리지 않았다. runner는 기존 `table-editing/pack.json`을 그대로 둔다.

Closes #5230

## 추가 과제

| ID | 제목 | 명령 | 표본 | 지목 연산자 |
|---|---|---|---|---|
| TB09 | 병합 표 앵커 셀 교정 | `edit set-cell` | `samples/table-001.hwp` (0,1) | `file_exists` · `differs_from_input` · `cell_text_eq` |
| TB10 | HWPX 격자 셀 교정 | `edit set-cell` | `samples/hwpx/basic-table-01.hwpx` (0,0) | `file_exists` · `differs_from_input` · `cell_text_eq` |
| TB11 | 실문서 표 칸 채움 | `edit set-cell` | `samples/복학원서.hwp` (1,1) | `file_exists` · `differs_from_input` · `cell_text_eq` |
| TB12 | 중첩 표 문서의 바깥 셀 | `edit set-cell` | `samples/inner-table-01.hwp` (0,0) | `file_exists` · `differs_from_input` · `cell_text_eq` |

기존 TB01–TB08은 유지한다. 편집 축에 `deep_contains`는 쓰지 않았다. 과제 ID는 전역 고유하다.

## 테스트

- [x] `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- [x] `python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_audit -v` — 20 tests OK
- [ ] **`cargo fmt --all -- --check`** — gym JSON만 변경, 생략
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — Rust 변경 없음, 생략
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — Rust 변경 없음, 생략
- [ ] `cargo test` — 해당 없음
- [ ] `cargo clippy -- -D warnings` — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (gym 과제만)
- 재현·측정: 미측정

## 위험

- `table-001.hwp`의 (0,2)는 병합으로 덮인 칸이다. TB09는 지식지도에 실측된 앵커 (0,1)만 쓴다.
- `복학원서.hwp` (1,1)은 편집 데모에서 검증된 대학 칸이다. fill-fields가 아니라 set-cell이다.
- `inner-table-01.hwp`는 중첩 표가 있는 최상위 표의 (0,0)만 고친다. 중첩 표는 set-cell v1 범위 밖이다.
- 로컬 rhwp 바이너리로 set-cell을 라이브 채점하지는 못했다. 기준 풀이는 기존 TB03·TB04와 같은 형식이다.