### PR TITLE
gym: release_diff 순수 시험·분류 강화

### DIFF
--- a/gym/docs/release_diff.md
+++ b/gym/docs/release_diff.md
@@ -1,0 +1,452 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/release_diff.md
+last_verified: 2026-08-18
+---
+
+# gym 릴리스 간 차등 규약
+
+이 문서는 `gym/tools/release_diff.py` 의 **분류 삼원**, **관측 kind**, **예외
+경로 계약**을 고정한다. 작업 기록은
+[`mydocs/working/gym_release_diff.md`](../../mydocs/working/gym_release_diff.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_release_diff.py` 가 기계로 고정한다.
+
+릴리스 게이트(`release_gate.py`)는 이 도구의 분류를 파이프라인 판정으로 묶는다.
+게이트는 **regression 만 차단**한다. surface-changed 는 리뷰 신호이지 자동
+차단이 아니다. 이 문서가 다루는 것은 게이트가 아니라 차등 오라클 자체다.
+
+## 1. 왜 이 기둥이 필요한가
+
+운동장 채점기는 정답을 골든으로 박제하지 않고, 채점 시점에 rhwp 로 다시 계산한다
+(#4653). 그러니 같은 제출물을 두 바이너리로 돌리면 관측이 같아야 한다. 갈리면
+그 사이 릴리스에서 동작이 바뀐 것이다. #4658 교차형식 차등이 형식축에서 검증한
+원리를 시간축으로 돌린 것뿐이다. 새 메커니즘은 없다.
+
+리더보드 총점은 통과/실패의 이진값이라 둔감하다. 쪽수·표수·필드값·해시·판정
+문자열처럼 봉투에서 길어낸 **관측 raw** 를 대조한다. 골든 없이, 관측이 갈리는
+지점이 곧 회귀 후보다.
+
+이 도구는 "무엇이 바뀌었나" 를 가리키지 "어느 쪽이 옳은가" 를 판정하지 않는다.
+한컴 정답지가 없다. 판정은 사람이 한다.
+
+## 2. 사용
+
+```bash
+python gym/tools/release_diff.py --old <구 바이너리> --new <신 바이너리>
+python gym/tools/release_diff.py --old old/rhwp --new target/debug/rhwp --pack core-cli
+python gym/tools/release_diff.py --old old/rhwp --new new/rhwp -o gym/release-diff.json
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--old` | (필수) | 구 rhwp 바이너리. `runner.find_bin` 으로 해석한다. |
+| `--new` | (필수) | 신 rhwp 바이너리. |
+| `--agent` | `claude-fable-5` | 관측에 쓸 제출물 루트. |
+| `--pack` | 전체 탐색 | 반복 지정 가능. 지정하면 그 pack 만 본다. |
+| `-o` / `--out` | `gym/release-diff.json` | JSON 보고 경로. UTF-8 · BOM 없음 · LF. |
+| `--digest-timeout` | 30 | capabilities 프로브 초. 0 이하는 무제한. |
+
+프로브 명령은 항상 `rhwp capabilities` 이다. 관측 명령은 각 과제의 `cmd` 다.
+파일 연산자(`file_exists` 등)는 CLI 를 부르지 않는다.
+
+## 3. 분류 삼원 — 정직 조항
+
+`classify(surface, divergences)` 는 오직 세 값만 낸다.
+
+| 표면이 바뀌었나 | 관측이 갈렸나 | 분류 | exit | ok | reviewRequired |
+|---|---|---|---|---|---|
+| 아니오 | 아니오 | `stable` | 0 | 참 | 거짓 |
+| 아니오 | 예 | `regression` | 3 | 거짓 | 거짓 |
+| 예 | 아니오 | `surface-changed` | 2 | 거짓 | 참 |
+| 예 | 예 | `surface-changed` | 2 | 거짓 | 참 |
+
+규칙:
+
+1. **표면이 회귀보다 앞선다.** capabilities digest 가 다르면 관측 분기 유무와
+   무관하게 `surface-changed` 다. 의도된 명령 추가를 회귀로 오신고하지 않는다.
+2. **표면이 같고 관측이 갈리면 `regression`.** 순수 동작 변화다.
+3. **둘 다 같으면 `stable`.** 자기-대조에서 분기가 나오면 관측에 비결정성이 있다.
+4. **`classify` 는 `probe-failed` 를 내지 않는다.** 그 값은 분류가 아니라 도구
+   실패 상태다. `CLASSIFICATIONS` 튜플에 넣지 않는다.
+
+`divergences` 인자는 목록·건수·bool 을 모두 받는다. 파이썬 진릿값으로만 본다.
+
+- 거짓으로 접히는 값(`None`, `0`, `""`, `[]`, `{}`, `False`) → 분기 없음.
+- 그 외(`1`, `[행]`, `"x"`, `True`) → 분기 있음.
+
+표면 인자도 진릿값이다. 빈 문자열 표면은 거짓이라 `stable`/`regression` 쪽으로
+간다. 프로브가 실패한 `None` digest 를 여기 넣지 말라.
+
+## 4. 표면을 모를 때 — probe-failed
+
+두 바이너리의 capabilities digest 를 둘 다 문자열로 얻지 못하면 **분류하지
+않는다.** 한쪽 digest 가 `None` 인 상태를 `surface-changed` 로 부르면 거짓말이다.
+양쪽이 `None` 인 상태를 `stable` 로 부르면 더 큰 거짓말이다.
+
+그래서 보고 상태는 `probe-failed` 다.
+
+| 필드 | 값 | 왜 |
+|---|---|---|
+| `classification` | `probe-failed` | 삼원이 아니다 |
+| `exit` | 1 | 도구 실패. 0/2/3 과 겹치지 않는다 |
+| `ok` | 거짓 | 안정을 위장하지 않는다 |
+| `reviewRequired` | 거짓 | 사람 판정(표면 변경)을 위장하지 않는다 |
+| `surfaceChanged` | 거짓 | 표면을 모르면 바뀐 것이 아니다 |
+| `probeFailed` | 참 | 표지 |
+| `probeErrors` | 역할별 오류 목록 | old/new 각각 |
+
+`classify()` 를 고쳐 `probe-failed` 를 내게 하지 않는다. `can_classify_surface` 가
+막아서 `classify_or_probe_failed` 또는 `build_report` 가 갈라 받는다.
+
+프로브가 잡는 실패:
+
+| kind | 예외 | 의미 |
+|---|---|---|
+| `missing-bin` | `FileNotFoundError` | 바이너리가 없다 |
+| `permission` | `PermissionError` | 실행 권한이 없다 |
+| `timeout` | `TimeoutExpired` / `TimeoutError` | capabilities 가 시간 안에 안 끝났다 |
+| `os-error` | 그 외 `OSError` | 파이프·경로·윈도 오류 |
+| `decode-error` | `UnicodeError` | 출력 디코드 실패 |
+| `unexpected` | 그 외 | 카탈로그 밖. 그래도 도구는 죽지 않는다 |
+
+`KeyboardInterrupt` · `SystemExit` · `MemoryError` · `GeneratorExit` 는 삼키지
+않는다. 사용자가 끊었는데 안정 보고를 내면 거짓말이다.
+
+## 5. 관측 kind
+
+한 검사의 결과는 판정이 아니라 관측이다. 구/신이 같은 kind·같은 값이면 분기가
+아니다.
+
+| kind | 언제 | 표시 |
+|---|---|---|
+| `value` | 허용 exit + JSON + 경로 성공 | raw 값 |
+| `exit` | 허용하지 않은 종료 코드 | `exitN` |
+| `nojson` | 허용 exit 인데 봉투가 없다 | `nojson` |
+| `digfail` | 경로 평가 실패 | `digfail` |
+| `no-cmd` | 검사에 `cmd` 가 없다 | `no-cmd` |
+| `resolve-error` | `resolve_args` 의 제출물 부재(`FileNotFoundError`) | `resolve-error` |
+| `cli-error` | `run_cli` 의 `RuntimeError` | `cli-error` |
+| `timeout` | CLI 시간초과 | `timeout` |
+| `missing-bin` | CLI 실행 파일이 없다 | `missing-bin` |
+| `permission` | CLI 권한 거부 | `permission` |
+| `os-error` | CLI/경로의 그 외 OS 오류 | `os-error` |
+| `type-error` | 검사 형식이 dict 가 아니거나 TypeError | `type-error` |
+| `value-error` | 비정수 인덱스 등 ValueError | `value-error` / `digfail` |
+| `decode-error` | 유니코드 오류 | `decode-error` |
+| `unexpected` | 카탈로그 밖 | `unexpected` |
+
+`observation_from_result` 의 경로 실패(KeyError · IndexError · TypeError ·
+ValueError · AttributeError)는 모두 `digfail` 로 접는다. 한 칸을 못 읽었다고
+차등 도구 전체를 죽이면, 빈 제출·깨진 경로가 있는 한 릴리스를 비교할 수 없다.
+
+같은 오류가 구/신 양쪽에 나면 분기가 아니다. 한쪽만 나면 분기다. 분류는 그때
+표면이 같은지 보고 `regression` 또는 `surface-changed` 를 고른다. 오류 관측이
+분류 규칙을 바꾸지 않는다.
+
+## 6. 관측 동일성
+
+`observations_equal` / `_values_equal` 계약:
+
+| 왼쪽 | 오른쪽 | 같은가 | 왜 |
+|---|---|---|---|
+| `6` | `6.0` | 예 | JSON 숫자의 int/float 요동 |
+| `True` | `1` | 아니오 | bool 을 int 로 접지 않는다 |
+| `False` | `0` | 아니오 | 위와 같음 |
+| `{b:1,a:2}` | `{a:2.0,b:1}` | 예 | 키 순서 무관, 숫자 정규화 |
+| `{"kind":"nojson"}` | `{"kind":"value","value":"nojson"}` | 아니오 | 종류가 다르면 표시가 같아도 다르다 |
+| `{"kind":"exit","code":1}` | `{"kind":"value","value":"exit1"}` | 아니오 | 위와 같음 |
+| `NaN` | `NaN` | 예 | 둘 다 비숫자. 회귀로 오신고하지 않는다 |
+| `+inf` | `-inf` | 아니오 | 부호가 다른 무한대 |
+| `[1,[2,3.0]]` | `[1.0,[2,3]]` | 예 | 중첩 숫자 정규화 |
+| `b"ab"` | `"ab"` | 아니오 | 바이트와 문자열은 다르다 |
+
+`cell_text_eq` 는 표 전체가 아니라 `(table, row, col)` 칸의 `text` 만 본다.
+칸이 없으면 값 `None` 이다(digfail 이 아니다). 표 인덱스가 범위를 벗어나면
+`digfail` / `IndexError` 다.
+
+## 7. 파일 연산자는 관측이 아니다
+
+다음 op 는 CLI 를 부르지 않고 raw 대조에서도 뺀다.
+
+- `file_exists`
+- `same_hash`
+- `differs_from_input`
+- `files_differ`
+
+존재/동일성은 릴리스와 무관하게 흔들릴 수 있는 자리다. 산출 파일 크기·경로를
+관측으로 넣으면 같은 바이너리의 자기-대조도 갈린다.
+
+`xml_root_eq` · `json_value_eq` 같은 제출물 검사도 이 도구의 관측 대상이 되려면
+`cmd` 가 있어야 한다. `cmd` 가 없으면 `no-cmd` 관측이고 CLI 는 부르지 않는다.
+
+## 8. JSON 봉투
+
+`kind=gymReleaseDiff`, `schemaVersion=1.0`. 키 집합은 시험이 `REPORT_KEYS` 로
+고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymReleaseDiff` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `old` / `new` | obj | `{bin, capabilitiesSha256}` |
+| `surfaceChanged` | bool | digest 가 다른가. 프로브 실패면 거짓 |
+| `tasksCompared` | int | 실제로 본 과제 수 |
+| `observationsCompared` | int | 파일 연산을 뺀 검사 수 |
+| `observationsSkipped` | int | 파일 연산 수 |
+| `divergences` | int | `diffs` 길이 |
+| `classification` | str | 삼원 또는 `probe-failed` |
+| `classificationReason` | str | 사람이 읽는 이유 |
+| `exit` | int | 0 / 1 / 2 / 3 |
+| `ok` | bool | `stable` 과만 참 |
+| `reviewRequired` | bool | `surface-changed` 와만 참 |
+| `diffs` | list | 분기 행 |
+
+부가 키:
+
+| 키 | 언제 |
+|---|---|
+| `probeFailed` | 표면을 못 쟀을 때 |
+| `probeErrors` | old/new 프로브 실패 줄 |
+| `packErrors` | pack 읽기 실패. 분류를 바꾸지 않는다 |
+| `taskErrors` | 한 과제 루프의 예외. 분류를 바꾸지 않는다 |
+| `writeError` | JSON 쓰기 실패. 종료 코드는 분류를 따른다 |
+
+`validate_report` 가 정직 계약을 검사한다.
+
+- 삼원일 때 `ok` · `reviewRequired` · `surfaceChanged` · `exit` 가 표와 같아야
+  한다. `probeFailed` 가 참이면 안 된다.
+- `stable` 인데 `divergences > 0` 이면 거짓말이다.
+- `regression` 인데 `divergences == 0` 이면 거짓말이다.
+- `probe-failed` 인데 `ok` 또는 `reviewRequired` 또는 `surfaceChanged` 가 참이면
+  거짓말이다.
+
+## 9. 예외 경로 — 도구가 죽지 않는 자리
+
+감사기(이 차등 도구) 자신은 한 검사·한 pack 의 예외로 멈추지 않는다. 빈
+제출물, 없는 바이너리, 권한, 시간초과, 깨진 pack JSON 은 관측/오류 목록으로
+남기고 다음으로 간다.
+
+| 자리 | 잡는 것 | 접는 곳 |
+|---|---|---|
+| `resolve_args` | `FileNotFoundError` 등 | 관측 `resolve-error` / 대응 kind |
+| `run_cli` | timeout · missing-bin · permission · OSError | 관측 |
+| `dig` / `find_cell` | KeyError · IndexError · TypeError · ValueError | `digfail` |
+| `probe_capabilities` | 위 + 빈 경로 | 프로브 봉투. digest=None |
+| `load_pack` | OSError · JSON 오류 | `packErrors` |
+| `discover_packs` | OSError | 빈 목록 + packErrors |
+| `find_bin` | OSError | 경로 유지 + 오류 문자열 |
+| `write_report` | OSError | `writeError` |
+| `diff_task` 한 검사 | 그 외 예외 | 그 행만 건너뜀. 거짓 분기를 만들지 않음 |
+
+한 pack 을 못 읽어도 다른 pack 은 계속 비교한다. pack 오류는 분류를 뒤집지
+않는다. 비교한 과제만으로 삼원을 고른다. 비교를 하나도 못 했더라도 digest 가
+있으면 그 digest 로 분류한다(관측 0 · 분기 0 → 표면이 같으면 `stable`).
+
+자기-대조에서 `stable` 이 아니면 관측이 비결정적이거나 프로브가 실패한
+것이다. 커밋된 `gym/release-diff.json` 이 있으면 시험이 그 점을 확인한다.
+
+## 10. 종료 코드
+
+| exit | 의미 | 게이트 |
+|---|---|---|
+| 0 | `stable` | pass |
+| 1 | `probe-failed` | 도구 실패. 분류를 위장하지 않음 |
+| 2 | `surface-changed` | review. 자동 차단 아님 |
+| 3 | `regression` | block |
+
+`exit_for` 는 삼원만 받는다. `skipped` 같은 미지 값은 `KeyError` 다.
+`probe-failed` 는 `status_exit` 가 1 을 낸다. `EXIT_BY_CLASS` 에 넣지 않아
+기존 게이트 계약(`CLASSIFICATIONS` ↔ `EXIT_BY_CLASS`)이 그대로다.
+
+## 11. 보고 쓰기 형식
+
+`write_report` 는 UTF-8, BOM 없음, LF, 마지막 개행 하나, `ensure_ascii=False`,
+`indent=2` 다. 같은 입력이면 바이트가 같다. 시험이 BOM/`\r\n` 부재를 고정한다.
+
+쓰기 실패는 예외로 도구를 죽이지 않고 `writeError` 에 남긴다. 종료 코드는
+이미 계산한 분류를 따른다. 디스크가 가득 찼다고 회귀를 안정으로 바꾸지 않는다.
+
+## 12. 오검출 관문 요약
+
+도구가 거짓말하지 않도록 지키는 문:
+
+1. **명령 표면 대조.** digest 가 같아야 관측 변화를 회귀로 부른다.
+2. **판정성 종료 코드 허용.** `expect_exits` 에 3 이 있으면 exit 3 은 실패가
+   아니라 값이다.
+3. **비결정 관측 배제.** 파일 존재/동일성은 raw 대조에서 뺀다.
+4. **표면을 모르면 분류하지 않는다.** `probe-failed` 는 삼원이 아니다.
+5. **오류도 관측이다.** 제출물 부재·CLI 실패를 예외로 올리지 않고 구/신이
+   같은 실패인지를 본다.
+6. **한 pack 의 파싱 실패는 전 저장소 비교를 죽이지 않는다.** 오류 목록에
+   남긴다.
+
+## 13. 시험이 고정하는 것
+
+`python -m unittest scripts.tests.test_gym_release_diff`
+
+바이너리 없이 돈다. `run_cli` · `subprocess.run` · `load_pack` 을 목으로
+갈아끼운다.
+
+고정하는 축:
+
+- 분류 행렬과 확장 진릿값 표.
+- `classify` 가 `probe-failed` 를 내지 않음.
+- digest 부재를 삼원으로 위장하지 않음.
+- 관측 동일성(숫자·bool·kind·NaN·중첩).
+- 예외 kind 카탈로그와 context 분기(resolve 의 FileNotFound 는 resolve-error).
+- 프로브 성공/실패 봉투.
+- `validate_report` 정직 계약.
+- `main` 의 exit 0/1/2/3.
+- 커밋된 자기-대조 리포트가 있으면 divergences=0.
+
+## 14. 이 도구가 하지 않는 것
+
+- pack JSON 을 고치지 않는다. 과제의 기대값을 바꾸지 않는다.
+- 한컴 문서가 맞는지 틀리는지 말하지 않는다.
+- 어느 바이너리가 "더 옳은지" 고르지 않는다.
+- 표면이 바뀐 릴리스를 자동으로 막지 않는다. 그건 사람 몫이다.
+- 파일 산출의 바이트 동일성을 릴리스 회귀로 부르지 않는다.
+- 치명 예외(키보드 중단 등)를 삼켜 성공인 척하지 않는다.
+
+## 15. 관련 기둥
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 종점 무결성 | `discriminate.py` | 일 안 한 제출이 만점을 받나? |
+| 경로 무결성 | `trajectory.py` | 마지막 스텝을 빼도 통과하나? |
+| 도구 강건성 | `robustness.py` | 손상 입력에 rhwp 가 패닉·행 하나? |
+| 릴리스 차등 | `release_diff.py` | 두 바이너리가 같은 관측을 내나? |
+| 릴리스 게이트 | `release_gate.py` | 차등 + 리더보드를 파이프라인 판정으로 묶나? |
+
+차등은 오라클이다. 게이트는 그 오라클을 읽는다. 오라클이 표면을 모르는데
+안정이라고 쓰면 게이트도 속는다. 그래서 `probe-failed` 를 삼원 밖에 둔다.
+
+## 16. 봉투 표본
+
+아래는 시험이 조립하는 최소 표본이다. 필드의 참/거짓이 분류와 어긋나면
+`validate_report` 가 거부한다.
+
+### 16.1 stable
+
+```json
+{
+  "kind": "gymReleaseDiff",
+  "schemaVersion": "1.0",
+  "old": {"bin": "rhwp", "capabilitiesSha256": "aaa"},
+  "new": {"bin": "rhwp", "capabilitiesSha256": "aaa"},
+  "surfaceChanged": false,
+  "tasksCompared": 10,
+  "observationsCompared": 20,
+  "observationsSkipped": 3,
+  "divergences": 0,
+  "classification": "stable",
+  "classificationReason": "명령 표면과 관측이 같다",
+  "exit": 0,
+  "ok": true,
+  "reviewRequired": false,
+  "diffs": []
+}
+```
+
+자기-대조(같은 바이너리를 `--old` 와 `--new` 에 넣음)는 이 모양이어야 한다.
+`divergences` 가 0 이 아니면 관측에 비결정 자리가 남아 있는 것이다.
+
+### 16.2 regression
+
+```json
+{
+  "classification": "regression",
+  "surfaceChanged": false,
+  "ok": false,
+  "reviewRequired": false,
+  "exit": 3,
+  "divergences": 1,
+  "diffs": [
+    {
+      "pack": "core-cli",
+      "task": "T01",
+      "check": "쪽수",
+      "op": "value_eq",
+      "path": "pageCount",
+      "old": {"kind": "value", "value": 6},
+      "new": {"kind": "value", "value": 7}
+    }
+  ]
+}
+```
+
+표면이 같은데 쪽수가 6→7 이면 순수 동작 변화다. 어느 쪽이 한컴과 맞는지는
+이 도구가 말하지 않는다.
+
+### 16.3 surface-changed
+
+```json
+{
+  "classification": "surface-changed",
+  "surfaceChanged": true,
+  "ok": false,
+  "reviewRequired": true,
+  "exit": 2,
+  "divergences": 0
+}
+```
+
+명령이 늘거나 빠진 릴리스다. 관측이 같아도 사람 판정이 필요하다. 관측이
+갈려도 분류는 그대로 `surface-changed` 다. 회귀로 접지 않는다.
+
+### 16.4 probe-failed
+
+```json
+{
+  "classification": "probe-failed",
+  "surfaceChanged": false,
+  "ok": false,
+  "reviewRequired": false,
+  "exit": 1,
+  "probeFailed": true,
+  "probeErrors": [
+    {
+      "role": "old",
+      "bin": "rhwp",
+      "kind": "missing-bin",
+      "error": "FileNotFoundError",
+      "head": "..."
+    }
+  ]
+}
+```
+
+구 바이너리가 없을 때 `stable` 이라고 쓰면 게이트가 pass 한다. `surface-changed`
+라고 쓰면 사람 리뷰를 요구한다. 둘 다 표면을 모르는 상태를 아는 척하는
+것이다. exit 1 은 그 거짓말을 막는다.
+
+## 17. 한 검사의 예외가 분류를 바꾸지 않는 예
+
+같은 제출물, 같은 표면 digest.
+
+| old 관측 | new 관측 | 분기? | 분류 |
+|---|---|---|---|
+| value 6 | value 6 | 아니오 | stable |
+| value 6 | value 7 | 예 | regression |
+| timeout | timeout (같은 페이로드) | 아니오 | stable |
+| timeout | value 6 | 예 | regression |
+| missing-bin | missing-bin | 아니오 | stable |
+| resolve-error | value "ok" | 예 | regression |
+| digfail KeyError | digfail KeyError | 아니오 | stable |
+| digfail KeyError | digfail IndexError | 예 | regression |
+
+표면 digest 가 다르면 위 표의 마지막 칸은 전부 `surface-changed` 다.
+오류 관측은 값을 대신할 뿐, 오검출 관문의 순서를 바꾸지 않는다.
+
+## 18. pack 오류와 분류
+
+`packErrors` 가 있어도 분류는 이미 비교한 과제만 본다.
+
+- pack A 를 읽지 못하고 pack B 의 관측이 같으면 → `stable` + packErrors.
+- pack A 를 읽지 못하고 pack B 의 관측이 갈리면 → `regression` + packErrors.
+- 모든 pack 을 읽지 못했고 digest 는 같다 → 과제 0 · 분기 0 → `stable`.
+  "비교할 것이 없었다" 이지 "도구가 실패했다" 가 아니다.
+- digest 자체를 못 얻으면 → 과제 수와 무관하게 `probe-failed`.
+
+마지막 두 줄을 섞지 말라. pack 부재와 바이너리 부재는 다른 거짓말이다.

--- a/gym/tools/release_diff.py
+++ b/gym/tools/release_diff.py
@@ -21,6 +21,9 @@
    흔들리는 자리는 대조에서 뺀다(파일 산출 과제의 file_exists 는 관측이 아니라
    존재 여부라 애초에 raw 비교 대상이 아니다).
 
+분류·관측 동일성·보고 조립은 순수 함수라
+`scripts/tests/test_gym_release_diff.py` 가 바이너리 없이 고정한다.
+
 ## 정직 조항
 
 이 도구는 "무엇이 바뀌었나" 를 가리키지 "어느 쪽이 옳은가" 를 판정하지 않는다
@@ -30,6 +33,8 @@
   python gym/tools/release_diff.py --old <구 바이너리> --new <신 바이너리>
                                    [--pack <id> ...] [-o 리포트.json]
 """
+
+from __future__ import annotations
 
 import argparse
 import hashlib
@@ -52,13 +57,118 @@ from gym.core import checks as check_registry  # noqa: E402
 
 ROOT = runner.ROOT
 
+REPORT_KIND = "gymReleaseDiff"
+SCHEMA_VERSION = "1.0"
+
 #: 봉투를 부르지 않는 파일 연산자 — 관측이 아니라 존재/동일성이라 raw 대조 제외.
 FILE_OPS = {"file_exists", "same_hash", "differs_from_input", "files_differ"}
+
+CLASSIFICATIONS = ("stable", "regression", "surface-changed")
+EXIT_BY_CLASS = {"stable": 0, "regression": 3, "surface-changed": 2}
+CLASSIFICATION_REASON = {
+    "stable": "명령 표면과 관측이 같다",
+    "regression": "명령 표면은 같고 관측이 갈렸다 — 순수 동작 변화",
+    "surface-changed": "명령 표면(capabilities digest)이 달라 사람 판정이 필요하다",
+}
 
 
 def capabilities_digest(bin_path):
     proc = subprocess.run([bin_path, "capabilities"], cwd=ROOT, capture_output=True)
     return hashlib.sha256(proc.stdout).hexdigest()
+
+
+def surface_changed(old_digest, new_digest):
+    """capabilities digest 가 다르면 표면이 바뀐 것이다. 순수."""
+    return old_digest != new_digest
+
+
+def classify(surface, divergences):
+    """오검출 관문. 표면 변경이 회귀보다 앞선다.
+
+    divergences 는 분기 목록·건수·bool 모두 받는다. 표면이 바뀌면 분기 유무와
+    무관하게 surface-changed — 의도된 명령 추가를 회귀로 오신고하지 않는다.
+    """
+    if surface:
+        return "surface-changed"
+    if divergences:
+        return "regression"
+    return "stable"
+
+
+def exit_for(classification):
+    """stable=0, surface-changed=2(사람 판정), regression=3(회귀)."""
+    return EXIT_BY_CLASS[classification]
+
+
+def expected_exits(check):
+    return check.get("expect_exits") or [check.get("expect_exit", 0)]
+
+
+def should_observe(check):
+    return check.get("op") not in FILE_OPS
+
+
+def _values_equal(left, right):
+    """숫자 6 과 6.0 은 같고, bool 은 int 로 접히지 않는다."""
+    if left is right:
+        return True
+    if isinstance(left, bool) or isinstance(right, bool):
+        return isinstance(left, bool) and isinstance(right, bool) and left is right
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return float(left) == float(right)
+    if isinstance(left, str) and isinstance(right, str):
+        return left == right
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _values_equal(a, b) for a, b in zip(left, right)
+        )
+    if isinstance(left, dict) and isinstance(right, dict):
+        if set(left) != set(right):
+            return False
+        return all(_values_equal(left[k], right[k]) for k in left)
+    return left == right
+
+
+def observations_equal(left, right):
+    """관측 동일성. 종류가 다르면 값이 같아도 같지 않다."""
+    return _values_equal(left, right)
+
+
+def observation_display(obs):
+    """사람이 읽는 한 칸. 값 관측은 raw, 그 외는 kind 또는 exitN."""
+    if isinstance(obs, dict):
+        kind = obs.get("kind")
+        if kind == "value":
+            return obs.get("value")
+        if kind == "exit":
+            return f"exit{obs.get('code')}"
+        if kind:
+            return kind
+    return obs
+
+
+def observation_from_result(code, env, head, check, dig_fn=None, find_cell_fn=None):
+    """CLI 결과에서 대조 가능한 관측을 뽑는다. 순수.
+
+    종료 코드·JSON 부재·경로 실패를 kind 로 가른다. 판정이 아니라 값이다.
+    """
+    if code not in expected_exits(check):
+        return {"kind": "exit", "code": code, "head": (head or "")[:80]}
+    if env is None:
+        return {"kind": "nojson", "head": (head or "")[:80]}
+    dig_fn = check_registry.dig if dig_fn is None else dig_fn
+    try:
+        val = dig_fn(env, check.get("path", ""))
+    except (KeyError, IndexError, TypeError) as e:
+        return {"kind": "digfail", "error": type(e).__name__}
+    if check.get("op") == "cell_text_eq":
+        find_cell_fn = check_registry.find_cell if find_cell_fn is None else find_cell_fn
+        try:
+            cell = find_cell_fn(val, check["table"], check["row"], check["col"])
+        except (KeyError, IndexError, TypeError) as e:
+            return {"kind": "digfail", "error": type(e).__name__}
+        val = None if cell is None else cell.get("text")
+    return {"kind": "value", "value": val}
 
 
 def observe(bin_path, check, task, sub_dir):
@@ -73,20 +183,18 @@ def observe(bin_path, check, task, sub_dir):
         # 예외를 내면 legacy baseline이 비어 있는 한 차등 도구 전체가 멈춘다.
         return {"kind": "resolve-error", "error": type(e).__name__}
     code, env, head = runner.run_cli(bin_path, args)
-    expect = check.get("expect_exits") or [check.get("expect_exit", 0)]
-    if code not in expect:
-        return {"kind": "exit", "code": code, "head": head[:80]}
-    if env is None:
-        return {"kind": "nojson", "head": head[:80]}
-    try:
-        val = check_registry.dig(env, check.get("path", ""))
-    except (KeyError, IndexError, TypeError) as e:
-        return {"kind": "digfail", "error": f"{type(e).__name__}"}
-    # 표·목록은 통째 대조하면 잡음이 크다 — 지목 연산자는 그 좌표만 관측한다.
-    if check["op"] == "cell_text_eq":
-        cell = check_registry.find_cell(val, check["table"], check["row"], check["col"])
-        val = None if cell is None else cell.get("text")
-    return {"kind": "value", "value": val}
+    return observation_from_result(code, env, head, check)
+
+
+def make_diff_row(task_id, check, old_obs, new_obs):
+    return {
+        "task": task_id,
+        "check": check.get("name", check["op"]),
+        "op": check["op"],
+        "path": check.get("path", ""),
+        "old": old_obs,
+        "new": new_obs,
+    }
 
 
 def diff_task(old_bin, new_bin, task, sub_root, pack_id):
@@ -95,15 +203,64 @@ def diff_task(old_bin, new_bin, task, sub_root, pack_id):
         sub_dir = os.path.join(sub_root, task["id"])  # 평면 제출 호환
     rows = []
     for check in task.get("checks", []):
-        if check["op"] in FILE_OPS:
+        if not should_observe(check):
             continue
         o = observe(old_bin, check, task, sub_dir)
         n = observe(new_bin, check, task, sub_dir)
-        if o != n:
-            rows.append({"task": task["id"], "check": check.get("name", check["op"]),
-                         "op": check["op"], "path": check.get("path", ""),
-                         "old": o, "new": n})
+        if not observations_equal(o, n):
+            rows.append(make_diff_row(task["id"], check, o, n))
     return rows
+
+
+def build_report(old_bin, old_digest, new_bin, new_digest,
+                 tasks_compared, observations_compared, diffs,
+                 observations_skipped=0):
+    """릴리스 차등 JSON 봉투. 순수 — 바이너리를 부르지 않는다."""
+    surface = surface_changed(old_digest, new_digest)
+    classification = classify(surface, diffs)
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "old": {"bin": os.path.basename(old_bin), "capabilitiesSha256": old_digest},
+        "new": {"bin": os.path.basename(new_bin), "capabilitiesSha256": new_digest},
+        "surfaceChanged": surface,
+        "tasksCompared": tasks_compared,
+        "observationsCompared": observations_compared,
+        "observationsSkipped": observations_skipped,
+        "divergences": len(diffs),
+        "classification": classification,
+        "classificationReason": CLASSIFICATION_REASON[classification],
+        "exit": exit_for(classification),
+        "ok": classification == "stable",
+        "reviewRequired": classification == "surface-changed",
+        "diffs": list(diffs),
+    }
+
+
+def write_report(report, path):
+    """UTF-8 · BOM 없음 · LF. 같은 입력이면 바이트가 같다."""
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(json.dumps(report, ensure_ascii=False, indent=2))
+        fh.write("\n")
+
+
+def render_summary(report, out_path):
+    surface = report["surfaceChanged"]
+    classification = report["classification"]
+    lines = [
+        f"과제 {report['tasksCompared']} · 관측 대조 {report['observationsCompared']}건",
+        f"명령 표면(capabilities): {'다름 → surface-changed' if surface else '같음'}",
+        f"관측 분기: {report['divergences']}건 → 분류 [{classification}]",
+        f"이유: {report['classificationReason']}",
+    ]
+    for row in report.get("diffs", [])[:30]:
+        ov = observation_display(row["old"])
+        nv = observation_display(row["new"])
+        pack = row.get("pack", "")
+        loc = f"{pack}/{row['task']}" if pack else row["task"]
+        lines.append(f"  {loc} · {row['check']}: {ov!r} → {nv!r}")
+    lines.append(f"→ {out_path}")
+    return lines
 
 
 def main():
@@ -119,45 +276,33 @@ def main():
     new_bin = runner.find_bin(a.new)
     old_dig = capabilities_digest(old_bin)
     new_dig = capabilities_digest(new_bin)
-    surface_changed = old_dig != new_dig
 
     sub_root = os.path.join(runner.GYM, "submissions", a.agent)
     pack_ids = a.pack or runner.discover_packs()
-    diffs, tasks_seen, checks_seen = [], 0, 0
+    diffs, tasks_seen, checks_seen, skipped = [], 0, 0, 0
     for pack_id in pack_ids:
         _manifest, tasks = runner.load_pack(pack_id)
         for task in tasks:
             tasks_seen += 1
-            checks_seen += sum(1 for c in task.get("checks", []) if c["op"] not in FILE_OPS)
+            for check in task.get("checks", []):
+                if should_observe(check):
+                    checks_seen += 1
+                else:
+                    skipped += 1
             for row in diff_task(old_bin, new_bin, task, sub_root, pack_id):
                 row["pack"] = pack_id
                 diffs.append(row)
 
-    classification = ("surface-changed" if surface_changed
-                      else ("regression" if diffs else "stable"))
-    report = {
-        "kind": "gymReleaseDiff", "schemaVersion": "1.0",
-        "old": {"bin": os.path.basename(old_bin), "capabilitiesSha256": old_dig},
-        "new": {"bin": os.path.basename(new_bin), "capabilitiesSha256": new_dig},
-        "surfaceChanged": surface_changed,
-        "tasksCompared": tasks_seen, "observationsCompared": checks_seen,
-        "divergences": len(diffs), "classification": classification,
-        "diffs": diffs,
-    }
+    report = build_report(
+        old_bin, old_dig, new_bin, new_dig,
+        tasks_seen, checks_seen, diffs, observations_skipped=skipped,
+    )
     out = a.out or os.path.join(runner.GYM, "release-diff.json")
-    with io.open(out, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write(json.dumps(report, ensure_ascii=False, indent=2))
+    write_report(report, out)
 
-    print(f"과제 {tasks_seen} · 관측 대조 {checks_seen}건")
-    print(f"명령 표면(capabilities): {'다름 → surface-changed' if surface_changed else '같음'}")
-    print(f"관측 분기: {len(diffs)}건 → 분류 [{classification}]")
-    for row in diffs[:30]:
-        ov = row["old"].get("value", row["old"])
-        nv = row["new"].get("value", row["new"])
-        print(f"  {row['pack']}/{row['task']} · {row['check']}: {ov!r} → {nv!r}")
-    print(f"→ {out}")
-    # stable=0, regression=3(회귀), surface-changed=2(사람 판정 필요)
-    return {"stable": 0, "regression": 3, "surface-changed": 2}[classification]
+    for line in render_summary(report, out):
+        print(line)
+    return report["exit"]
 
 
 if __name__ == "__main__":

--- a/gym/tools/release_diff.py
+++ b/gym/tools/release_diff.py
@@ -29,6 +29,10 @@
 이 도구는 "무엇이 바뀌었나" 를 가리키지 "어느 쪽이 옳은가" 를 판정하지 않는다
 (한컴 정답지 없음 — #4658 과 같은 결). 판정은 사람이 한다.
 
+분류 함수 `classify` 는 오직 stable / regression / surface-changed 만 낸다.
+바이너리를 부르지 못해 표면을 재지 못하면 그 세 값 중 아무것으로도 위장하지
+않는다 — `probe-failed` 는 분류가 아니라 **도구 실패 상태**다.
+
 사용:
   python gym/tools/release_diff.py --old <구 바이너리> --new <신 바이너리>
                                    [--pack <id> ...] [-o 리포트.json]
@@ -63,6 +67,7 @@ SCHEMA_VERSION = "1.0"
 #: 봉투를 부르지 않는 파일 연산자 — 관측이 아니라 존재/동일성이라 raw 대조 제외.
 FILE_OPS = {"file_exists", "same_hash", "differs_from_input", "files_differ"}
 
+#: 분류 삼원. 이 튜플에 probe-failed 를 넣지 않는다 — 그건 분류가 아니다.
 CLASSIFICATIONS = ("stable", "regression", "surface-changed")
 EXIT_BY_CLASS = {"stable": 0, "regression": 3, "surface-changed": 2}
 CLASSIFICATION_REASON = {
@@ -71,15 +76,337 @@ CLASSIFICATION_REASON = {
     "surface-changed": "명령 표면(capabilities digest)이 달라 사람 판정이 필요하다",
 }
 
+#: 표면을 재지 못했을 때의 도구 상태. classify() 가 이 값을 내는 일은 없다.
+STATUS_PROBE_FAILED = "probe-failed"
+EXIT_PROBE_FAILED = 1
+PROBE_FAILED_REASON = (
+    "capabilities digest 를 구하지 못해 분류하지 않는다 "
+    "— stable/regression/surface-changed 로 위장하지 않는다"
+)
 
-def capabilities_digest(bin_path):
-    proc = subprocess.run([bin_path, "capabilities"], cwd=ROOT, capture_output=True)
-    return hashlib.sha256(proc.stdout).hexdigest()
+#: capabilities 프로브 기본 초. 0 이하는 시간제한 없음(호출 측에서 거른다).
+DIGEST_TIMEOUT = 30
+
+#: 관측 head / 오류 메시지 머리 길이.
+HEAD_LIMIT = 80
+ERROR_HEAD_LIMIT = 160
+
+#: 관측 kind 카탈로그. 시험과 문서가 같은 표를 본다.
+OBSERVATION_KINDS = (
+    "value",
+    "exit",
+    "nojson",
+    "digfail",
+    "no-cmd",
+    "resolve-error",
+    "cli-error",
+    "timeout",
+    "missing-bin",
+    "permission",
+    "os-error",
+    "type-error",
+    "value-error",
+    "decode-error",
+    "unexpected",
+)
+
+#: JSON 보고 고정 키. 분류가 성공한 봉투의 최소 집합.
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "old",
+    "new",
+    "surfaceChanged",
+    "tasksCompared",
+    "observationsCompared",
+    "observationsSkipped",
+    "divergences",
+    "classification",
+    "classificationReason",
+    "exit",
+    "ok",
+    "reviewRequired",
+    "diffs",
+)
+
+#: 프로브 실패 봉투에 추가로 붙는 키.
+PROBE_REPORT_KEYS = (
+    "probeFailed",
+    "probeErrors",
+)
+
+#: 분류가 성공한 뒤에도 남을 수 있는 부가 키(팩 읽기 실패 등).
+OPTIONAL_REPORT_KEYS = (
+    "packErrors",
+    "taskErrors",
+    "writeError",
+)
+
+#: 예외 → 관측/프로브 kind. context 가 digest 이면 FileNotFound 는 missing-bin.
+EXCEPTION_KIND_BY_TYPE = {
+    FileNotFoundError: "missing-bin",
+    PermissionError: "permission",
+    TimeoutError: "timeout",
+    subprocess.TimeoutExpired: "timeout",
+    UnicodeError: "decode-error",
+    UnicodeDecodeError: "decode-error",
+    UnicodeEncodeError: "decode-error",
+    ValueError: "value-error",
+    TypeError: "type-error",
+    KeyError: "digfail",
+    IndexError: "digfail",
+    AttributeError: "digfail",
+    OSError: "os-error",
+}
+
+#: 삼키면 안 되는 예외 — 도구를 죽이는 것이 정직하다.
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+#: 관측/프로브에서 잡는 예외. BaseException 전부가 아니다.
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    TimeoutError,
+    subprocess.TimeoutExpired,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    json.JSONDecodeError,
+    RuntimeError,
+)
+
+
+def is_fatal_exception(exc):
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def exception_kind(exc, context="observe"):
+    """예외를 관측/프로브 kind 로 접는다. 순수.
+
+    context:
+      - digest: 바이너리 capabilities 프로브. FileNotFound → missing-bin.
+      - resolve: 제출물 경로 해석. FileNotFound → resolve-error (기존 계약).
+      - cli: run_cli 실패. FileNotFound → missing-bin.
+      - observe / dig: 경로 평가. KeyError/IndexError → digfail.
+    """
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, subprocess.TimeoutExpired) or isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, FileNotFoundError):
+        if context == "resolve":
+            return "resolve-error"
+        return "missing-bin"
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, json.JSONDecodeError):
+        return "value-error"
+    if isinstance(exc, (KeyError, IndexError, AttributeError)):
+        return "digfail"
+    if isinstance(exc, TypeError):
+        return "type-error"
+    if isinstance(exc, ValueError):
+        return "value-error"
+    if isinstance(exc, OSError):
+        return "os-error"
+    if isinstance(exc, RuntimeError):
+        return "cli-error"
+    return "unexpected"
+
+
+def exception_observation(exc, context="observe", head=""):
+    """예외를 관측 봉투로 접는다. 여기서 예외를 다시 올리지 않는다."""
+    kind = exception_kind(exc, context=context)
+    return {
+        "kind": kind,
+        "error": type(exc).__name__ if exc is not None else "NoneType",
+        "head": truncate_head(head or (str(exc) if exc is not None else ""), ERROR_HEAD_LIMIT),
+    }
+
+
+def exception_probe(exc, bin_path, role):
+    """capabilities 프로브 실패 한 줄. 분류에 쓰지 않는다."""
+    return {
+        "role": role,
+        "bin": os.path.basename(bin_path) if bin_path else "",
+        "kind": exception_kind(exc, context="digest"),
+        "error": type(exc).__name__ if exc is not None else "NoneType",
+        "head": truncate_head(str(exc) if exc is not None else "", ERROR_HEAD_LIMIT),
+    }
+
+
+def truncate_head(text, limit=HEAD_LIMIT):
+    """출력 머리. None/비문자는 빈 문자열. 한도는 0 이하면 빈 값."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return ""
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        n = HEAD_LIMIT
+    if n <= 0:
+        return ""
+    return text[:n]
+
+
+def normalize_timeout(timeout):
+    """프로브 초. 변환 불능·비양수는 0 — 호출 측에서 시간제한을 끈다."""
+    try:
+        n = int(timeout)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def sha256_bytes(payload):
+    """바이트열 SHA-256 16진. 비-바이트는 빈 바이트로 접지 않는다 — TypeError."""
+    if isinstance(payload, memoryview):
+        payload = payload.tobytes()
+    if isinstance(payload, bytearray):
+        payload = bytes(payload)
+    if not isinstance(payload, bytes):
+        raise TypeError(f"sha256_bytes 는 bytes-like 만 받습니다 (got {type(payload).__name__})")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def is_sha256_hex(value):
+    """64자 소문자/숫자 hex 인가. 순수. None/짧은 값은 거짓."""
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return value == value.lower()
+
+
+def normalize_digest(value):
+    """digest 후보를 소문자 hex 로. 형식이 아니면 None — 빈 문자열로 위장하지 않는다."""
+    if not isinstance(value, str):
+        return None
+    folded = value.strip().lower()
+    return folded if is_sha256_hex(folded) else None
+
+
+def observation_kind_of(obs):
+    """관측 봉투의 kind. 형식이 아니면 None."""
+    if isinstance(obs, dict):
+        kind = obs.get("kind")
+        if isinstance(kind, str) and kind:
+            return kind
+    return None
+
+
+def is_known_observation_kind(kind):
+    return kind in OBSERVATION_KINDS
+
+
+def is_error_observation(obs):
+    """값 관측이 아닌 실패/부재 관측인가. 분류를 바꾸지 않는다 — 대조 대상일 뿐이다."""
+    kind = observation_kind_of(obs)
+    if kind is None:
+        return False
+    return kind != "value"
+
+
+def capabilities_digest(bin_path, timeout=None):
+    """capabilities stdout 의 SHA-256. 성공 경로의 기존 계약.
+
+    timeout 이 양수면 subprocess 에 넘긴다. 예외는 여기서 삼키지 않는다 —
+    호출자가 probe_capabilities 로 접는다. stdout 이 비어 있어도 해시한다
+    (기존 동작: 빈 출력의 digest 는 고정값이지 오류가 아니다).
+    """
+    kwargs = {"cwd": ROOT, "capture_output": True}
+    limit = normalize_timeout(timeout) if timeout is not None else 0
+    if limit:
+        kwargs["timeout"] = limit
+    proc = subprocess.run([bin_path, "capabilities"], **kwargs)
+    payload = proc.stdout
+    if isinstance(payload, str):
+        payload = payload.encode("utf-8", errors="replace")
+    if not isinstance(payload, (bytes, bytearray, memoryview)):
+        payload = b""
+    return sha256_bytes(bytes(payload) if not isinstance(payload, bytes) else payload)
+
+
+def probe_capabilities(bin_path, timeout=DIGEST_TIMEOUT):
+    """capabilities digest 를 예외 없이 접는다.
+
+    성공: {ok: True, digest, kind: "digest", exit}.
+    실패: {ok: False, digest: None, kind, error, head}.
+    digest 가 None 이면 classify/surface_changed 에 넣지 않는다.
+    """
+    try:
+        if not bin_path:
+            raise FileNotFoundError("바이너리 경로가 비어 있다")
+        kwargs = {"cwd": ROOT, "capture_output": True}
+        limit = normalize_timeout(timeout)
+        if limit:
+            kwargs["timeout"] = limit
+        proc = subprocess.run([bin_path, "capabilities"], **kwargs)
+        payload = proc.stdout
+        if isinstance(payload, str):
+            payload = payload.encode("utf-8", errors="replace")
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            payload = b""
+        digest = sha256_bytes(bytes(payload) if not isinstance(payload, bytes) else payload)
+        return {
+            "ok": True,
+            "kind": "digest",
+            "digest": digest,
+            "exit": proc.returncode,
+            "error": None,
+            "head": "",
+        }
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return {
+            "ok": False,
+            "kind": exception_kind(exc, context="digest"),
+            "digest": None,
+            "exit": None,
+            "error": type(exc).__name__,
+            "head": truncate_head(str(exc), ERROR_HEAD_LIMIT),
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "kind": "unexpected",
+            "digest": None,
+            "exit": None,
+            "error": type(exc).__name__,
+            "head": truncate_head(str(exc), ERROR_HEAD_LIMIT),
+        }
 
 
 def surface_changed(old_digest, new_digest):
-    """capabilities digest 가 다르면 표면이 바뀐 것이다. 순수."""
+    """capabilities digest 가 다르면 표면이 바뀐 것이다. 순수.
+
+    None 과 문자열을 비교하면 True 가 된다. 프로브 실패의 None 을 여기에
+    넣지 말라 — can_classify_surface 가 막는다. classify 는 이 함수의
+    결과만 보고 삼원을 고른다.
+    """
     return old_digest != new_digest
+
+
+def can_classify_surface(old_digest, new_digest):
+    """두 digest 가 모두 재졌을 때만 분류할 수 있다. 순수.
+
+    한쪽이라도 None/비문자면 표면을 모르는 것이지 표면이 바뀐 것이 아니다.
+    """
+    return isinstance(old_digest, str) and isinstance(new_digest, str)
 
 
 def classify(surface, divergences):
@@ -87,6 +414,8 @@ def classify(surface, divergences):
 
     divergences 는 분기 목록·건수·bool 모두 받는다. 표면이 바뀌면 분기 유무와
     무관하게 surface-changed — 의도된 명령 추가를 회귀로 오신고하지 않는다.
+
+    이 함수는 probe-failed 를 내지 않는다. 표면을 모를 때는 호출하지 말라.
     """
     if surface:
         return "surface-changed"
@@ -95,9 +424,32 @@ def classify(surface, divergences):
     return "stable"
 
 
+def classify_or_probe_failed(old_digest, new_digest, divergences):
+    """분류 가능하면 classify, 아니면 probe-failed. classify 자체는 건드리지 않는다."""
+    if not can_classify_surface(old_digest, new_digest):
+        return STATUS_PROBE_FAILED
+    return classify(surface_changed(old_digest, new_digest), divergences)
+
+
 def exit_for(classification):
-    """stable=0, surface-changed=2(사람 판정), regression=3(회귀)."""
+    """stable=0, surface-changed=2(사람 판정), regression=3(회귀).
+
+    probe-failed 는 이 표에 없다. status_exit 를 쓴다.
+    """
     return EXIT_BY_CLASS[classification]
+
+
+def status_exit(status):
+    """보고 상태의 종료 코드. 분류 삼원은 EXIT_BY_CLASS, 도구 실패는 1."""
+    if status == STATUS_PROBE_FAILED:
+        return EXIT_PROBE_FAILED
+    return exit_for(status)
+
+
+def reason_for(status):
+    if status == STATUS_PROBE_FAILED:
+        return PROBE_FAILED_REASON
+    return CLASSIFICATION_REASON[status]
 
 
 def expected_exits(check):
@@ -105,6 +457,8 @@ def expected_exits(check):
 
 
 def should_observe(check):
+    if not isinstance(check, dict):
+        return False
     return check.get("op") not in FILE_OPS
 
 
@@ -115,10 +469,18 @@ def _values_equal(left, right):
     if isinstance(left, bool) or isinstance(right, bool):
         return isinstance(left, bool) and isinstance(right, bool) and left is right
     if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        # NaN 은 자기 자신과도 같지 않다. 회귀로 오신고하지 않도록 둘 다 NaN 이면 같다.
+        if isinstance(left, float) and isinstance(right, float):
+            if left != left and right != right:
+                return True
         return float(left) == float(right)
     if isinstance(left, str) and isinstance(right, str):
         return left == right
     if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _values_equal(a, b) for a, b in zip(left, right)
+        )
+    if isinstance(left, tuple) and isinstance(right, tuple):
         return len(left) == len(right) and all(
             _values_equal(a, b) for a, b in zip(left, right)
         )
@@ -151,71 +513,199 @@ def observation_from_result(code, env, head, check, dig_fn=None, find_cell_fn=No
     """CLI 결과에서 대조 가능한 관측을 뽑는다. 순수.
 
     종료 코드·JSON 부재·경로 실패를 kind 로 가른다. 판정이 아니라 값이다.
+    dig 경로의 ValueError(비정수 인덱스)도 도구를 죽이지 않고 digfail 로 접는다.
     """
     if code not in expected_exits(check):
-        return {"kind": "exit", "code": code, "head": (head or "")[:80]}
+        return {"kind": "exit", "code": code, "head": truncate_head(head or "", HEAD_LIMIT)}
     if env is None:
-        return {"kind": "nojson", "head": (head or "")[:80]}
+        return {"kind": "nojson", "head": truncate_head(head or "", HEAD_LIMIT)}
     dig_fn = check_registry.dig if dig_fn is None else dig_fn
     try:
         val = dig_fn(env, check.get("path", ""))
-    except (KeyError, IndexError, TypeError) as e:
+    except CATCHABLE_EXCEPTIONS as e:
+        return {"kind": "digfail", "error": type(e).__name__}
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception as e:
         return {"kind": "digfail", "error": type(e).__name__}
     if check.get("op") == "cell_text_eq":
         find_cell_fn = check_registry.find_cell if find_cell_fn is None else find_cell_fn
         try:
             cell = find_cell_fn(val, check["table"], check["row"], check["col"])
-        except (KeyError, IndexError, TypeError) as e:
+        except CATCHABLE_EXCEPTIONS as e:
+            return {"kind": "digfail", "error": type(e).__name__}
+        except FATAL_EXCEPTIONS:
+            raise
+        except Exception as e:
             return {"kind": "digfail", "error": type(e).__name__}
         val = None if cell is None else cell.get("text")
     return {"kind": "value", "value": val}
 
 
 def observe(bin_path, check, task, sub_dir):
-    """한 검사의 관측값을 뽑는다 — 봉투의 지목된 자리(raw). 판정이 아니라 값."""
+    """한 검사의 관측값을 뽑는다 — 봉투의 지목된 자리(raw). 판정이 아니라 값.
+
+    resolve_args / run_cli / 경로 평가 예외는 관측 상태로 접는다. 한 검사가
+    실패해도 차등 도구 전체가 멈추지 않는다. KeyboardInterrupt 는 삼키지 않는다.
+    """
+    if not isinstance(check, dict):
+        return {"kind": "type-error", "error": "TypeError", "head": "check 가 dict 가 아니다"}
     cmd = check.get("cmd")
     if not cmd:
         return {"kind": "no-cmd"}
     try:
         args = runner.resolve_args(cmd, task, sub_dir)
-    except (FileNotFoundError, OSError, KeyError, IndexError, TypeError) as e:
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as e:
         # 제출물 부재도 구/신 양쪽에서 비교할 수 있는 관측 상태다. 여기서
         # 예외를 내면 legacy baseline이 비어 있는 한 차등 도구 전체가 멈춘다.
-        return {"kind": "resolve-error", "error": type(e).__name__}
-    code, env, head = runner.run_cli(bin_path, args)
-    return observation_from_result(code, env, head, check)
+        return exception_observation(e, context="resolve")
+    except Exception as e:
+        return exception_observation(e, context="resolve")
+    try:
+        code, env, head = runner.run_cli(bin_path, args)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as e:
+        return exception_observation(e, context="cli")
+    except Exception as e:
+        return exception_observation(e, context="cli")
+    try:
+        return observation_from_result(code, env, head, check)
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception as e:
+        return exception_observation(e, context="observe")
 
 
 def make_diff_row(task_id, check, old_obs, new_obs):
+    op = ""
+    name = ""
+    path = ""
+    if isinstance(check, dict):
+        op = check.get("op", "")
+        name = check.get("name", op)
+        path = check.get("path", "")
     return {
         "task": task_id,
-        "check": check.get("name", check["op"]),
-        "op": check["op"],
-        "path": check.get("path", ""),
+        "check": name,
+        "op": op,
+        "path": path,
         "old": old_obs,
         "new": new_obs,
     }
 
 
+def resolve_submission_dir(sub_root, pack_id, task_id):
+    """pack/과제 제출 폴더. 평면 제출 호환. 예외를 올리지 않는다."""
+    if not sub_root or not task_id:
+        return ""
+    packed = os.path.join(sub_root, pack_id, task_id) if pack_id else ""
+    try:
+        if packed and os.path.isdir(packed):
+            return packed
+    except OSError:
+        packed = ""
+    flat = os.path.join(sub_root, task_id)
+    try:
+        if os.path.isdir(flat):
+            return flat
+    except OSError:
+        return packed or flat
+    return packed or flat
+
+
 def diff_task(old_bin, new_bin, task, sub_root, pack_id):
-    sub_dir = os.path.join(sub_root, pack_id, task["id"])
-    if not os.path.isdir(sub_dir):
-        sub_dir = os.path.join(sub_root, task["id"])  # 평면 제출 호환
+    if not isinstance(task, dict):
+        return []
+    task_id = task.get("id", "")
+    sub_dir = resolve_submission_dir(sub_root, pack_id, task_id)
     rows = []
-    for check in task.get("checks", []):
-        if not should_observe(check):
+    checks = task.get("checks", [])
+    if not isinstance(checks, list):
+        return []
+    for check in checks:
+        try:
+            if not should_observe(check):
+                continue
+            o = observe(old_bin, check, task, sub_dir)
+            n = observe(new_bin, check, task, sub_dir)
+            if not observations_equal(o, n):
+                rows.append(make_diff_row(task_id, check, o, n))
+        except FATAL_EXCEPTIONS:
+            raise
+        except Exception:
+            # 한 검사의 예외는 행을 건너뛴다. 도구를 죽이지 않되 거짓 분기도 만들지 않는다.
             continue
-        o = observe(old_bin, check, task, sub_dir)
-        n = observe(new_bin, check, task, sub_dir)
-        if not observations_equal(o, n):
-            rows.append(make_diff_row(task["id"], check, o, n))
     return rows
+
+
+def count_observable_checks(task):
+    """관측 대상 검사 수와 건너뛴(파일 연산) 수. 순수."""
+    if not isinstance(task, dict):
+        return 0, 0
+    checks = task.get("checks", [])
+    if not isinstance(checks, list):
+        return 0, 0
+    seen = 0
+    skipped = 0
+    for check in checks:
+        if should_observe(check):
+            seen += 1
+        else:
+            skipped += 1
+    return seen, skipped
+
+
+def load_pack_safe(pack_id):
+    """pack 하나를 읽는다. 실패하면 (None, [], error) — 전체를 멈추지 않는다."""
+    try:
+        manifest, tasks = runner.load_pack(pack_id)
+        if not isinstance(tasks, list):
+            return manifest, [], f"pack {pack_id}: tasks 가 list 가 아니다"
+        return manifest, tasks, None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, [], f"pack {pack_id}: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+    except Exception as exc:
+        return None, [], f"pack {pack_id}: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+
+
+def discover_packs_safe(explicit):
+    """--pack 목록 또는 탐색. 탐색 예외는 빈 목록 + 오류 문자열."""
+    if explicit:
+        return list(explicit), None
+    try:
+        return list(runner.discover_packs()), None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return [], f"discover_packs: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+    except Exception as exc:
+        return [], f"discover_packs: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
 
 
 def build_report(old_bin, old_digest, new_bin, new_digest,
                  tasks_compared, observations_compared, diffs,
                  observations_skipped=0):
-    """릴리스 차등 JSON 봉투. 순수 — 바이너리를 부르지 않는다."""
+    """릴리스 차등 JSON 봉투. 순수 — 바이너리를 부르지 않는다.
+
+    digest 가 둘 다 문자열일 때만 classify 한다. 한쪽이라도 없으면
+    probe-failed 로 두고 삼원 분류를 위장하지 않는다.
+    """
+    if not can_classify_surface(old_digest, new_digest):
+        return build_probe_failed_report(
+            old_bin, {"digest": old_digest, "ok": False, "kind": "missing-digest",
+                      "error": "digest-missing", "head": ""},
+            new_bin, {"digest": new_digest, "ok": False, "kind": "missing-digest",
+                      "error": "digest-missing", "head": ""},
+            tasks_compared=tasks_compared,
+            observations_compared=observations_compared,
+            observations_skipped=observations_skipped,
+            diffs=diffs,
+        )
     surface = surface_changed(old_digest, new_digest)
     classification = classify(surface, diffs)
     return {
@@ -227,7 +717,7 @@ def build_report(old_bin, old_digest, new_bin, new_digest,
         "tasksCompared": tasks_compared,
         "observationsCompared": observations_compared,
         "observationsSkipped": observations_skipped,
-        "divergences": len(diffs),
+        "divergences": len(diffs) if hasattr(diffs, "__len__") else int(bool(diffs)),
         "classification": classification,
         "classificationReason": CLASSIFICATION_REASON[classification],
         "exit": exit_for(classification),
@@ -237,6 +727,131 @@ def build_report(old_bin, old_digest, new_bin, new_digest,
     }
 
 
+def build_probe_failed_report(old_bin, old_probe, new_bin, new_probe,
+                              tasks_compared=0, observations_compared=0,
+                              observations_skipped=0, diffs=None):
+    """표면을 재지 못했을 때의 봉투. classification 은 probe-failed.
+
+    ok/reviewRequired/surfaceChanged 는 모두 거짓이다. 모르는 것을 안정·회귀·
+    표면변경으로 부르지 않는다.
+    """
+    diffs = list(diffs or [])
+    old_probe = old_probe or {}
+    new_probe = new_probe or {}
+    errors = []
+    if not old_probe.get("ok"):
+        errors.append({
+            "role": "old",
+            "bin": os.path.basename(old_bin) if old_bin else "",
+            "kind": old_probe.get("kind") or "unexpected",
+            "error": old_probe.get("error") or "digest-missing",
+            "head": old_probe.get("head") or "",
+        })
+    if not new_probe.get("ok"):
+        errors.append({
+            "role": "new",
+            "bin": os.path.basename(new_bin) if new_bin else "",
+            "kind": new_probe.get("kind") or "unexpected",
+            "error": new_probe.get("error") or "digest-missing",
+            "head": new_probe.get("head") or "",
+        })
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "old": {
+            "bin": os.path.basename(old_bin) if old_bin else "",
+            "capabilitiesSha256": old_probe.get("digest"),
+        },
+        "new": {
+            "bin": os.path.basename(new_bin) if new_bin else "",
+            "capabilitiesSha256": new_probe.get("digest"),
+        },
+        "surfaceChanged": False,
+        "tasksCompared": tasks_compared,
+        "observationsCompared": observations_compared,
+        "observationsSkipped": observations_skipped,
+        "divergences": len(diffs),
+        "classification": STATUS_PROBE_FAILED,
+        "classificationReason": PROBE_FAILED_REASON,
+        "exit": EXIT_PROBE_FAILED,
+        "ok": False,
+        "reviewRequired": False,
+        "diffs": diffs,
+        "probeFailed": True,
+        "probeErrors": errors,
+    }
+
+
+def empty_report(old_bin="", new_bin=""):
+    """대조 전 빈 봉투. digest 가 없어 probe-failed 가 정직하다."""
+    return build_probe_failed_report(
+        old_bin, {"ok": False, "kind": "missing-digest", "error": "empty", "head": ""},
+        new_bin, {"ok": False, "kind": "missing-digest", "error": "empty", "head": ""},
+    )
+
+
+def validate_report(report):
+    """보고 봉투의 정직 계약. 문제 문자열 목록(비면 통과).
+
+    classify 삼원일 때:
+      - exit 는 EXIT_BY_CLASS 와 같다.
+      - ok 는 stable 과만 같다.
+      - reviewRequired 는 surface-changed 와만 같다.
+      - surfaceChanged 는 분류가 surface-changed 일 때 참, 그 외 거짓.
+      - probeFailed 가 참이면 안 된다.
+    probe-failed 일 때:
+      - exit 는 1.
+      - ok / reviewRequired / surfaceChanged 는 거짓.
+      - 분류는 CLASSIFICATIONS 에 없다.
+    """
+    issues = []
+    if not isinstance(report, dict):
+        return ["report 가 dict 가 아니다"]
+    for key in REPORT_KEYS:
+        if key not in report:
+            issues.append(f"키 없음: {key}")
+    if report.get("kind") != REPORT_KIND:
+        issues.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append(f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
+    classification = report.get("classification")
+    diffs = report.get("diffs")
+    if isinstance(diffs, list):
+        if report.get("divergences") != len(diffs):
+            issues.append("divergences 가 diffs 길이와 다르다")
+    else:
+        issues.append("diffs 가 list 가 아니다")
+    if classification in CLASSIFICATIONS:
+        if report.get("exit") != EXIT_BY_CLASS[classification]:
+            issues.append(f"exit 가 {classification} 계약과 다르다")
+        if report.get("ok") != (classification == "stable"):
+            issues.append("ok 는 stable 과만 같아야 한다")
+        if report.get("reviewRequired") != (classification == "surface-changed"):
+            issues.append("reviewRequired 는 surface-changed 와만 같아야 한다")
+        if report.get("surfaceChanged") != (classification == "surface-changed"):
+            issues.append("surfaceChanged 는 분류와 어긋난다")
+        if report.get("probeFailed"):
+            issues.append("삼원 분류에 probeFailed 가 붙으면 안 된다")
+        if classification == "regression" and not report.get("divergences"):
+            issues.append("regression 인데 divergences 가 0 이다")
+        if classification == "stable" and report.get("divergences"):
+            issues.append("stable 인데 divergences 가 있다")
+    elif classification == STATUS_PROBE_FAILED:
+        if report.get("exit") != EXIT_PROBE_FAILED:
+            issues.append("probe-failed 의 exit 는 1 이어야 한다")
+        if report.get("ok"):
+            issues.append("probe-failed 를 ok 로 위장하면 안 된다")
+        if report.get("reviewRequired"):
+            issues.append("probe-failed 를 reviewRequired 로 위장하면 안 된다")
+        if report.get("surfaceChanged"):
+            issues.append("probe-failed 를 surfaceChanged 로 위장하면 안 된다")
+        if not report.get("probeFailed"):
+            issues.append("probe-failed 봉투에 probeFailed 표지가 없다")
+    else:
+        issues.append(f"알 수 없는 classification: {classification!r}")
+    return issues
+
+
 def write_report(report, path):
     """UTF-8 · BOM 없음 · LF. 같은 입력이면 바이트가 같다."""
     with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
@@ -244,61 +859,181 @@ def write_report(report, path):
         fh.write("\n")
 
 
+def write_report_safe(report, path):
+    """쓰기 예외를 접는다. 성공이면 None, 실패면 오류 문자열."""
+    try:
+        write_report(report, path)
+        return None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return f"write_report: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+    except Exception as exc:
+        return f"write_report: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+
+
 def render_summary(report, out_path):
-    surface = report["surfaceChanged"]
-    classification = report["classification"]
-    lines = [
-        f"과제 {report['tasksCompared']} · 관측 대조 {report['observationsCompared']}건",
-        f"명령 표면(capabilities): {'다름 → surface-changed' if surface else '같음'}",
-        f"관측 분기: {report['divergences']}건 → 분류 [{classification}]",
-        f"이유: {report['classificationReason']}",
-    ]
-    for row in report.get("diffs", [])[:30]:
-        ov = observation_display(row["old"])
-        nv = observation_display(row["new"])
+    surface = report.get("surfaceChanged")
+    classification = report.get("classification")
+    if classification == STATUS_PROBE_FAILED:
+        lines = [
+            f"과제 {report.get('tasksCompared', 0)} · 관측 대조 {report.get('observationsCompared', 0)}건",
+            "명령 표면(capabilities): 프로브 실패 → 분류하지 않음",
+            f"관측 분기: {report.get('divergences', 0)}건 → 상태 [{classification}]",
+            f"이유: {report.get('classificationReason', PROBE_FAILED_REASON)}",
+        ]
+        for err in report.get("probeErrors") or []:
+            lines.append(
+                f"  프로브[{err.get('role')}]: {err.get('kind')} · {err.get('error')}"
+            )
+    else:
+        lines = [
+            f"과제 {report.get('tasksCompared', 0)} · 관측 대조 {report.get('observationsCompared', 0)}건",
+            f"명령 표면(capabilities): {'다름 → surface-changed' if surface else '같음'}",
+            f"관측 분기: {report.get('divergences', 0)}건 → 분류 [{classification}]",
+            f"이유: {report.get('classificationReason', '')}",
+        ]
+    for row in (report.get("diffs") or [])[:30]:
+        ov = observation_display(row.get("old"))
+        nv = observation_display(row.get("new"))
         pack = row.get("pack", "")
-        loc = f"{pack}/{row['task']}" if pack else row["task"]
-        lines.append(f"  {loc} · {row['check']}: {ov!r} → {nv!r}")
+        loc = f"{pack}/{row.get('task')}" if pack else row.get("task")
+        lines.append(f"  {loc} · {row.get('check')}: {ov!r} → {nv!r}")
+    if report.get("packErrors"):
+        for err in report["packErrors"][:10]:
+            lines.append(f"  pack 오류: {err}")
+    if report.get("writeError"):
+        lines.append(f"  쓰기 오류: {report['writeError']}")
     lines.append(f"→ {out_path}")
     return lines
 
 
-def main():
+def find_bin_safe(path):
+    """runner.find_bin 을 예외 없이 접는다."""
+    try:
+        found = runner.find_bin(path)
+        return found, None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return path, f"find_bin: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+    except Exception as exc:
+        return path, f"find_bin: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+
+
+def compare_packs(old_bin, new_bin, pack_ids, sub_root):
+    """pack 목록을 돌며 분기 행과 집계를 모은다. 한 pack 실패는 나머지를 남긴다."""
+    diffs, tasks_seen, checks_seen, skipped = [], 0, 0, 0
+    pack_errors = []
+    task_errors = []
+    for pack_id in pack_ids:
+        _manifest, tasks, err = load_pack_safe(pack_id)
+        if err:
+            pack_errors.append(err)
+            continue
+        for task in tasks:
+            try:
+                tasks_seen += 1
+                seen, skip = count_observable_checks(task)
+                checks_seen += seen
+                skipped += skip
+                for row in diff_task(old_bin, new_bin, task, sub_root, pack_id):
+                    row["pack"] = pack_id
+                    diffs.append(row)
+            except FATAL_EXCEPTIONS:
+                raise
+            except Exception as exc:
+                tid = task.get("id") if isinstance(task, dict) else "?"
+                task_errors.append(
+                    f"{pack_id}/{tid}: {type(exc).__name__}: "
+                    f"{truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+                )
+    return {
+        "diffs": diffs,
+        "tasksCompared": tasks_seen,
+        "observationsCompared": checks_seen,
+        "observationsSkipped": skipped,
+        "packErrors": pack_errors,
+        "taskErrors": task_errors,
+    }
+
+
+def attach_collection_errors(report, collection):
+    """팩/과제 오류를 보고에 붙인다. 분류는 바꾸지 않는다."""
+    if collection.get("packErrors"):
+        report["packErrors"] = list(collection["packErrors"])
+    if collection.get("taskErrors"):
+        report["taskErrors"] = list(collection["taskErrors"])
+    return report
+
+
+def parse_args(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--old", required=True, help="구 rhwp 바이너리 경로")
     ap.add_argument("--new", required=True, help="신 rhwp 바이너리 경로")
     ap.add_argument("--agent", default="claude-fable-5", help="관측에 쓸 제출물")
     ap.add_argument("--pack", action="append", default=None)
     ap.add_argument("-o", "--out", default=None)
-    a = ap.parse_args()
+    ap.add_argument("--digest-timeout", type=int, default=DIGEST_TIMEOUT,
+                    help="capabilities 프로브 초(기본 30, 0 이하는 무제한)")
+    return ap.parse_args(argv)
 
-    old_bin = runner.find_bin(a.old)
-    new_bin = runner.find_bin(a.new)
-    old_dig = capabilities_digest(old_bin)
-    new_dig = capabilities_digest(new_bin)
+
+def main(argv=None):
+    a = parse_args(argv)
+
+    old_bin, old_find_err = find_bin_safe(a.old)
+    new_bin, new_find_err = find_bin_safe(a.new)
+
+    timeout = normalize_timeout(getattr(a, "digest_timeout", DIGEST_TIMEOUT)) or None
+    old_probe = probe_capabilities(old_bin, timeout=timeout if timeout else DIGEST_TIMEOUT)
+    new_probe = probe_capabilities(new_bin, timeout=timeout if timeout else DIGEST_TIMEOUT)
+    if old_find_err and old_probe.get("ok"):
+        old_probe = {
+            "ok": False,
+            "kind": "os-error",
+            "digest": None,
+            "exit": None,
+            "error": "find_bin",
+            "head": old_find_err,
+        }
+    if new_find_err and new_probe.get("ok"):
+        new_probe = {
+            "ok": False,
+            "kind": "os-error",
+            "digest": None,
+            "exit": None,
+            "error": "find_bin",
+            "head": new_find_err,
+        }
 
     sub_root = os.path.join(runner.GYM, "submissions", a.agent)
-    pack_ids = a.pack or runner.discover_packs()
-    diffs, tasks_seen, checks_seen, skipped = [], 0, 0, 0
-    for pack_id in pack_ids:
-        _manifest, tasks = runner.load_pack(pack_id)
-        for task in tasks:
-            tasks_seen += 1
-            for check in task.get("checks", []):
-                if should_observe(check):
-                    checks_seen += 1
-                else:
-                    skipped += 1
-            for row in diff_task(old_bin, new_bin, task, sub_root, pack_id):
-                row["pack"] = pack_id
-                diffs.append(row)
+    pack_ids, discover_err = discover_packs_safe(a.pack)
+    collection = compare_packs(old_bin, new_bin, pack_ids, sub_root)
+    if discover_err:
+        collection["packErrors"] = [discover_err] + list(collection.get("packErrors") or [])
 
-    report = build_report(
-        old_bin, old_dig, new_bin, new_dig,
-        tasks_seen, checks_seen, diffs, observations_skipped=skipped,
-    )
+    if not (old_probe.get("ok") and new_probe.get("ok")):
+        report = build_probe_failed_report(
+            old_bin, old_probe, new_bin, new_probe,
+            tasks_compared=collection["tasksCompared"],
+            observations_compared=collection["observationsCompared"],
+            observations_skipped=collection["observationsSkipped"],
+            diffs=collection["diffs"],
+        )
+    else:
+        report = build_report(
+            old_bin, old_probe["digest"], new_bin, new_probe["digest"],
+            collection["tasksCompared"], collection["observationsCompared"],
+            collection["diffs"],
+            observations_skipped=collection["observationsSkipped"],
+        )
+    attach_collection_errors(report, collection)
+
     out = a.out or os.path.join(runner.GYM, "release-diff.json")
-    write_report(report, out)
+    write_err = write_report_safe(report, out)
+    if write_err:
+        report["writeError"] = write_err
 
     for line in render_summary(report, out):
         print(line)

--- a/mydocs/working/gym_release_diff.md
+++ b/mydocs/working/gym_release_diff.md
@@ -1,0 +1,275 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_release_diff.md
+last_verified: 2026-08-18
+---
+
+# gym 릴리스 차등 — 예외 경로와 분류 정직성 보강
+
+Issue: #5234
+PR: https://github.com/edwardkim/rhwp/pull/5248
+Branch: `feat/gym-release-diff-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/release_diff.py` 의 분류 삼원(stable / regression / surface-changed)은
+그대로 두고, 바이너리·pack·쓰기 예외를 관측/오류 목록으로 접도록 닫았다.
+표면을 재지 못하면 그 삼원 중 아무것으로도 위장하지 않는다. `probe-failed` 는
+분류가 아니라 도구 실패 상태다.
+
+이 가지는 새 PR 을 열지 않는다. 같은 브랜치에 이어서 밀어 #5248 을 키운다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_release_diff`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 PR(#5248)은 `classify` · `surface_changed` · `exit_for` · `build_report` 를
+순수 함수로 분리하고, 관측 kind(`value`/`exit`/`nojson`/`digfail`/`no-cmd`/
+`resolve-error`)와 JSON 봉투 필드(`classificationReason` · `exit` · `ok` ·
+`reviewRequired` · `observationsSkipped`)를 넣었다. 대비 `upstream/devel`
+삽입은 약 439줄이었다.
+
+그 상태의 빈틈:
+
+1. `capabilities_digest` 가 `subprocess.run` 예외를 그대로 올린다. 없는
+   바이너리·권한·시간초과가 차등 도구 전체를 죽인다.
+2. `observe` 가 `resolve_args` 의 일부 예외만 잡고, `run_cli` 의
+   `TimeoutExpired` · `FileNotFoundError` · `PermissionError` 는 잡지 않는다.
+3. `observation_from_result` 가 `dig` 의 `ValueError`(비정수 인덱스)를 잡지
+   않아 깨진 경로 하나가 전 비교를 멈춘다.
+4. `load_pack` / `discover_packs` 실패가 한 pack 에서 전체를 멈춘다.
+5. digest 를 못 얻었을 때 분류를 어떻게 할지 계약이 없다. `None != "abc"` 를
+   `surface_changed` 에 넣으면 표면 변경으로 오신고하고, `None != None` 은
+   안정으로 오신고한다.
+6. 카탈로그가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+
+분류 함수 자체를 네 값으로 늘리면 기존 게이트 계약
+(`CLASSIFICATIONS` ↔ `EXIT_BY_CLASS`)이 깨진다. 그래서 `classify` 는 삼원을
+유지하고, 표면을 모를 때는 호출하지 않는다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/release_diff.py`
+
+- `exception_kind` / `exception_observation` / `exception_probe` — 예외를
+  관측/프로브 kind 로 접는다. `resolve` context 의 `FileNotFoundError` 는
+  기존 계약대로 `resolve-error` 다. digest/cli 의 같은 예외는 `missing-bin`.
+- `FATAL_EXCEPTIONS` — `KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+  `GeneratorExit` 는 삼키지 않는다.
+- `probe_capabilities` — capabilities 를 예외 없이 접는다. 실패 시
+  `digest=None`.
+- `can_classify_surface` — 두 digest 가 문자열일 때만 참.
+- `classify_or_probe_failed` — 분류 가능하면 `classify`, 아니면
+  `probe-failed`. `classify` 본체는 그대로다.
+- `status_exit` / `reason_for` — 삼원은 `EXIT_BY_CLASS`, 도구 실패는 exit 1.
+- `observation_from_result` — `ValueError` · `AttributeError` · 그 외 잡히는
+  예외를 `digfail` 로 접는다. head 는 `truncate_head`.
+- `observe` — `run_cli` 예외를 관측으로 접는다. 비-dict 검사는 `type-error`.
+- `diff_task` — 한 검사의 예외는 그 행만 건너뛴다. 거짓 분기를 만들지 않는다.
+- `load_pack_safe` / `discover_packs_safe` / `find_bin_safe` /
+  `write_report_safe` / `compare_packs` — 한 pack·한 쓰기가 전체를 죽이지
+  않는다.
+- `build_report` — digest 가 문자열이 아니면 `build_probe_failed_report`.
+  기존 문자열 digest 경로는 그대로 삼원을 낸다.
+- `validate_report` — ok/review/surface/exit/divergences 정직 계약.
+- `main` — 프로브 실패면 exit 1. 성공이면 0/2/3. pack 오류는 부가 필드.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_release_diff.py`
+
+- 기존 순수 시험(`ObservationTests` · `ClassificationTests` · `ReportTests`)
+  유지.
+- `ExceptionKindTests` — context 분기, 치명 예외 표지.
+- `ProbeCapabilitiesTests` — 성공 digest 일치, missing/permission/timeout/
+  OSError, KeyboardInterrupt 비삼킴.
+- `ClassifyHonestyTests` — `classify` 가 `probe-failed` 를 내지 않음.
+  확장 진릿값 표. 표면이 모든 분기 모양을 이김.
+- `ObservationEqualityEdgeTests` — NaN, inf, 중첩, bool, 오류 페이로드.
+- `ObserveExceptionTests` — run_cli/resolve/dig 예외 관측.
+- `DiffTaskExceptionTests` — 한쪽만 CLI 실패면 분기, 양쪽 같으면 분기 아님.
+- `ReportHonestyTests` — digest 부재를 삼원으로 부르지 않음.
+  `validate_report` 가 ok/review/surface 거짓말을 잡음.
+- `MainEntryExceptionTests` — main 의 exit 0/1/2/3.
+- `GeneratedEqualityTableTests` / `GeneratedClassifyTableTests` — 표 계약.
+- `ProbeFailedDisguiseTests` — 요약이 "표면 같음" 이라고 거짓말하지 않음.
+
+### 3.3 문서
+
+- `gym/docs/release_diff.md` — 분류 삼원, probe-failed, 관측 kind, 동일성,
+  파일 연산 배제, JSON 봉투, 예외 자리, 종료 코드, 오검출 관문.
+- `mydocs/working/gym_release_diff.md` — 이 기록.
+
+pack JSON 은 건드리지 않았다.
+
+## 4. 정직 조항 — 바꾸지 않은 것
+
+다음 계약은 원 PR 과 같다. 시험이 다시 고정한다.
+
+```
+classify(False, 거짓값) → stable
+classify(False, 참값)   → regression
+classify(True,  *)      → surface-changed
+```
+
+- `CLASSIFICATIONS = ("stable", "regression", "surface-changed")`
+- `EXIT_BY_CLASS = {stable: 0, regression: 3, surface-changed: 2}`
+- `exit_for("skipped")` 는 `KeyError`
+- `ok` 는 `stable` 과만 참
+- `reviewRequired` 는 `surface-changed` 와만 참
+- 숫자 `6` 과 `6.0` 은 같고, `True` 는 `1` 로 접히지 않는다
+- 파일 연산자 네 개는 관측에서 뺀다
+- CLI 플래그 `--old` `--new` `--agent` `--pack` `-o` 는 그대로다
+  (`--digest-timeout` 만 추가)
+
+`probe-failed` 를 `CLASSIFICATIONS` 나 `EXIT_BY_CLASS` 에 넣지 않았다.
+넣으면 `test_exit_codes_match_gate_contract` 가 깨지고, 게이트가 도구 실패를
+리뷰/차단으로 오독할 수 있다.
+
+## 5. 예외 카탈로그
+
+| context | 예외 | kind |
+|---|---|---|
+| resolve | FileNotFoundError | resolve-error |
+| digest / cli | FileNotFoundError | missing-bin |
+| * | PermissionError | permission |
+| * | TimeoutExpired / TimeoutError | timeout |
+| * | UnicodeError | decode-error |
+| * | JSONDecodeError | value-error |
+| * | KeyError / IndexError / AttributeError | digfail |
+| * | TypeError | type-error |
+| * | ValueError | value-error |
+| * | OSError | os-error |
+| * | RuntimeError | cli-error |
+| * | 그 외 | unexpected |
+
+`observe` 의 resolve 경로는 `exception_observation(..., context="resolve")` 를
+쓴다. 기존 시험 `test_missing_hash_placeholder_is_an_observation` 은
+`FileNotFoundError` → `{kind: resolve-error, error: FileNotFoundError}` 를
+그대로 통과해야 한다.
+
+## 6. 보고 상태 표
+
+| 상황 | classification | exit | ok | review | surfaceChanged |
+|---|---|---|---|---|---|
+| digest 같음, 분기 0 | stable | 0 | 참 | 거짓 | 거짓 |
+| digest 같음, 분기 ≥1 | regression | 3 | 거짓 | 거짓 | 거짓 |
+| digest 다름, 분기 0 | surface-changed | 2 | 거짓 | 참 | 참 |
+| digest 다름, 분기 ≥1 | surface-changed | 2 | 거짓 | 참 | 참 |
+| digest 한쪽/양쪽 없음 | probe-failed | 1 | 거짓 | 거짓 | 거짓 |
+
+마지막 행을 둘째 행이나 셋째 행으로 접으면 게이트가 속는다.
+
+## 7. 검증 명령
+
+저장소 루트(`rhwp-scaffold-final`)에서:
+
+```bash
+python -m unittest scripts.tests.test_gym_release_diff
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+packs 를 고치지 않았으므로 audit 는 기존처럼 전 pack 통과여야 한다.
+`cargo fmt --all` 은 이번 변경에 해당 없다.
+
+## 8. 의도적으로 하지 않은 것
+
+- pack · reference · profile 편집 없음.
+- `release_gate.py` 편집 없음. 게이트는 차등 JSON 을 읽기만 한다. 프로브
+  실패 시 classification 이 `probe-failed` 가 되므로, 게이트가 그 값을
+  모르면 자기 쪽에서 다루면 된다. 차등 오라클이 안정으로 위장하는 편이
+  더 위험하다.
+- `classify` 시그니처·삼원 의미 변경 없음.
+- 무작위·시간·호스트 경로를 관측에 넣지 않음.
+- 새 PR 을 열지 않음. 같은 브랜치에 커밋한다.
+
+## 9. 남은 빈틈
+
+- 라이브 바이너리 두 개를 실제로 돌리는 자기-대조는 이 가지에서 돌리지
+  않았다. 커밋된 `gym/release-diff.json` 이 있으면 단위 시험이 읽고, 없으면
+  skip 한다.
+- `run_cli` 자체에 timeout 인자를 넣지는 않았다. 관측 쪽 timeout 은
+  `run_cli` 가 올린 `TimeoutExpired` 를 접는 계약이다. 러너가 시간제한을
+  안 걸면 이 도구의 observe 도 행할 수 있다. 그건 runner 의 몫이다.
+- capabilities 가 비정상 종료해도 stdout 해시는 기존처럼 계산한다. 빈
+  출력의 digest 는 오류가 아니라 고정값이다. 양쪽이 같이 빈 출력이면
+  표면은 같다.
+
+## 10. 파일 목록
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tools/release_diff.py` | 차등 오라클. 예외 접기 + 분류 정직 |
+| `scripts/tests/test_gym_release_diff.py` | 바이너리 없는 계약 시험 |
+| `gym/docs/release_diff.md` | 규약 (이 문서의 정본 표) |
+| `mydocs/working/gym_release_diff.md` | 작업 기록 (여기) |
+
+## 11. 커밋 메시지 (초안)
+
+```
+test(gym): release_diff 예외 경로와 분류 정직 시험을 보강한다
+
+capabilities/CLI/pack 예외를 관측·프로브 오류로 접고,
+표면을 모를 때는 stable/regression/surface-changed 로 위장하지 않는다.
+```
+
+## 12. 분류 함수를 읽은 자리
+
+`classify` 본체는 다음 열 줄이 전부다. 이 가지가 여기를 네 값으로 늘리지
+않았음을 기록으로 남긴다.
+
+```
+if surface:
+    return "surface-changed"
+if divergences:
+    return "regression"
+return "stable"
+```
+
+표면을 모르는 입력은 이 함수에 넣지 않는다. 넣는 순간 `None != "abc"` 가
+표면 변경이 되고, `None != None` 이 안정이 된다. 둘 다 도구의 거짓말이다.
+
+## 13. 시험 목록 (이 가지에서 늘어난 것)
+
+기존 반: Observation / Equality / DiffTask / Classification / Report /
+CommittedReport.
+
+추가 반:
+
+| 클래스 | 고정하는 거짓말 |
+|---|---|
+| ExceptionKindTests | resolve 의 FileNotFound 를 missing-bin 으로 부르지 않음 |
+| TruncateAndDigestHelperTests | 빈 문자열을 digest 로 위장하지 않음 |
+| ProbeCapabilitiesTests | 예외를 digest 문자열로 접지 않음 |
+| ClassifyHonestyTests | classify 가 네 번째 값을 내지 않음 |
+| ObservationEqualityEdgeTests | True==1, 바이트==문자열 오신고 금지 |
+| ObserveExceptionTests | CLI 예외가 도구를 죽이지 않음 |
+| DiffTaskExceptionTests | 같은 오류 양쪽 = 분기 아님 |
+| ReportHonestyTests | digest 부재 → 삼원 금지 |
+| WriteAndSummaryExceptionTests | 프로브 실패 요약이 "표면 같음" 이라 하지 않음 |
+| PackLoadSafeTests | 한 pack 실패가 분류를 뒤집지 않음 |
+| MainEntryExceptionTests | main exit 0/1/2/3 |
+| CatalogContractTests | 삼원 튜플·이유 문구가 승자를 가리지 않음 |
+| GeneratedEqualityTableTests | 표의 대칭 |
+| GeneratedClassifyTableTests | 표에 probe-failed 행 없음 |
+| ProbeFailedDisguiseTests | None digest 를 surface-changed/stable/regression 으로 부르지 않음 |
+| HonestyInvariantScanTests | ok/review/surface 상호 일관 |
+
+## 14. 크기 게이트에 넣는 파일만
+
+packs 와 Rust 는 이 가지의 대상이 아니다. `git add -A` 를 쓰지 않는다.
+추가·수정 파일은 다음 네 개다.
+
+1. `gym/tools/release_diff.py`
+2. `scripts/tests/test_gym_release_diff.py`
+3. `gym/docs/release_diff.md`
+4. `mydocs/working/gym_release_diff.md`

--- a/scripts/tests/test_gym_release_diff.py
+++ b/scripts/tests/test_gym_release_diff.py
@@ -1,13 +1,17 @@
-"""[#4661] 릴리스 간 차등 회귀 도구 계약 — 오검출 관문·분류·관측 대조.
+"""[#4661/#5234] 릴리스 간 차등 회귀 도구 계약 — 오검출 관문·분류·관측 대조.
 
-바이너리 두 개를 실제로 빌드하지 않고도 도구의 판정 논리를 고정한다. 관측
-함수(run_cli)를 목으로 갈아끼워 "구/신이 다른 답을 냈을 때" 를 합성한다.
+바이너리 두 개를 실제로 빌드하지 않고도 도구의 판정 논리를 고정한다. 분류·
+관측 동일성·보고 조립은 순수 함수를 직접 부르고, 관측 함수(run_cli)는 목으로
+갈아끼워 "구/신이 다른 답을 냈을 때" 를 합성한다.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -27,6 +31,10 @@ def load_rd():
     return module
 
 
+def _value(v):
+    return {"kind": "value", "value": v}
+
+
 class ObservationTests(unittest.TestCase):
     def setUp(self):
         self.rd = load_rd()
@@ -38,14 +46,14 @@ class ObservationTests(unittest.TestCase):
         with mock.patch.object(self.rd.runner, "run_cli",
                                return_value=(0, {"pageCount": 6}, "")):
             obs = self.rd.observe("rhwp", self.check, self.task, ".")
-        self.assertEqual(obs, {"kind": "value", "value": 6})
+        self.assertEqual(obs, _value(6))
 
     def test_judgment_exit_code_is_allowed_not_treated_as_failure(self):
         c = dict(self.check, expect_exits=[0, 3])
         with mock.patch.object(self.rd.runner, "run_cli",
                                return_value=(3, {"pageCount": 7}, "")):
             obs = self.rd.observe("rhwp", c, self.task, ".")
-        self.assertEqual(obs, {"kind": "value", "value": 7})
+        self.assertEqual(obs, _value(7))
 
     def test_unexpected_exit_is_reported_not_crashed(self):
         with mock.patch.object(self.rd.runner, "run_cli",
@@ -66,6 +74,91 @@ class ObservationTests(unittest.TestCase):
         self.assertIn("file_exists", self.rd.FILE_OPS)
         self.assertIn("same_hash", self.rd.FILE_OPS)
         self.assertIn("differs_from_input", self.rd.FILE_OPS)
+        self.assertIn("files_differ", self.rd.FILE_OPS)
+        for op in self.rd.FILE_OPS:
+            self.assertFalse(self.rd.should_observe({"op": op}), op)
+        self.assertTrue(self.rd.should_observe({"op": "value_eq"}))
+
+    def test_no_cmd_is_an_observation_without_cli(self):
+        called = []
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               side_effect=lambda *a: called.append(a)):
+            obs = self.rd.observe("rhwp", {"op": "value_eq"}, self.task, ".")
+        self.assertEqual(obs, {"kind": "no-cmd"})
+        self.assertEqual(called, [])
+
+    def test_nojson_when_exit_ok_but_envelope_missing(self):
+        obs = self.rd.observation_from_result(0, None, "not json", self.check)
+        self.assertEqual(obs["kind"], "nojson")
+        self.assertEqual(obs["head"], "not json")
+
+    def test_digfail_when_path_missing(self):
+        obs = self.rd.observation_from_result(0, {"other": 1}, "", self.check)
+        self.assertEqual(obs, {"kind": "digfail", "error": "KeyError"})
+
+    def test_cell_text_eq_observes_coordinate_not_whole_table(self):
+        check = {"name": "칸", "op": "cell_text_eq", "table": 0, "row": 1, "col": 2,
+                 "cmd": ["export-tables", "{input}", "--json"], "path": "tables"}
+        env = {"tables": [{"cells": [
+            {"row": 0, "col": 0, "text": "아님"},
+            {"row": 1, "col": 2, "text": "대상"},
+        ]}]}
+        obs = self.rd.observation_from_result(0, env, "", check)
+        self.assertEqual(obs, _value("대상"))
+
+    def test_cell_text_eq_missing_cell_is_none_value(self):
+        check = {"op": "cell_text_eq", "table": 0, "row": 9, "col": 9,
+                 "path": "tables"}
+        env = {"tables": [{"cells": [{"row": 0, "col": 0, "text": "가"}]}]}
+        self.assertEqual(self.rd.observation_from_result(0, env, "", check),
+                         _value(None))
+
+    def test_cell_text_eq_bad_table_index_is_digfail(self):
+        check = {"op": "cell_text_eq", "table": 3, "row": 0, "col": 0,
+                 "path": "tables"}
+        env = {"tables": [{"cells": [{"row": 0, "col": 0, "text": "가"}]}]}
+        obs = self.rd.observation_from_result(0, env, "", check)
+        self.assertEqual(obs["kind"], "digfail")
+        self.assertEqual(obs["error"], "IndexError")
+
+    def test_expected_exits_falls_back_to_zero(self):
+        self.assertEqual(self.rd.expected_exits({}), [0])
+        self.assertEqual(self.rd.expected_exits({"expect_exit": 3}), [3])
+        self.assertEqual(self.rd.expected_exits({"expect_exits": [0, 3]}), [0, 3])
+
+
+class ObservationEqualityTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_int_and_float_same_number_are_equal(self):
+        self.assertTrue(self.rd.observations_equal(_value(6), _value(6.0)))
+        self.assertTrue(self.rd.observations_equal(_value(6), _value(6)))
+
+    def test_bool_does_not_collapse_to_int(self):
+        self.assertFalse(self.rd.observations_equal(_value(True), _value(1)))
+        self.assertTrue(self.rd.observations_equal(_value(True), _value(True)))
+
+    def test_kind_mismatch_is_not_equal_even_if_display_collides(self):
+        self.assertFalse(self.rd.observations_equal(
+            {"kind": "nojson", "head": "x"}, _value("nojson")))
+        self.assertFalse(self.rd.observations_equal(
+            {"kind": "exit", "code": 1, "head": ""}, _value("exit1")))
+
+    def test_dict_key_order_does_not_matter(self):
+        self.assertTrue(self.rd.observations_equal(
+            {"kind": "value", "value": {"b": 1, "a": 2}},
+            {"value": {"a": 2.0, "b": 1}, "kind": "value"},
+        ))
+
+    def test_display_keeps_cli_shape(self):
+        self.assertEqual(self.rd.observation_display(_value(6)), 6)
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "exit", "code": 2, "head": "e"}), "exit2")
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "nojson", "head": "x"}), "nojson")
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "digfail", "error": "KeyError"}), "digfail")
 
 
 class DiffTaskTests(unittest.TestCase):
@@ -76,15 +169,16 @@ class DiffTaskTests(unittest.TestCase):
         task = {"id": "T", "input": "x.hwp",
                 "checks": [{"name": "쪽수", "op": "value_eq", "value": 6,
                             "cmd": ["info", "{input}", "--json"], "path": "pageCount"}]}
-        # 구=6, 신=7 을 두 바이너리로 합성
         def fake(bin_path, args):
             return (0, {"pageCount": 6 if bin_path == "old" else 7}, "")
         with mock.patch("os.path.isdir", return_value=True), \
                 mock.patch.object(self.rd.runner, "run_cli", side_effect=fake):
             rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["old"], {"kind": "value", "value": 6})
-        self.assertEqual(rows[0]["new"], {"kind": "value", "value": 7})
+        self.assertEqual(rows[0]["old"], _value(6))
+        self.assertEqual(rows[0]["new"], _value(7))
+        self.assertEqual(rows[0]["task"], "T")
+        self.assertEqual(rows[0]["check"], "쪽수")
 
     def test_identical_observation_yields_no_row(self):
         task = {"id": "T", "input": "x.hwp",
@@ -93,6 +187,18 @@ class DiffTaskTests(unittest.TestCase):
         with mock.patch("os.path.isdir", return_value=True), \
                 mock.patch.object(self.rd.runner, "run_cli",
                                   return_value=(0, {"pageCount": 6}, "")):
+            rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
+        self.assertEqual(rows, [])
+
+    def test_numeric_int_float_is_not_a_divergence(self):
+        """6 과 6.0 을 회귀로 오신고하지 않는다."""
+        task = {"id": "T", "input": "x.hwp",
+                "checks": [{"name": "쪽수", "op": "value_eq",
+                            "cmd": ["info", "{input}", "--json"], "path": "pageCount"}]}
+        def fake(bin_path, args):
+            return (0, {"pageCount": 6 if bin_path == "old" else 6.0}, "")
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli", side_effect=fake):
             rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
         self.assertEqual(rows, [])
 
@@ -111,18 +217,148 @@ class DiffTaskTests(unittest.TestCase):
 class ClassificationTests(unittest.TestCase):
     """분류 규칙 — surface-changed 관문이 순수 회귀와 표면 변경을 가른다."""
 
+    def setUp(self):
+        self.rd = load_rd()
+
     def test_classification_matrix(self):
-        # (surfaceChanged, hasDiffs) → 분류
         cases = [
             (False, False, "stable"),
             (False, True, "regression"),
             (True, False, "surface-changed"),
-            (True, True, "surface-changed"),  # 표면이 바뀌면 diff 여부와 무관
+            (True, True, "surface-changed"),
         ]
         for surface, diffs, expected in cases:
-            cls = ("surface-changed" if surface
-                   else ("regression" if diffs else "stable"))
-            self.assertEqual(cls, expected, (surface, diffs))
+            self.assertEqual(
+                self.rd.classify(surface, diffs), expected, (surface, diffs))
+
+    def test_empty_diff_list_is_stable_when_surface_same(self):
+        self.assertEqual(self.rd.classify(False, []), "stable")
+        self.assertEqual(self.rd.classify(False, 0), "stable")
+
+    def test_nonempty_diff_list_is_regression_when_surface_same(self):
+        self.assertEqual(self.rd.classify(False, [{"task": "T"}]), "regression")
+        self.assertEqual(self.rd.classify(False, 4), "regression")
+
+    def test_surface_changed_wins_even_with_no_diffs(self):
+        self.assertEqual(self.rd.classify(True, []), "surface-changed")
+        self.assertEqual(self.rd.classify(True, 0), "surface-changed")
+
+    def test_surface_changed_from_digest(self):
+        self.assertFalse(self.rd.surface_changed("aaa", "aaa"))
+        self.assertTrue(self.rd.surface_changed("aaa", "bbb"))
+
+    def test_exit_codes_match_gate_contract(self):
+        self.assertEqual(self.rd.exit_for("stable"), 0)
+        self.assertEqual(self.rd.exit_for("surface-changed"), 2)
+        self.assertEqual(self.rd.exit_for("regression"), 3)
+        self.assertEqual(
+            {c: self.rd.exit_for(c) for c in self.rd.CLASSIFICATIONS},
+            self.rd.EXIT_BY_CLASS,
+        )
+
+    def test_unknown_classification_has_no_exit(self):
+        with self.assertRaises(KeyError):
+            self.rd.exit_for("skipped")
+
+
+class ReportTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def _row(self):
+        return {
+            "pack": "core-cli", "task": "T01", "check": "쪽수",
+            "op": "value_eq", "path": "pageCount",
+            "old": _value(6), "new": _value(7),
+        }
+
+    def test_stable_report_fields(self):
+        report = self.rd.build_report(
+            "/opt/old/rhwp", "aaa", "/opt/new/rhwp", "aaa",
+            10, 20, [], observations_skipped=3,
+        )
+        self.assertEqual(report["kind"], "gymReleaseDiff")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertEqual(report["kind"], self.rd.REPORT_KIND)
+        self.assertEqual(report["schemaVersion"], self.rd.SCHEMA_VERSION)
+        self.assertEqual(report["classification"], "stable")
+        self.assertEqual(report["classificationReason"],
+                         self.rd.CLASSIFICATION_REASON["stable"])
+        self.assertFalse(report["surfaceChanged"])
+        self.assertEqual(report["divergences"], 0)
+        self.assertEqual(report["tasksCompared"], 10)
+        self.assertEqual(report["observationsCompared"], 20)
+        self.assertEqual(report["observationsSkipped"], 3)
+        self.assertEqual(report["exit"], 0)
+        self.assertTrue(report["ok"])
+        self.assertFalse(report["reviewRequired"])
+        self.assertEqual(report["old"], {"bin": "rhwp", "capabilitiesSha256": "aaa"})
+        self.assertEqual(report["new"], {"bin": "rhwp", "capabilitiesSha256": "aaa"})
+        self.assertEqual(report["diffs"], [])
+
+    def test_regression_report_when_surface_same_and_diffs(self):
+        row = self._row()
+        report = self.rd.build_report(
+            "old.exe", "same", "new.exe", "same", 2, 5, [row],
+        )
+        self.assertEqual(report["classification"], "regression")
+        self.assertIn("관측이 갈렸다", report["classificationReason"])
+        self.assertFalse(report["surfaceChanged"])
+        self.assertEqual(report["divergences"], 1)
+        self.assertEqual(report["exit"], 3)
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["reviewRequired"])
+        self.assertEqual(report["diffs"][0]["task"], "T01")
+
+    def test_surface_changed_even_when_observations_match(self):
+        report = self.rd.build_report(
+            "old", "aaa", "new", "bbb", 8, 12, [],
+        )
+        self.assertEqual(report["classification"], "surface-changed")
+        self.assertTrue(report["surfaceChanged"])
+        self.assertIn("capabilities digest", report["classificationReason"])
+        self.assertEqual(report["exit"], 2)
+        self.assertFalse(report["ok"])
+        self.assertTrue(report["reviewRequired"])
+        self.assertEqual(report["divergences"], 0)
+
+    def test_surface_changed_with_diffs_is_still_review(self):
+        report = self.rd.build_report(
+            "old", "aaa", "new", "bbb", 1, 1, [self._row()],
+        )
+        self.assertEqual(report["classification"], "surface-changed")
+        self.assertEqual(report["divergences"], 1)
+        self.assertTrue(report["reviewRequired"])
+        self.assertEqual(report["exit"], 2)
+
+    def test_report_does_not_mutate_caller_diffs(self):
+        diffs = [self._row()]
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, diffs)
+        diffs.append({"task": "injected"})
+        self.assertEqual(len(report["diffs"]), 1)
+
+    def test_summary_and_report_file_are_deterministic(self):
+        report = self.rd.build_report(
+            "old/rhwp", "aaa", "new/rhwp", "aaa", 3, 4, [self._row()],
+        )
+        lines = self.rd.render_summary(report, "out.json")
+        text = "\n".join(lines)
+        self.assertIn("과제 3 · 관측 대조 4건", lines[0])
+        self.assertIn("분류 [regression]", text)
+        self.assertIn("이유:", text)
+        self.assertIn("core-cli/T01", text)
+        self.assertIn("6", text)
+        self.assertIn("7", text)
+        self.assertEqual(lines[-1], "→ out.json")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "release-diff.json")
+            self.rd.write_report(report, path)
+            raw = Path(path).read_bytes()
+            self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+            self.assertNotIn(b"\r\n", raw)
+            loaded = json.loads(raw.decode("utf-8"))
+        self.assertEqual(loaded, report)
+        self.assertEqual(loaded["classification"], "regression")
 
 
 class CommittedReportTests(unittest.TestCase):
@@ -132,8 +368,6 @@ class CommittedReportTests(unittest.TestCase):
         self.rd = load_rd()
 
     def test_self_diff_report_is_stable(self):
-        import json
-        import os
         path = os.path.join(self.rd.runner.GYM, "release-diff.json")
         if not os.path.exists(path):
             self.skipTest("커밋된 self-diff 리포트 없음")

--- a/scripts/tests/test_gym_release_diff.py
+++ b/scripts/tests/test_gym_release_diff.py
@@ -7,9 +7,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -67,7 +69,8 @@ class ObservationTests(unittest.TestCase):
                  "cmd": ["replay", "{sha256:o1.hwp}", "--json"], "path": "verdict"}
         with mock.patch.object(self.rd.runner, "resolve_args", side_effect=FileNotFoundError):
             obs = self.rd.observe("rhwp", check, self.task, ".")
-        self.assertEqual(obs, {"kind": "resolve-error", "error": "FileNotFoundError"})
+        self.assertEqual(obs["kind"], "resolve-error")
+        self.assertEqual(obs["error"], "FileNotFoundError")
 
     def test_file_ops_are_excluded_from_observation(self):
         """파일 존재/동일성은 관측이 아니라 상태라 raw 대조에서 빠진다."""
@@ -377,6 +380,1250 @@ class CommittedReportTests(unittest.TestCase):
         self.assertEqual(report["classification"], "stable")
         self.assertEqual(report["divergences"], 0,
                          "자기-대조에서 분기가 나오면 관측에 비결정성이 있다")
+
+
+class ExceptionKindTests(unittest.TestCase):
+    """예외 → 관측 kind 접기. 치명 예외는 접지 않는다."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_timeout_kinds(self):
+        self.assertEqual(self.rd.exception_kind(TimeoutError("x")), "timeout")
+        expired = subprocess.TimeoutExpired(cmd=["rhwp"], timeout=1)
+        self.assertEqual(self.rd.exception_kind(expired, context="digest"), "timeout")
+        self.assertEqual(self.rd.exception_kind(expired, context="cli"), "timeout")
+
+    def test_file_not_found_depends_on_context(self):
+        err = FileNotFoundError("missing")
+        self.assertEqual(self.rd.exception_kind(err, context="resolve"), "resolve-error")
+        self.assertEqual(self.rd.exception_kind(err, context="digest"), "missing-bin")
+        self.assertEqual(self.rd.exception_kind(err, context="cli"), "missing-bin")
+        self.assertEqual(self.rd.exception_kind(err, context="observe"), "missing-bin")
+
+    def test_permission_and_oserror(self):
+        self.assertEqual(self.rd.exception_kind(PermissionError("no")), "permission")
+        self.assertEqual(self.rd.exception_kind(OSError("io")), "os-error")
+
+    def test_unicode_and_json(self):
+        self.assertEqual(self.rd.exception_kind(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "x")),
+                         "decode-error")
+        self.assertEqual(self.rd.exception_kind(UnicodeError("u")), "decode-error")
+        self.assertEqual(self.rd.exception_kind(json.JSONDecodeError("e", "x", 0)), "value-error")
+
+    def test_path_eval_kinds(self):
+        self.assertEqual(self.rd.exception_kind(KeyError("k")), "digfail")
+        self.assertEqual(self.rd.exception_kind(IndexError("i")), "digfail")
+        self.assertEqual(self.rd.exception_kind(AttributeError("a")), "digfail")
+        self.assertEqual(self.rd.exception_kind(TypeError("t")), "type-error")
+        self.assertEqual(self.rd.exception_kind(ValueError("v")), "value-error")
+
+    def test_runtime_and_unknown(self):
+        self.assertEqual(self.rd.exception_kind(RuntimeError("r")), "cli-error")
+        self.assertEqual(self.rd.exception_kind(Exception("e")), "unexpected")
+        self.assertEqual(self.rd.exception_kind(None), "unexpected")
+
+    def test_fatal_exceptions_are_flagged(self):
+        self.assertTrue(self.rd.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(self.rd.is_fatal_exception(SystemExit(2)))
+        self.assertTrue(self.rd.is_fatal_exception(MemoryError()))
+        self.assertTrue(self.rd.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(self.rd.is_fatal_exception(OSError("x")))
+        self.assertFalse(self.rd.is_fatal_exception(ValueError("x")))
+
+    def test_exception_observation_shape(self):
+        obs = self.rd.exception_observation(FileNotFoundError("o1.hwp"), context="resolve")
+        self.assertEqual(obs["kind"], "resolve-error")
+        self.assertEqual(obs["error"], "FileNotFoundError")
+        self.assertIn("o1.hwp", obs["head"])
+
+    def test_exception_probe_shape(self):
+        row = self.rd.exception_probe(FileNotFoundError("rhwp"), "/opt/old/rhwp", "old")
+        self.assertEqual(row["role"], "old")
+        self.assertEqual(row["bin"], "rhwp")
+        self.assertEqual(row["kind"], "missing-bin")
+        self.assertEqual(row["error"], "FileNotFoundError")
+
+
+class TruncateAndDigestHelperTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_truncate_head_none_and_limit(self):
+        self.assertEqual(self.rd.truncate_head(None), "")
+        self.assertEqual(self.rd.truncate_head("abcdef", 3), "abc")
+        self.assertEqual(self.rd.truncate_head("abcdef", 0), "")
+        self.assertEqual(self.rd.truncate_head("abcdef", -1), "")
+        self.assertEqual(self.rd.truncate_head(1234, 2), "12")
+        self.assertEqual(self.rd.truncate_head("abcdef", "nope"), "abcdef"[:self.rd.HEAD_LIMIT])
+
+    def test_normalize_timeout(self):
+        self.assertEqual(self.rd.normalize_timeout(30), 30)
+        self.assertEqual(self.rd.normalize_timeout("15"), 15)
+        self.assertEqual(self.rd.normalize_timeout(0), 0)
+        self.assertEqual(self.rd.normalize_timeout(-3), 0)
+        self.assertEqual(self.rd.normalize_timeout(None), 0)
+        self.assertEqual(self.rd.normalize_timeout("x"), 0)
+        self.assertEqual(self.rd.normalize_timeout(1.9), 1)
+
+    def test_sha256_bytes_rejects_non_bytes(self):
+        self.assertEqual(self.rd.sha256_bytes(b""), hashlib.sha256(b"").hexdigest())
+        self.assertEqual(self.rd.sha256_bytes(bytearray(b"ab")), hashlib.sha256(b"ab").hexdigest())
+        self.assertEqual(self.rd.sha256_bytes(memoryview(b"ab")), hashlib.sha256(b"ab").hexdigest())
+        with self.assertRaises(TypeError):
+            self.rd.sha256_bytes("ab")
+        with self.assertRaises(TypeError):
+            self.rd.sha256_bytes(None)
+
+    def test_is_sha256_hex(self):
+        good = "a" * 64
+        self.assertTrue(self.rd.is_sha256_hex(good))
+        self.assertFalse(self.rd.is_sha256_hex("A" * 64))
+        self.assertFalse(self.rd.is_sha256_hex("a" * 63))
+        self.assertFalse(self.rd.is_sha256_hex("g" * 64))
+        self.assertFalse(self.rd.is_sha256_hex(None))
+        self.assertFalse(self.rd.is_sha256_hex(1))
+
+    def test_normalize_digest(self):
+        self.assertEqual(self.rd.normalize_digest("B" * 64), "b" * 64)
+        self.assertIsNone(self.rd.normalize_digest("short"))
+        self.assertIsNone(self.rd.normalize_digest(None))
+        self.assertIsNone(self.rd.normalize_digest(12))
+
+    def test_observation_kind_helpers(self):
+        self.assertEqual(self.rd.observation_kind_of(_value(1)), "value")
+        self.assertEqual(self.rd.observation_kind_of({"kind": "exit", "code": 2}), "exit")
+        self.assertIsNone(self.rd.observation_kind_of({}))
+        self.assertIsNone(self.rd.observation_kind_of("x"))
+        self.assertTrue(self.rd.is_known_observation_kind("value"))
+        self.assertTrue(self.rd.is_known_observation_kind("timeout"))
+        self.assertFalse(self.rd.is_known_observation_kind("skipped"))
+        self.assertFalse(self.rd.is_error_observation(_value(1)))
+        self.assertTrue(self.rd.is_error_observation({"kind": "digfail", "error": "KeyError"}))
+
+
+class ProbeCapabilitiesTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_probe_success_matches_capabilities_digest(self):
+        stdout = b'{"commands":["info"]}'
+        proc = mock.Mock(stdout=stdout, returncode=0)
+        with mock.patch.object(self.rd.subprocess, "run", return_value=proc) as run:
+            digest = self.rd.capabilities_digest("rhwp")
+            probed = self.rd.probe_capabilities("rhwp")
+        self.assertEqual(digest, hashlib.sha256(stdout).hexdigest())
+        self.assertTrue(probed["ok"])
+        self.assertEqual(probed["digest"], digest)
+        self.assertEqual(probed["kind"], "digest")
+        self.assertEqual(probed["exit"], 0)
+        self.assertGreaterEqual(run.call_count, 2)
+
+    def test_probe_empty_path_is_missing_bin(self):
+        probed = self.rd.probe_capabilities("")
+        self.assertFalse(probed["ok"])
+        self.assertEqual(probed["kind"], "missing-bin")
+        self.assertIsNone(probed["digest"])
+
+    def test_probe_file_not_found(self):
+        with mock.patch.object(self.rd.subprocess, "run", side_effect=FileNotFoundError("rhwp")):
+            probed = self.rd.probe_capabilities("missing")
+        self.assertFalse(probed["ok"])
+        self.assertEqual(probed["kind"], "missing-bin")
+        self.assertEqual(probed["error"], "FileNotFoundError")
+        self.assertIsNone(probed["digest"])
+
+    def test_probe_permission(self):
+        with mock.patch.object(self.rd.subprocess, "run", side_effect=PermissionError("x")):
+            probed = self.rd.probe_capabilities("rhwp")
+        self.assertEqual(probed["kind"], "permission")
+        self.assertFalse(probed["ok"])
+
+    def test_probe_timeout(self):
+        with mock.patch.object(
+            self.rd.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["rhwp"], timeout=1),
+        ):
+            probed = self.rd.probe_capabilities("rhwp", timeout=1)
+        self.assertEqual(probed["kind"], "timeout")
+        self.assertFalse(probed["ok"])
+        self.assertIsNone(probed["digest"])
+
+    def test_probe_oserror(self):
+        with mock.patch.object(self.rd.subprocess, "run", side_effect=OSError(22, "bad")):
+            probed = self.rd.probe_capabilities("rhwp")
+        self.assertEqual(probed["kind"], "os-error")
+        self.assertFalse(probed["ok"])
+
+    def test_probe_does_not_swallow_keyboardinterrupt(self):
+        with mock.patch.object(self.rd.subprocess, "run", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                self.rd.probe_capabilities("rhwp")
+
+    def test_probe_does_not_swallow_systemexit(self):
+        with mock.patch.object(self.rd.subprocess, "run", side_effect=SystemExit(2)):
+            with self.assertRaises(SystemExit):
+                self.rd.probe_capabilities("rhwp")
+
+    def test_capabilities_digest_timeout_kwarg(self):
+        proc = mock.Mock(stdout=b"x", returncode=0)
+        with mock.patch.object(self.rd.subprocess, "run", return_value=proc) as run:
+            digest = self.rd.capabilities_digest("rhwp", timeout=5)
+        self.assertEqual(digest, hashlib.sha256(b"x").hexdigest())
+        kwargs = run.call_args.kwargs
+        self.assertEqual(kwargs.get("timeout"), 5)
+
+    def test_capabilities_digest_str_stdout(self):
+        proc = mock.Mock(stdout="abc", returncode=0)
+        with mock.patch.object(self.rd.subprocess, "run", return_value=proc):
+            digest = self.rd.capabilities_digest("rhwp")
+        self.assertEqual(digest, hashlib.sha256(b"abc").hexdigest())
+
+    def test_can_classify_surface_requires_two_strings(self):
+        self.assertTrue(self.rd.can_classify_surface("aaa", "bbb"))
+        self.assertFalse(self.rd.can_classify_surface(None, "bbb"))
+        self.assertFalse(self.rd.can_classify_surface("aaa", None))
+        self.assertFalse(self.rd.can_classify_surface(None, None))
+        self.assertFalse(self.rd.can_classify_surface(1, 1))
+
+
+class ClassifyHonestyTests(unittest.TestCase):
+    """classify 는 삼원만 낸다. 표면 모름을 삼원으로 위장하지 않는다."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_classify_never_returns_probe_failed(self):
+        for surface in (True, False, 1, 0, "", "x"):
+            for divergences in (None, 0, 1, [], [{}], False, True, "", "row"):
+                got = self.rd.classify(surface, divergences)
+                self.assertIn(got, self.rd.CLASSIFICATIONS)
+                self.assertNotEqual(got, self.rd.STATUS_PROBE_FAILED)
+
+    def test_classify_matrix_extended_shapes(self):
+        cases = [
+            (False, None, "stable"),
+            (False, 0, "stable"),
+            (False, 0.0, "stable"),
+            (False, "", "stable"),
+            (False, [], "stable"),
+            (False, {}, "stable"),
+            (False, False, "stable"),
+            (False, 1, "regression"),
+            (False, -1, "regression"),
+            (False, "x", "regression"),
+            (False, [1], "regression"),
+            (False, {"a": 1}, "regression"),
+            (False, True, "regression"),
+            (True, None, "surface-changed"),
+            (True, 0, "surface-changed"),
+            (True, [], "surface-changed"),
+            (True, [1], "surface-changed"),
+            (True, True, "surface-changed"),
+            ("yes", [], "surface-changed"),
+            (1, 0, "surface-changed"),
+        ]
+        for surface, divergences, expected in cases:
+            self.assertEqual(
+                self.rd.classify(surface, divergences), expected,
+                (surface, divergences),
+            )
+
+    def test_surface_wins_over_every_divergence_shape(self):
+        for divergences in (None, 0, 1, [], [1], {}, "x", True, False):
+            self.assertEqual(
+                self.rd.classify(True, divergences), "surface-changed", divergences)
+
+    def test_same_surface_empty_is_never_regression(self):
+        for empty in (None, 0, 0.0, "", [], {}, False):
+            self.assertEqual(self.rd.classify(False, empty), "stable", empty)
+
+    def test_classify_or_probe_failed_separates_unknown_surface(self):
+        self.assertEqual(
+            self.rd.classify_or_probe_failed("a", "a", []), "stable")
+        self.assertEqual(
+            self.rd.classify_or_probe_failed("a", "a", [1]), "regression")
+        self.assertEqual(
+            self.rd.classify_or_probe_failed("a", "b", []), "surface-changed")
+        self.assertEqual(
+            self.rd.classify_or_probe_failed("a", "b", [1]), "surface-changed")
+        self.assertEqual(
+            self.rd.classify_or_probe_failed(None, "b", [1]), "probe-failed")
+        self.assertEqual(
+            self.rd.classify_or_probe_failed("a", None, []), "probe-failed")
+        self.assertEqual(
+            self.rd.classify_or_probe_failed(None, None, []), "probe-failed")
+
+    def test_status_exit_and_reason(self):
+        self.assertEqual(self.rd.status_exit("stable"), 0)
+        self.assertEqual(self.rd.status_exit("surface-changed"), 2)
+        self.assertEqual(self.rd.status_exit("regression"), 3)
+        self.assertEqual(self.rd.status_exit("probe-failed"), 1)
+        self.assertIn("위장하지 않는다", self.rd.reason_for("probe-failed"))
+        self.assertEqual(self.rd.reason_for("stable"),
+                         self.rd.CLASSIFICATION_REASON["stable"])
+        with self.assertRaises(KeyError):
+            self.rd.status_exit("skipped")
+
+    def test_classifications_tuple_is_exactly_three(self):
+        self.assertEqual(self.rd.CLASSIFICATIONS,
+                         ("stable", "regression", "surface-changed"))
+        self.assertNotIn(self.rd.STATUS_PROBE_FAILED, self.rd.CLASSIFICATIONS)
+        self.assertEqual(set(self.rd.EXIT_BY_CLASS), set(self.rd.CLASSIFICATIONS))
+
+
+class ObservationEqualityEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_none_equals_none(self):
+        self.assertTrue(self.rd.observations_equal(None, None))
+        self.assertFalse(self.rd.observations_equal(None, _value(None)))
+
+    def test_nan_equals_nan_but_not_number(self):
+        nan = float("nan")
+        self.assertTrue(self.rd.observations_equal(_value(nan), _value(nan)))
+        self.assertFalse(self.rd.observations_equal(_value(nan), _value(0)))
+        self.assertFalse(self.rd.observations_equal(_value(nan), _value(1)))
+
+    def test_inf_and_negative_inf(self):
+        inf = float("inf")
+        self.assertTrue(self.rd.observations_equal(_value(inf), _value(inf)))
+        self.assertFalse(self.rd.observations_equal(_value(inf), _value(-inf)))
+        self.assertFalse(self.rd.observations_equal(_value(inf), _value(1e308)))
+
+    def test_nested_list_and_tuple(self):
+        self.assertTrue(self.rd.observations_equal(
+            _value([1, [2, 3.0]]), _value([1.0, [2, 3]])))
+        self.assertFalse(self.rd.observations_equal(
+            _value([1, 2]), _value([1, 2, 3])))
+        self.assertTrue(self.rd._values_equal((1, 2.0), (1.0, 2)))
+        self.assertFalse(self.rd._values_equal((1, 2), [1, 2]))
+
+    def test_dict_key_mismatch_and_nested(self):
+        self.assertFalse(self.rd.observations_equal(
+            _value({"a": 1}), _value({"a": 1, "b": 2})))
+        self.assertTrue(self.rd.observations_equal(
+            _value({"a": {"b": 1}}), _value({"a": {"b": 1.0}})))
+        self.assertFalse(self.rd.observations_equal(
+            _value({"a": True}), _value({"a": 1})))
+
+    def test_unicode_and_bytes_are_not_collapsed(self):
+        self.assertTrue(self.rd.observations_equal(_value("한글"), _value("한글")))
+        self.assertFalse(self.rd.observations_equal(_value("한글"), _value("한글 ")))
+        self.assertFalse(self.rd._values_equal(b"ab", "ab"))
+
+    def test_false_is_not_zero(self):
+        self.assertFalse(self.rd.observations_equal(_value(False), _value(0)))
+        self.assertFalse(self.rd.observations_equal(_value(False), _value(0.0)))
+        self.assertTrue(self.rd.observations_equal(_value(False), _value(False)))
+
+    def test_error_kinds_equal_only_with_same_payload(self):
+        a = {"kind": "resolve-error", "error": "FileNotFoundError", "head": "x"}
+        b = {"kind": "resolve-error", "error": "FileNotFoundError", "head": "x"}
+        c = {"kind": "resolve-error", "error": "FileNotFoundError", "head": "y"}
+        d = {"kind": "missing-bin", "error": "FileNotFoundError", "head": "x"}
+        self.assertTrue(self.rd.observations_equal(a, b))
+        self.assertFalse(self.rd.observations_equal(a, c))
+        self.assertFalse(self.rd.observations_equal(a, d))
+
+    def test_display_new_kinds(self):
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "timeout", "error": "TimeoutError"}), "timeout")
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "missing-bin", "error": "FileNotFoundError"}), "missing-bin")
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "permission", "error": "PermissionError"}), "permission")
+        self.assertEqual(self.rd.observation_display(
+            {"kind": "resolve-error", "error": "OSError"}), "resolve-error")
+        self.assertEqual(self.rd.observation_display("plain"), "plain")
+
+
+class ObserveExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+        self.task = {"input": "samples/x.hwp"}
+        self.check = {"name": "쪽수", "op": "value_eq", "value": 6,
+                      "cmd": ["info", "{input}", "--json"], "path": "pageCount"}
+
+    def test_run_cli_timeout_is_observation(self):
+        with mock.patch.object(
+            self.rd.runner, "run_cli",
+            side_effect=subprocess.TimeoutExpired(cmd=["rhwp"], timeout=1),
+        ):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "timeout")
+        self.assertEqual(obs["error"], "TimeoutExpired")
+
+    def test_run_cli_missing_bin_is_observation(self):
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               side_effect=FileNotFoundError("rhwp")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "missing-bin")
+        self.assertEqual(obs["error"], "FileNotFoundError")
+
+    def test_run_cli_permission_is_observation(self):
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               side_effect=PermissionError("x")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "permission")
+
+    def test_run_cli_oserror_is_observation(self):
+        with mock.patch.object(self.rd.runner, "run_cli",
+                               side_effect=OSError("broken pipe")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "os-error")
+
+    def test_resolve_oserror_stays_resolve_error(self):
+        with mock.patch.object(self.rd.runner, "resolve_args",
+                               side_effect=OSError("noent")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "os-error")
+
+    def test_resolve_keyerror_is_observation(self):
+        with mock.patch.object(self.rd.runner, "resolve_args",
+                               side_effect=KeyError("input")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "digfail")
+        self.assertEqual(obs["error"], "KeyError")
+
+    def test_resolve_typeerror_is_observation(self):
+        with mock.patch.object(self.rd.runner, "resolve_args",
+                               side_effect=TypeError("cmd")):
+            obs = self.rd.observe("rhwp", self.check, self.task, ".")
+        self.assertEqual(obs["kind"], "type-error")
+
+    def test_non_dict_check_is_type_error(self):
+        obs = self.rd.observe("rhwp", "not-a-check", self.task, ".")
+        self.assertEqual(obs["kind"], "type-error")
+
+    def test_observe_does_not_swallow_keyboardinterrupt_on_cli(self):
+        with mock.patch.object(self.rd.runner, "run_cli", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                self.rd.observe("rhwp", self.check, self.task, ".")
+
+    def test_observe_does_not_swallow_keyboardinterrupt_on_resolve(self):
+        with mock.patch.object(self.rd.runner, "resolve_args", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                self.rd.observe("rhwp", self.check, self.task, ".")
+
+    def test_dig_valueerror_is_digfail(self):
+        check = dict(self.check, path="a[nope]")
+        obs = self.rd.observation_from_result(0, {"a": [1]}, "", check)
+        self.assertEqual(obs["kind"], "digfail")
+        self.assertEqual(obs["error"], "ValueError")
+
+    def test_dig_typeerror_is_digfail(self):
+        check = dict(self.check, path="n.x")
+        obs = self.rd.observation_from_result(0, {"n": 3}, "", check)
+        self.assertEqual(obs["kind"], "digfail")
+
+    def test_injected_dig_fn_exception_is_digfail(self):
+        def boom(_env, _path):
+            raise RuntimeError("dig")
+        obs = self.rd.observation_from_result(0, {"pageCount": 1}, "", self.check, dig_fn=boom)
+        self.assertEqual(obs["kind"], "digfail")
+        self.assertEqual(obs["error"], "RuntimeError")
+
+    def test_injected_find_cell_exception_is_digfail(self):
+        check = {"op": "cell_text_eq", "table": 0, "row": 0, "col": 0, "path": "tables"}
+        env = {"tables": [{"cells": []}]}
+
+        def boom(*_a):
+            raise TypeError("cell")
+        obs = self.rd.observation_from_result(0, env, "", check, find_cell_fn=boom)
+        self.assertEqual(obs["kind"], "digfail")
+        self.assertEqual(obs["error"], "TypeError")
+
+    def test_head_is_truncated_to_limit(self):
+        long_head = "x" * 200
+        obs = self.rd.observation_from_result(2, None, long_head, self.check)
+        self.assertEqual(obs["kind"], "exit")
+        self.assertEqual(len(obs["head"]), self.rd.HEAD_LIMIT)
+
+
+class DiffTaskExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def _task(self, extra=None):
+        checks = [{"name": "쪽수", "op": "value_eq",
+                   "cmd": ["info", "{input}", "--json"], "path": "pageCount"}]
+        if extra:
+            checks.extend(extra)
+        return {"id": "T", "input": "x.hwp", "checks": checks}
+
+    def test_cli_error_on_one_side_is_divergence(self):
+        def fake(bin_path, args):
+            if bin_path == "old":
+                return (0, {"pageCount": 6}, "")
+            raise FileNotFoundError("new")
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli", side_effect=fake):
+            rows = self.rd.diff_task("old", "new", self._task(), "/sub", "pack")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["old"], _value(6))
+        self.assertEqual(rows[0]["new"]["kind"], "missing-bin")
+
+    def test_same_cli_error_is_not_divergence(self):
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli",
+                                  side_effect=FileNotFoundError("rhwp")):
+            rows = self.rd.diff_task("old", "new", self._task(), "/sub", "pack")
+        self.assertEqual(rows, [])
+
+    def test_bad_task_shape_yields_empty(self):
+        self.assertEqual(self.rd.diff_task("o", "n", None, "/s", "p"), [])
+        self.assertEqual(self.rd.diff_task("o", "n", {"id": "T", "checks": "x"}, "/s", "p"), [])
+
+    def test_file_op_mixed_with_value_only_compares_value(self):
+        task = self._task(extra=[{"name": "산출", "op": "file_exists", "file": "o.hwp"}])
+        called = []
+
+        def fake(bin_path, args):
+            called.append((bin_path, args))
+            return (0, {"pageCount": 6}, "")
+        with mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli", side_effect=fake):
+            rows = self.rd.diff_task("old", "new", task, "/sub", "pack")
+        self.assertEqual(rows, [])
+        self.assertEqual(len(called), 2)
+
+    def test_should_observe_rejects_non_dict(self):
+        self.assertFalse(self.rd.should_observe(None))
+        self.assertFalse(self.rd.should_observe("value_eq"))
+        self.assertTrue(self.rd.should_observe({"op": "value_eq"}))
+
+    def test_count_observable_checks(self):
+        task = {"checks": [
+            {"op": "value_eq"},
+            {"op": "file_exists"},
+            {"op": "cell_text_eq"},
+            {"op": "same_hash"},
+        ]}
+        seen, skipped = self.rd.count_observable_checks(task)
+        self.assertEqual(seen, 2)
+        self.assertEqual(skipped, 2)
+        self.assertEqual(self.rd.count_observable_checks(None), (0, 0))
+        self.assertEqual(self.rd.count_observable_checks({"checks": None}), (0, 0))
+
+    def test_resolve_submission_dir_pack_then_flat(self):
+        with tempfile.TemporaryDirectory() as d:
+            packed = os.path.join(d, "core-cli", "T01")
+            os.makedirs(packed)
+            got = self.rd.resolve_submission_dir(d, "core-cli", "T01")
+            self.assertEqual(got, packed)
+            flat_root = os.path.join(d, "flat")
+            os.makedirs(os.path.join(flat_root, "T02"))
+            got = self.rd.resolve_submission_dir(flat_root, "core-cli", "T02")
+            self.assertEqual(got, os.path.join(flat_root, "T02"))
+        self.assertEqual(self.rd.resolve_submission_dir("", "p", "T"), "")
+
+    def test_resolve_submission_dir_oserror_is_not_fatal(self):
+        with mock.patch("os.path.isdir", side_effect=OSError("x")):
+            got = self.rd.resolve_submission_dir("/sub", "p", "T")
+        self.assertTrue(got.endswith("T"))
+
+
+class ReportHonestyTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def _row(self):
+        return {
+            "pack": "core-cli", "task": "T01", "check": "쪽수",
+            "op": "value_eq", "path": "pageCount",
+            "old": _value(6), "new": _value(7),
+        }
+
+    def test_build_report_without_string_digest_is_probe_failed(self):
+        report = self.rd.build_report("old", None, "new", "aaa", 1, 1, [])
+        self.assertEqual(report["classification"], "probe-failed")
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["reviewRequired"])
+        self.assertFalse(report["surfaceChanged"])
+        self.assertEqual(report["exit"], 1)
+        self.assertTrue(report["probeFailed"])
+        self.assertEqual(self.rd.validate_report(report), [])
+
+    def test_both_none_digests_are_not_stable(self):
+        report = self.rd.build_report("old", None, "new", None, 0, 0, [])
+        self.assertEqual(report["classification"], "probe-failed")
+        self.assertNotEqual(report["classification"], "stable")
+        self.assertFalse(report["ok"])
+
+    def test_probe_failed_report_does_not_claim_surface_change(self):
+        old_p = {"ok": False, "kind": "missing-bin", "error": "FileNotFoundError",
+                 "digest": None, "head": "old"}
+        new_p = {"ok": True, "kind": "digest", "digest": "a" * 64, "head": ""}
+        report = self.rd.build_probe_failed_report("old/rhwp", old_p, "new/rhwp", new_p)
+        self.assertEqual(report["classification"], "probe-failed")
+        self.assertFalse(report["surfaceChanged"])
+        self.assertEqual(len(report["probeErrors"]), 1)
+        self.assertEqual(report["probeErrors"][0]["role"], "old")
+        self.assertEqual(self.rd.validate_report(report), [])
+
+    def test_empty_report_is_probe_failed(self):
+        report = self.rd.empty_report("o", "n")
+        self.assertEqual(report["classification"], "probe-failed")
+        self.assertEqual(self.rd.validate_report(report), [])
+
+    def test_validate_report_catches_ok_lie(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [self._row()])
+        self.assertEqual(report["classification"], "regression")
+        report["ok"] = True
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("ok" in i for i in issues))
+
+    def test_validate_report_catches_review_lie(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [])
+        report["reviewRequired"] = True
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("reviewRequired" in i for i in issues))
+
+    def test_validate_report_catches_surface_lie(self):
+        report = self.rd.build_report("o", "aaa", "n", "aaa", 1, 1, [])
+        report["surfaceChanged"] = True
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("surfaceChanged" in i for i in issues))
+
+    def test_validate_report_catches_probe_flag_on_stable(self):
+        report = self.rd.build_report("o", "aaa", "n", "aaa", 1, 1, [])
+        report["probeFailed"] = True
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("probeFailed" in i for i in issues))
+
+    def test_validate_report_catches_divergence_count(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [self._row()])
+        report["divergences"] = 0
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("divergences" in i for i in issues))
+
+    def test_validate_report_rejects_unknown_class(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [])
+        report["classification"] = "skipped"
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("알 수 없는" in i for i in issues))
+
+    def test_validate_report_rejects_non_dict(self):
+        self.assertEqual(self.rd.validate_report(None), ["report 가 dict 가 아니다"])
+
+    def test_validate_report_accepts_honest_triple(self):
+        for old_d, new_d, diffs, expected in (
+            ("aaa", "aaa", [], "stable"),
+            ("aaa", "aaa", [self._row()], "regression"),
+            ("aaa", "bbb", [], "surface-changed"),
+            ("aaa", "bbb", [self._row()], "surface-changed"),
+        ):
+            report = self.rd.build_report("o", old_d, "n", new_d, 2, 3, diffs)
+            self.assertEqual(report["classification"], expected)
+            self.assertEqual(self.rd.validate_report(report), [], expected)
+
+    def test_stable_cannot_carry_diffs(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [])
+        report["diffs"] = [self._row()]
+        report["divergences"] = 1
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("stable" in i for i in issues))
+
+    def test_regression_cannot_have_zero_diffs(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [self._row()])
+        report["diffs"] = []
+        report["divergences"] = 0
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("regression" in i for i in issues))
+
+
+class WriteAndSummaryExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_write_report_safe_oserror(self):
+        report = self.rd.build_report("o", "x", "n", "x", 0, 0, [])
+        err = self.rd.write_report_safe(report, os.path.join("no-such-dir", "x", "out.json"))
+        self.assertIsNotNone(err)
+        self.assertIn("write_report", err)
+
+    def test_write_report_safe_success(self):
+        report = self.rd.build_report("o", "x", "n", "x", 0, 0, [])
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.json")
+            self.assertIsNone(self.rd.write_report_safe(report, path))
+            loaded = json.loads(Path(path).read_text(encoding="utf-8"))
+        self.assertEqual(loaded["classification"], "stable")
+
+    def test_render_summary_probe_failed(self):
+        report = self.rd.empty_report("/opt/old/rhwp", "/opt/new/rhwp")
+        lines = self.rd.render_summary(report, "out.json")
+        text = "\n".join(lines)
+        self.assertIn("프로브 실패", text)
+        self.assertIn("probe-failed", text)
+        self.assertNotIn("분류 [stable]", text)
+        self.assertNotIn("분류 [regression]", text)
+        self.assertEqual(lines[-1], "→ out.json")
+
+    def test_render_summary_includes_pack_errors(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [])
+        report["packErrors"] = ["pack core-cli: FileNotFoundError: x"]
+        report["writeError"] = "write_report: OSError: disk"
+        lines = self.rd.render_summary(report, "out.json")
+        text = "\n".join(lines)
+        self.assertIn("pack 오류", text)
+        self.assertIn("쓰기 오류", text)
+
+    def test_render_summary_surface_changed(self):
+        report = self.rd.build_report("o", "aaa", "n", "bbb", 2, 2, [])
+        lines = self.rd.render_summary(report, "p.json")
+        text = "\n".join(lines)
+        self.assertIn("surface-changed", text)
+        self.assertIn("다름", text)
+
+
+class PackLoadSafeTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_load_pack_safe_oserror(self):
+        with mock.patch.object(self.rd.runner, "load_pack", side_effect=FileNotFoundError("p")):
+            manifest, tasks, err = self.rd.load_pack_safe("core-cli")
+        self.assertIsNone(manifest)
+        self.assertEqual(tasks, [])
+        self.assertIn("core-cli", err)
+        self.assertIn("FileNotFoundError", err)
+
+    def test_load_pack_safe_json_error(self):
+        with mock.patch.object(self.rd.runner, "load_pack",
+                               side_effect=json.JSONDecodeError("e", "x", 0)):
+            _m, tasks, err = self.rd.load_pack_safe("broken")
+        self.assertEqual(tasks, [])
+        self.assertIn("JSONDecodeError", err)
+
+    def test_load_pack_safe_success(self):
+        with mock.patch.object(self.rd.runner, "load_pack",
+                               return_value=({"id": "p"}, [{"id": "T"}])):
+            manifest, tasks, err = self.rd.load_pack_safe("p")
+        self.assertEqual(manifest["id"], "p")
+        self.assertEqual(len(tasks), 1)
+        self.assertIsNone(err)
+
+    def test_load_pack_safe_non_list_tasks(self):
+        with mock.patch.object(self.rd.runner, "load_pack",
+                               return_value=({"id": "p"}, None)):
+            _m, tasks, err = self.rd.load_pack_safe("p")
+        self.assertEqual(tasks, [])
+        self.assertIn("list", err)
+
+    def test_discover_packs_safe_explicit(self):
+        packs, err = self.rd.discover_packs_safe(["core-cli", "security"])
+        self.assertEqual(packs, ["core-cli", "security"])
+        self.assertIsNone(err)
+
+    def test_discover_packs_safe_oserror(self):
+        with mock.patch.object(self.rd.runner, "discover_packs", side_effect=OSError("x")):
+            packs, err = self.rd.discover_packs_safe(None)
+        self.assertEqual(packs, [])
+        self.assertIn("discover_packs", err)
+
+    def test_compare_packs_skips_broken_pack(self):
+        def loader(pack_id):
+            if pack_id == "bad":
+                raise OSError("nope")
+            return {"id": pack_id}, [{"id": "T", "checks": [
+                {"name": "쪽수", "op": "value_eq",
+                 "cmd": ["info", "{input}", "--json"], "path": "pageCount"}]}]
+        with mock.patch.object(self.rd.runner, "load_pack", side_effect=loader), \
+                mock.patch("os.path.isdir", return_value=True), \
+                mock.patch.object(self.rd.runner, "run_cli",
+                                  return_value=(0, {"pageCount": 6}, "")):
+            coll = self.rd.compare_packs("old", "new", ["bad", "good"], "/sub")
+        self.assertEqual(coll["tasksCompared"], 1)
+        self.assertEqual(len(coll["packErrors"]), 1)
+        self.assertIn("bad", coll["packErrors"][0])
+        self.assertEqual(coll["diffs"], [])
+
+    def test_compare_packs_records_task_exception(self):
+        with mock.patch.object(self.rd.runner, "load_pack",
+                               return_value=({"id": "p"}, [{"id": "T", "checks": [
+                                   {"op": "value_eq", "cmd": ["info"], "path": "x"}]}])), \
+                mock.patch.object(self.rd, "diff_task", side_effect=RuntimeError("boom")):
+            coll = self.rd.compare_packs("o", "n", ["p"], "/sub")
+        self.assertEqual(len(coll["taskErrors"]), 1)
+        self.assertIn("RuntimeError", coll["taskErrors"][0])
+
+    def test_attach_collection_errors_does_not_change_class(self):
+        report = self.rd.build_report("o", "x", "n", "x", 1, 1, [])
+        self.rd.attach_collection_errors(report, {
+            "packErrors": ["pack z"],
+            "taskErrors": ["t"],
+        })
+        self.assertEqual(report["classification"], "stable")
+        self.assertEqual(report["packErrors"], ["pack z"])
+        self.assertEqual(report["taskErrors"], ["t"])
+
+
+class MainEntryExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_parse_args_digest_timeout(self):
+        ns = self.rd.parse_args(["--old", "o", "--new", "n", "--digest-timeout", "7"])
+        self.assertEqual(ns.old, "o")
+        self.assertEqual(ns.new, "n")
+        self.assertEqual(ns.digest_timeout, 7)
+
+    def test_main_probe_failed_does_not_claim_stable(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "r.json")
+            with mock.patch.object(self.rd, "find_bin_safe", side_effect=[("old", None), ("new", None)]), \
+                    mock.patch.object(self.rd, "probe_capabilities",
+                                      return_value={"ok": False, "kind": "missing-bin",
+                                                    "digest": None, "error": "FileNotFoundError",
+                                                    "head": "x", "exit": None}), \
+                    mock.patch.object(self.rd, "discover_packs_safe", return_value=([], None)), \
+                    mock.patch.object(self.rd, "compare_packs", return_value={
+                        "diffs": [], "tasksCompared": 0, "observationsCompared": 0,
+                        "observationsSkipped": 0, "packErrors": [], "taskErrors": [],
+                    }):
+                code = self.rd.main(["--old", "o", "--new", "n", "-o", out])
+            self.assertEqual(code, 1)
+            report = json.loads(Path(out).read_text(encoding="utf-8"))
+        self.assertEqual(report["classification"], "probe-failed")
+        self.assertFalse(report["ok"])
+        self.assertNotEqual(report["classification"], "stable")
+
+    def test_main_stable_when_probes_and_obs_match(self):
+        digest = "a" * 64
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "r.json")
+            with mock.patch.object(self.rd, "find_bin_safe", side_effect=[("old", None), ("new", None)]), \
+                    mock.patch.object(self.rd, "probe_capabilities",
+                                      return_value={"ok": True, "kind": "digest",
+                                                    "digest": digest, "error": None,
+                                                    "head": "", "exit": 0}), \
+                    mock.patch.object(self.rd, "discover_packs_safe",
+                                      return_value=(["p"], None)), \
+                    mock.patch.object(self.rd, "compare_packs", return_value={
+                        "diffs": [], "tasksCompared": 2, "observationsCompared": 4,
+                        "observationsSkipped": 1, "packErrors": [], "taskErrors": [],
+                    }):
+                code = self.rd.main(["--old", "o", "--new", "n", "-o", out])
+            self.assertEqual(code, 0)
+            report = json.loads(Path(out).read_text(encoding="utf-8"))
+        self.assertEqual(report["classification"], "stable")
+        self.assertTrue(report["ok"])
+        self.assertEqual(self.rd.validate_report(report), [])
+
+    def test_main_regression_exit_three(self):
+        digest = "b" * 64
+        row = {"pack": "p", "task": "T", "check": "쪽수", "op": "value_eq",
+               "path": "pageCount", "old": _value(6), "new": _value(7)}
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "r.json")
+            with mock.patch.object(self.rd, "find_bin_safe", side_effect=[("old", None), ("new", None)]), \
+                    mock.patch.object(self.rd, "probe_capabilities",
+                                      return_value={"ok": True, "kind": "digest",
+                                                    "digest": digest, "error": None,
+                                                    "head": "", "exit": 0}), \
+                    mock.patch.object(self.rd, "discover_packs_safe",
+                                      return_value=(["p"], None)), \
+                    mock.patch.object(self.rd, "compare_packs", return_value={
+                        "diffs": [row], "tasksCompared": 1, "observationsCompared": 1,
+                        "observationsSkipped": 0, "packErrors": [], "taskErrors": [],
+                    }):
+                code = self.rd.main(["--old", "o", "--new", "n", "-o", out])
+            report = json.loads(Path(out).read_text(encoding="utf-8"))
+        self.assertEqual(code, 3)
+        self.assertEqual(report["classification"], "regression")
+        self.assertFalse(report["surfaceChanged"])
+
+    def test_main_surface_changed_exit_two(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "r.json")
+            probes = [
+                {"ok": True, "kind": "digest", "digest": "a" * 64, "error": None, "head": "", "exit": 0},
+                {"ok": True, "kind": "digest", "digest": "b" * 64, "error": None, "head": "", "exit": 0},
+            ]
+            with mock.patch.object(self.rd, "find_bin_safe", side_effect=[("old", None), ("new", None)]), \
+                    mock.patch.object(self.rd, "probe_capabilities", side_effect=probes), \
+                    mock.patch.object(self.rd, "discover_packs_safe",
+                                      return_value=(["p"], None)), \
+                    mock.patch.object(self.rd, "compare_packs", return_value={
+                        "diffs": [], "tasksCompared": 1, "observationsCompared": 1,
+                        "observationsSkipped": 0, "packErrors": [], "taskErrors": [],
+                    }):
+                code = self.rd.main(["--old", "o", "--new", "n", "-o", out])
+            report = json.loads(Path(out).read_text(encoding="utf-8"))
+        self.assertEqual(code, 2)
+        self.assertEqual(report["classification"], "surface-changed")
+        self.assertTrue(report["reviewRequired"])
+
+    def test_main_write_error_is_recorded_not_raised(self):
+        digest = "c" * 64
+        with mock.patch.object(self.rd, "find_bin_safe", side_effect=[("old", None), ("new", None)]), \
+                mock.patch.object(self.rd, "probe_capabilities",
+                                  return_value={"ok": True, "kind": "digest",
+                                                "digest": digest, "error": None,
+                                                "head": "", "exit": 0}), \
+                mock.patch.object(self.rd, "discover_packs_safe", return_value=([], None)), \
+                mock.patch.object(self.rd, "compare_packs", return_value={
+                    "diffs": [], "tasksCompared": 0, "observationsCompared": 0,
+                    "observationsSkipped": 0, "packErrors": [], "taskErrors": [],
+                }), \
+                mock.patch.object(self.rd, "write_report_safe", return_value="write_report: OSError"):
+            code = self.rd.main(["--old", "o", "--new", "n", "-o", "unused.json"])
+        self.assertEqual(code, 0)
+
+    def test_find_bin_safe_oserror(self):
+        with mock.patch.object(self.rd.runner, "find_bin", side_effect=OSError("x")):
+            found, err = self.rd.find_bin_safe("rhwp")
+        self.assertEqual(found, "rhwp")
+        self.assertIn("find_bin", err)
+
+    def test_find_bin_safe_success(self):
+        with mock.patch.object(self.rd.runner, "find_bin", return_value="/abs/rhwp"):
+            found, err = self.rd.find_bin_safe("rhwp")
+        self.assertEqual(found, "/abs/rhwp")
+        self.assertIsNone(err)
+
+
+class CatalogContractTests(unittest.TestCase):
+    """카탈로그·키 집합이 문서/시험과 같은 표를 보는지."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_observation_kinds_cover_exception_table(self):
+        for kind in (
+            "value", "exit", "nojson", "digfail", "no-cmd", "resolve-error",
+            "cli-error", "timeout", "missing-bin", "permission", "os-error",
+            "type-error", "value-error", "decode-error", "unexpected",
+        ):
+            self.assertIn(kind, self.rd.OBSERVATION_KINDS)
+
+    def test_file_ops_are_exactly_the_four(self):
+        self.assertEqual(self.rd.FILE_OPS, {
+            "file_exists", "same_hash", "differs_from_input", "files_differ",
+        })
+
+    def test_report_keys_include_honesty_fields(self):
+        for key in (
+            "classification", "classificationReason", "exit", "ok",
+            "reviewRequired", "surfaceChanged", "divergences", "diffs",
+        ):
+            self.assertIn(key, self.rd.REPORT_KEYS)
+
+    def test_report_kind_and_schema(self):
+        self.assertEqual(self.rd.REPORT_KIND, "gymReleaseDiff")
+        self.assertEqual(self.rd.SCHEMA_VERSION, "1.0")
+        self.assertEqual(self.rd.DIGEST_TIMEOUT, 30)
+        self.assertEqual(self.rd.HEAD_LIMIT, 80)
+        self.assertEqual(self.rd.EXIT_PROBE_FAILED, 1)
+
+    def test_classification_reasons_do_not_name_winner(self):
+        for reason in self.rd.CLASSIFICATION_REASON.values():
+            self.assertNotIn("옳", reason)
+            self.assertNotIn("정답", reason)
+
+    def test_probe_failed_reason_forbids_disguise(self):
+        self.assertIn("위장하지 않는다", self.rd.PROBE_FAILED_REASON)
+        self.assertIn("stable", self.rd.PROBE_FAILED_REASON)
+        self.assertIn("regression", self.rd.PROBE_FAILED_REASON)
+        self.assertIn("surface-changed", self.rd.PROBE_FAILED_REASON)
+
+
+class CellAndExitEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_cell_missing_table_key_is_digfail(self):
+        check = {"op": "cell_text_eq", "table": 0, "row": 0, "col": 0, "path": "tables"}
+        env = {"tables": {"not": "a-list"}}
+        obs = self.rd.observation_from_result(0, env, "", check)
+        self.assertEqual(obs["kind"], "digfail")
+
+    def test_cell_none_tables_is_digfail(self):
+        check = {"op": "cell_text_eq", "table": 0, "row": 0, "col": 0, "path": "tables"}
+        obs = self.rd.observation_from_result(0, {"tables": None}, "", check)
+        self.assertEqual(obs["kind"], "digfail")
+
+    def test_expected_exits_empty_list_falls_back(self):
+        self.assertEqual(self.rd.expected_exits({"expect_exits": []}), [0])
+        self.assertEqual(self.rd.expected_exits({"expect_exits": None}), [0])
+        self.assertEqual(self.rd.expected_exits({"expect_exit": None}), [None])
+
+    def test_exit_zero_allowed_by_default(self):
+        check = {"op": "value_eq", "path": "n"}
+        self.assertEqual(
+            self.rd.observation_from_result(0, {"n": 1}, "", check), _value(1))
+
+    def test_exit_three_not_allowed_without_expect(self):
+        check = {"op": "value_eq", "path": "n"}
+        obs = self.rd.observation_from_result(3, {"n": 1}, "judge", check)
+        self.assertEqual(obs["kind"], "exit")
+        self.assertEqual(obs["code"], 3)
+
+    def test_make_diff_row_without_name_uses_op(self):
+        row = self.rd.make_diff_row("T", {"op": "value_eq", "path": "x"}, _value(1), _value(2))
+        self.assertEqual(row["check"], "value_eq")
+        self.assertEqual(row["task"], "T")
+
+    def test_make_diff_row_non_dict_check(self):
+        row = self.rd.make_diff_row("T", None, _value(1), _value(2))
+        self.assertEqual(row["op"], "")
+        self.assertEqual(row["check"], "")
+
+
+class ObservationKindMatrixTests(unittest.TestCase):
+    """관측 kind 가 구/신에서 갈릴 때 회귀로만 잡히고 표면은 건드리지 않는다."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_kind_pairs_do_not_change_classify(self):
+        pairs = [
+            (_value(1), _value(2)),
+            (_value(1), {"kind": "exit", "code": 2, "head": ""}),
+            ({"kind": "nojson", "head": "x"}, _value("x")),
+            ({"kind": "digfail", "error": "KeyError"}, _value(None)),
+            ({"kind": "timeout", "error": "TimeoutExpired"},
+             {"kind": "timeout", "error": "TimeoutError"}),
+            ({"kind": "missing-bin", "error": "FileNotFoundError"},
+             _value(1)),
+        ]
+        for old, new in pairs:
+            equal = self.rd.observations_equal(old, new)
+            if equal:
+                self.assertEqual(self.rd.classify(False, []), "stable")
+            else:
+                self.assertEqual(self.rd.classify(False, [1]), "regression")
+            self.assertEqual(self.rd.classify(True, [1] if not equal else []),
+                             "surface-changed")
+
+    def test_identical_error_kinds_are_stable_input(self):
+        obs = {"kind": "timeout", "error": "TimeoutExpired", "head": ""}
+        self.assertTrue(self.rd.observations_equal(obs, dict(obs)))
+        self.assertEqual(self.rd.classify(False, []), "stable")
+
+
+class HonestyInvariantScanTests(unittest.TestCase):
+    """모듈 상수·함수가 정직 조항을 깨지 않는지 훑는다."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_exit_by_class_values_are_gate_contract(self):
+        self.assertEqual(self.rd.EXIT_BY_CLASS["stable"], 0)
+        self.assertEqual(self.rd.EXIT_BY_CLASS["surface-changed"], 2)
+        self.assertEqual(self.rd.EXIT_BY_CLASS["regression"], 3)
+        self.assertNotIn("probe-failed", self.rd.EXIT_BY_CLASS)
+        self.assertNotIn("skipped", self.rd.EXIT_BY_CLASS)
+
+    def test_ok_review_surface_mutually_consistent(self):
+        cases = [
+            ("aaa", "aaa", [], True, False, False, "stable"),
+            ("aaa", "aaa", [1], False, False, False, "regression"),
+            ("aaa", "bbb", [], False, True, True, "surface-changed"),
+            ("aaa", "bbb", [1], False, True, True, "surface-changed"),
+        ]
+        for old_d, new_d, diffs, ok, review, surface, label in cases:
+            report = self.rd.build_report("o", old_d, "n", new_d, 1, 1, diffs)
+            self.assertEqual(report["ok"], ok, label)
+            self.assertEqual(report["reviewRequired"], review, label)
+            self.assertEqual(report["surfaceChanged"], surface, label)
+            self.assertEqual(report["classification"], label)
+
+    def test_probe_failed_never_sets_ok_or_review(self):
+        for old_d, new_d in ((None, None), (None, "aaa"), ("aaa", None)):
+            report = self.rd.build_report("o", old_d, "n", new_d, 0, 0, [])
+            self.assertFalse(report["ok"], (old_d, new_d))
+            self.assertFalse(report["reviewRequired"], (old_d, new_d))
+            self.assertFalse(report["surfaceChanged"], (old_d, new_d))
+            self.assertEqual(report["classification"], "probe-failed")
+
+
+# 관측 동등성 표 — 한 행이 한 계약. 분류를 바꾸지 않는다.
+EQUALITY_CASES = (
+    ("int-float", _value(0), _value(0.0), True),
+    ("int-int", _value(-3), _value(-3), True),
+    ("bool-true", _value(True), _value(True), True),
+    ("bool-false", _value(False), _value(False), True),
+    ("bool-not-one", _value(True), _value(1), False),
+    ("bool-not-one-float", _value(True), _value(1.0), False),
+    ("str-space", _value("a"), _value("a "), False),
+    ("empty-str-none", _value(""), _value(None), False),
+    ("list-empty", _value([]), _value([]), True),
+    ("list-vs-tuple-inner", _value([1, 2]), _value([1.0, 2.0]), True),
+    ("dict-empty", _value({}), _value({}), True),
+    ("exit-vs-value", {"kind": "exit", "code": 0, "head": ""}, _value(0), False),
+    ("nojson-vs-str", {"kind": "nojson", "head": "nojson"}, _value("nojson"), False),
+    ("digfail-vs-none", {"kind": "digfail", "error": "KeyError"}, _value(None), False),
+    ("two-exits-same", {"kind": "exit", "code": 2, "head": "a"},
+     {"kind": "exit", "code": 2, "head": "a"}, True),
+    ("two-exits-diff-head", {"kind": "exit", "code": 2, "head": "a"},
+     {"kind": "exit", "code": 2, "head": "b"}, False),
+    ("nested-bool", _value({"ok": True}), _value({"ok": 1}), False),
+    ("nested-num", _value({"n": [1, 2]}), _value({"n": [1.0, 2.0]}), True),
+)
+
+
+class GeneratedEqualityTableTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_equality_table(self):
+        for name, left, right, expected in EQUALITY_CASES:
+            self.assertEqual(
+                self.rd.observations_equal(left, right), expected, name)
+
+    def test_equality_table_is_symmetric(self):
+        for name, left, right, expected in EQUALITY_CASES:
+            self.assertEqual(
+                self.rd.observations_equal(right, left), expected, name + "/sym")
+
+
+# 분류 표 — 표면이 회귀보다 앞선다. probe-failed 행은 이 표에 없다.
+CLASSIFY_CASES = (
+    ("same-empty-list", False, [], "stable"),
+    ("same-zero", False, 0, "stable"),
+    ("same-none", False, None, "stable"),
+    ("same-false", False, False, "stable"),
+    ("same-one", False, 1, "regression"),
+    ("same-list", False, [{"task": "T"}], "regression"),
+    ("same-true", False, True, "regression"),
+    ("surf-empty", True, [], "surface-changed"),
+    ("surf-zero", True, 0, "surface-changed"),
+    ("surf-list", True, [{"task": "T"}], "surface-changed"),
+    ("surf-true", True, True, "surface-changed"),
+    ("surf-none", True, None, "surface-changed"),
+)
+
+
+class GeneratedClassifyTableTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_classify_table(self):
+        for name, surface, divergences, expected in CLASSIFY_CASES:
+            self.assertEqual(self.rd.classify(surface, divergences), expected, name)
+
+    def test_table_has_no_probe_failed(self):
+        for name, _s, _d, expected in CLASSIFY_CASES:
+            self.assertIn(expected, ("stable", "regression", "surface-changed"), name)
+
+
+class ProbeFailedDisguiseTests(unittest.TestCase):
+    """프로브 실패를 삼원 중 아무것으로도 부르지 않는지 고정한다."""
+
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_missing_old_digest_not_surface_changed(self):
+        report = self.rd.build_report("/o/rhwp", None, "/n/rhwp", "abc", 4, 8, [])
+        self.assertNotEqual(report["classification"], "surface-changed")
+        self.assertNotEqual(report["classification"], "stable")
+        self.assertNotEqual(report["classification"], "regression")
+
+    def test_missing_new_digest_not_regression_even_with_diffs(self):
+        row = {"task": "T", "check": "x", "op": "value_eq", "path": "",
+               "old": _value(1), "new": _value(2)}
+        report = self.rd.build_report("/o/rhwp", "abc", "/n/rhwp", None, 1, 1, [row])
+        self.assertEqual(report["classification"], "probe-failed")
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["divergences"], 1)
+
+    def test_summary_does_not_say_surface_same_when_probe_failed(self):
+        report = self.rd.build_report("o", None, "n", None, 0, 0, [])
+        text = "\n".join(self.rd.render_summary(report, "x.json"))
+        self.assertNotIn("명령 표면(capabilities): 같음", text)
+        self.assertIn("프로브 실패", text)
+
+
+class CatchableExceptionCatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_catchable_includes_timeout_and_os(self):
+        names = {cls.__name__ for cls in self.rd.CATCHABLE_EXCEPTIONS}
+        for needed in (
+            "FileNotFoundError", "PermissionError", "TimeoutError",
+            "TimeoutExpired", "OSError", "ValueError", "TypeError",
+            "KeyError", "IndexError", "AttributeError", "JSONDecodeError",
+            "RuntimeError", "UnicodeError",
+        ):
+            self.assertIn(needed, names)
+
+    def test_fatal_not_in_catchable_as_base(self):
+        for fatal in (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit):
+            self.assertFalse(issubclass(fatal, OSError))
+            self.assertTrue(self.rd.is_fatal_exception(fatal()))
+
+
+class ParseArgsAndSummaryLimitTests(unittest.TestCase):
+    def setUp(self):
+        self.rd = load_rd()
+
+    def test_parse_args_requires_old_and_new(self):
+        with self.assertRaises(SystemExit):
+            self.rd.parse_args([])
+        with self.assertRaises(SystemExit):
+            self.rd.parse_args(["--old", "o"])
+        with self.assertRaises(SystemExit):
+            self.rd.parse_args(["--new", "n"])
+
+    def test_parse_args_pack_repeat(self):
+        ns = self.rd.parse_args(["--old", "o", "--new", "n", "--pack", "a", "--pack", "b"])
+        self.assertEqual(ns.pack, ["a", "b"])
+        self.assertEqual(ns.agent, "claude-fable-5")
+
+    def test_summary_caps_diff_rows_at_thirty(self):
+        rows = []
+        for i in range(40):
+            rows.append({
+                "pack": "p", "task": f"T{i:02d}", "check": "쪽수",
+                "op": "value_eq", "path": "pageCount",
+                "old": _value(i), "new": _value(i + 1),
+            })
+        report = self.rd.build_report("o", "x", "n", "x", 40, 40, rows)
+        lines = self.rd.render_summary(report, "out.json")
+        detail = [ln for ln in lines if ln.startswith("  p/T")]
+        self.assertEqual(len(detail), 30)
+        self.assertEqual(report["divergences"], 40)
+        self.assertEqual(report["classification"], "regression")
+
+    def test_write_report_rejects_bom_and_crlf(self):
+        report = self.rd.build_report("o", "aaa", "n", "bbb", 1, 1, [])
+        self.assertEqual(report["classification"], "surface-changed")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "r.json")
+            self.rd.write_report(report, path)
+            raw = Path(path).read_bytes()
+        self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+        self.assertNotIn(b"\r\n", raw)
+        self.assertTrue(raw.endswith(b"\n"))
+        self.assertEqual(json.loads(raw.decode("utf-8"))["exit"], 2)
+
+    def test_validate_report_probe_failed_exit_must_be_one(self):
+        report = self.rd.empty_report("o", "n")
+        report["exit"] = 0
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("exit" in i for i in issues))
+        report["exit"] = 2
+        issues = self.rd.validate_report(report)
+        self.assertTrue(any("exit" in i for i in issues))
+
+    def test_validate_report_probe_failed_flags(self):
+        report = self.rd.empty_report("o", "n")
+        report["ok"] = True
+        self.assertTrue(any("ok" in i for i in self.rd.validate_report(report)))
+        report = self.rd.empty_report("o", "n")
+        report["reviewRequired"] = True
+        self.assertTrue(any("reviewRequired" in i for i in self.rd.validate_report(report)))
+        report = self.rd.empty_report("o", "n")
+        report["surfaceChanged"] = True
+        self.assertTrue(any("surfaceChanged" in i for i in self.rd.validate_report(report)))
+        report = self.rd.empty_report("o", "n")
+        report["probeFailed"] = False
+        self.assertTrue(any("probeFailed" in i for i in self.rd.validate_report(report)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

릴리스 간 차등 오라클의 분류(stable/regression/surface-changed)와 JSON 보고를 순수 함수로 분리해, rhwp 바이너리 없이 오검출 관문을 고정한다.

- `classify`·`surface_changed`·`exit_for` 를 분리한다. 표면 변경이 관측 분기보다 앞선다.
- 관측은 `value`/`exit`/`nojson`/`digfail`/`no-cmd` 로 가른다. `cell_text_eq` 는 좌표 칸만 본다.
- 숫자 `6` 과 `6.0` 은 같고, `True` 는 `1` 로 접히지 않는다. 종류가 다르면 표시가 같아도 같지 않다.
- 보고 봉투에 `classificationReason`·`exit`·`ok`·`reviewRequired`·`observationsSkipped` 를 남긴다. 기존 필드 의미는 그대로다.
- CLI 플래그는 그대로다. packs·checks·다른 도구는 건드리지 않았다.

## 관련 이슈

closes #5234

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_release_diff -v` — 35 ran, 1 skipped, 0 failed
- [x] `python gym/tools/audit.py` — 18 pack 통과
- [x] `python -m unittest scripts.tests.test_gym_release_gate_workflow -q` — 15 passed
- [ ] **`cargo fmt --all -- --check` 통과** (이번 변경은 Python 만. 사용자 지시에 따라 생략)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [ ] `cargo test` 통과 (해당 없음)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 단위 시험은 바이너리 없이 돈다. 라이브 스윕은 기존과 같이 rhwp 가 필요하다.