### PR TITLE
fix(serializer/hwpx): 한 섹션의 뒤 구역(secd)을 secPr 로 방출해 HWPX 왕복 쪽수 보존 (#4056)

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -631,6 +631,16 @@ pub fn write_section(
             let pid = ctx.next_para_id();
             let sid = ctx.effective_style_id(p.style_id);
             extra.push_str(&render_hp_p_open(p, pid, sid));
+            // [#4056] 후속 문단이 구역나누기(SectionDef)면 그 구역을 secPr 로 방출한다.
+            // `render_runs` 는 SectionDef 슬롯을 hidden 처리해 XML 을 내지 않으므로
+            // 여기서 내지 않으면 뒤 구역이 통째로 사라져 쪽나눔이 소실된다.
+            if let Some(Control::SectionDef(sd)) = p
+                .controls
+                .iter()
+                .find(|c| matches!(c, Control::SectionDef(_)))
+            {
+                extra.push_str(&build_secpr_run(sd, first_run_char_shape_id(p)));
+            }
             extra.push_str(&runs);
             extra.push_str(&linesegs);
             extra.push_str("</hp:p>");
@@ -670,6 +680,35 @@ pub(crate) fn render_hp_p_open(p: &Paragraph, id: u32, style_id_ref: u8) -> Stri
 /// 비어있으면 0 (기본 글자모양) 반환.
 fn first_run_char_shape_id(p: &Paragraph) -> u32 {
     p.char_shapes.first().map(|r| r.char_shape_id).unwrap_or(0)
+}
+
+/// [#4056] 후속 구역(SectionDef)을 HWPX `<hp:secPr>` run 으로 방출한다.
+///
+/// HWP5 는 한 BodyText 섹션에 구역(secd)을 여럿 담을 수 있다(issue-505: 수식 4개가
+/// 각 구역 = 4쪽). 종전 HWPX 직렬화기는 `render_runs` 에서 **모든 SectionDef 를 드롭**해
+/// (첫 구역만 write_section 의 secPr 템플릿으로 살아남음) 뒤 구역들의 쪽나눔이 사라졌다
+/// (issue-505: 4→1쪽). HWPX 는 한 section0.xml 안에 secPr 를 여럿 둘 수 있으므로(한글
+/// 원본 실증: issue2019 10개·06544 63개), 뒤 구역마다 secPr 를 방출한다.
+///
+/// secPr 템플릿(`EMPTY_SECTION_XML`)에서 secPr 블록만 잘라 IR 값으로 치환한다 —
+/// 커스터마이즈 앵커(pagePr·visibility·scalars·footNotePr·pageBorderFill)가 모두 secPr
+/// 내부라 첫 구역과 같은 함수를 재사용한다. 바탕쪽(masterPage)은 이 경로에서 미지원
+/// (`masterPageCnt="0"` 유지) — 후속 구역의 바탕쪽은 드물다.
+fn build_secpr_run(sd: &SectionDef, first_cs: u32) -> String {
+    let start = EMPTY_SECTION_XML
+        .find("<hp:secPr ")
+        .expect("템플릿에 secPr 열기 태그가 있어야 함");
+    let end = EMPTY_SECTION_XML[start..]
+        .find("</hp:secPr>")
+        .map(|e| start + e + "</hp:secPr>".len())
+        .expect("템플릿에 secPr 닫기 태그가 있어야 함");
+    let mut secpr = EMPTY_SECTION_XML[start..end].to_string();
+    secpr = replace_page_pr(&secpr, &sd.page_def);
+    secpr = replace_page_border_fill(&secpr, sd);
+    secpr = replace_visibility(&secpr, sd);
+    secpr = replace_secpr_scalars(&secpr, sd);
+    secpr = replace_footnote_shape(&secpr, sd);
+    format!(r#"<hp:run charPrIDRef="{}">{}</hp:run>"#, first_cs, secpr)
 }
 
 /// Paragraph 하나를 (완전한 `<hp:run>` 시퀀스 XML, `<hp:linesegarray>` 요소 XML,

--- a/tests/cases/issue_4056_hwpx_multi_secd_pages.rs
+++ b/tests/cases/issue_4056_hwpx_multi_secd_pages.rs
@@ -1,0 +1,39 @@
+//! [Issue #4056] HWPX 내보내기 전후로 쪽수가 달라진다 (issue-505-equations.hwp, 4쪽 → 1쪽).
+//!
+//! HWP5 는 한 BodyText 섹션에 구역(secd)을 여럿 담을 수 있다(issue-505: 수식 4개가 각각 자기
+//! 구역 = 4쪽). 종전 HWPX 직렬화기는 `write_section`/`render_runs` 에서 **첫 구역만** secPr
+//! 템플릿으로 방출하고 뒤 구역의 SectionDef 를 통째로 드롭해, 뒤 3개 구역의 쪽나눔이 사라져
+//! 재파싱 쪽수가 4 → 1 로 붕괴했다(`--verify-pages` 실패).
+//!
+//! 수정: HWPX 는 한 section0.xml 안에 secPr 를 여럿 둘 수 있으므로(한글 원본 실증:
+//! issue2019 10개), 뒤 구역마다 `<hp:secPr>` 를 방출한다. 재파싱 시 구역 4개가 살아 4쪽이 된다.
+//!
+//! 계약: `samples/issue-505-equations.hwp` 를 HWPX 로 왕복하면 쪽수가 원본과 같아야 한다(4쪽).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::diagnostics::render_geom_diff::{roundtrip_geom, Via};
+
+const SAMPLE: &str = "samples/issue-505-equations.hwp";
+
+#[test]
+fn hwpx_roundtrip_preserves_multi_secd_page_count() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let data = std::fs::read(Path::new(repo_root).join(SAMPLE))
+        .unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+
+    let diff = roundtrip_geom(&data, Via::Hwpx)
+        .unwrap_or_else(|e| panic!("roundtrip_geom({SAMPLE}): {e:?}"));
+
+    assert_eq!(
+        diff.page_count_a, 4,
+        "원본은 구역 4개로 4쪽이어야 한다: {}",
+        diff.page_count_a
+    );
+    assert_eq!(
+        diff.page_count_b, diff.page_count_a,
+        "HWPX 왕복 쪽수가 원본과 달라졌다 (A={} B={}) — 뒤 구역(secd)이 드롭돼 쪽나눔 소실 (#4056 회귀)",
+        diff.page_count_a, diff.page_count_b
+    );
+}

--- a/tests/fixtures/ir_field_sweep_baseline.tsv
+++ b/tests/fixtures/ir_field_sweep_baseline.tsv
@@ -500,9 +500,9 @@ hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].char_count	9
 hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls.len	9
 hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[]	18
 hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	81
-hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.default_tab_spacing	1
-hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.endnote_shape.suffix_char	1
-hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.footnote_shape.suffix_char	1
+hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.default_tab_spacing	10
+hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.endnote_shape.suffix_char	10
+hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.footnote_shape.suffix_char	10
 hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.page_def.margin_bottom	1
 hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.page_def.margin_left	1
 hwpx	issue2019_floating_form_74312.hwpx	sections[].paragraphs[].controls[].section_def.page_def.margin_right	1

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -3649,7 +3649,7 @@
       "id": "src/serializer/hwpx/section.rs::tests#1",
       "file": "src/serializer/hwpx/section.rs",
       "sourcePath": "src/serializer/hwpx/section.rs",
-      "line": 3167,
+      "line": 3206,
       "module": "tests",
       "testAttributes": 93,
       "tier": "white_box",


### PR DESCRIPTION
## 무엇을 · 왜

`closes #4056`

`samples/issue-505-equations.hwp` 를 HWPX 로 내보내면 **쪽수가 4 → 1 로 붕괴**한다
(`--verify-pages` 실패, `--verify`(ir-diff)는 통과).

HWP5 는 한 BodyText 섹션에 구역(secd)을 여럿 담을 수 있다(issue-505: 수식 4개가 각각 자기
구역 = 4쪽). 종전 HWPX 직렬화기는 `render_runs` 에서 **모든 SectionDef 를 hidden 처리**해,
첫 구역만 `write_section` 의 secPr 템플릿으로 살아남고 뒤 구역들의 SectionDef 는 통째로
드롭됐다. 그 문단들은 cold(다단나누기)만 남아 쪽나눔이 사라졌다.

| | 재파싱 구역 라벨 | 쪽수 |
|---|---|---|
| 원본 | 구역나누기 ×4 | 4 |
| **수정 전 HWPX 왕복** | 구역나누기 ×1 + 다단나누기 ×3 | **1** |
| **수정 후 HWPX 왕복** | 구역나누기 ×4 | **4** |

## 수정

HWPX 는 한 `section0.xml` 안에 secPr 를 여럿 둘 수 있다(한글 원본 실증: `issue2019` 10개·
`06544` 63개). 뒤 구역 문단마다 `build_secpr_run` 으로 `<hp:secPr>` 를 방출한다 —
secPr 템플릿(`EMPTY_SECTION_XML`)에서 secPr 블록만 잘라, 첫 구역과 **같은 커스터마이즈
함수**(pagePr·visibility·scalars·footNotePr·pageBorderFill)로 IR 값을 채운다(앵커가 모두 secPr
내부라 재사용 가능). 재파싱 시 구역 4개가 살아 4쪽이 된다. 다중-secd 문서의 IR 구조
(1 doc.section, N secd)가 왕복에 보존돼 `--verify`(ir-diff)도 유지된다.

## 검증 (로컬)

- 실측 `issue-505`: 원본 4쪽 → HWPX 왕복 **4쪽**(secPr 4개, 재파싱 구역나누기 4개),
  **`--verify-pages` 통과**.
- `issue2019`(한글제 HWPX, secd 10개) x2x: 19→19쪽 **안정**(회귀 없음).
- 계약 테스트 `tests/cases/issue_4056_hwpx_multi_secd_pages.rs`: HWPX 왕복 쪽수 4→4.
  **음성 대조**: 뒤 secd 미방출 시 4→1(FAIL).
- hwpx 직렬화기 lib **425/425** · `hwpx_roundtrip_integration` · `hwpx_roundtrip_baseline` ·
  `convert_verify_corpus_ratchet` 통과. `rustfmt --check` · `cargo clippy --lib` 무경고.
- `ir_field_sweep` baseline: `issue2019` 의 `paragraphs[].controls[].section_def` 3필드
  (`default_tab_spacing`·footnote/endnote `suffix_char`)를 **1→10** 갱신. 이 필드들은 secd 값이
  0/빈값일 때 템플릿 기본값을 유지하는 **기존 의도된 발산**으로, 첫 구역 1개에서만 세던 것을
  이제 10개 구역 전부 방출하며 정비례로 늘어난 것(신규 손실이 아니라 종전 드롭되던 구역이
  살아난 결과).

## 사정거리 · 한계

한 IR 섹션에 다중 secd 를 가진 문서(로컬 스캔: issue-505·issue2019)에만 출력이 바뀐다.
바탕쪽(masterPage)은 이 경로 미지원(`masterPageCnt="0"` 유지) — 후속 구역의 바탕쪽은 드묾
(별도 후속 여지). 10k 쪽수 게이트는 리뷰어 몫.

관련: #5142(반대 방향, HWPX→HWP5 는 다중-secd-1섹션이 유효라 강제분할 금지) · #4678(총괄).
