### PR TITLE
feat(gym): automation pack 과제 확장 (AU14–AU70)

### DIFF
--- a/gym/packs/automation/README.md
+++ b/gym/packs/automation/README.md
@@ -1,0 +1,279 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/automation/README.md
+last_verified: 2026-08-18
+---
+
+# automation — 자동화·검증 사다리
+
+## 왜 이 pack 인가
+
+제출이 곧 증명이다. 에이전트가 한 일을 말로 주장하지 않고, 사다리의 판정
+명령 한 번으로 채점한다. 계획서 원자 실행 → 작업 캡슐 → 서명 귀속 →
+앵커 등재 → 적합성 → 선택적 공개 → 관문 → 정산 청구 → 감사 보고 →
+오염 범위 → 연합 번들 → 계보.
+
+이 pack 은 그 축들을 **기존 CLI 표면**만으로 과제화한다. 새 pack 도, 새
+명령도, 새 연산자도, 새 픽스처도 없다. `pack.json` 의 `runner` 신원은
+그대로 둔다 — 이 확장은 바이너리를 바꾸지 않는다.
+
+권위 출처: `mydocs/manual/cli_commands.md` §계획 실행·증명·감사,
+스킬 `rhwp-work-receipt`, 에이전트 작업 표준 AW-L1~AW-L5.
+
+## 이 확장이 지키는 규칙
+
+1. **기존 명령만.** `pack.json` requires 는 `anchor` · `audit` ·
+   `audit-report` · `bundle` · `conformance` · `disclose` · `export-tables` ·
+   `gate` · `lineage` · `recall-scope` · `settle` · `verify-signature` 이다.
+   서식 채움·필드 조사·inspect·scan 을 채점 명령으로 부르지 않는다.
+   기준 풀이가 산출을 만들 때 쓰는 `run` · `replay` · `keygen` 은
+   채점 명령이 아니다.
+2. **기존 연산자만.** `gym/core/checks.py` REGISTRY 에 있는 것만 고른다.
+   `cell_text_eq` · `differs_from_input` · `value_eq` · `value_ge` ·
+   `len_ge` · `file_exists` · `files_differ` · `same_hash` 가 전부다.
+3. **기존 표본만.** `samples/` 밖 파일을 만들지 않는다. table-001,
+   table-004, multi-table-001/002, inner-table-01, hwp_table_test,
+   table-complex, hwpx/basic-table-01 — 이미 있는 실문서를 축만 바꿔
+   다시 묻는다.
+4. **라이브 오라클.** 해시·건수를 과제에 박제하지 않는다. 채점기가 같은
+   명령을 다시 돌려 봉투 필드를 읽는다.
+5. **T07 을 복제하지 않는다.** 서식 채움·첫 필드 홍길동은 core-cli 의
+   일이다. 이 pack 은 누름틀을 채우지 않는다.
+6. **XC01–XC05 를 복제하지 않는다.** L5 완주, 오염 무영향 0, 정산 4관문
+   + 원장, 3세대 lineage --deep, L3 서명+앵커 완주는 expert-challenges
+   의 보스다. 여기서는 한 축만 지목한다.
+7. **WR01+ 를 복제하지 않는다.** 일일 영수증 3해시 answer.json 여정은
+   work-receipt pack 의 일이다. 이 pack 은 캡슐·관문·정산 사다리다.
+8. **원본을 덮지 않는다.** 산출은 제출 폴더의 `-o` / `--capsule` 뿐이다.
+
+## 명령 표면 (pack.json requires)
+
+| 명령 | 하는 일 | 이 pack 에서 읽는 봉투 |
+|------|---------|------------------------|
+| `export-tables` | 표 좌표 텍스트 | `tables[i].cells` → `cell_text_eq` |
+| `audit` | 폴더 직속 캡슐 전수 재현 | `reproducedRate` · `total` |
+| `verify-signature` | 분리 서명 검증 | `verdict` |
+| `anchor verify` | 등재·체인 무결 | `logged` · `logChainOk` |
+| `conformance` | L1~L2 자가진단 | `verdict` |
+| `disclose restore` | 가림 복원 | `byteIdentical` |
+| `gate` | 반입 관문 | `verdict` |
+| `settle verify` | 청구 3해시 | `verdict` |
+| `audit-report` | 감사 보고서 | `lineage.valid` |
+| `recall-scope` | 오염 후손 폐쇄 | `affected` |
+| `bundle verify` | 오프라인 교환 | `containerOk` · `closureOk` |
+| `lineage` | 머리→뿌리 계보 | `valid` · `depth` (기존 AU12) |
+
+`--deep` 은 관문 일부(AU07, AU52, AU54, AU56)에만 쓴다. 적합성 L3/L5 와
+3세대 계보에는 붙이지 않는다.
+
+## 함정 (실측, 과제에 녹여 둔 것)
+
+- **좌표가 바뀌면 다른 계약이다.** AU01 의 (0,0) 제출을 AU14 (0,1) 이나
+  AU15 (1,0) 에 재사용하면 cell_text_eq 가 실패한다.
+- **표본이 바뀌면 산출 해시가 다르다.** table-001 산출을 table-004 과제에
+  복사하면 differs_from_input 은 통과할 수 있어도 표 내용이 틀리다.
+- **audit 대상은 폴더 직속 `*.capsule.json`** (비재귀). 0개면 실패. AU02
+  는 `total≥1` 이고 AU19+ 는 `total==1` 이다. 두 장을 넣으면 정확 건수가
+  어긋난다.
+- **비밀키를 제출하지 마라.** 키링에는 공개키만 넣는다.
+- **앵커 로그를 손으로 편집하면 체인이 끊긴다.** `anchor add` 한 번이
+  등재다.
+- **L1 과 L2 는 누적이다.** L2 를 건너뛰어 L5 로 가지 마라. 그 완주는
+  XC01 이다.
+- **가림본이 원본과 같으면 가림이 일어나지 않은 것이다.**
+- **관문 default 는 deny.** reproduced==true 규칙이 있어야 allow 다.
+- **정산 원장은 이 확장의 범위가 아니다.** AU08/AU57+ 는 settle verify
+  의 `verdict==ok` 만 본다. 4관문+ledger 는 XC03.
+- **서로 무관한 두 캡슐은 리콜 영향권이 1 이다.** 부모 링크가 필요하다.
+- **T07 금지.** 누름틀 값을 넣지 마라.
+
+## 과제 지도
+
+난도 1=입문 · 2=초급 · 3=중급 · 4=고급 · 5=보스. 보스 완주는 XC 의
+일이다. 이 pack 의 확장은 2~3 에 머문다.
+
+### AU01–AU13 — 개장 코어 (devel 에 이미 있음)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| AU01 | 2 | 계획서 원자 실행 (0,0)=계획실행 | table-001 |
+| AU02 | 2 | 작업 영수증 · 재현율 1.0 + total≥1 | table-001 |
+| AU03 | 3 | 서명 귀속 valid | table-001 |
+| AU04 | 3 | 앵커 등재 logged + 체인 | table-001 |
+| AU05 | 2 | 적합성 L1 | table-001 |
+| AU06 | 3 | 선택적 공개 왕복 | table-001 |
+| AU07 | 3 | 관문 allow --deep | table-001 |
+| AU08 | 3 | 정산 청구 verdict ok | table-001 |
+| AU09 | 3 | 감사 보고 lineage.valid=1 | table-001 |
+| AU10 | 3 | 오염 리콜 affected≥2 | table-001 |
+| AU11 | 3 | 연합 번들 container+closure | table-001 |
+| AU12 | 3 | 계보 체인 depth 2 | table-001 |
+| AU13 | 2 | 적합성 L2 | table-001 |
+
+### AU14–AU18 — 계획서 좌표를 가른다
+
+AU01 은 (0,0) 한 칸이다. 옆칸·둘째 행·다른 표 표본으로 좌표를 흩는다.
+
+| ID | 질문 |
+|----|------|
+| AU14 | table-001 (0,1) = 옆칸확장 |
+| AU15 | table-001 (1,0) = 둘째행확장 |
+| AU16 | table-004 (0,0) = 표사다리 |
+| AU17 | multi-table-001 첫 표 |
+| AU18 | inner-table-01 첫 표 |
+
+### AU19–AU26 — 감사 정확 1건
+
+AU02 는 total≥1 이라 두 장을 넣어도 통과한다. 여기서는 **정확 1건** 과
+다른 표본·다른 폴더 이름을 묻는다.
+
+| ID | 질문 |
+|----|------|
+| AU19 | table-004 · capsules/ · total==1 |
+| AU20 | multi-table-001 · total==1 |
+| AU21 | inner-table-01 · work/ |
+| AU22 | hwp_table_test |
+| AU23 | table-complex · receipts/ |
+| AU24 | hwpx/basic-table-01 |
+| AU25 | multi-table-002 |
+| AU26 | table-001 · ledger/ · total==1 (AU02 와 비교) |
+
+### AU27–AU32 — 서명 귀속, 키 id 를 가른다
+
+AU03 은 gym-agent. 표본과 키 id 만 바꾼다. L3 앵커 완주(XC05) 는 하지
+않는다.
+
+| ID | 키 id |
+|----|-------|
+| AU27 | au-sign-t004 |
+| AU28 | au-sign-mt1 |
+| AU29 | au-sign-inner |
+| AU30 | au-sign-ttest |
+| AU31 | au-sign-hwpx |
+| AU32 | au-sign-complex |
+
+### AU33–AU38 — 앵커 축을 가른다
+
+AU04 는 logged + logChainOk 를 한 번에 본다. 여기서는 등재·체인·파일
+실재를 가르고 표본을 옮긴다.
+
+| ID | 축 |
+|----|-----|
+| AU33 | table-004 logged |
+| AU34 | 다중표 logChainOk |
+| AU35 | 내부표 logged |
+| AU36 | 표시험 logChainOk |
+| AU37 | HWPX logged |
+| AU38 | 복합표 로그 파일 + logged |
+
+### AU39–AU45 — 적합성 L1/L2 표본 확장
+
+AU05=L1, AU13=L2, 둘 다 table-001. L3 --deep 과 L5 는 XC 다.
+
+| ID | 등급 | 표본 |
+|----|------|------|
+| AU39 | L1 | table-004 |
+| AU40 | L2 | multi-table-001 |
+| AU41 | L1 | inner-table-01 · work/ |
+| AU42 | L2 | hwp_table_test |
+| AU43 | L1 | HWPX |
+| AU44 | L2 | table-complex · ladder/ |
+| AU45 | L1 | multi-table-002 |
+
+### AU46–AU51 — 선택적 공개 축
+
+AU06 은 restore + same_hash + files_differ 세 검사. 여기서는 축을 가르고
+표본을 옮긴다.
+
+| ID | 축 |
+|----|-----|
+| AU46 | table-004 byteIdentical |
+| AU47 | 다중표 files_differ |
+| AU48 | 내부표 same_hash |
+| AU49 | 표시험 opening 실재 |
+| AU50 | HWPX byteIdentical |
+| AU51 | 복합표 files_differ |
+
+### AU52–AU56 — 관문, 깊이와 규칙 id
+
+AU07 은 --deep + R1-재현. 얕은 관문과 다른 규칙 id 를 섞는다.
+
+| ID | 깊이 | 규칙 |
+|----|------|------|
+| AU52 | --deep | R-표사-재현 |
+| AU53 | 얕음 | R-다중-재현 |
+| AU54 | --deep | R-내부-재현 |
+| AU55 | 얕음 | R-시험-재현 |
+| AU56 | --deep | R-hwpx-재현 |
+
+### AU57–AU61 — 정산 청구 (원장 없음)
+
+AU08 은 gym-wo-1. 원장 4관문은 XC03.
+
+| ID | workorderId |
+|----|-------------|
+| AU57 | gym-wo-t004 |
+| AU58 | gym-wo-mt1 + claim 실재 |
+| AU59 | gym-wo-inner |
+| AU60 | gym-wo-ttest + claim 실재 |
+| AU61 | gym-wo-hwpx |
+
+### AU62–AU64 — 감사 보고
+
+| ID | 질문 |
+|----|------|
+| AU62 | table-004 lineage.valid=1 |
+| AU63 | 다중표 report.json 실재 |
+| AU64 | 내부표 work/ 보고 |
+
+### AU65–AU67 — 2링크 리콜 (무영향 0 을 묻지 않음)
+
+| ID | 폴더 |
+|----|------|
+| AU65 | table-004 · capsules/ |
+| AU66 | 다중표 · chain/ |
+| AU67 | 내부표 · capsules/ |
+
+### AU68–AU70 — 연합 번들 축
+
+| ID | 축 |
+|----|-----|
+| AU68 | table-004 containerOk · domain=gym-t004 |
+| AU69 | 다중표 closureOk · gym-mt1 |
+| AU70 | 내부표 번들 실재 · gym-inner |
+
+## 기준 풀이 왕복
+
+```bash
+python gym/tools/build_baseline.py --agent baseline --pack automation --bin target/debug/rhwp
+python gym/score.py --agent baseline --pack automation --bin target/debug/rhwp
+```
+
+`reference/AU*.json` 은 정답 노출이다. 푸는 쪽은 보지 않는다. 채점 재현용이다.
+runner 신원은 기존 `pack.json` 을 그대로 쓴다.
+
+## 정합 가드
+
+```bash
+python gym/tools/audit.py
+python -m unittest scripts/tests/test_gym_packs.py
+python -m unittest scripts/tests/test_gym_automation_pack.py
+```
+
+`test_gym_automation_pack.py` 는 AU14+ 짝 기준풀이, 기존 연산자만, 기존
+표본만, pack requires 밖 명령 금지, T07/XC/WR 복제 금지를 파일만으로
+고정한다.
+
+## 이 문서가 말하지 않는 것
+
+- gym/README.md · PARK.md · profiles/*.json 의 과제 수 집계는 후속이다.
+- `checks.py` · 새 연산자 · 새 CLI 는 이 pack 의 범위가 아니다.
+- work-receipt pack 의 일일 3해시 여정, expert-challenges 의 보스 완주는
+  각자 자리에서 다룬다.
+
+## 재현 (사람용 한 줄)
+
+계획서를 원자 실행하고, 캡슐을 남기고, 필요한 축(서명·앵커·적합·가림·
+관문·청구·보고·리콜·번들)만 판정 명령으로 닫는다. 숫자가 아니라 봉투가
+게이트다.

--- a/gym/packs/automation/reference/AU14.json
+++ b/gym/packs/automation/reference/AU14.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU14",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:out.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 1, \"text\": \"옆칸확장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU15.json
+++ b/gym/packs/automation/reference/AU15.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU15",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:out.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 1, \"col\": 0, \"text\": \"둘째행확장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU16.json
+++ b/gym/packs/automation/reference/AU16.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU16",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:out.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"표사다리\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU17.json
+++ b/gym/packs/automation/reference/AU17.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU17",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:out.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"다중표확장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU18.json
+++ b/gym/packs/automation/reference/AU18.json
@@ -1,0 +1,13 @@
+{
+  "id": "AU18",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:out.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"내부표확장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU19.json
+++ b/gym/packs/automation/reference/AU19.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU19",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사표사\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU20.json
+++ b/gym/packs/automation/reference/AU20.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU20",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사다중\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU21.json
+++ b/gym/packs/automation/reference/AU21.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU21",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사내부\"}]}",
+        "--capsule",
+        "{sub:work/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU22.json
+++ b/gym/packs/automation/reference/AU22.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU22",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사시험\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU23.json
+++ b/gym/packs/automation/reference/AU23.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU23",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사복합\"}]}",
+        "--capsule",
+        "{sub:receipts/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU24.json
+++ b/gym/packs/automation/reference/AU24.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU24",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사hwpx\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU25.json
+++ b/gym/packs/automation/reference/AU25.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU25",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-002.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사다중둘\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU26.json
+++ b/gym/packs/automation/reference/AU26.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU26",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"감사정확일\"}]}",
+        "--capsule",
+        "{sub:ledger/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU27.json
+++ b/gym/packs/automation/reference/AU27.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU27",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "au-sign-t004",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"서명표사\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json",
+        "--sign-key",
+        "{sub:agent.key.json}"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "au-sign-t004"
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU28.json
+++ b/gym/packs/automation/reference/AU28.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU28",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "au-sign-mt1",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"서명다중\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json",
+        "--sign-key",
+        "{sub:agent.key.json}"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "au-sign-mt1"
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU29.json
+++ b/gym/packs/automation/reference/AU29.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU29",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "au-sign-inner",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"서명내부\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json",
+        "--sign-key",
+        "{sub:agent.key.json}"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "au-sign-inner"
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU30.json
+++ b/gym/packs/automation/reference/AU30.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU30",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "au-sign-ttest",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"서명시험\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json",
+        "--sign-key",
+        "{sub:agent.key.json}"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "au-sign-ttest"
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU31.json
+++ b/gym/packs/automation/reference/AU31.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU31",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "au-sign-hwpx",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"서명hwpx\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json",
+        "--sign-key",
+        "{sub:agent.key.json}"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "au-sign-hwpx"
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU32.json
+++ b/gym/packs/automation/reference/AU32.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU32",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "au-sign-complex",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"서명복합\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json",
+        "--sign-key",
+        "{sub:agent.key.json}"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "au-sign-complex"
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU33.json
+++ b/gym/packs/automation/reference/AU33.json
@@ -1,0 +1,25 @@
+{
+  "id": "AU33",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"앵커표사\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:capsules/work.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU34.json
+++ b/gym/packs/automation/reference/AU34.json
@@ -1,0 +1,25 @@
+{
+  "id": "AU34",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"앵커다중\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:capsules/work.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU35.json
+++ b/gym/packs/automation/reference/AU35.json
@@ -1,0 +1,25 @@
+{
+  "id": "AU35",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"앵커내부\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:capsules/work.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU36.json
+++ b/gym/packs/automation/reference/AU36.json
@@ -1,0 +1,25 @@
+{
+  "id": "AU36",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"앵커시험\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:capsules/work.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU37.json
+++ b/gym/packs/automation/reference/AU37.json
@@ -1,0 +1,25 @@
+{
+  "id": "AU37",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"앵커hwpx\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:capsules/work.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU38.json
+++ b/gym/packs/automation/reference/AU38.json
@@ -1,0 +1,25 @@
+{
+  "id": "AU38",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"앵커복합\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:capsules/work.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU39.json
+++ b/gym/packs/automation/reference/AU39.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU39",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L1표사\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU40.json
+++ b/gym/packs/automation/reference/AU40.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU40",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L2다중\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU41.json
+++ b/gym/packs/automation/reference/AU41.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU41",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L1내부\"}]}",
+        "--capsule",
+        "{sub:work/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU42.json
+++ b/gym/packs/automation/reference/AU42.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU42",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L2시험\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU43.json
+++ b/gym/packs/automation/reference/AU43.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU43",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L1hwpx\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU44.json
+++ b/gym/packs/automation/reference/AU44.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU44",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L2복합\"}]}",
+        "--capsule",
+        "{sub:ladder/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU45.json
+++ b/gym/packs/automation/reference/AU45.json
@@ -1,0 +1,15 @@
+{
+  "id": "AU45",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-002.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"적합L1다중둘\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU46.json
+++ b/gym/packs/automation/reference/AU46.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU46",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가림표사\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "redact",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:redacted.json}",
+        "--opening-out",
+        "{sub:opening.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "restore",
+        "{sub:redacted.json}",
+        "--opening",
+        "{sub:opening.json}",
+        "-o",
+        "{sub:restored.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU47.json
+++ b/gym/packs/automation/reference/AU47.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU47",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가림다중\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "redact",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:redacted.json}",
+        "--opening-out",
+        "{sub:opening.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "restore",
+        "{sub:redacted.json}",
+        "--opening",
+        "{sub:opening.json}",
+        "-o",
+        "{sub:restored.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU48.json
+++ b/gym/packs/automation/reference/AU48.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU48",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가림내부\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "redact",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:redacted.json}",
+        "--opening-out",
+        "{sub:opening.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "restore",
+        "{sub:redacted.json}",
+        "--opening",
+        "{sub:opening.json}",
+        "-o",
+        "{sub:restored.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU49.json
+++ b/gym/packs/automation/reference/AU49.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU49",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가림시험\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "redact",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:redacted.json}",
+        "--opening-out",
+        "{sub:opening.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "restore",
+        "{sub:redacted.json}",
+        "--opening",
+        "{sub:opening.json}",
+        "-o",
+        "{sub:restored.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU50.json
+++ b/gym/packs/automation/reference/AU50.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU50",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가림hwpx\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "redact",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:redacted.json}",
+        "--opening-out",
+        "{sub:opening.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "restore",
+        "{sub:redacted.json}",
+        "--opening",
+        "{sub:opening.json}",
+        "-o",
+        "{sub:restored.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU51.json
+++ b/gym/packs/automation/reference/AU51.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU51",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가림복합\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "redact",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:redacted.json}",
+        "--opening-out",
+        "{sub:opening.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "disclose",
+        "restore",
+        "{sub:redacted.json}",
+        "--opening",
+        "{sub:opening.json}",
+        "-o",
+        "{sub:restored.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU52.json
+++ b/gym/packs/automation/reference/AU52.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU52",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"관문표사\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R-표사-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU53.json
+++ b/gym/packs/automation/reference/AU53.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU53",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"관문다중\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R-다중-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU54.json
+++ b/gym/packs/automation/reference/AU54.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU54",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"관문내부\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R-내부-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU55.json
+++ b/gym/packs/automation/reference/AU55.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU55",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"관문시험\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R-시험-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU56.json
+++ b/gym/packs/automation/reference/AU56.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU56",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"관문hwpx\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R-hwpx-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU57.json
+++ b/gym/packs/automation/reference/AU57.json
@@ -1,0 +1,70 @@
+{
+  "id": "AU57",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"정산표사\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "gym-wo-t004",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU58.json
+++ b/gym/packs/automation/reference/AU58.json
@@ -1,0 +1,70 @@
+{
+  "id": "AU58",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"정산다중\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "gym-wo-mt1",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU59.json
+++ b/gym/packs/automation/reference/AU59.json
@@ -1,0 +1,70 @@
+{
+  "id": "AU59",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"정산내부\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "gym-wo-inner",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU60.json
+++ b/gym/packs/automation/reference/AU60.json
@@ -1,0 +1,70 @@
+{
+  "id": "AU60",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"정산시험\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "gym-wo-ttest",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU61.json
+++ b/gym/packs/automation/reference/AU61.json
@@ -1,0 +1,70 @@
+{
+  "id": "AU61",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"정산hwpx\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "gym-wo-hwpx",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU62.json
+++ b/gym/packs/automation/reference/AU62.json
@@ -1,0 +1,24 @@
+{
+  "id": "AU62",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"보고표사\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:capsules}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU63.json
+++ b/gym/packs/automation/reference/AU63.json
@@ -1,0 +1,24 @@
+{
+  "id": "AU63",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"보고다중\"}]}",
+        "--capsule",
+        "{sub:capsules/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:capsules}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU64.json
+++ b/gym/packs/automation/reference/AU64.json
@@ -1,0 +1,24 @@
+{
+  "id": "AU64",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"보고내부\"}]}",
+        "--capsule",
+        "{sub:work/work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:work}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU65.json
+++ b/gym/packs/automation/reference/AU65.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU65",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜표사1\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜표사1\"}]}",
+        "--capsule",
+        "{sub:capsules/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜표사2\"}]}",
+        "--capsule",
+        "{sub:capsules/b.capsule.json}",
+        "--parent",
+        "{sub:capsules/a.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU66.json
+++ b/gym/packs/automation/reference/AU66.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU66",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜다중1\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜다중1\"}]}",
+        "--capsule",
+        "{sub:chain/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜다중2\"}]}",
+        "--capsule",
+        "{sub:chain/b.capsule.json}",
+        "--parent",
+        "{sub:chain/a.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU67.json
+++ b/gym/packs/automation/reference/AU67.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU67",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜내부1\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜내부1\"}]}",
+        "--capsule",
+        "{sub:capsules/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"리콜내부2\"}]}",
+        "--capsule",
+        "{sub:capsules/b.capsule.json}",
+        "--parent",
+        "{sub:capsules/a.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU68.json
+++ b/gym/packs/automation/reference/AU68.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU68",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"번들표사\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "bundle",
+        "export",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:work.lineage-bundle}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:domain.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "trustDomain",
+          "domain": "gym-t004",
+          "keyring": {
+            "schemaVersion": "1.0",
+            "kind": "keyring",
+            "keys": []
+          },
+          "checkpoints": []
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU69.json
+++ b/gym/packs/automation/reference/AU69.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU69",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"번들다중\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "bundle",
+        "export",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:work.lineage-bundle}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:domain.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "trustDomain",
+          "domain": "gym-mt1",
+          "keyring": {
+            "schemaVersion": "1.0",
+            "kind": "keyring",
+            "keys": []
+          },
+          "checkpoints": []
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/reference/AU70.json
+++ b/gym/packs/automation/reference/AU70.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU70",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"out.hwp\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"번들내부\"}]}",
+        "--capsule",
+        "{sub:work.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "bundle",
+        "export",
+        "{sub:work.capsule.json}",
+        "-o",
+        "{sub:work.lineage-bundle}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:domain.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "trustDomain",
+          "domain": "gym-inner",
+          "keyring": {
+            "schemaVersion": "1.0",
+            "kind": "keyring",
+            "keys": []
+          },
+          "checkpoints": []
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/automation/tasks/AU14.json
+++ b/gym/packs/automation/tasks/AU14.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU14",
+  "tier": 2,
+  "title": "계획서 옆칸 원자 실행",
+  "input": "samples/table-001.hwp",
+  "instructions": "AU14 — 계획서 옆칸 원자 실행.\n\n입력 표본은 `samples/table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\nAU01 은 첫 표 (0,0) 을 '계획실행' 으로 바꾼다. 이 과제는 **같은 표의 옆칸 (0,1)** 만 지목한다. 좌표를 바꾸지 않고 첫 칸만 고치면 채점이 거절한다. run 계획서를 원자 실행해 산출물 out.hwp 를 제출하라.\n\n수행 힌트: rhwp run --plan-json 으로 set_cell table=0 row=0 col=1 text=옆칸확장. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n판별력: 무편집 복사본은 differs_from_input 이 거절한다. 옆칸이 아니면 cell_text_eq 가 실패한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,1) == 옆칸확장",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "옆칸확장",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:out.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "out.hwp"
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU15.json
+++ b/gym/packs/automation/tasks/AU15.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU15",
+  "tier": 2,
+  "title": "둘째 행 계획 실행",
+  "input": "samples/table-001.hwp",
+  "instructions": "AU15 — 둘째 행 계획 실행.\n\n입력 표본은 `samples/table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n같은 표본이라도 **행이 바뀌면 다른 계약**이다. 첫 표 (1,0) 을 '둘째행확장' 으로 바꾸고 out.hwp 를 제출하라. (0,0) 만 고친 AU01 제출을 재사용하면 이 칸은 그대로라 실패한다.\n\n수행 힌트: rhwp run --plan-json set_cell row=1 col=0. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n좌표 지목이 이 pack 의 판별력이다. 전역 치환으로 맞추려 하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(1,0) == 둘째행확장",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "둘째행확장",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:out.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "out.hwp"
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU16.json
+++ b/gym/packs/automation/tasks/AU16.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU16",
+  "tier": 2,
+  "title": "table-004 첫 칸 계획",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU16 — table-004 첫 칸 계획.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n표본을 table-001 에서 **table-004** 로 옮긴다. 같은 set_cell 이라도 입력이 바뀌면 산출 해시가 다르다. 첫 표 (0,0) 을 '표사다리' 로 바꿔 out.hwp 를 제출하라. AU01 산출을 복사해 오면 입력 대조가 어긋난다.\n\n수행 힌트: rhwp run --plan-json input=samples/table-004.hwp set_cell (0,0)=표사다리. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n표본을 흩는 것이 이 확장의 핵심이다. 한 파일에 질문을 몰지 않는다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 표사다리",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "표사다리",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:out.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "out.hwp"
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU17.json
+++ b/gym/packs/automation/tasks/AU17.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU17",
+  "tier": 2,
+  "title": "다중표 첫 표 계획",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU17 — 다중표 첫 표 계획.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n다중표 표본 `multi-table-001.hwp` 의 **첫 번째 표**만 지목한다. 둘째 표를 고치면 table=0 채점이 실패한다. (0,0) 을 '다중표확장' 으로 바꿔 out.hwp 를 제출하라.\n\n수행 힌트: rhwp run --plan-json table=0 row=0 col=0 text=다중표확장. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n표 인덱스를 짐작하지 마라. 첫 표가 0 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "첫 표 (0,0) == 다중표확장",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "다중표확장",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:out.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "out.hwp"
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU18.json
+++ b/gym/packs/automation/tasks/AU18.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU18",
+  "tier": 2,
+  "title": "내부표 계획 실행",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU18 — 내부표 계획 실행.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n중첩·내부 표 표본 `inner-table-01.hwp` 에서 첫 표 (0,0) 을 '내부표확장' 으로 바꿔라. 바깥 문단만 고치면 표 좌표 채점이 실패한다.\n\n수행 힌트: rhwp run --plan-json input=samples/inner-table-01.hwp. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n내부 표도 좌표는 table/row/col 이다. 전역 훑기는 쓰지 않는다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "내부표 (0,0) == 내부표확장",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "내부표확장",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:out.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "out.hwp"
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU19.json
+++ b/gym/packs/automation/tasks/AU19.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU19",
+  "tier": 2,
+  "title": "table-004 단건 재현율",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU19 — table-004 단건 재현율.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `capsules/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 정확 1건 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule capsules/work.capsule.json 후 채점은 audit capsules. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU20.json
+++ b/gym/packs/automation/tasks/AU20.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU20",
+  "tier": 2,
+  "title": "다중표 단건 재현율",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU20 — 다중표 단건 재현율.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `capsules/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 다중표 표본 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule capsules/work.capsule.json 후 채점은 audit capsules. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU21.json
+++ b/gym/packs/automation/tasks/AU21.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU21",
+  "tier": 2,
+  "title": "내부표 단건 재현율",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU21 — 내부표 단건 재현율.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `work/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 폴더 이름을 work/ 로 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule work/work.capsule.json 후 채점은 audit work. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:work}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:work}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU22.json
+++ b/gym/packs/automation/tasks/AU22.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU22",
+  "tier": 2,
+  "title": "표시험 단건 재현율",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU22 — 표시험 단건 재현율.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `capsules/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 hwp_table_test 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule capsules/work.capsule.json 후 채점은 audit capsules. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU23.json
+++ b/gym/packs/automation/tasks/AU23.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU23",
+  "tier": 2,
+  "title": "복합표 단건 재현율",
+  "input": "samples/table-complex.hwp",
+  "instructions": "AU23 — 복합표 단건 재현율.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `receipts/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 폴더 receipts/ 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule receipts/work.capsule.json 후 채점은 audit receipts. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU24.json
+++ b/gym/packs/automation/tasks/AU24.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU24",
+  "tier": 2,
+  "title": "HWPX 표 단건 재현율",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU24 — HWPX 표 단건 재현율.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `capsules/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 형식 짝 HWPX 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule capsules/work.capsule.json 후 채점은 audit capsules. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU25.json
+++ b/gym/packs/automation/tasks/AU25.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU25",
+  "tier": 2,
+  "title": "다중표2 단건 재현율",
+  "input": "samples/multi-table-002.hwp",
+  "instructions": "AU25 — 다중표2 단건 재현율.\n\n입력 표본은 `samples/multi-table-002.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `capsules/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 multi-table-002 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule capsules/work.capsule.json 후 채점은 audit capsules. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:capsules}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU26.json
+++ b/gym/packs/automation/tasks/AU26.json
@@ -1,0 +1,46 @@
+{
+  "id": "AU26",
+  "tier": 2,
+  "title": "table-001 정확 1건 회계",
+  "input": "samples/table-001.hwp",
+  "instructions": "AU26 — table-001 정확 1건 회계.\n\n입력 표본은 `samples/table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐 한 장을 `ledger/work.capsule.json` 으로 제출하라. 채점기는 폴더를 전수 감사해 재현율 1.0 과 **정확 건수 1** 을 본다. AU02 는 table-001 + total≥1 이다. 이 과제는 AU02 는 total≥1, 여기는 total==1 이다. 빈 폴더나 두 장을 넣으면 정확 건수가 어긋난다.\n\n수행 힌트: rhwp replay --capsule ledger/work.capsule.json 후 채점은 audit ledger. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n비율만 맞추고 건수를 속이지 마라. audit 대상은 폴더 직속 *.capsule.json 이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "ledger/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "전수 재현율 1.0",
+      "op": "value_eq",
+      "value": 1.0,
+      "path": "reproducedRate",
+      "cmd": [
+        "audit",
+        "{file:ledger}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "캡슐 정확 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:ledger}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU27.json
+++ b/gym/packs/automation/tasks/AU27.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU27",
+  "tier": 3,
+  "title": "table-004 서명 귀속",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU27 — table-004 서명 귀속.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n키 `au-sign-t004` 를 발급해 작업 캡슐에 **분리 서명**을 붙여라. 제출은 capsules/work.capsule.json 과 keyring.json 이다. AU03 은 table-001 + gym-agent 이다. 이 과제는 표본 `samples/table-004.hwp` 와 키 id 가 다르다. XC05 의 L3+앵커+보고서 완주를 하지 마라.\n\n수행 힌트: rhwp keygen --key-id au-sign-t004 → replay --sign-key → verify-signature. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n키링에 공개키만 넣는다. 비밀키를 제출 폴더에 남기지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "keyring.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서명 판정 valid",
+      "op": "value_eq",
+      "value": "valid",
+      "path": "verdict",
+      "cmd": [
+        "verify-signature",
+        "{file:capsules/work.capsule.json}",
+        "--keyring",
+        "{file:keyring.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU28.json
+++ b/gym/packs/automation/tasks/AU28.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU28",
+  "tier": 3,
+  "title": "다중표 서명 귀속",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU28 — 다중표 서명 귀속.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n키 `au-sign-mt1` 를 발급해 작업 캡슐에 **분리 서명**을 붙여라. 제출은 capsules/work.capsule.json 과 keyring.json 이다. AU03 은 table-001 + gym-agent 이다. 이 과제는 표본 `samples/multi-table-001.hwp` 와 키 id 가 다르다. XC05 의 L3+앵커+보고서 완주를 하지 마라.\n\n수행 힌트: rhwp keygen --key-id au-sign-mt1 → replay --sign-key → verify-signature. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n키링에 공개키만 넣는다. 비밀키를 제출 폴더에 남기지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "keyring.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서명 판정 valid",
+      "op": "value_eq",
+      "value": "valid",
+      "path": "verdict",
+      "cmd": [
+        "verify-signature",
+        "{file:capsules/work.capsule.json}",
+        "--keyring",
+        "{file:keyring.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU29.json
+++ b/gym/packs/automation/tasks/AU29.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU29",
+  "tier": 3,
+  "title": "내부표 서명 귀속",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU29 — 내부표 서명 귀속.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n키 `au-sign-inner` 를 발급해 작업 캡슐에 **분리 서명**을 붙여라. 제출은 capsules/work.capsule.json 과 keyring.json 이다. AU03 은 table-001 + gym-agent 이다. 이 과제는 표본 `samples/inner-table-01.hwp` 와 키 id 가 다르다. XC05 의 L3+앵커+보고서 완주를 하지 마라.\n\n수행 힌트: rhwp keygen --key-id au-sign-inner → replay --sign-key → verify-signature. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n키링에 공개키만 넣는다. 비밀키를 제출 폴더에 남기지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "keyring.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서명 판정 valid",
+      "op": "value_eq",
+      "value": "valid",
+      "path": "verdict",
+      "cmd": [
+        "verify-signature",
+        "{file:capsules/work.capsule.json}",
+        "--keyring",
+        "{file:keyring.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU30.json
+++ b/gym/packs/automation/tasks/AU30.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU30",
+  "tier": 3,
+  "title": "표시험 서명 귀속",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU30 — 표시험 서명 귀속.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n키 `au-sign-ttest` 를 발급해 작업 캡슐에 **분리 서명**을 붙여라. 제출은 capsules/work.capsule.json 과 keyring.json 이다. AU03 은 table-001 + gym-agent 이다. 이 과제는 표본 `samples/hwp_table_test.hwp` 와 키 id 가 다르다. XC05 의 L3+앵커+보고서 완주를 하지 마라.\n\n수행 힌트: rhwp keygen --key-id au-sign-ttest → replay --sign-key → verify-signature. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n키링에 공개키만 넣는다. 비밀키를 제출 폴더에 남기지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "keyring.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서명 판정 valid",
+      "op": "value_eq",
+      "value": "valid",
+      "path": "verdict",
+      "cmd": [
+        "verify-signature",
+        "{file:capsules/work.capsule.json}",
+        "--keyring",
+        "{file:keyring.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU31.json
+++ b/gym/packs/automation/tasks/AU31.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU31",
+  "tier": 3,
+  "title": "HWPX 표 서명 귀속",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU31 — HWPX 표 서명 귀속.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n키 `au-sign-hwpx` 를 발급해 작업 캡슐에 **분리 서명**을 붙여라. 제출은 capsules/work.capsule.json 과 keyring.json 이다. AU03 은 table-001 + gym-agent 이다. 이 과제는 표본 `samples/hwpx/basic-table-01.hwpx` 와 키 id 가 다르다. XC05 의 L3+앵커+보고서 완주를 하지 마라.\n\n수행 힌트: rhwp keygen --key-id au-sign-hwpx → replay --sign-key → verify-signature. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n키링에 공개키만 넣는다. 비밀키를 제출 폴더에 남기지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "keyring.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서명 판정 valid",
+      "op": "value_eq",
+      "value": "valid",
+      "path": "verdict",
+      "cmd": [
+        "verify-signature",
+        "{file:capsules/work.capsule.json}",
+        "--keyring",
+        "{file:keyring.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU32.json
+++ b/gym/packs/automation/tasks/AU32.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU32",
+  "tier": 3,
+  "title": "복합표 서명 귀속",
+  "input": "samples/table-complex.hwp",
+  "instructions": "AU32 — 복합표 서명 귀속.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n키 `au-sign-complex` 를 발급해 작업 캡슐에 **분리 서명**을 붙여라. 제출은 capsules/work.capsule.json 과 keyring.json 이다. AU03 은 table-001 + gym-agent 이다. 이 과제는 표본 `samples/table-complex.hwp` 와 키 id 가 다르다. XC05 의 L3+앵커+보고서 완주를 하지 마라.\n\n수행 힌트: rhwp keygen --key-id au-sign-complex → replay --sign-key → verify-signature. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n키링에 공개키만 넣는다. 비밀키를 제출 폴더에 남기지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "keyring.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서명 판정 valid",
+      "op": "value_eq",
+      "value": "valid",
+      "path": "verdict",
+      "cmd": [
+        "verify-signature",
+        "{file:capsules/work.capsule.json}",
+        "--keyring",
+        "{file:keyring.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU33.json
+++ b/gym/packs/automation/tasks/AU33.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU33",
+  "tier": 3,
+  "title": "table-004 앵커 등재",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU33 — table-004 앵커 등재.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n서명 없는 작업 캡슐을 append-only 앵커 로그에 등재하라. AU04 는 table-001 에서 logged 와 logChainOk 를 함께 본다. 이 과제는 표본 `samples/table-004.hwp` 에서 **logged** 축만 지목한다. 체크포인트를 요구하지 않는다.\n\n수행 힌트: rhwp replay --capsule 후 rhwp anchor add --log anchor.ndjson. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n로그를 손으로 편집하면 체인이 끊긴다. add 한 번이 등재다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "로그에 등재됨",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:capsules/work.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU34.json
+++ b/gym/packs/automation/tasks/AU34.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU34",
+  "tier": 3,
+  "title": "다중표 앵커 체인",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU34 — 다중표 앵커 체인.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n서명 없는 작업 캡슐을 append-only 앵커 로그에 등재하라. AU04 는 table-001 에서 logged 와 logChainOk 를 함께 본다. 이 과제는 표본 `samples/multi-table-001.hwp` 에서 **chain** 축만 지목한다. 체크포인트를 요구하지 않는다.\n\n수행 힌트: rhwp replay --capsule 후 rhwp anchor add --log anchor.ndjson. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n로그를 손으로 편집하면 체인이 끊긴다. add 한 번이 등재다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "로그 체인 무결",
+      "op": "value_eq",
+      "value": true,
+      "path": "logChainOk",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:capsules/work.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU35.json
+++ b/gym/packs/automation/tasks/AU35.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU35",
+  "tier": 3,
+  "title": "내부표 앵커 등재",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU35 — 내부표 앵커 등재.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n서명 없는 작업 캡슐을 append-only 앵커 로그에 등재하라. AU04 는 table-001 에서 logged 와 logChainOk 를 함께 본다. 이 과제는 표본 `samples/inner-table-01.hwp` 에서 **logged** 축만 지목한다. 체크포인트를 요구하지 않는다.\n\n수행 힌트: rhwp replay --capsule 후 rhwp anchor add --log anchor.ndjson. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n로그를 손으로 편집하면 체인이 끊긴다. add 한 번이 등재다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "로그에 등재됨",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:capsules/work.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU36.json
+++ b/gym/packs/automation/tasks/AU36.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU36",
+  "tier": 3,
+  "title": "표시험 앵커 체인",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU36 — 표시험 앵커 체인.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n서명 없는 작업 캡슐을 append-only 앵커 로그에 등재하라. AU04 는 table-001 에서 logged 와 logChainOk 를 함께 본다. 이 과제는 표본 `samples/hwp_table_test.hwp` 에서 **chain** 축만 지목한다. 체크포인트를 요구하지 않는다.\n\n수행 힌트: rhwp replay --capsule 후 rhwp anchor add --log anchor.ndjson. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n로그를 손으로 편집하면 체인이 끊긴다. add 한 번이 등재다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "로그 체인 무결",
+      "op": "value_eq",
+      "value": true,
+      "path": "logChainOk",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:capsules/work.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU37.json
+++ b/gym/packs/automation/tasks/AU37.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU37",
+  "tier": 3,
+  "title": "HWPX 앵커 등재",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU37 — HWPX 앵커 등재.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n서명 없는 작업 캡슐을 append-only 앵커 로그에 등재하라. AU04 는 table-001 에서 logged 와 logChainOk 를 함께 본다. 이 과제는 표본 `samples/hwpx/basic-table-01.hwpx` 에서 **logged** 축만 지목한다. 체크포인트를 요구하지 않는다.\n\n수행 힌트: rhwp replay --capsule 후 rhwp anchor add --log anchor.ndjson. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n로그를 손으로 편집하면 체인이 끊긴다. add 한 번이 등재다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "로그에 등재됨",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:capsules/work.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU38.json
+++ b/gym/packs/automation/tasks/AU38.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU38",
+  "tier": 3,
+  "title": "복합표 앵커 로그 실재",
+  "input": "samples/table-complex.hwp",
+  "instructions": "AU38 — 복합표 앵커 로그 실재.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n서명 없는 작업 캡슐을 append-only 앵커 로그에 등재하라. AU04 는 table-001 에서 logged 와 logChainOk 를 함께 본다. 이 과제는 표본 `samples/table-complex.hwp` 에서 **file** 축만 지목한다. 체크포인트를 요구하지 않는다.\n\n수행 힌트: rhwp replay --capsule 후 rhwp anchor add --log anchor.ndjson. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n로그를 손으로 편집하면 체인이 끊긴다. add 한 번이 등재다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "앵커 로그 산출",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 32
+    },
+    {
+      "name": "로그에 등재됨",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:capsules/work.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU39.json
+++ b/gym/packs/automation/tasks/AU39.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU39",
+  "tier": 2,
+  "title": "table-004 적합성 L1",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU39 — table-004 적합성 L1.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 가 적합성 **L1** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/table-004.hwp` + L1 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L1. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L1 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:capsules}",
+        "--level",
+        "L1",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU40.json
+++ b/gym/packs/automation/tasks/AU40.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU40",
+  "tier": 3,
+  "title": "다중표 적합성 L2",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU40 — 다중표 적합성 L2.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 가 적합성 **L2** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/multi-table-001.hwp` + L2 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L2. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L2 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:capsules}",
+        "--level",
+        "L2",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU41.json
+++ b/gym/packs/automation/tasks/AU41.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU41",
+  "tier": 2,
+  "title": "내부표 적합성 L1",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU41 — 내부표 적합성 L1.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `work/` 가 적합성 **L1** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/inner-table-01.hwp` + L1 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L1. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L1 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:work}",
+        "--level",
+        "L1",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU42.json
+++ b/gym/packs/automation/tasks/AU42.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU42",
+  "tier": 3,
+  "title": "표시험 적합성 L2",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU42 — 표시험 적합성 L2.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 가 적합성 **L2** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/hwp_table_test.hwp` + L2 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L2. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L2 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:capsules}",
+        "--level",
+        "L2",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU43.json
+++ b/gym/packs/automation/tasks/AU43.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU43",
+  "tier": 2,
+  "title": "HWPX 적합성 L1",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU43 — HWPX 적합성 L1.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 가 적합성 **L1** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/hwpx/basic-table-01.hwpx` + L1 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L1. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L1 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:capsules}",
+        "--level",
+        "L1",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU44.json
+++ b/gym/packs/automation/tasks/AU44.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU44",
+  "tier": 3,
+  "title": "복합표 적합성 L2",
+  "input": "samples/table-complex.hwp",
+  "instructions": "AU44 — 복합표 적합성 L2.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `ladder/` 가 적합성 **L2** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/table-complex.hwp` + L2 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L2. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "ladder/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L2 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:ladder}",
+        "--level",
+        "L2",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU45.json
+++ b/gym/packs/automation/tasks/AU45.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU45",
+  "tier": 2,
+  "title": "다중표2 적합성 L1",
+  "input": "samples/multi-table-002.hwp",
+  "instructions": "AU45 — 다중표2 적합성 L1.\n\n입력 표본은 `samples/multi-table-002.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 가 적합성 **L1** 를 통과하게 만들어라. AU05 는 table-001 L1, AU13 은 table-001 L2 이다. 이 과제는 `samples/multi-table-002.hwp` + L1 이다. L3 --deep 서명 완주(XC05) 와 L5 사다리 완주(XC01) 를 하지 마라. --deep 플래그도 넣지 마라.\n\n수행 힌트: rhwp replay --capsule 후 rhwp conformance --level L1. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\nL1 은 산출마다 영수증, L2 는 감사+계보다. 누적 등급을 건너뛰지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L1 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:capsules}",
+        "--level",
+        "L1",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU46.json
+++ b/gym/packs/automation/tasks/AU46.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU46",
+  "tier": 3,
+  "title": "table-004 가림 복원 무결",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU46 — table-004 가림 복원 무결.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 가림(salt 커밋)한 뒤 개봉으로 복원해 work.capsule.json · redacted.json · opening.json · restored.json 을 제출하라. AU06 은 table-001 에서 세 검사를 한 번에 본다. 이 과제는 `samples/table-004.hwp` 에서 **restore** 축만 지목한다. 부분 개봉으로 우회하지 마라.\n\n수행 힌트: rhwp disclose redact -o redacted.json --opening-out opening.json 후 restore. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n가림본이 원본과 같으면 가림이 일어나지 않은 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "redacted.json",
+      "opening.json",
+      "restored.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "가림 복원 무결",
+      "op": "value_eq",
+      "value": true,
+      "path": "byteIdentical",
+      "cmd": [
+        "disclose",
+        "restore",
+        "{file:redacted.json}",
+        "--opening",
+        "{file:opening.json}",
+        "-o",
+        "{file:_grader_restore.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU47.json
+++ b/gym/packs/automation/tasks/AU47.json
@@ -1,0 +1,27 @@
+{
+  "id": "AU47",
+  "tier": 3,
+  "title": "다중표 가림본 차이",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU47 — 다중표 가림본 차이.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 가림(salt 커밋)한 뒤 개봉으로 복원해 work.capsule.json · redacted.json · opening.json · restored.json 을 제출하라. AU06 은 table-001 에서 세 검사를 한 번에 본다. 이 과제는 `samples/multi-table-001.hwp` 에서 **differ** 축만 지목한다. 부분 개봉으로 우회하지 마라.\n\n수행 힌트: rhwp disclose redact -o redacted.json --opening-out opening.json 후 restore. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n가림본이 원본과 같으면 가림이 일어나지 않은 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "redacted.json",
+      "opening.json",
+      "restored.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "가림이 실제로 일어남",
+      "op": "files_differ",
+      "files": [
+        "redacted.json",
+        "work.capsule.json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU48.json
+++ b/gym/packs/automation/tasks/AU48.json
@@ -1,0 +1,27 @@
+{
+  "id": "AU48",
+  "tier": 3,
+  "title": "내부표 복원 해시",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU48 — 내부표 복원 해시.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 가림(salt 커밋)한 뒤 개봉으로 복원해 work.capsule.json · redacted.json · opening.json · restored.json 을 제출하라. AU06 은 table-001 에서 세 검사를 한 번에 본다. 이 과제는 `samples/inner-table-01.hwp` 에서 **hash** 축만 지목한다. 부분 개봉으로 우회하지 마라.\n\n수행 힌트: rhwp disclose redact -o redacted.json --opening-out opening.json 후 restore. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n가림본이 원본과 같으면 가림이 일어나지 않은 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "redacted.json",
+      "opening.json",
+      "restored.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "복원본이 원본 캡슐과 바이트 동일",
+      "op": "same_hash",
+      "files": [
+        "restored.json",
+        "work.capsule.json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU49.json
+++ b/gym/packs/automation/tasks/AU49.json
@@ -1,0 +1,33 @@
+{
+  "id": "AU49",
+  "tier": 3,
+  "title": "표시험 개봉 실재",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU49 — 표시험 개봉 실재.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 가림(salt 커밋)한 뒤 개봉으로 복원해 work.capsule.json · redacted.json · opening.json · restored.json 을 제출하라. AU06 은 table-001 에서 세 검사를 한 번에 본다. 이 과제는 `samples/hwp_table_test.hwp` 에서 **opening** 축만 지목한다. 부분 개봉으로 우회하지 마라.\n\n수행 힌트: rhwp disclose redact -o redacted.json --opening-out opening.json 후 restore. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n가림본이 원본과 같으면 가림이 일어나지 않은 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "redacted.json",
+      "opening.json",
+      "restored.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "개봉 파일 산출",
+      "op": "file_exists",
+      "file": "opening.json",
+      "minBytes": 32
+    },
+    {
+      "name": "가림이 실제로 일어남",
+      "op": "files_differ",
+      "files": [
+        "redacted.json",
+        "work.capsule.json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU50.json
+++ b/gym/packs/automation/tasks/AU50.json
@@ -1,0 +1,39 @@
+{
+  "id": "AU50",
+  "tier": 3,
+  "title": "HWPX 가림 복원",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU50 — HWPX 가림 복원.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 가림(salt 커밋)한 뒤 개봉으로 복원해 work.capsule.json · redacted.json · opening.json · restored.json 을 제출하라. AU06 은 table-001 에서 세 검사를 한 번에 본다. 이 과제는 `samples/hwpx/basic-table-01.hwpx` 에서 **restore** 축만 지목한다. 부분 개봉으로 우회하지 마라.\n\n수행 힌트: rhwp disclose redact -o redacted.json --opening-out opening.json 후 restore. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n가림본이 원본과 같으면 가림이 일어나지 않은 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "redacted.json",
+      "opening.json",
+      "restored.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "가림 복원 무결",
+      "op": "value_eq",
+      "value": true,
+      "path": "byteIdentical",
+      "cmd": [
+        "disclose",
+        "restore",
+        "{file:redacted.json}",
+        "--opening",
+        "{file:opening.json}",
+        "-o",
+        "{file:_grader_restore.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU51.json
+++ b/gym/packs/automation/tasks/AU51.json
@@ -1,0 +1,27 @@
+{
+  "id": "AU51",
+  "tier": 3,
+  "title": "복합표 가림본 차이",
+  "input": "samples/table-complex.hwp",
+  "instructions": "AU51 — 복합표 가림본 차이.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 가림(salt 커밋)한 뒤 개봉으로 복원해 work.capsule.json · redacted.json · opening.json · restored.json 을 제출하라. AU06 은 table-001 에서 세 검사를 한 번에 본다. 이 과제는 `samples/table-complex.hwp` 에서 **differ** 축만 지목한다. 부분 개봉으로 우회하지 마라.\n\n수행 힌트: rhwp disclose redact -o redacted.json --opening-out opening.json 후 restore. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n가림본이 원본과 같으면 가림이 일어나지 않은 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "redacted.json",
+      "opening.json",
+      "restored.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "가림이 실제로 일어남",
+      "op": "files_differ",
+      "files": [
+        "redacted.json",
+        "work.capsule.json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU52.json
+++ b/gym/packs/automation/tasks/AU52.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU52",
+  "tier": 3,
+  "title": "table-004 관문 통과",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU52 — table-004 관문 통과.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐과 정책 policy.json 을 제출해 관문 판정 **allow** 를 받아라. AU07 은 table-001 + --deep + 규칙 R1-재현 이다. 이 과제는 `samples/table-004.hwp` , 규칙 id `R-표사-재현` , --deep 재현 이다. 정산 원장이나 L5 를 붙이지 마라.\n\n수행 힌트: rhwp replay --capsule 후 재현을 요구하는 admissionPolicy 를 두고 rhwp gate. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\ndefault deny 정책에 reproduced==true 규칙 하나가 있으면 된다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "관문 allow",
+      "op": "value_eq",
+      "value": "allow",
+      "path": "verdict",
+      "cmd": [
+        "gate",
+        "{file:work.capsule.json}",
+        "--policy",
+        "{file:policy.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU53.json
+++ b/gym/packs/automation/tasks/AU53.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU53",
+  "tier": 3,
+  "title": "다중표 얕은 관문",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU53 — 다중표 얕은 관문.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐과 정책 policy.json 을 제출해 관문 판정 **allow** 를 받아라. AU07 은 table-001 + --deep + 규칙 R1-재현 이다. 이 과제는 `samples/multi-table-001.hwp` , 규칙 id `R-다중-재현` , 얕은 관문(--deep 없음) 이다. 정산 원장이나 L5 를 붙이지 마라.\n\n수행 힌트: rhwp replay --capsule 후 재현을 요구하는 admissionPolicy 를 두고 rhwp gate. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\ndefault deny 정책에 reproduced==true 규칙 하나가 있으면 된다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "관문 allow",
+      "op": "value_eq",
+      "value": "allow",
+      "path": "verdict",
+      "cmd": [
+        "gate",
+        "{file:work.capsule.json}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU54.json
+++ b/gym/packs/automation/tasks/AU54.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU54",
+  "tier": 3,
+  "title": "내부표 관문 통과",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU54 — 내부표 관문 통과.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐과 정책 policy.json 을 제출해 관문 판정 **allow** 를 받아라. AU07 은 table-001 + --deep + 규칙 R1-재현 이다. 이 과제는 `samples/inner-table-01.hwp` , 규칙 id `R-내부-재현` , --deep 재현 이다. 정산 원장이나 L5 를 붙이지 마라.\n\n수행 힌트: rhwp replay --capsule 후 재현을 요구하는 admissionPolicy 를 두고 rhwp gate. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\ndefault deny 정책에 reproduced==true 규칙 하나가 있으면 된다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "관문 allow",
+      "op": "value_eq",
+      "value": "allow",
+      "path": "verdict",
+      "cmd": [
+        "gate",
+        "{file:work.capsule.json}",
+        "--policy",
+        "{file:policy.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU55.json
+++ b/gym/packs/automation/tasks/AU55.json
@@ -1,0 +1,34 @@
+{
+  "id": "AU55",
+  "tier": 3,
+  "title": "표시험 얕은 관문",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU55 — 표시험 얕은 관문.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐과 정책 policy.json 을 제출해 관문 판정 **allow** 를 받아라. AU07 은 table-001 + --deep + 규칙 R1-재현 이다. 이 과제는 `samples/hwp_table_test.hwp` , 규칙 id `R-시험-재현` , 얕은 관문(--deep 없음) 이다. 정산 원장이나 L5 를 붙이지 마라.\n\n수행 힌트: rhwp replay --capsule 후 재현을 요구하는 admissionPolicy 를 두고 rhwp gate. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\ndefault deny 정책에 reproduced==true 규칙 하나가 있으면 된다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "관문 allow",
+      "op": "value_eq",
+      "value": "allow",
+      "path": "verdict",
+      "cmd": [
+        "gate",
+        "{file:work.capsule.json}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU56.json
+++ b/gym/packs/automation/tasks/AU56.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU56",
+  "tier": 3,
+  "title": "HWPX 관문 통과",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU56 — HWPX 관문 통과.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐과 정책 policy.json 을 제출해 관문 판정 **allow** 를 받아라. AU07 은 table-001 + --deep + 규칙 R1-재현 이다. 이 과제는 `samples/hwpx/basic-table-01.hwpx` , 규칙 id `R-hwpx-재현` , --deep 재현 이다. 정산 원장이나 L5 를 붙이지 마라.\n\n수행 힌트: rhwp replay --capsule 후 재현을 요구하는 admissionPolicy 를 두고 rhwp gate. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\ndefault deny 정책에 reproduced==true 규칙 하나가 있으면 된다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.capsule.json",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "관문 allow",
+      "op": "value_eq",
+      "value": "allow",
+      "path": "verdict",
+      "cmd": [
+        "gate",
+        "{file:work.capsule.json}",
+        "--policy",
+        "{file:policy.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU57.json
+++ b/gym/packs/automation/tasks/AU57.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU57",
+  "tier": 3,
+  "title": "table-004 청구 검증",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU57 — table-004 청구 검증.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐·발주 명세서(gym-wo-t004)·게이트 판정 봉투를 3해시로 고정한 청구 claim.json 을 발급하라. AU08 은 table-001 + gym-wo-1 이다. 이 과제는 `samples/table-004.hwp` + gym-wo-t004 이다. XC03 처럼 원장 4관문(capsuleOk/gateOk/ledgerOk/workorderOk) 과 ledger.ndjson 을 요구하지 않는다. settle verify 의 verdict 만 본다.\n\n수행 힌트: rhwp settle propose --workorder wo.json --capsule ... --gate-envelope gate.json -o claim.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n원장 기록(settle record)은 이 과제의 범위가 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "claim.json",
+      "work.capsule.json",
+      "wo.json",
+      "gate.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:work.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU58.json
+++ b/gym/packs/automation/tasks/AU58.json
@@ -1,0 +1,47 @@
+{
+  "id": "AU58",
+  "tier": 3,
+  "title": "다중표 청구 실재",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU58 — 다중표 청구 실재.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐·발주 명세서(gym-wo-mt1)·게이트 판정 봉투를 3해시로 고정한 청구 claim.json 을 발급하라. AU08 은 table-001 + gym-wo-1 이다. 이 과제는 `samples/multi-table-001.hwp` + gym-wo-mt1 이다. XC03 처럼 원장 4관문(capsuleOk/gateOk/ledgerOk/workorderOk) 과 ledger.ndjson 을 요구하지 않는다. settle verify 의 verdict 만 본다.\n\n수행 힌트: rhwp settle propose --workorder wo.json --capsule ... --gate-envelope gate.json -o claim.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n원장 기록(settle record)은 이 과제의 범위가 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "claim.json",
+      "work.capsule.json",
+      "wo.json",
+      "gate.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "청구 파일 산출",
+      "op": "file_exists",
+      "file": "claim.json",
+      "minBytes": 64
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:work.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU59.json
+++ b/gym/packs/automation/tasks/AU59.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU59",
+  "tier": 3,
+  "title": "내부표 청구 검증",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU59 — 내부표 청구 검증.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐·발주 명세서(gym-wo-inner)·게이트 판정 봉투를 3해시로 고정한 청구 claim.json 을 발급하라. AU08 은 table-001 + gym-wo-1 이다. 이 과제는 `samples/inner-table-01.hwp` + gym-wo-inner 이다. XC03 처럼 원장 4관문(capsuleOk/gateOk/ledgerOk/workorderOk) 과 ledger.ndjson 을 요구하지 않는다. settle verify 의 verdict 만 본다.\n\n수행 힌트: rhwp settle propose --workorder wo.json --capsule ... --gate-envelope gate.json -o claim.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n원장 기록(settle record)은 이 과제의 범위가 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "claim.json",
+      "work.capsule.json",
+      "wo.json",
+      "gate.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:work.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU60.json
+++ b/gym/packs/automation/tasks/AU60.json
@@ -1,0 +1,47 @@
+{
+  "id": "AU60",
+  "tier": 3,
+  "title": "표시험 청구 실재",
+  "input": "samples/hwp_table_test.hwp",
+  "instructions": "AU60 — 표시험 청구 실재.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐·발주 명세서(gym-wo-ttest)·게이트 판정 봉투를 3해시로 고정한 청구 claim.json 을 발급하라. AU08 은 table-001 + gym-wo-1 이다. 이 과제는 `samples/hwp_table_test.hwp` + gym-wo-ttest 이다. XC03 처럼 원장 4관문(capsuleOk/gateOk/ledgerOk/workorderOk) 과 ledger.ndjson 을 요구하지 않는다. settle verify 의 verdict 만 본다.\n\n수행 힌트: rhwp settle propose --workorder wo.json --capsule ... --gate-envelope gate.json -o claim.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n원장 기록(settle record)은 이 과제의 범위가 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "claim.json",
+      "work.capsule.json",
+      "wo.json",
+      "gate.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "청구 파일 산출",
+      "op": "file_exists",
+      "file": "claim.json",
+      "minBytes": 64
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:work.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU61.json
+++ b/gym/packs/automation/tasks/AU61.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU61",
+  "tier": 3,
+  "title": "HWPX 청구 검증",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "instructions": "AU61 — HWPX 청구 검증.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐·발주 명세서(gym-wo-hwpx)·게이트 판정 봉투를 3해시로 고정한 청구 claim.json 을 발급하라. AU08 은 table-001 + gym-wo-1 이다. 이 과제는 `samples/hwpx/basic-table-01.hwpx` + gym-wo-hwpx 이다. XC03 처럼 원장 4관문(capsuleOk/gateOk/ledgerOk/workorderOk) 과 ledger.ndjson 을 요구하지 않는다. settle verify 의 verdict 만 본다.\n\n수행 힌트: rhwp settle propose --workorder wo.json --capsule ... --gate-envelope gate.json -o claim.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n원장 기록(settle record)은 이 과제의 범위가 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "claim.json",
+      "work.capsule.json",
+      "wo.json",
+      "gate.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:work.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU62.json
+++ b/gym/packs/automation/tasks/AU62.json
@@ -1,0 +1,30 @@
+{
+  "id": "AU62",
+  "tier": 3,
+  "title": "table-004 감사 보고",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU62 — table-004 감사 보고.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 에 대한 감사 보고서를 report.json 으로 발급하라. AU09 는 table-001 + capsules/ + lineage.valid==1 이다. 이 과제는 `samples/table-004.hwp` 이다. --deep 서명 귀속 보고서를 요구하지 않는다.\n\n수행 힌트: rhwp audit-report capsules -o report.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n채점기는 보고서를 다시 만들어 계보 절 수치를 대조한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계보 유효 머리 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:capsules}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU63.json
+++ b/gym/packs/automation/tasks/AU63.json
@@ -1,0 +1,36 @@
+{
+  "id": "AU63",
+  "tier": 3,
+  "title": "다중표 감사 보고 실재",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU63 — 다중표 감사 보고 실재.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `capsules/` 에 대한 감사 보고서를 report.json 으로 발급하라. AU09 는 table-001 + capsules/ + lineage.valid==1 이다. 이 과제는 `samples/multi-table-001.hwp` 이다. --deep 서명 귀속 보고서를 요구하지 않는다.\n\n수행 힌트: rhwp audit-report capsules -o report.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n채점기는 보고서를 다시 만들어 계보 절 수치를 대조한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/work.capsule.json",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "보고서 산출",
+      "op": "file_exists",
+      "file": "report.json",
+      "minBytes": 64
+    },
+    {
+      "name": "계보 유효 머리 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:capsules}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU64.json
+++ b/gym/packs/automation/tasks/AU64.json
@@ -1,0 +1,30 @@
+{
+  "id": "AU64",
+  "tier": 3,
+  "title": "내부표 감사 보고",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU64 — 내부표 감사 보고.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 폴더 `work/` 에 대한 감사 보고서를 report.json 으로 발급하라. AU09 는 table-001 + capsules/ + lineage.valid==1 이다. 이 과제는 `samples/inner-table-01.hwp` 이다. --deep 서명 귀속 보고서를 요구하지 않는다.\n\n수행 힌트: rhwp audit-report work -o report.json. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n채점기는 보고서를 다시 만들어 계보 절 수치를 대조한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work/work.capsule.json",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계보 유효 머리 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:work}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU65.json
+++ b/gym/packs/automation/tasks/AU65.json
@@ -1,0 +1,31 @@
+{
+  "id": "AU65",
+  "tier": 3,
+  "title": "table-004 2링크 리콜",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU65 — table-004 2링크 리콜.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 2링크 체인(a→b)을 `capsules/` 로 제출하라. 채점기는 뿌리 a 를 오염으로 지목해 **영향 캡슐이 2건 이상**인지 본다. AU10 은 table-001 + capsules/ 이다. 이 과제는 `samples/table-004.hwp` + `capsules/` 이다. XC02 처럼 unaffected==0 을 함께 묻지 않는다. 3세대도 만들지 마라.\n\n수행 힌트: replay 로 a, replay --parent a 로 b. 채점은 recall-scope --contaminated a --among. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n서로 무관한 두 장을 내면 영향권이 1 이라 실패한다. 부모 링크가 필요하다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/a.capsule.json",
+      "capsules/b.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향 캡슐 2건 이상",
+      "op": "len_ge",
+      "value": 2,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:capsules/a.capsule.json}",
+        "--among",
+        "{file:capsules}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU66.json
+++ b/gym/packs/automation/tasks/AU66.json
@@ -1,0 +1,31 @@
+{
+  "id": "AU66",
+  "tier": 3,
+  "title": "다중표 2링크 리콜",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU66 — 다중표 2링크 리콜.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 2링크 체인(a→b)을 `chain/` 로 제출하라. 채점기는 뿌리 a 를 오염으로 지목해 **영향 캡슐이 2건 이상**인지 본다. AU10 은 table-001 + capsules/ 이다. 이 과제는 `samples/multi-table-001.hwp` + `chain/` 이다. XC02 처럼 unaffected==0 을 함께 묻지 않는다. 3세대도 만들지 마라.\n\n수행 힌트: replay 로 a, replay --parent a 로 b. 채점은 recall-scope --contaminated a --among. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n서로 무관한 두 장을 내면 영향권이 1 이라 실패한다. 부모 링크가 필요하다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "chain/a.capsule.json",
+      "chain/b.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향 캡슐 2건 이상",
+      "op": "len_ge",
+      "value": 2,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:chain/a.capsule.json}",
+        "--among",
+        "{file:chain}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU67.json
+++ b/gym/packs/automation/tasks/AU67.json
@@ -1,0 +1,31 @@
+{
+  "id": "AU67",
+  "tier": 3,
+  "title": "내부표 2링크 리콜",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU67 — 내부표 2링크 리콜.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n캡슐 2링크 체인(a→b)을 `capsules/` 로 제출하라. 채점기는 뿌리 a 를 오염으로 지목해 **영향 캡슐이 2건 이상**인지 본다. AU10 은 table-001 + capsules/ 이다. 이 과제는 `samples/inner-table-01.hwp` + `capsules/` 이다. XC02 처럼 unaffected==0 을 함께 묻지 않는다. 3세대도 만들지 마라.\n\n수행 힌트: replay 로 a, replay --parent a 로 b. 채점은 recall-scope --contaminated a --among. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n서로 무관한 두 장을 내면 영향권이 1 이라 실패한다. 부모 링크가 필요하다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capsules/a.capsule.json",
+      "capsules/b.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향 캡슐 2건 이상",
+      "op": "len_ge",
+      "value": 2,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:capsules/a.capsule.json}",
+        "--among",
+        "{file:capsules}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU68.json
+++ b/gym/packs/automation/tasks/AU68.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU68",
+  "tier": 3,
+  "title": "table-004 번들 컨테이너",
+  "input": "samples/table-004.hwp",
+  "instructions": "AU68 — table-004 번들 컨테이너.\n\n입력 표본은 `samples/table-004.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 오프라인 교환 번들(.lineage-bundle)로 내보내고 신뢰 도메인 `gym-t004` 파일과 함께 제출하라. AU11 은 table-001 + domain=gym + 두 검사다. 이 과제는 `samples/table-004.hwp` 에서 **container** 축이다.\n\n수행 힌트: rhwp bundle export work.capsule.json -o work.lineage-bundle 후 bundle verify. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n빈 키링 도메인이면 서명 없는 캡슐 번들을 검증할 수 있다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.lineage-bundle",
+      "domain.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "컨테이너 무결",
+      "op": "value_eq",
+      "value": true,
+      "path": "containerOk",
+      "cmd": [
+        "bundle",
+        "verify",
+        "{file:work.lineage-bundle}",
+        "--trust-domain",
+        "{file:domain.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU69.json
+++ b/gym/packs/automation/tasks/AU69.json
@@ -1,0 +1,35 @@
+{
+  "id": "AU69",
+  "tier": 3,
+  "title": "다중표 번들 폐쇄집합",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "AU69 — 다중표 번들 폐쇄집합.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 오프라인 교환 번들(.lineage-bundle)로 내보내고 신뢰 도메인 `gym-mt1` 파일과 함께 제출하라. AU11 은 table-001 + domain=gym + 두 검사다. 이 과제는 `samples/multi-table-001.hwp` 에서 **closure** 축이다.\n\n수행 힌트: rhwp bundle export work.capsule.json -o work.lineage-bundle 후 bundle verify. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n빈 키링 도메인이면 서명 없는 캡슐 번들을 검증할 수 있다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.lineage-bundle",
+      "domain.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "폐쇄집합 완전",
+      "op": "value_eq",
+      "value": true,
+      "path": "closureOk",
+      "cmd": [
+        "bundle",
+        "verify",
+        "{file:work.lineage-bundle}",
+        "--trust-domain",
+        "{file:domain.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/gym/packs/automation/tasks/AU70.json
+++ b/gym/packs/automation/tasks/AU70.json
@@ -1,0 +1,41 @@
+{
+  "id": "AU70",
+  "tier": 3,
+  "title": "내부표 번들 교환",
+  "input": "samples/inner-table-01.hwp",
+  "instructions": "AU70 — 내부표 번들 교환.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. automation pack 은 기존 CLI 표면(anchor · audit · audit-report · bundle · conformance · disclose · export-tables · gate · lineage · recall-scope · settle · verify-signature) 만으로 검증 사다리 여정을 늘린다. 새 명령·새 연산자·새 pack 은 없다.\n\n작업 캡슐을 오프라인 교환 번들(.lineage-bundle)로 내보내고 신뢰 도메인 `gym-inner` 파일과 함께 제출하라. AU11 은 table-001 + domain=gym + 두 검사다. 이 과제는 `samples/inner-table-01.hwp` 에서 **both** 축이다.\n\n수행 힌트: rhwp bundle export work.capsule.json -o work.lineage-bundle 후 bundle verify. 채점은 제출 폴더에서 같은 판정 명령을 다시 돌린다. 정답 해시·건수를 과제 파일에 박제하지 마라. 표본이 바뀌면 라이브 재계산이 따라간다.\n\n금지: XC01 L5 완주, XC02 오염 무영향 0, XC03 정산 4관문, XC04 3세대 --deep, XC05 L3 서명+앵커 완주, WR 일일 3해시, T07 서식 채움을 복제하지 마라. 원본 픽스처를 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. T07 서식 채움(fill-fields, 첫 필드 홍길동)을 복제하지 마라. XC01–XC05 사다리 완주(L5 · 3세대 --deep · 정산 4관문 · 오염 무영향 0 · L3 서명+앵커 완주)를 베끼지 마라. WR01+ 일일 영수증 3해시 answer.json 여정도 이 pack 의 일이 아니다.\n\n빈 키링 도메인이면 서명 없는 캡슐 번들을 검증할 수 있다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "work.lineage-bundle",
+      "domain.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "번들 파일 산출",
+      "op": "file_exists",
+      "file": "work.lineage-bundle",
+      "minBytes": 64
+    },
+    {
+      "name": "컨테이너 무결",
+      "op": "value_eq",
+      "value": true,
+      "path": "containerOk",
+      "cmd": [
+        "bundle",
+        "verify",
+        "{file:work.lineage-bundle}",
+        "--trust-domain",
+        "{file:domain.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "자동화"
+}

--- a/mydocs/working/gym_automation.md
+++ b/mydocs/working/gym_automation.md
@@ -1,0 +1,100 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_automation.md
+last_verified: 2026-08-18
+issue: 5257
+---
+
+# gym automation pack 확장 작업 노트 (이슈 #5257)
+
+## 한 줄
+
+`feat/gym-automation-expand` 가 AU01–AU13 에서 멈춰 있던 검증 사다리
+여정을, 기존 명령·기존 표본만으로 AU14–AU70 과 README·가드 시험까지
+늘린다. 새 CLI 는 없다.
+
+## 배경
+
+사다리 pack 은 계획·캡슐·서명·앵커·적합·가림·관문·정산·보고·리콜·번들·
+계보를 한 바퀴 돌리지만, 표본이 table-001 한 장에 몰려 있고 같은 봉투
+필드를 한 과제에 묶어 두었다. 에이전트가 AU01–AU13 힌트를 외우면 축
+전체를 통과한다. 이슈 #5257 은 기존 명령만으로 여정을 늘리라고 한다.
+
+건드리지 않은 것:
+
+- 새 연산자 (`checks.py` 미변경)
+- 새 CLI · 새 표본 · 새 pack
+- T07 서식 채움 복제 (`fill-fields`, 첫 필드 홍길동)
+- XC01–XC05 복제 (L5, 오염 무영향 0, 정산 4관문, 3세대 --deep, L3 완주)
+- WR01+ 복제 (일일 영수증 3해시 answer.json)
+- `gym/README.md` · `gym/PARK.md` · `profiles/*.json` 집계 갱신
+- 다른 pack 의 과제 파일
+- `cargo fmt --all` (JSON·문서·테스트만)
+- `pack.json` 의 `runner` 신원 (`rhwpVersion` / `rhwpCommit` /
+  `capabilitiesSha256`). 요구 명령 목록도 기존 값을 유지했다.
+
+## 설계 원칙
+
+1. **한 축만 지목한다.** AU04 의 logged+logChainOk, AU06 의 restore+
+   hash+differ, AU11 의 container+closure 를 쪼개 표본을 옮긴다. 한
+   숫자가 나와도 추측으로 차이를 만들지 않고 봉투를 옮긴다.
+2. **표본을 흩는다.** table-001 한 장에 질문을 몰지 않는다. table-004,
+   multi-table-001/002, inner-table-01, hwp_table_test, table-complex,
+   hwpx/basic-table-01. 전부 `samples/` 에 이미 있다.
+3. **정확 건수.** AU02 는 `total≥1` 이라 두 장도 통과한다. AU19+ 는
+   `total==1` 로 속임수를 거절한다.
+4. **보스를 훔치지 않는다.** L5 · 3세대 --deep · 원장 4관문 · 무영향 0
+   콤보는 XC 의 자이로드롭이다.
+5. **T07 금지.** 누름틀을 채우지 않는다.
+
+## 과제 묶음
+
+| 구간 | 축 | 건수 | 핵심 필드 |
+|------|----|------|-----------|
+| AU14–AU18 | 계획·표 좌표 | 5 | `cell_text_eq` · `differs_from_input` |
+| AU19–AU26 | 감사 정확 1건 | 8 | `reproducedRate` · `total==1` |
+| AU27–AU32 | 서명 귀속 | 6 | `verify-signature.verdict` |
+| AU33–AU38 | 앵커 | 6 | `logged` · `logChainOk` |
+| AU39–AU45 | 적합성 L1/L2 | 7 | `conformance.verdict` |
+| AU46–AU51 | 선택적 공개 | 6 | `byteIdentical` · `same_hash` · `files_differ` |
+| AU52–AU56 | 관문 | 5 | `gate.verdict` · `--deep` / 얕음 |
+| AU57–AU61 | 정산 청구 | 5 | `settle.verify.verdict` |
+| AU62–AU64 | 감사 보고 | 3 | `audit-report` · `lineage.valid` |
+| AU65–AU67 | 2링크 리콜 | 3 | `recall-scope.affected` |
+| AU68–AU70 | 연합 번들 | 3 | `containerOk` · `closureOk` |
+
+AU01–AU13 은 그대로 둔다. 번호 구멍 없음 (1…70).
+
+## 사용한 기존 표본
+
+- `samples/table-001.hwp`
+- `samples/table-004.hwp`
+- `samples/multi-table-001.hwp`
+- `samples/multi-table-002.hwp`
+- `samples/inner-table-01.hwp`
+- `samples/hwp_table_test.hwp`
+- `samples/table-complex.hwp`
+- `samples/hwpx/basic-table-01.hwpx`
+
+## 검증
+
+```bash
+python gym/tools/audit.py
+python -m unittest scripts/tests/test_gym_packs.py
+python -m unittest scripts/tests/test_gym_automation_pack.py
+```
+
+바이너리 없이 파일 계약만 닫는다. 기준 풀이 왕복(`build_baseline.py`)은
+로컬에 `target/debug/rhwp` 가 있을 때 선택이다. 이 작업은 JSON·문서·
+테스트만 바꾸므로 `cargo fmt --all` 을 돌리지 않는다.
+
+## 산출물
+
+- `gym/packs/automation/README.md`
+- `gym/packs/automation/tasks/AU14.json` … `AU70.json`
+- `gym/packs/automation/reference/AU14.json` … `AU70.json`
+- `scripts/tests/test_gym_automation_pack.py`
+- `mydocs/working/gym_automation.md` — 이 노트
+
+`pack.json` 은 runner 복사가 이미 되어 있어 손대지 않았다.

--- a/scripts/tests/test_gym_automation_pack.py
+++ b/scripts/tests/test_gym_automation_pack.py
@@ -1,0 +1,356 @@
+"""automation pack 확장 계약 — AU14+ · README · 기존 명령/표본만.
+
+이 가드는 이슈 #5257 의 확장 규칙을 파일만으로 고정한다. 바이너리·네트워크가
+없어도 돈다. 새 연산자·새 표본·T07/XC/WR 복제·다른 pack 편집이 들어오면 red.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+PACK = GYM / "packs" / "automation"
+TASKS = PACK / "tasks"
+REFS = PACK / "reference"
+README = PACK / "README.md"
+WORKING = REPO_ROOT / "mydocs" / "working" / "gym_automation.md"
+
+# gym/core/checks.py REGISTRY 와 같은 기존 연산자만 허용.
+EXISTING_OPS = {
+    "same_hash",
+    "differs_from_input",
+    "file_exists",
+    "files_differ",
+    "xml_root_eq",
+    "json_value_eq",
+    "csv_cell_eq",
+    "utf8_bom",
+    "answer_eq",
+    "len_answer_eq",
+    "len_ge",
+    "value_eq",
+    "value_ge",
+    "value_in",
+    "deep_contains",
+    "not_contains",
+    "cell_text_eq",
+}
+
+# pack.json requires.commands — 채점 cmd[0] 은 이 집합 안이어야 한다.
+PACK_COMMANDS = {
+    "anchor",
+    "audit",
+    "audit-report",
+    "bundle",
+    "conformance",
+    "disclose",
+    "export-tables",
+    "gate",
+    "lineage",
+    "recall-scope",
+    "settle",
+    "verify-signature",
+}
+
+# devel 에 이미 있던 runner 신원. 이 확장은 복사만 한다.
+RUNNER_PIN = {
+    "rhwpVersion": "0.8.2",
+    "rhwpCommit": "1e8667aa86aeb979119aa9152112b42e4f16a76c",
+    "capabilitiesSha256": "2c7c41bc8952b63c4502ec0685b76990e4ece5b178f6dc28a1a495b12880af75",
+}
+
+FORBIDDEN_SCORE_CMDS = {"fill-fields", "fields", "inspect", "scan", "replay", "run", "keygen"}
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def task_paths():
+    return sorted(TASKS.glob("AU*.json"))
+
+
+def au_num(path: Path) -> int:
+    return int(path.stem[2:])
+
+
+class AutomationPackLayoutTests(unittest.TestCase):
+    def test_pack_manifest_identity_and_runner_copied(self):
+        manifest = read_json(PACK / "pack.json")
+        self.assertEqual(manifest["id"], "automation")
+        self.assertEqual(manifest["kind"], "gymPack")
+        self.assertEqual(manifest["schemaVersion"], "1.0")
+        self.assertIn("자동화", manifest["axis"])
+        cmds = set(manifest["requires"]["commands"])
+        self.assertEqual(cmds, PACK_COMMANDS)
+        self.assertEqual(manifest["runner"], RUNNER_PIN)
+
+    def test_readme_exists_and_is_korean(self):
+        self.assertTrue(README.is_file(), "gym/packs/automation/README.md 가 없다")
+        text = README.read_text(encoding="utf-8")
+        self.assertGreater(len(text), 2000)
+        for needle in ("자동화", "AU14", "기존 명령", "T07", "XC01", "WR01"):
+            self.assertIn(needle, text, f"README 에 '{needle}' 가 없다")
+        self.assertNotIn("fill-fields", text)
+
+    def test_working_notes_exist_and_are_korean(self):
+        self.assertTrue(WORKING.is_file(), "mydocs/working/gym_automation.md 가 없다")
+        text = WORKING.read_text(encoding="utf-8")
+        self.assertGreater(len(text), 2000)
+        for needle in ("AU14", "기존 표본", "T07", "audit", "test_gym_packs"):
+            self.assertIn(needle, text, f"작업 노트에 '{needle}' 가 없다")
+
+
+class AutomationTaskContractTests(unittest.TestCase):
+    def test_au14_plus_ship_with_paired_reference(self):
+        plus = [p for p in task_paths() if au_num(p) >= 14]
+        self.assertGreaterEqual(len(plus), 50, "AU14+ 과제가 50건 미만이다")
+        missing = []
+        for path in plus:
+            tid = path.stem
+            ref = REFS / f"{tid}.json"
+            if not ref.is_file():
+                missing.append(tid)
+                continue
+            task = read_json(path)
+            ref_obj = read_json(ref)
+            self.assertEqual(task["id"], tid)
+            self.assertEqual(ref_obj["id"], tid)
+        self.assertEqual(missing, [], f"기준풀이 없음: {missing}")
+
+    def test_task_ids_are_contiguous_au_prefix(self):
+        nums = sorted(au_num(p) for p in task_paths())
+        self.assertEqual(nums[0], 1)
+        self.assertGreaterEqual(nums[-1], 70)
+        self.assertEqual(nums, list(range(1, nums[-1] + 1)), "AU 번호에 구멍이 있다")
+
+    def test_operators_are_existing_only(self):
+        unknown = []
+        for path in task_paths():
+            task = read_json(path)
+            for check in task["checks"]:
+                op = check["op"]
+                if op not in EXISTING_OPS:
+                    unknown.append(f"{task['id']}:{op}")
+        self.assertEqual(unknown, [], f"새 연산자: {unknown}")
+
+    def test_score_commands_stay_inside_pack_requires(self):
+        bad = []
+        for path in task_paths():
+            task = read_json(path)
+            for check in task.get("checks", []):
+                cmd = check.get("cmd")
+                if cmd and cmd[0] not in PACK_COMMANDS:
+                    bad.append(f"{task['id']}:{cmd[0]}")
+        self.assertEqual(bad, [], f"pack requires 밖 채점 명령: {bad}")
+
+    def test_inputs_are_existing_samples(self):
+        missing = []
+        for path in task_paths():
+            task = read_json(path)
+            rel = task["input"]
+            self.assertTrue(rel.startswith("samples/"), task["id"])
+            if not (REPO_ROOT / rel).exists():
+                missing.append(f"{task['id']}:{rel}")
+        self.assertEqual(missing, [], f"없는 표본: {missing}")
+
+    def test_no_t07_clone(self):
+        hits = []
+        for path in task_paths():
+            task = read_json(path)
+            if task["id"].startswith("T0"):
+                hits.append(f"{task['id']}:core-cli id")
+            if task.get("title") == "서식 채움":
+                hits.append(f"{task['id']}:title")
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] in ("fields", "fill-fields"):
+                    hits.append(f"{task['id']}:{cmd[0]}")
+                if "fill-fields" in cmd:
+                    hits.append(f"{task['id']}:fill-fields")
+                if check.get("value") == "홍길동":
+                    hits.append(f"{task['id']}:홍길동")
+        self.assertEqual(hits, [], f"T07 복제 흔적: {hits}")
+
+    def test_no_xc_clone(self):
+        """XC01 L5 · XC02 unaffected==0 · XC03 4관문 · XC04 depth 3 --deep · XC05 L3 --deep."""
+        hits = []
+        for path in task_paths():
+            if au_num(path) < 14:
+                continue
+            task = read_json(path)
+            blob = json.dumps(task, ensure_ascii=False)
+            if '"L5"' in blob:
+                hits.append(f"{task['id']}:L5")
+            if task.get("title", "").startswith("사다리 완주"):
+                hits.append(f"{task['id']}:xc-title")
+            cmds = [c.get("cmd") or [] for c in task["checks"]]
+            for cmd in cmds:
+                if "recall-scope" in cmd:
+                    # XC02 는 unaffected==0 과 affected>=2 를 한 과제에 묶는다.
+                    paths = {c.get("path") for c in task["checks"]}
+                    if "unaffected" in paths and "affected" in paths:
+                        hits.append(f"{task['id']}:xc02-combo")
+                if cmd[:2] == ["lineage", "{file:caps/c.capsule.json}"] or (
+                    "lineage" in cmd and "--deep" in cmd
+                ):
+                    for check in task["checks"]:
+                        if check.get("path") == "depth" and check.get("value") == 3:
+                            hits.append(f"{task['id']}:xc04-depth3")
+                if "settle" in cmd and "--ledger" in cmd:
+                    hits.append(f"{task['id']}:xc03-ledger")
+                if "conformance" in cmd and "--level" in cmd:
+                    idx = cmd.index("--level")
+                    level = cmd[idx + 1] if idx + 1 < len(cmd) else ""
+                    if level in {"L3", "L4", "L5"} and "--deep" in cmd:
+                        hits.append(f"{task['id']}:xc-conform-deep")
+        self.assertEqual(hits, [], f"XC 복제 흔적: {hits}")
+
+    def test_no_wr_clone(self):
+        """WR 는 replay 를 채점 명령으로 쓰고 3해시를 answer.json 에 옮긴다."""
+        hits = []
+        for path in task_paths():
+            task = read_json(path)
+            if task["id"].startswith("WR"):
+                hits.append(f"{task['id']}:wr-id")
+            if task.get("title") == "일일 영수증 3해시 발급":
+                hits.append(f"{task['id']}:wr-title")
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] == "replay":
+                    hits.append(f"{task['id']}:replay-score")
+                if check.get("op") == "answer_eq" and check.get("answer") in {
+                    "inputSha256",
+                    "planSha256",
+                    "outputSha256",
+                }:
+                    hits.append(f"{task['id']}:wr-3hash")
+        self.assertEqual(hits, [], f"WR 복제 흔적: {hits}")
+
+    def test_every_check_has_a_name(self):
+        unnamed = []
+        for path in task_paths():
+            task = read_json(path)
+            for check in task["checks"]:
+                if not check.get("name"):
+                    unnamed.append(task["id"])
+        self.assertEqual(unnamed, [])
+
+    def test_tiers_are_in_range(self):
+        for path in task_paths():
+            task = read_json(path)
+            self.assertIsInstance(task["tier"], int)
+            self.assertGreaterEqual(task["tier"], 1, task["id"])
+            self.assertLessEqual(task["tier"], 5, task["id"])
+
+    def test_au14_plus_stay_off_boss_tier(self):
+        for path in task_paths():
+            if au_num(path) < 14:
+                continue
+            task = read_json(path)
+            self.assertLessEqual(task["tier"], 3, f"{task['id']} 보스 티어는 XC 의 일")
+
+    def test_reference_steps_use_input_or_sub_placeholders(self):
+        for path in sorted(REFS.glob("AU*.json")):
+            if au_num(path) < 14:
+                continue
+            ref = read_json(path)
+            self.assertTrue(ref.get("steps"), path.name)
+            blob = json.dumps(ref, ensure_ascii=False)
+            self.assertTrue(
+                "{input}" in blob or "{sub:" in blob or "samples/" in blob,
+                f"{path.name} 자리표/표본 경로가 없다",
+            )
+
+    def test_no_hardcoded_golden_hashes(self):
+        bad = []
+        for path in task_paths():
+            if au_num(path) < 14:
+                continue
+            task = read_json(path)
+            blob = json.dumps(task, ensure_ascii=False)
+            if "sha256:" in blob.lower() and "inputSha256" not in blob:
+                # 박제 해시 금지. 필드 이름 언급은 허용.
+                if any(len(tok) == 64 and all(c in "0123456789abcdef" for c in tok)
+                       for tok in blob.lower().replace('"', " ").split()):
+                    bad.append(task["id"])
+        self.assertEqual(bad, [], f"박제 해시: {bad}")
+
+
+class AutomationExpansionScopeTests(unittest.TestCase):
+    def test_au14_plus_cover_command_families(self):
+        families = {
+            "export-tables": 0,
+            "audit": 0,
+            "verify-signature": 0,
+            "anchor": 0,
+            "conformance": 0,
+            "disclose": 0,
+            "gate": 0,
+            "settle": 0,
+            "audit-report": 0,
+            "recall-scope": 0,
+            "bundle": 0,
+        }
+        for path in task_paths():
+            if au_num(path) < 14:
+                continue
+            task = read_json(path)
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] in families:
+                    families[cmd[0]] += 1
+        for key, count in families.items():
+            self.assertGreaterEqual(count, 2, f"AU14+ 에 {key} 축이 부족하다: {count}")
+
+    def test_instructions_are_korean_and_unique(self):
+        seen = {}
+        for path in task_paths():
+            task = read_json(path)
+            inst = task["instructions"]
+            self.assertRegex(inst, r"[가-힣]", task["id"])
+            if au_num(path) >= 14:
+                self.assertGreater(len(inst), 200, task["id"])
+            dup = seen.get(inst)
+            self.assertIsNone(dup, f"{task['id']} 지시문이 {dup} 와 같다")
+            seen[inst] = task["id"]
+
+    def test_titles_are_unique(self):
+        seen = {}
+        for path in task_paths():
+            title = read_json(path)["title"]
+            dup = seen.get(title)
+            self.assertIsNone(dup, f"{path.stem} 제목이 {dup} 와 같다")
+            seen[title] = path.stem
+
+    def test_other_packs_untouched_by_new_ids(self):
+        """새 ID 는 AU 접두만. 다른 pack 폴더에 AU14+ 를 심지 않는다."""
+        leaked = []
+        packs = GYM / "packs"
+        for pack_dir in sorted(p for p in packs.iterdir() if p.is_dir()):
+            if pack_dir.name == "automation":
+                continue
+            for path in (pack_dir / "tasks").glob("AU*.json"):
+                leaked.append(f"{pack_dir.name}/{path.name}")
+        self.assertEqual(leaked, [], f"다른 pack 에 AU 과제: {leaked}")
+
+    def test_audit_still_passes_for_automation_pack(self):
+        spec_name = "gym_audit_automation_pack"
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(spec_name, GYM / "tools" / "audit.py")
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        report = module.audit(str(GYM))
+        self.assertTrue(report["ok"], f"audit 실패: {report}")
+        auto = [p for p in report.get("packs", []) if p["id"] == "automation"]
+        self.assertEqual(auto, [], f"automation pack 위반: {auto}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

사다리 pack 이 AU01–AU13 에서 멈췄다. 기존 CLI(`anchor` · `audit` · `audit-report` · `bundle` · `conformance` · `disclose` · `export-tables` · `gate` · `lineage` · `recall-scope` · `settle` · `verify-signature`)와 `samples/` 만으로 AU14–AU70 을 추가한다. 새 pack · 새 CLI · T07/XC01–XC05/WR01+ 복제는 없다. `pack.json` 의 `runner` 신원과 `requires.commands` 는 그대로 둔다. 다른 pack · `profiles/` · `gym/README.md` · `PARK.md` · `checks.py` 는 건드리지 않았다.

pack 내부 `README.md`, `scripts/tests/test_gym_automation_pack.py`, `mydocs/working/gym_automation.md` 를 추가해 금지 목록(T07 · XC 완주 · WR 3해시)을 문서와 기계 양쪽에 고정한다.

closes #5257

## 추가 과제

| 구간 | 축 | 건수 |
| --- | --- | --- |
| AU14–AU18 | 계획서 좌표 (옆칸·둘째 행·다른 표 표본) | 5 |
| AU19–AU26 | 감사 정확 1건 (`total==1`) | 8 |
| AU27–AU32 | 서명 귀속 (키 id·표본 분리) | 6 |
| AU33–AU38 | 앵커 logged / logChainOk | 6 |
| AU39–AU45 | 적합성 L1/L2 (L3--deep·L5 없음) | 7 |
| AU46–AU51 | 선택적 공개 축 분리 | 6 |
| AU52–AU56 | 관문 --deep / 얕음 | 5 |
| AU57–AU61 | 정산 청구 verdict (원장 4관문 없음) | 5 |
| AU62–AU64 | 감사 보고 | 3 |
| AU65–AU67 | 2링크 리콜 (unaffected==0 콤보 없음) | 3 |
| AU68–AU70 | 연합 번들 container/closure | 3 |

기존 AU01–AU13 은 유지한다. 과제 ID 는 전역 고유하다. 정답 해시·건수를 박제하지 않는다.

## 테스트

- `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- `python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_automation_pack` — 36 tests OK
- **`cargo fmt --all -- --check`** — 해당 없음 (JSON·문서만 변경)
- `node scripts/rust-test-suite-manifest.mjs --check` — 해당 없음
- `node scripts/rust-unit-test-tiers.mjs --check` — 해당 없음
- `cargo test` — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음
- 재현·측정: gym JSON 과제·기준풀이·pack 안내·전용 테스트만 추가. 런타임 경로 없음.
