### PR TITLE
gym: discriminate 음성 대조(sentinel/copy/garbage) 고도화

### DIFF
--- a/gym/docs/discriminate.md
+++ b/gym/docs/discriminate.md
@@ -1,0 +1,504 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/discriminate.md
+last_verified: 2026-08-18
+---
+
+# gym 판별력 감사 규약
+
+이 문서는 `gym/tools/discriminate.py` 의 **음성 대조 종류**, **오답
+sentinel**, **artifact 무편집 복사**, **garbage 산출**, **보고 봉투**,
+**경로 안전**, **예외 접기**를 고정한다. 작업 기록은
+[`mydocs/working/gym_discriminate.md`](../../mydocs/working/gym_discriminate.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_discriminate.py` 가 기계로
+고정한다.
+
+릴리스 차등(`release_diff.py`)은 시간축이고, 교차형식 차등
+(`differential.py`)은 형식축이다. 이 도구는 **약한 오라클 축**이다.
+채점이 '파일이 있나'만 보면 일 안 한 제출이 만점을 받는다. 그 결함을
+과제 등재 전에 색출한다.
+
+## 1. 왜 이 기둥이 필요한가
+
+2026 벤치마크의 최대 위기는 false-pass 다. OpenAI 감사에서 SWE-Bench
+Verified 최난도 과제의 59.4%가 버그를 고치지 않아도 테스트가 통과했다.
+운동장도 같은 구멍에 빠질 수 있다.
+
+- answer 과제가 키 존재만 보면 아무 문자열이나 통과한다.
+- artifact 과제가 `file_exists` 만 보면 입력 복사본이 통과한다.
+- artifact 과제가 `differs_from_input` 만 보면 1KiB garbage 가 통과한다.
+
+그래서 각 과제에 **일부러 틀린 제출**을 넣어 채점한다. 그 제출이
+통과하면 과제는 판별력이 없다. 거부하면 진짜 일을 요구한다.
+
+이 도구는 "정답이 무엇인가"를 다시 계산하지 않는다. 러너가 이미 하는
+일이다. 여기서 묻는 것은 하나다: **일 안 한 제출을 거부하는가.**
+
+## 2. 사용
+
+```bash
+python gym/tools/discriminate.py --bin target/debug/rhwp
+python gym/tools/discriminate.py --bin target/debug/rhwp --json
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--bin` | (필수) | rhwp 바이너리. `runner.find_bin` 이 상대경로를 절대화한다. |
+| `--json` | 꺼짐 | 사람 요약 대신 `gymDiscrimination` 봉투를 stdout 에 쓴다. |
+
+새 플래그는 없다. `--pack` / `--task` / `--limit` / `--out` 은 없다.
+전 pack 을 도는 것이 이 감사의 점이다. 한 과제만 봐서 약한 오라클이
+없다고 말하면 거짓말이다.
+
+종료 코드:
+
+| 코드 | 상수 | 의미 |
+|---|---|---|
+| 0 | `EXIT_OK` | `falsePass` 가 비었다 |
+| 1 | `EXIT_FALSE_PASS` | 약한 오라클이 한 건이라도 있다 |
+
+도구 자리 오류(`loadErrors` · `scoreErrors`)는 집계에 남기되, 음성
+대조가 실제로 통과하지 않는 한 `ok` 를 뒤집지 않는다. 채점이 죽은
+것을 "통과"로 부르지 않고, "거부"로 위장 집계해 만점 처리하지도
+않는다 — 그 행은 `discriminates=true` 이되 `scoreErrors` 에 이유가
+남는다.
+
+음성 제출물은 `gym/submissions/_negative_control/<control>/<pack>/<task>/`
+아래에 다시 만든다. 매 실행마다 이 뿌리를 지우고 시작한다.
+
+## 3. 음성 대조 종류 — 세 칸만
+
+`CONTROL_KINDS` 는 정확히 세 값이다. 시험이 이 튜플을 고정한다.
+
+| id | 적용 | 쓰는 파일 | 페이로드 | 거부 이유 |
+|---|---|---|---|---|
+| `wrong-answer` | answer (및 artifact 가 아닌 과제) | `answer.json` | `WRONG_SENTINEL` | `answer_eq` 가 진값과 대조 |
+| `input-copy` | artifact | `submit.files` | `task.input` 바이트 | 무편집 복사는 일을 하지 않음 |
+| `garbage` | artifact | `submit.files` | `GARBAGE_BYTES` | 입력과 다른 쓰레기만으로는 부족 |
+
+규칙:
+
+1. **artifact 과제는 copy 와 garbage 를 둘 다 돌린다.** 한쪽만 거부하고
+   다른 쪽이 통과하면 그 과제는 약한 오라클이다.
+2. **그 외 과제(`answer` · `pair` · kind 없음)는 wrong-answer 만 돈다.**
+   pair 에 산출 복사를 얹지 않는다. 그 확장 축은 이 이슈의 범위가 아니다.
+3. **미지 대조 id 는 카탈로그에 없다.** `validate_report` 가 거부한다.
+4. **네 번째 대조를 몰래 넣지 않는다.** truncate · empty-file ·
+   missing-file 은 종류가 아니다. 파일이 없으면 러너가 이미 실패한다.
+
+`controls_for(task)`:
+
+| `submit.kind` | 반환 |
+|---|---|
+| `artifact` | `("input-copy", "garbage")` |
+| 그 외 | `("wrong-answer",)` |
+
+순서는 결정적이다. copy 가 garbage 보다 앞선다. pack · 과제 파일 이름
+도 사전순이다.
+
+## 4. 오답 sentinel
+
+상수:
+
+```
+WRONG_SENTINEL = "__NEGATIVE_CONTROL_definitely_wrong__"
+```
+
+성질:
+
+- 숫자 진값(0, 1, 쪽수, 표 수)과 타입이 다르다.
+- 흔한 문자열 진값(`""`, `"0"`, `"ok"`, `"pages"`, `"true"`)과 값이 다르다.
+- `None` / `True` / `False` / `[]` / `{}` 와도 다르다.
+- `answer_eq` 의 `norm` 이 숫자 문자열을 float 로 접어도 이 문자열은
+  숫자가 아니므로 접히지 않는다.
+
+`answer_keys(task)` 는 `checks[].answer` 가 비지 않은 문자열인 것만
+모은다. 빈 문자열 · 숫자 · 비-dict 검사 · `checks` 부재는 무시한다.
+
+키가 있으면 `answer.json` 을 UTF-8 · BOM 없음 · `ensure_ascii=False` 로
+쓴다. 키 순서는 정렬한다. 키가 없으면 `answer.json` 을 만들지 않는다.
+
+artifact 과제에도 답 키가 있으면 sentinel 을 같이 쓴다. copy/garbage
+대조가 산출만 바꾸고 답을 진값으로 남겨 통과하는 구멍을 막기 위함이다.
+`wrong-answer` 모드를 artifact 에 직접 주면 산출 파일은 쓰지 않고 답만
+쓴다.
+
+## 5. artifact 무편집 복사
+
+`artifact_mode="input-copy"` 일 때 각 안전 상대경로에 `task.input` 을
+`shutil.copyfile` 한다.
+
+- 입력 경로는 저장소 루트 기준 상대경로이거나 절대경로다.
+- 입력 파일이 없으면 그 산출은 **건너뛴다.** 빈 파일을 지어내지 않는다.
+  예외로 전수 감사를 죽이지 않는다. 건너뛴 사실은 `buildErrors` 에 남는다.
+- 원본 픽스처는 읽기만 한다. 덮어쓰지 않는다.
+- 같은 입력을 여러 산출 자리에 복사할 수 있다. 각각의 해시가 입력과
+  같으면 `differs_from_input` 이 거부해야 한다.
+
+`differs_from_input` 만 있는 과제는 garbage 를 통과시킬 수 있다. 그래서
+복사 대조만으로 판별력을 선언하지 않는다.
+
+## 6. garbage 산출
+
+```
+GARBAGE_MARKER = b"RHWP_GYM_GARBAGE_NEGATIVE_CONTROL\x00"
+GARBAGE_REPEAT = 64
+GARBAGE_BYTES  = GARBAGE_MARKER * 64
+GARBAGE_MIN_SIZE = 1024
+```
+
+성질:
+
+- 길이는 1KiB 를 넘는다(`garbage_meets_minimum`).
+- UTF-8 로 디코드되지 않는다(널 바이트).
+- JSON 객체도 XML 도 PDF 도 아니다.
+- 입력 샘플 바이트와 다르다. `differs_from_input` 은 통과할 수 있다.
+- 입력 파일이 없어도 쓴다. garbage 는 원본이 필요 없다.
+
+이 대조가 통과하면 과제는 형식·핵심값 검사가 없다. `file_exists` +
+`differs_from_input` 만으로는 부족하다는 것이 이 칸의 점이다.
+
+실측 근거: `SR05` 는 `file_exists`(minBytes 128) + `differs_from_input` +
+`json_value_eq(dialect=…)` 를 같이 건다. 앞의 두 칸만 있으면 garbage 가
+통과한다. 세 번째 칸이 있어서 거부된다.
+
+## 7. 경로 안전
+
+`submit.files` 항목은 제출 폴더 안으로만 쓴다.
+
+| 입력 | `normalize_rel` | `unsafe_rel_reason` |
+|---|---|---|
+| `out.svg` | `out.svg` | `None` |
+| `a/b/c.svg` | `a/b/c.svg` | `None` |
+| `./a/./b` | `a/b` | `None` |
+| `a\b\c` | `a/b/c` | `None` |
+| `../x` | `None` | `parent` |
+| `a/../b` | `None` | `parent` |
+| `/abs` | `None` | `absolute` |
+| `C:/abs` | `None` | `drive` |
+| `//unc/x` | `None` | `unc` |
+| `~/x` | `None` | `home` |
+| `""` / `None` / `3` | `None` | `empty` / `not-str` |
+
+거절된 항목은 쓰지 않는다. 이웃한 안전 경로는 그대로 쓴다. 전수 감사를
+죽이지 않는다.
+
+`join_sub` 는 정규화된 상대경로만 받는다. 불안전하면 `ValueError`.
+
+## 8. JSON 봉투
+
+`kind=gymDiscrimination`, `schemaVersion=1.0`. 키 집합은 시험이
+`REPORT_KEYS` 로 고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymDiscrimination` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `ok` | bool | `falsePass` 가 비었을 때만 참 |
+| `taskCount` | int | 읽기에 성공한 과제 수 |
+| `controlCount` | int | 돌린 대조 행 수 = `len(results)` |
+| `discriminating` | int | `taskCount - len(falsePass)` |
+| `falsePass` | list | `pack/task` 라벨. 과제당 한 번 |
+| `falsePassControls` | list | `pack/task (control)` 라벨. 대조마다 |
+
+부가 키:
+
+| 키 | 언제 |
+|---|---|
+| `results` | 모든 대조 행 `{pack,task,control,discriminates}` |
+| `loadErrors` | 깨진 JSON · id 없음. 그 파일은 과제 수에 넣지 않는다 |
+| `scoreErrors` | 채점 예외. 그 행은 통과로 치지 않는다 |
+| `buildErrors` | 입력 없음 · 불안전 경로 |
+| `toolFailed` / `toolErrors` | packs 목록 실패 |
+| `controlKinds` | 카탈로그 id 세 개 |
+
+`validate_report` 계약:
+
+- 필수 키가 있다.
+- `ok` 와 `falsePass` 가 모순되지 않는다.
+- `discriminating == taskCount - len(falsePass)`.
+- `controlCount == len(results)` (results 가 있을 때).
+- 대조 id 는 카탈로그에 있다.
+- `falsePass` 는 `pack/task` 형식이다.
+- `falsePassControls` 는 `pack/task (control)` 형식이다.
+
+한 과제가 copy 는 거부하고 garbage 는 통과하면 `falsePass` 에는 과제
+라벨이 한 줄, `falsePassControls` 에는 `(garbage)` 한 줄이다. 두 대조가
+모두 통과해도 과제 라벨은 한 줄이다.
+
+깨진 과제 파일은 `taskCount` 에 넣지 않는다. 없는 과제를 판별력 있다고
+부르지 않기 위함이다.
+
+## 9. 예외 경로 — 한 과제가 전수 감사를 죽이지 않는다
+
+| 자리 | 잡는 것 | 접는 곳 |
+|---|---|---|
+| 과제 JSON | `OSError` · `ValueError` · 비-객체 | `loadErrors`, 건너뜀 |
+| 산출 경로 | 불안전 상대경로 | `buildErrors`, 그 파일만 거부 |
+| 입력 복사 | 원본 없음 | `buildErrors`, 파일 생략 |
+| 채점 | `CATCHABLE_EXCEPTIONS` | `pass=False` + `scoreErrors` |
+| packs 목록 | `OSError` | `toolFailed`, 빈 보고 |
+
+삼키면 안 되는 예외: `KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+`GeneratorExit`. 사용자가 끊었는데 약한 오라클 0건이라고 쓰면 거짓말이다.
+
+채점 예외는 false-pass 가 아니다. 통과를 관측하지 못했기 때문이다. 그
+행의 `discriminates` 는 참(거부한 것으로 집계)이고 이유는
+`scoreErrors` 에 남는다. 반대 — 예외를 통과로 접으면 — 감사기가 스스로
+약한 오라클이 된다.
+
+## 10. 사람 출력
+
+`--json` 이 아니면 두 갈래다.
+
+성공:
+
+```
+gym 판별력 감사: N 과제 전부 음성 대조를 거부 — 약한 오라클 0
+```
+
+실패:
+
+```
+gym 판별력 감사: 약한 오라클(false-pass) K건 — 일 안 한 제출이 통과한다:
+  - pack/task
+대조별:
+  - pack/task (control)
+```
+
+기존 한 줄 형식(`N 과제 전부…` / `약한 오라클(false-pass) K건`)은
+유지한다. 시험과 릴리스 게이트가 그 문장을 본다.
+
+## 11. 하지 않는 일
+
+- 새 rhwp CLI 를 만들지 않는다.
+- 새 gym pack 을 만들지 않는다.
+- `trajectory.py` · `fuzz_corpus.py` · `automation` / `core-cli` /
+  `casual-rides` pack 을 고치지 않는다.
+- 열린 PR 이 만지는 파일을 고치지 않는다.
+- 라이브 채점 기대를 골든 파일로 박제하지 않는다. 기대값은 러너가
+  계산하고, 이 도구는 음성 제출만 만든다.
+
+## 12. 다른 기둥과의 자리
+
+| 도구 | 축 | 거짓말을 막는 관문 |
+|---|---|---|
+| `discriminate.py` | 약한 오라클 | 음성 대조가 반드시 실패 |
+| `audit.py` | 정합 | 과제↔기준 짝, ID 고유 |
+| `differential.py` | 형식 | 본문 해시가 다를 때 결함으로 부르지 않음 |
+| `release_diff.py` | 시간 | 표면 변경을 regression 으로 부르지 않음 |
+
+릴리스 게이트(`gym-release-gate.yml`)는 차등 **이전**에 이 감사를 돈다.
+벤치마크 자체가 성립하는지 먼저 본다. 표면 변경과 달리 약한 오라클은
+리뷰 신호가 아니라 결함이다.
+
+## 13. 시험이 고정하는 표
+
+`scripts/tests/test_gym_discriminate.py` 의 핵심 칸:
+
+1. `wrong-answer` 는 `WRONG_SENTINEL` 을 쓰고 입력 바이트를 쓰지 않는다.
+2. `input-copy` 는 저장소 샘플 바이트와 같고 `GARBAGE_BYTES` 와 다르다.
+3. `garbage` 는 `GARBAGE_BYTES` 와 같고 입력 바이트와 다르다.
+4. artifact 과제의 `controlCount` 는 2 다.
+5. garbage 만 통과하면 `falsePassControls` 는 `pack/task (garbage)` 한 줄이다.
+6. 세 종류 이외의 대조 id 는 보고 검증이 거부한다.
+
+이 여섯 칸이 깨지면 도구를 고쳐야 한다. 시험을 느슨하게 만들지 않는다.
+
+## 14. 연산자가 어느 대조를 거부해야 하는가
+
+채점 연산자는 이 도구가 만들지 않는다. 다만 음성 대조가 통과하면
+**어느 연산자가 비었는지**가 바로 드러난다. 아래 표는 과제 작성자가
+약한 오라클을 피할 때 보는 대응이다.
+
+| 대조가 통과함 | 비어 있는 검사 | 넣어야 할 연산자 |
+|---|---|---|
+| `wrong-answer` | 답을 진값과 대조하지 않음 | `answer_eq` / `len_answer_eq` |
+| `input-copy` | 입력과 같은 바이트를 허용 | `differs_from_input` |
+| `garbage` | 입력과 다른 쓰레기면 통과 | `json_value_eq` · `xml_root_eq` · `csv_cell_eq` · 형식 검사 |
+| copy 는 거부, garbage 는 통과 | 형식·핵심값이 없음 | 위에 더해 지목 검사 |
+| 두 artifact 대조가 모두 통과 | 파일 존재만 봄 | `file_exists` 만으로는 부족 |
+
+`file_exists` 의 `minBytes` 는 garbage(1KiB 초과)를 막지 못한다.
+`differs_from_input` 은 복사를 막지만 garbage 는 통과시킨다. 둘을
+같이 걸어도 garbage 칸이 남는다. 그래서 산출 과제는 **형식 또는
+핵심값**을 한 칸 더 둬야 한다.
+
+`SR03`(answer, 손실 계수) — `answer_eq(loss)` 가 있으면 sentinel 이
+거부된다. 이 칸이 없으면 `wrong-answer` 가 만점이다.
+
+`SR05`(artifact, IR 스키마) — `file_exists` + `differs_from_input` +
+`json_value_eq(dialect=…)` 세 칸이 있어야 copy 와 garbage 를 둘 다
+거부한다. 앞의 두 칸만 있으면 garbage 가 통과한다.
+
+## 15. 음성 제출 디렉터리
+
+한 번의 전수 감사는 아래 나무를 지우고 다시 만든다.
+
+```
+gym/submissions/_negative_control/
+├── wrong-answer/<pack>/<task>/answer.json
+├── input-copy/<pack>/<task>/<submit.files…>
+└── garbage/<pack>/<task>/<submit.files…>
+```
+
+- 뿌리는 `NEGATIVE_DIRNAME` (`_negative_control`) 이다.
+- 대조 id 가 첫 폴더다. 채점 목킹이 경로에 `garbage` / `input-copy`
+  를 보고 갈라지는 시험이 이 배치를 전제로 한다.
+- 과제 폴더 이름은 `task.id` 다. 파일 이름과 id 가 달라도 id 를 쓴다.
+- 매 실행 `shutil.rmtree` 후 시작한다. 이전 실행의 쓰레기 파일이
+  다음 채점을 통과시키지 못하게 한다.
+
+라이브 채점은 `runner.score_task(task, <control>/<pack>, bin)` 이다.
+러너는 `<control>/<pack>/<task.id>` 를 제출 폴더로 본다.
+
+## 16. 보고 봉투 보기
+
+약한 오라클이 없는 최소 봉투:
+
+```json
+{
+  "kind": "gymDiscrimination",
+  "schemaVersion": "1.0",
+  "ok": true,
+  "taskCount": 2,
+  "controlCount": 3,
+  "discriminating": 2,
+  "falsePass": [],
+  "falsePassControls": []
+}
+```
+
+answer 1 + artifact 1 이면 `controlCount` 는 3 이다. `ok` 는
+`falsePass` 가 비었을 때만 참이다. `discriminating` 은
+`taskCount - len(falsePass)` 이지 `controlCount` 가 아니다.
+
+garbage 만 통과한 artifact 한 건:
+
+```json
+{
+  "ok": false,
+  "taskCount": 1,
+  "controlCount": 2,
+  "discriminating": 0,
+  "falsePass": ["serialization/SR05"],
+  "falsePassControls": ["serialization/SR05 (garbage)"]
+}
+```
+
+과제 라벨은 한 줄이다. 대조 라벨은 통과한 대조만 남긴다. copy 는
+거부했으므로 `falsePassControls` 에 `(input-copy)` 가 없다.
+
+## 17. 결정적 순서
+
+같은 gym 나무를 두 번 돌리면 같은 `results` 순서가 나와야 한다.
+
+1. pack id `sorted(os.listdir)`
+2. 과제 파일 이름 `*.json` 사전순
+3. 그 과제의 `controls_for` 튜플 순서
+
+`--limit` 이 없으므로 접두를 자를 자리가 없다. 순서가 흔들리면
+`falsePassControls` 스냅샷 시험이 깨진다. 파일 시스템 나열 순서를
+그대로 쓰지 말고 항상 정렬한다.
+
+## 18. FAQ
+
+**Q. 왜 garbage 를 1KiB 넘게 쓰나?**
+`file_exists` 의 `minBytes` 기본은 1, 어떤 과제는 128 이다. 몇 바이트
+짜리 마커는 그 칸에 걸린다. 1KiB 를 넘기면 "파일이 있다"는 이유로
+통과하지 못하고, 형식 검사가 있는지만이 남는다.
+
+**Q. 입력 파일이 없으면 copy 를 실패로 부르나?**
+부르지 않는다. 쓸 바이트가 없다. 산출 파일을 만들지 않고
+`buildErrors` 에 남긴다. 채점은 빈 제출을 보게 되고, 파일 검사가
+있으면 거부(판별력 있음)다.
+
+**Q. 채점이 예외를 내면 약한 오라클인가?**
+아니다. 통과를 관측하지 못했다. `scoreErrors` 에 남기고
+`discriminates=true` 로 집계한다. 예외를 통과로 접으면 감사기 자신이
+약한 오라클이 된다.
+
+**Q. pair 과제는 왜 copy/garbage 가 없나?**
+이슈 #5255 가 고정한 종류는 answer sentinel · artifact copy ·
+garbage artifact 다. pair 는 `wrong-answer` 만 돈다. 산출 쌍에
+복사를 얹는 확장은 후속이다.
+
+**Q. 새 플래그를 달면 안 되나?**
+전수 감사가 점이다. `--pack` 으로 한 pack 만 보면 다른 pack 의
+약한 오라클을 못 본다. CLI 표면은 `--bin` 과 `--json` 만 유지한다.
+
+## 19. 함수 표면 (시험이 import 하는 것)
+
+도구를 통째로 갈아엎지 않도록, 아래 이름은 시험을 깨지 않고는
+지우지 않는다.
+
+| 이름 | 순수? | 역할 |
+|---|---|---|
+| `WRONG_SENTINEL` / `GARBAGE_BYTES` | 상수 | 페이로드 |
+| `CONTROL_KINDS` / `CONTROL_CATALOG` | 상수 | 세 종류 |
+| `answer_keys` | 예 | 답 키 집합 |
+| `controls_for` | 예 | 과제 → 대조 튜플 |
+| `normalize_rel` / `unsafe_rel_reason` | 예 | 경로 안전 |
+| `build_negative` | 아니오 | 제출 폴더 구성 |
+| `score_discriminates` | 예 | 채점 봉투 → 판별력 |
+| `aggregate_rows` / `validate_report` | 예 | 보고 정직 |
+| `discriminate` | 아니오 | 전수 루프 |
+| `parse_args` / `main` | 아니오 | `--bin` · `--json` |
+
+`discriminate(..., score_fn=)` 는 시험 주입용이다. CLI 플래그가 아니다.
+주입이 없으면 `runner.score_task` 를 쓴다.
+
+## 20. 잘못된 수정 예시
+
+이 도구를 고칠 때 하지 말아야 할 것.
+
+1. **garbage 를 빈 파일로 바꾸기.** `file_exists` 기본 `minBytes=1` 에
+   걸려 형식 검사 없이도 거부된다. 그러면 garbage 칸이 사라진다.
+2. **copy 만 돌리고 garbage 를 옵션으로 빼기.** `differs_from_input`
+   만 있는 과제가 만점을 받는다.
+3. **`ok` 를 `toolFailed` 와 AND 하기.** 디스크 오류와 약한 오라클을
+   같은 종료 코드로 묶으면 게이트가 원인을 못 가린다.
+4. **깨진 JSON 을 `taskCount` 에 넣기.** 없는 과제를 판별력 있다고
+   부르게 된다.
+5. **`submit.files` 의 `..` 를 그대로 `join` 하기.** 음성 대조가
+   저장소 밖의 파일을 덮어쓴다.
+6. **채점 예외를 `pass=True` 로 접기.** 감사기 자신이 약한 오라클이
+   된다.
+
+## 21. 게이트와의 연결
+
+`.github/workflows/gym-release-gate.yml` 는 구/신 바이너리 차등 앞에
+`python gym/tools/discriminate.py --bin <new>` 를 돈다. 이 가지가
+워크플로 파일을 고치지 않는 이유: 열린 PR 과 겹치고, CLI 표면이
+그대로라 고칠 것이 없다.
+
+게이트가 보는 것:
+
+- 종료 코드 0/1
+- 사람 출력의 `약한 오라클` 문장 (json 이 아님)
+
+`--json` 은 로컬·시험용이다. 게이트는 기본(사람) 출력을 쓴다.
+
+## 22. 상수 표
+
+시험이 값을 고정하는 상수다. 바꾸면 기존 다섯 시험 또는 카탈로그
+시험이 깨진다.
+
+| 상수 | 값 |
+|---|---|
+| `WRONG_SENTINEL` | `__NEGATIVE_CONTROL_definitely_wrong__` |
+| `GARBAGE_MARKER` | `b"RHWP_GYM_GARBAGE_NEGATIVE_CONTROL\x00"` |
+| `GARBAGE_REPEAT` | `64` |
+| `GARBAGE_MIN_SIZE` | `1024` |
+| `REPORT_KIND` | `gymDiscrimination` |
+| `SCHEMA_VERSION` | `1.0` |
+| `NEGATIVE_DIRNAME` | `_negative_control` |
+| `EXIT_OK` / `EXIT_FALSE_PASS` | `0` / `1` |
+
+`GARBAGE_BYTES` 는 `MARKER * REPEAT` 이다. 길이를 손으로 하드코딩하지
+말고 `garbage_size()` 와 `garbage_meets_minimum()` 을 본다.
+
+`expected_control_count(task)` 는 `len(controls_for(task))` 다.
+artifact 는 2, 그 외는 1. 보고의 `controlCount` 는 전 과제 합이다.
+

--- a/gym/tools/discriminate.py
+++ b/gym/tools/discriminate.py
@@ -9,15 +9,21 @@
 이 감사기는 그 결함을 gym 에 **못 들어오게** 막는다 — 사후에 손으로 발견하는 대신,
 각 과제에 **음성 대조**(일 안 한 제출)를 넣어 채점해 **반드시 실패**하는지 본다.
 
-음성 대조 구성:
-- **answer 과제** — 모든 답 키에 명백한 오답(sentinel). answer_eq 가 진값과 대조하니
-  거부해야 한다.
-- **artifact 과제** — 입력을 산출물로 그대로 복사하는 대조와 1KiB synthetic garbage
-  대조를 모두 실행한다. `differs_from_input`만으로는 garbage가 통과할 수 있으므로
-  형식·핵심값 검사도 함께 요구한다.
+음성 대조 구성(종류는 시험이 고정한다):
+- **wrong-answer** — 모든 답 키에 명백한 오답(sentinel). answer_eq 가 진값과
+  대조하니 거부해야 한다.
+- **input-copy** — artifact 과제의 산출 자리에 입력을 그대로 복사한다.
+  `differs_from_input` 이 거부해야 한다.
+- **garbage** — 같은 자리에 1KiB 넘는 synthetic garbage 를 쓴다.
+  `differs_from_input` 만으로는 통과할 수 있으므로 형식·핵심값 검사도
+  함께 요구한다.
 
-음성 대조에 **통과하는** 과제 = 판별력 없는 약한 오라클(false-pass). 이걸 리포트한다.
-통과 못 하면(=거부) 그 과제는 진짜 일을 요구하는 것이다.
+음성 대조에 **통과하는** 과제 = 판별력 없는 약한 오라클(false-pass). 이걸
+리포트한다. 통과 못 하면(=거부) 그 과제는 진짜 일을 요구하는 것이다.
+
+보고 봉투: `kind=gymDiscrimination`, `schemaVersion=1.0`. 판정·집계·경로
+안전·예외 접기는 순수 함수라 `scripts/tests/test_gym_discriminate.py` 가
+바이너리 없이 고정한다. 새 CLI 플래그·새 pack 은 없다.
 
 ## 사용
 
@@ -43,107 +49,861 @@ from core import runner  # noqa: E402
 # 진값과 절대 같을 리 없는 오답 — 숫자 진값엔 문자열이라 타입부터 다르고, 문자열
 # 진값엔 이 특이 문자열이라 값이 다르다. answer_eq 는 어느 쪽이든 거부한다.
 WRONG_SENTINEL = "__NEGATIVE_CONTROL_definitely_wrong__"
-GARBAGE_BYTES = (b"RHWP_GYM_GARBAGE_NEGATIVE_CONTROL\x00" * 64)
+GARBAGE_MARKER = b"RHWP_GYM_GARBAGE_NEGATIVE_CONTROL\x00"
+GARBAGE_REPEAT = 64
+GARBAGE_BYTES = GARBAGE_MARKER * GARBAGE_REPEAT
+GARBAGE_MIN_SIZE = 1024
+
+CONTROL_WRONG_ANSWER = "wrong-answer"
+CONTROL_INPUT_COPY = "input-copy"
+CONTROL_GARBAGE = "garbage"
+
+ANSWER_CONTROLS = (CONTROL_WRONG_ANSWER,)
+ARTIFACT_CONTROLS = (CONTROL_INPUT_COPY, CONTROL_GARBAGE)
+CONTROL_KINDS = ANSWER_CONTROLS + ARTIFACT_CONTROLS
+
+#: 음성 대조 카탈로그. 문서·시험·도구가 같은 표를 본다.
+CONTROL_CATALOG = (
+    {
+        "id": CONTROL_WRONG_ANSWER,
+        "submit": "answer",
+        "writes": "answer.json",
+        "payload": "WRONG_SENTINEL",
+        "mustFail": True,
+        "why": "answer_eq 가 진값과 대조하므로 sentinel 은 거부돼야 한다",
+    },
+    {
+        "id": CONTROL_INPUT_COPY,
+        "submit": "artifact",
+        "writes": "submit.files",
+        "payload": "task.input 바이트 복사",
+        "mustFail": True,
+        "why": "무편집 복사는 일을 하지 않은 제출이다",
+    },
+    {
+        "id": CONTROL_GARBAGE,
+        "submit": "artifact",
+        "writes": "submit.files",
+        "payload": "GARBAGE_BYTES",
+        "mustFail": True,
+        "why": "입력과 다른 쓰레기만으로는 형식·핵심값 검사가 있어야 거부된다",
+    },
+)
+
+REPORT_KIND = "gymDiscrimination"
+SCHEMA_VERSION = "1.0"
+NEGATIVE_DIRNAME = "_negative_control"
+
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "taskCount",
+    "controlCount",
+    "discriminating",
+    "falsePass",
+    "falsePassControls",
+)
+
+OPTIONAL_REPORT_KEYS = (
+    "results",
+    "loadErrors",
+    "scoreErrors",
+    "buildErrors",
+    "skipped",
+    "toolFailed",
+    "toolErrors",
+    "controlKinds",
+)
+
+EXIT_OK = 0
+EXIT_FALSE_PASS = 1
+
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+CATCHABLE_EXCEPTIONS = (
+    OSError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    json.JSONDecodeError,
+    RuntimeError,
+)
+
+UNSAFE_REL_REASONS = (
+    "empty",
+    "not-str",
+    "absolute",
+    "drive",
+    "parent",
+    "unc",
+    "home",
+)
+
+
+def is_fatal_exception(exc) -> bool:
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def control_ids() -> tuple[str, ...]:
+    """카탈로그 id 튜플. 순서는 answer → copy → garbage."""
+    return tuple(item["id"] for item in CONTROL_CATALOG)
+
+
+def control_spec(control_id: str) -> dict | None:
+    """id 로 카탈로그 행을 찾는다. 없으면 None."""
+    for item in CONTROL_CATALOG:
+        if item["id"] == control_id:
+            return dict(item)
+    return None
+
+
+def is_known_control(control_id: str) -> bool:
+    return control_id in CONTROL_KINDS
+
+
+def is_artifact_control(control_id: str) -> bool:
+    return control_id in ARTIFACT_CONTROLS
+
+
+def is_answer_control(control_id: str) -> bool:
+    return control_id in ANSWER_CONTROLS
+
+
+def submit_mapping(task) -> dict:
+    """task.submit 이 dict 가 아니면 빈 dict."""
+    if not isinstance(task, dict):
+        return {}
+    submit = task.get("submit")
+    return submit if isinstance(submit, dict) else {}
+
+
+def submit_kind(task) -> str:
+    kind = submit_mapping(task).get("kind")
+    return kind if isinstance(kind, str) else ""
+
+
+def is_artifact_task(task) -> bool:
+    return submit_kind(task) == "artifact"
+
+
+def is_answer_task(task) -> bool:
+    return submit_kind(task) == "answer"
+
+
+def is_pair_task(task) -> bool:
+    return submit_kind(task) == "pair"
 
 
 def answer_keys(task: dict) -> set[str]:
+    """answer_eq 계열이 지목한 키. 비-dict 검사·빈 checks 는 무시."""
     keys = set()
-    for check in task.get("checks", []):
-        if check.get("answer"):
-            keys.add(check["answer"])
+    if not isinstance(task, dict):
+        return keys
+    checks = task.get("checks")
+    if not isinstance(checks, list):
+        return keys
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        key = check.get("answer")
+        if isinstance(key, str) and key:
+            keys.add(key)
     return keys
 
 
-def build_negative(task: dict, neg_pack_dir: str, artifact_mode: str = "input-copy") -> None:
-    """음성 대조 제출물 — 오답 answer.json + artifact별 무편집/garbage 대조."""
-    sub_dir = os.path.join(neg_pack_dir, task["id"])
-    shutil.rmtree(sub_dir, ignore_errors=True)
-    os.makedirs(sub_dir, exist_ok=True)
-
-    keys = answer_keys(task)
-    if keys:
-        with open(os.path.join(sub_dir, "answer.json"), "w", encoding="utf-8") as fh:
-            json.dump({k: WRONG_SENTINEL for k in keys}, fh, ensure_ascii=False)
-
-    submit = task.get("submit", {})
-    if submit.get("kind") == "artifact":
-        src = os.path.join(REPO_ROOT, task["input"])
-        for rel in submit.get("files", []):
-            dst = os.path.join(sub_dir, rel)
-            os.makedirs(os.path.dirname(dst) or sub_dir, exist_ok=True)
-            if artifact_mode == "input-copy" and os.path.isfile(src):
-                shutil.copyfile(src, dst)   # 무편집 복사 = 일 안 함
-            elif artifact_mode == "garbage":
-                with open(dst, "wb") as fh:
-                    fh.write(GARBAGE_BYTES)
-            else:
-                raise ValueError(f"지원하지 않는 artifact 음성 대조: {artifact_mode}")
-
-
-def discriminate(bin_path: str, gym_root: str, neg_root: str) -> dict:
-    packs_dir = os.path.join(gym_root, "packs")
-    results = []
-    false_pass = []
-    false_pass_controls = []
-    task_count = 0
-    for pack_id in sorted(os.listdir(packs_dir)):
-        pack_dir = os.path.join(packs_dir, pack_id)
-        tasks_dir = os.path.join(pack_dir, "tasks")
-        if not os.path.isdir(tasks_dir):
+def submit_files(task) -> list[str]:
+    """submit.files 중 상대경로로 쓸 수 있는 것만. 순서는 선언 순."""
+    raw = submit_mapping(task).get("files")
+    if not isinstance(raw, list):
+        return []
+    out = []
+    seen = set()
+    for item in raw:
+        rel = normalize_rel(item)
+        if rel is None or rel in seen:
             continue
-        neg_pack_dir = os.path.join(neg_root, pack_id)
-        for name in sorted(os.listdir(tasks_dir)):
-            if not name.endswith(".json"):
-                continue
-            with open(os.path.join(tasks_dir, name), encoding="utf-8") as fh:
-                task = json.load(fh)
-            task_count += 1
-            artifact = task.get("submit", {}).get("kind") == "artifact"
-            controls = ("input-copy", "garbage") if artifact else ("wrong-answer",)
-            for control in controls:
-                control_pack_dir = os.path.join(neg_root, control, pack_id)
-                build_negative(task, control_pack_dir, artifact_mode=control)
-                result = runner.score_task(task, control_pack_dir, bin_path)
-                # 음성 대조는 '실패'(=거부) 해야 판별력이 있다. pass=True 면 약한 오라클.
-                discriminates = not result.get("pass")
-                results.append({"pack": pack_id, "task": task["id"], "control": control,
-                                "discriminates": discriminates})
-                if not discriminates:
-                    label = f"{pack_id}/{task['id']}"
-                    if label not in false_pass:
-                        false_pass.append(label)
-                    false_pass_controls.append(f"{label} ({control})")
+        seen.add(rel)
+        out.append(rel)
+    return out
+
+
+def controls_for(task) -> tuple[str, ...]:
+    """과제에 적용할 음성 대조. artifact 는 copy+garbage, 그 외는 sentinel."""
+    if is_artifact_task(task):
+        return ARTIFACT_CONTROLS
+    return ANSWER_CONTROLS
+
+
+def sentinel_answers(keys) -> dict:
+    """모든 키에 같은 sentinel. 키 순서는 정렬해 결정적으로 쓴다."""
+    return {str(k): WRONG_SENTINEL for k in sorted(keys)}
+
+
+def is_wrong_sentinel(value) -> bool:
+    return value == WRONG_SENTINEL
+
+
+def garbage_size() -> int:
+    return len(GARBAGE_BYTES)
+
+
+def is_garbage_payload(data) -> bool:
+    return data == GARBAGE_BYTES
+
+
+def garbage_meets_minimum() -> bool:
+    return garbage_size() >= GARBAGE_MIN_SIZE
+
+
+def _as_rel_text(rel) -> str | None:
+    if not isinstance(rel, str):
+        return None
+    text = rel.strip()
+    return text if text else None
+
+
+def normalize_rel(rel) -> str | None:
+    """제출 상대경로를 `/` 로 정규화한다. 불안전하면 None.
+
+    절대경로·드라이브·UNC·홈·부모(`..`)는 제출 폴더 밖으로 쓸 수 있으므로
+    버린다. `.` 구간과 빈 구간만 접는다.
+    """
+    text = _as_rel_text(rel)
+    if text is None:
+        return None
+    unified = text.replace("\\", "/")
+    if unified.startswith("/") or unified.startswith("//"):
+        return None
+    if unified.startswith("~"):
+        return None
+    head = unified.split("/", 1)[0]
+    if ":" in head:
+        return None
+    parts = []
+    for part in unified.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            return None
+        parts.append(part)
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
+def unsafe_rel_reason(rel) -> str | None:
+    """정규화가 거절한 이유를 카탈로그 단어로. 안전하면 None."""
+    if not isinstance(rel, str):
+        return "not-str"
+    text = rel.strip()
+    if not text:
+        return "empty"
+    unified = text.replace("\\", "/")
+    if unified.startswith("//") or unified.startswith("\\\\"):
+        return "unc"
+    if unified.startswith("/"):
+        return "absolute"
+    if unified.startswith("~"):
+        return "home"
+    head = unified.split("/", 1)[0]
+    if ":" in head:
+        return "drive"
+    for part in unified.split("/"):
+        if part == "..":
+            return "parent"
+    if normalize_rel(rel) is None:
+        return "empty"
+    return None
+
+
+def is_safe_rel(rel) -> bool:
+    return normalize_rel(rel) is not None
+
+
+def join_sub(sub_dir: str, rel: str) -> str:
+    """정규화된 상대경로를 제출 폴더 아래에 붙인다."""
+    safe = normalize_rel(rel)
+    if safe is None:
+        raise ValueError(f"불안전 상대경로: {rel!r}")
+    parts = safe.split("/")
+    return os.path.join(sub_dir, *parts)
+
+
+def score_is_pass(result) -> bool:
+    """채점 봉투의 pass 만 본다. 비-dict·키 없음은 실패."""
+    if not isinstance(result, dict):
+        return False
+    return bool(result.get("pass"))
+
+
+def score_discriminates(result) -> bool:
+    """음성 대조가 거부되면 판별력이 있다."""
+    return not score_is_pass(result)
+
+
+def normalize_score(result) -> dict:
+    """채점 결과를 최소 봉투로. 비-dict 는 pass=False + error."""
+    if not isinstance(result, dict):
+        return {"pass": False, "error": "채점 결과가 dict 가 아니다"}
+    out = {"pass": bool(result.get("pass"))}
+    if "error" in result:
+        out["error"] = result.get("error")
+    if "id" in result:
+        out["id"] = result.get("id")
+    return out
+
+
+def false_pass_label(pack_id: str, task_id: str) -> str:
+    return f"{pack_id}/{task_id}"
+
+
+def false_pass_control_label(pack_id: str, task_id: str, control: str) -> str:
+    return f"{pack_id}/{task_id} ({control})"
+
+
+def parse_false_pass_label(label: str) -> tuple[str, str] | None:
+    if not isinstance(label, str) or "/" not in label:
+        return None
+    pack_id, task_id = label.split("/", 1)
+    if not pack_id or not task_id:
+        return None
+    return pack_id, task_id
+
+
+def split_false_pass_control_label(label: str) -> tuple[str, str, str] | None:
+    """`pack/task (control)` → (pack, task, control). 형식이 아니면 None."""
+    if not isinstance(label, str) or " (" not in label or not label.endswith(")"):
+        return None
+    head, tail = label.rsplit(" (", 1)
+    parsed = parse_false_pass_label(head)
+    if parsed is None:
+        return None
+    control = tail[:-1]
+    if not is_known_control(control):
+        return None
+    return parsed[0], parsed[1], control
+
+
+def expected_control_count(task) -> int:
+    return len(controls_for(task))
+
+
+def row_is_false_pass(row) -> bool:
+    if not isinstance(row, dict):
+        return False
+    return not bool(row.get("discriminates"))
+
+
+def format_json_report(report: dict) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+
+
+def empty_report() -> dict:
     return {
-        "kind": "gymDiscrimination",
-        "schemaVersion": "1.0",
-        "ok": len(false_pass) == 0,
-        "taskCount": task_count,
-        "controlCount": len(results),
-        "discriminating": task_count - len(false_pass),
-        "falsePass": false_pass,
-        "falsePassControls": false_pass_controls,
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": True,
+        "taskCount": 0,
+        "controlCount": 0,
+        "discriminating": 0,
+        "falsePass": [],
+        "falsePassControls": [],
+        "results": [],
+        "loadErrors": [],
+        "scoreErrors": [],
+        "buildErrors": [],
+        "skipped": [],
+        "toolFailed": False,
+        "toolErrors": [],
+        "controlKinds": list(CONTROL_KINDS),
     }
 
 
-def main() -> int:
+def unique_keep_order(items) -> list:
+    seen = set()
+    out = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def aggregate_rows(rows, task_count: int, extras: dict | None = None) -> dict:
+    """대조 행에서 보고 봉투를 만든다. 순수."""
+    report = empty_report()
+    false_pass = []
+    false_pass_controls = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        report["results"].append(row)
+        if row.get("discriminates"):
+            continue
+        pack_id = row.get("pack") or ""
+        task_id = row.get("task") or ""
+        control = row.get("control") or ""
+        label = false_pass_label(pack_id, task_id)
+        if label not in false_pass:
+            false_pass.append(label)
+        false_pass_controls.append(false_pass_control_label(pack_id, task_id, control))
+    report["taskCount"] = int(task_count)
+    report["controlCount"] = len(report["results"])
+    report["falsePass"] = false_pass
+    report["falsePassControls"] = false_pass_controls
+    report["discriminating"] = report["taskCount"] - len(false_pass)
+    report["ok"] = len(false_pass) == 0
+    if extras:
+        for key in OPTIONAL_REPORT_KEYS:
+            if key in extras and extras[key] is not None:
+                report[key] = extras[key]
+        if extras.get("toolFailed"):
+            report["toolFailed"] = True
+    return report
+
+
+def validate_report(report) -> list[str]:
+    """보고 봉투의 정직 계약. 문제 문장 목록(없으면 빈 목록)."""
+    issues = []
+    if not isinstance(report, dict):
+        return ["보고가 dict 가 아니다"]
+    for key in REPORT_KEYS:
+        if key not in report:
+            issues.append(f"필수 키 없음: {key}")
+    if report.get("kind") != REPORT_KIND:
+        issues.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append("schemaVersion 이 1.0 이 아니다")
+    if not isinstance(report.get("ok"), bool):
+        issues.append("ok 가 bool 이 아니다")
+    for key in ("taskCount", "controlCount", "discriminating"):
+        value = report.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            issues.append(f"{key} 가 음이 아닌 정수가 아니다")
+    false_pass = report.get("falsePass")
+    controls = report.get("falsePassControls")
+    if not isinstance(false_pass, list):
+        issues.append("falsePass 가 list 가 아니다")
+        false_pass = []
+    if not isinstance(controls, list):
+        issues.append("falsePassControls 가 list 가 아니다")
+        controls = []
+    if bool(false_pass) == bool(report.get("ok")) and report.get("ok") is not None:
+        # ok 는 falsePass 가 비었을 때만 참이어야 한다.
+        if report.get("ok") and false_pass:
+            issues.append("ok 가 참인데 falsePass 가 있다")
+        if (not report.get("ok")) and (not false_pass):
+            issues.append("ok 가 거짓인데 falsePass 가 비었다")
+    expected_disc = report.get("taskCount", 0) - len(false_pass)
+    if report.get("discriminating") != expected_disc:
+        issues.append("discriminating 이 taskCount-len(falsePass) 가 아니다")
+    results = report.get("results")
+    if results is not None:
+        if not isinstance(results, list):
+            issues.append("results 가 list 가 아니다")
+        elif report.get("controlCount") != len(results):
+            issues.append("controlCount 가 results 길이와 다르다")
+        for row in results:
+            if not isinstance(row, dict):
+                issues.append("results 행이 dict 가 아니다")
+                continue
+            control = row.get("control")
+            if control is not None and not is_known_control(control):
+                issues.append(f"미지 대조: {control}")
+    for label in false_pass:
+        if parse_false_pass_label(label) is None:
+            issues.append(f"falsePass 라벨 형식 오류: {label!r}")
+    for label in controls:
+        if not isinstance(label, str) or " (" not in label or not label.endswith(")"):
+            issues.append(f"falsePassControls 라벨 형식 오류: {label!r}")
+            continue
+        head, tail = label.rsplit(" (", 1)
+        control = tail[:-1]
+        if parse_false_pass_label(head) is None:
+            issues.append(f"falsePassControls 머리 형식 오류: {label!r}")
+        if not is_known_control(control):
+            issues.append(f"falsePassControls 미지 대조: {control}")
+    kinds = report.get("controlKinds")
+    if kinds is not None and list(kinds) != list(CONTROL_KINDS):
+        issues.append("controlKinds 가 카탈로그와 다르다")
+    return issues
+
+
+def human_lines(report: dict) -> list[str]:
+    """사람이 읽는 한 줄 요약 + false-pass 목록."""
+    if report.get("ok"):
+        return [
+            f"gym 판별력 감사: {report.get('taskCount', 0)} 과제 전부 음성 대조를 거부 — 약한 오라클 0"
+        ]
+    lines = [
+        f"gym 판별력 감사: 약한 오라클(false-pass) {len(report.get('falsePass') or [])}건 — "
+        "일 안 한 제출이 통과한다:"
+    ]
+    for item in report.get("falsePass") or []:
+        lines.append(f"  - {item}")
+    extra = report.get("falsePassControls") or []
+    if extra:
+        lines.append("대조별:")
+        for item in extra:
+            lines.append(f"  - {item}")
+    return lines
+
+
+def format_human_report(report: dict) -> str:
+    return "\n".join(human_lines(report)) + "\n"
+
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def write_json(path: str, obj) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        ensure_dir(parent)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(obj, fh, ensure_ascii=False)
+
+
+def write_bytes(path: str, data: bytes) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        ensure_dir(parent)
+    with open(path, "wb") as fh:
+        fh.write(data)
+
+
+def copy_file(src: str, dst: str) -> None:
+    parent = os.path.dirname(dst)
+    if parent:
+        ensure_dir(parent)
+    shutil.copyfile(src, dst)
+
+
+def load_json(path: str):
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def iter_pack_ids(packs_dir: str) -> list[str]:
+    """tasks/ 가 있는 pack id. 사전순. 없거나 읽기 실패면 빈 목록."""
+    if not packs_dir or not os.path.isdir(packs_dir):
+        return []
+    try:
+        names = os.listdir(packs_dir)
+    except OSError:
+        return []
+    out = []
+    for name in sorted(names):
+        pack_dir = os.path.join(packs_dir, name)
+        try:
+            if os.path.isdir(os.path.join(pack_dir, "tasks")):
+                out.append(name)
+        except OSError:
+            continue
+    return out
+
+
+def iter_task_names(tasks_dir: str) -> list[str]:
+    """*.json 파일 이름. 사전순."""
+    if not tasks_dir or not os.path.isdir(tasks_dir):
+        return []
+    try:
+        names = os.listdir(tasks_dir)
+    except OSError:
+        return []
+    return sorted(name for name in names if name.endswith(".json"))
+
+
+def load_task(path: str) -> tuple[dict | None, str | None]:
+    """과제 JSON. (task, None) 또는 (None, error)."""
+    try:
+        task = load_json(path)
+    except (OSError, ValueError) as exc:
+        return None, f"{os.path.basename(path)} 파싱 실패: {exc}"
+    if not isinstance(task, dict):
+        return None, f"{os.path.basename(path)} 가 객체가 아니다"
+    return task, None
+
+
+def task_id_of(task) -> str | None:
+    if not isinstance(task, dict):
+        return None
+    tid = task.get("id")
+    if isinstance(tid, str) and tid.strip():
+        return tid
+    return None
+
+
+def resolve_input_path(task, repo_root: str | None = None) -> str:
+    root = repo_root if repo_root is not None else REPO_ROOT
+    rel = task.get("input") if isinstance(task, dict) else None
+    if not isinstance(rel, str) or not rel:
+        return ""
+    if os.path.isabs(rel):
+        return rel
+    return os.path.join(root, *rel.replace("\\", "/").split("/"))
+
+
+def write_answer_file(sub_dir: str, keys) -> str | None:
+    if not keys:
+        return None
+    path = os.path.join(sub_dir, "answer.json")
+    write_json(path, sentinel_answers(keys))
+    return path
+
+
+def write_artifact_file(dst: str, src: str, mode: str) -> str:
+    """copied / garbage / skipped / rejected 중 하나."""
+    if mode == CONTROL_GARBAGE:
+        write_bytes(dst, GARBAGE_BYTES)
+        return "garbage"
+    if mode == CONTROL_INPUT_COPY:
+        if src and os.path.isfile(src):
+            copy_file(src, dst)
+            return "copied"
+        return "skipped"
+    return "rejected"
+
+
+def prepare_submission_dir(neg_pack_dir: str, task_id: str) -> str:
+    sub_dir = os.path.join(neg_pack_dir, task_id)
+    shutil.rmtree(sub_dir, ignore_errors=True)
+    ensure_dir(sub_dir)
+    return sub_dir
+
+
+def build_negative(task: dict, neg_pack_dir: str, artifact_mode: str = "input-copy") -> dict:
+    """음성 대조 제출물 — 오답 answer.json + artifact별 무편집/garbage 대조.
+
+    artifact_mode:
+      - input-copy: 입력을 산출 자리에 복사. 입력이 없으면 그 파일은 건너뛴다.
+      - garbage: GARBAGE_BYTES 를 산출 자리에 쓴다.
+      - wrong-answer: 답만 쓰고 산출 파일은 만들지 않는다.
+    미지 모드는 artifact 과제에서 ValueError.
+    """
+    tid = task_id_of(task) or "T"
+    sub_dir = prepare_submission_dir(neg_pack_dir, tid)
+    keys = answer_keys(task)
+    answer_path = write_answer_file(sub_dir, keys)
+    files_out = []
+    errors = []
+    if is_artifact_task(task):
+        if artifact_mode not in (CONTROL_INPUT_COPY, CONTROL_GARBAGE, CONTROL_WRONG_ANSWER):
+            raise ValueError(f"지원하지 않는 artifact 음성 대조: {artifact_mode}")
+        if artifact_mode != CONTROL_WRONG_ANSWER:
+            src = resolve_input_path(task)
+            raw_files = submit_mapping(task).get("files") or []
+            if not isinstance(raw_files, list):
+                raw_files = []
+            for item in raw_files:
+                reason = unsafe_rel_reason(item)
+                rel = normalize_rel(item)
+                if rel is None:
+                    errors.append(f"불안전 산출 경로 거부: {item!r} ({reason})")
+                    files_out.append({"rel": item, "action": "rejected", "path": None})
+                    continue
+                dst = join_sub(sub_dir, rel)
+                action = write_artifact_file(dst, src, artifact_mode)
+                path = dst if action in ("copied", "garbage") else None
+                if action == "skipped":
+                    errors.append(f"입력 복사 생략(원본 없음): {task.get('input')!r} → {rel}")
+                files_out.append({"rel": rel, "action": action, "path": path})
+    return {
+        "taskId": tid,
+        "mode": artifact_mode,
+        "answerKeys": sorted(keys),
+        "answerPath": answer_path,
+        "files": files_out,
+        "errors": errors,
+        "dir": sub_dir,
+    }
+
+
+def score_task_safe(task, pack_dir, bin_path, score_fn=None):
+    """채점 예외를 봉투로 접는다. 치명 예외는 다시 올린다."""
+    fn = score_fn or runner.score_task
+    try:
+        return normalize_score(fn(task, pack_dir, bin_path))
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return {"pass": False, "error": f"채점 예외: {type(exc).__name__}: {exc}"}
+    except Exception as exc:  # noqa: BLE001 — 한 과제가 전수 감사를 죽이면 안 된다
+        if is_fatal_exception(exc):
+            raise
+        return {"pass": False, "error": f"채점 예외: {type(exc).__name__}: {exc}"}
+
+
+def packs_dir_of(gym_root: str) -> str:
+    return os.path.join(gym_root, "packs")
+
+
+def control_pack_dir(neg_root: str, control: str, pack_id: str) -> str:
+    return os.path.join(neg_root, control, pack_id)
+
+
+def make_result_row(pack_id, task_id, control, discriminates, extra=None) -> dict:
+    row = {
+        "pack": pack_id,
+        "task": task_id,
+        "control": control,
+        "discriminates": bool(discriminates),
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def discover_task_entries(gym_root: str) -> tuple[list[dict], list[str], list[str]]:
+    """(entries, loadErrors, toolErrors). entry: pack, name, task."""
+    entries = []
+    load_errors = []
+    tool_errors = []
+    packs_dir = packs_dir_of(gym_root)
+    if not os.path.isdir(packs_dir):
+        return entries, load_errors, tool_errors
+    try:
+        pack_ids = iter_pack_ids(packs_dir)
+    except OSError as exc:
+        tool_errors.append(f"packs 목록 실패: {exc}")
+        return entries, load_errors, tool_errors
+    for pack_id in pack_ids:
+        tasks_dir = os.path.join(packs_dir, pack_id, "tasks")
+        try:
+            names = iter_task_names(tasks_dir)
+        except OSError as exc:
+            tool_errors.append(f"{pack_id} tasks 목록 실패: {exc}")
+            continue
+        for name in names:
+            path = os.path.join(tasks_dir, name)
+            task, err = load_task(path)
+            if err:
+                load_errors.append(f"{pack_id}/{name}: {err}")
+                continue
+            tid = task_id_of(task)
+            if tid is None:
+                load_errors.append(f"{pack_id}/{name}: 과제 id 가 없다")
+                continue
+            entries.append({"pack": pack_id, "name": name, "task": task})
+    return entries, load_errors, tool_errors
+
+
+def run_one_control(task, pack_id, control, neg_root, bin_path, score_fn=None) -> tuple[dict, list[str], list[str]]:
+    """한 과제의 한 대조. (row, buildErrors, scoreErrors)."""
+    build_errors = []
+    score_errors = []
+    tid = task_id_of(task) or "?"
+    dest = control_pack_dir(neg_root, control, pack_id)
+    try:
+        built = build_negative(task, dest, artifact_mode=control)
+    except FATAL_EXCEPTIONS:
+        raise
+    except (OSError, ValueError, TypeError) as exc:
+        build_errors.append(f"{pack_id}/{tid} ({control}): 구성 실패: {exc}")
+        row = make_result_row(pack_id, tid, control, True, {"error": f"구성 실패: {exc}"})
+        return row, build_errors, score_errors
+    for item in built.get("errors") or []:
+        build_errors.append(f"{pack_id}/{tid} ({control}): {item}")
+    scored = score_task_safe(task, dest, bin_path, score_fn=score_fn)
+    if scored.get("error"):
+        score_errors.append(f"{pack_id}/{tid} ({control}): {scored['error']}")
+    row = make_result_row(
+        pack_id,
+        tid,
+        control,
+        score_discriminates(scored),
+        {"error": scored.get("error")} if scored.get("error") else None,
+    )
+    return row, build_errors, score_errors
+
+
+def discriminate(bin_path: str, gym_root: str, neg_root: str, score_fn=None) -> dict:
+    """전 pack 음성 대조. score_fn 이 있으면 runner.score_task 대신 쓴다."""
+    extras = {
+        "loadErrors": [],
+        "scoreErrors": [],
+        "buildErrors": [],
+        "skipped": [],
+        "toolFailed": False,
+        "toolErrors": [],
+        "controlKinds": list(CONTROL_KINDS),
+    }
+    try:
+        entries, load_errors, tool_errors = discover_task_entries(gym_root)
+    except FATAL_EXCEPTIONS:
+        raise
+    except OSError as exc:
+        extras["toolFailed"] = True
+        extras["toolErrors"] = [f"과제 탐색 실패: {exc}"]
+        return aggregate_rows([], 0, extras)
+    extras["loadErrors"] = load_errors
+    extras["toolErrors"] = tool_errors
+    if tool_errors:
+        extras["toolFailed"] = True
+    rows = []
+    fn = score_fn or runner.score_task
+    for entry in entries:
+        task = entry["task"]
+        pack_id = entry["pack"]
+        for control in controls_for(task):
+            row, build_err, score_err = run_one_control(
+                task, pack_id, control, neg_root, bin_path, score_fn=fn
+            )
+            rows.append(row)
+            extras["buildErrors"].extend(build_err)
+            extras["scoreErrors"].extend(score_err)
+    return aggregate_rows(rows, len(entries), extras)
+
+
+def prepare_neg_root(neg_root: str) -> str:
+    shutil.rmtree(neg_root, ignore_errors=True)
+    ensure_dir(neg_root)
+    return neg_root
+
+
+def default_neg_root(gym_root: str | None = None) -> str:
+    root = gym_root if gym_root is not None else GYM_ROOT
+    return os.path.join(root, "submissions", NEGATIVE_DIRNAME)
+
+
+def run_audit(bin_path: str, gym_root: str | None = None, neg_root: str | None = None) -> dict:
+    gym = gym_root if gym_root is not None else GYM_ROOT
+    dest = neg_root if neg_root is not None else default_neg_root(gym)
+    prepare_neg_root(dest)
+    return discriminate(bin_path, gym, dest)
+
+
+def parse_args(argv=None) -> argparse.Namespace:
     ap = argparse.ArgumentParser(description="gym 판별력 감사 — 약한 오라클(false-pass) 색출")
     ap.add_argument("--bin", required=True)
     ap.add_argument("--json", action="store_true")
-    a = ap.parse_args()
-    bin_path = runner.find_bin(a.bin)
-    neg_root = os.path.join(GYM_ROOT, "submissions", "_negative_control")
-    shutil.rmtree(neg_root, ignore_errors=True)
-    report = discriminate(bin_path, GYM_ROOT, neg_root)
-    if a.json:
-        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
-    elif report["ok"]:
-        print(f"gym 판별력 감사: {report['taskCount']} 과제 전부 음성 대조를 거부 — 약한 오라클 0")
-    else:
-        print(f"gym 판별력 감사: 약한 오라클(false-pass) {len(report['falsePass'])}건 — "
-              "일 안 한 제출이 통과한다:")
-        for t in report["falsePass"]:
-            print(f"  - {t}")
-    return 0 if report["ok"] else 1
+    return ap.parse_args(argv)
+
+
+def emit_report(report: dict, as_json: bool, stream=None) -> None:
+    out = sys.stdout if stream is None else stream
+    if as_json:
+        out.write(format_json_report(report))
+        return
+    out.write(format_human_report(report))
+
+
+def exit_code(report: dict) -> int:
+    return EXIT_OK if report.get("ok") else EXIT_FALSE_PASS
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    bin_path = runner.find_bin(args.bin)
+    report = run_audit(bin_path)
+    emit_report(report, args.json)
+    return exit_code(report)
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_discriminate.md
+++ b/mydocs/working/gym_discriminate.md
@@ -1,0 +1,226 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_discriminate.md
+last_verified: 2026-08-18
+---
+
+# gym 판별력 감사 — 음성 대조 세 종류 고정
+
+Issue: #5255
+Branch: `feat/gym-discriminate-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/discriminate.py` 의 음성 대조를 세 종류로 고정하고, 경로
+안전·예외 접기·보고 정직 계약을 순수 함수로 분리했다. 새 CLI 플래그와
+새 pack 은 없다. `trajectory.py` · `fuzz_corpus.py` · `automation` /
+`core-cli` / `casual-rides` 는 열지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_discriminate`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+devel 의 감사기는 이미 세 가지를 돌렸다.
+
+1. answer 키에 `__NEGATIVE_CONTROL_definitely_wrong__`
+2. artifact 산출에 입력 복사
+3. artifact 산출에 `GARBAGE_BYTES`
+
+시험은 다섯 개였다. 복사와 garbage 가 실제로 다른 바이트인지, 입력이
+없을 때 전수 감사가 죽는지, `../` 산출 경로가 제출 폴더 밖으로 쓰는지,
+깨진 과제 JSON 이 도구를 죽이는지, 채점 예외를 통과로 접는지 — 이
+자리들은 시험이 없었다.
+
+이슈 #5255 의 DoD 는 `additions >= 3000`, 음성 대조 종류를 시험으로
+고정, `audit.py` 통과다. 새 CLI/pack 금지, 열린 PR 파일 미수정.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/discriminate.py`
+
+- `CONTROL_KINDS` / `CONTROL_CATALOG` — `wrong-answer` · `input-copy` ·
+  `garbage` 만. 문서·시험이 같은 표를 본다.
+- `controls_for` — artifact 는 copy+garbage, 그 외는 sentinel.
+- `answer_keys` — 비-dict 검사·빈 키를 무시한다.
+- `normalize_rel` / `unsafe_rel_reason` — 절대·드라이브·UNC·홈·부모
+  경로는 쓰지 않는다.
+- `build_negative` — 미지 모드는 기존처럼 `ValueError`. 입력 없음은
+  건너뛴다. garbage 는 원본이 필요 없다. 반환 dict 에 쓴 파일과
+  오류를 남긴다. 기존 호출 서명(`task, dir, artifact_mode=`)은 유지.
+- `score_task_safe` — 채점 예외는 `pass=False` 로 접는다.
+  `KeyboardInterrupt` · `SystemExit` · `MemoryError` · `GeneratorExit`
+  는 다시 올린다.
+- `aggregate_rows` / `validate_report` — `ok` 는 `falsePass` 가 비었을
+  때만 참. `discriminating` 산술을 검사한다.
+- `discriminate` — 깨진 JSON 은 `loadErrors` 로 건너뛴다. 기존 키
+  (`kind` · `schemaVersion` · `ok` · `taskCount` · `controlCount` ·
+  `discriminating` · `falsePass` · `falsePassControls`) 의미는 그대로다.
+- CLI 는 `--bin` · `--json` 만. 종료 코드 0/1.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_discriminate.py`
+
+기존 다섯 시험을 유지한다.
+
+- 무편집 복사 + sentinel
+- 음성이 통과하면 false-pass
+- 음성이 거부되면 ok
+- garbage 만 통과하면 대조 라벨이 따로 난다
+- garbage 바이트가 입력과 다르다
+
+추가한 칸:
+
+- 카탈로그가 세 종류뿐인지
+- sentinel 이 흔한 진값과 다른지
+- garbage 가 1KiB 를 넘고 UTF-8/JSON/XML 이 아닌지
+- 경로 탈출이 거절되는지
+- 입력 부재가 예외가 아닌지
+- answer 과제는 대조 1건, artifact 는 2건
+- 채점 예외는 false-pass 가 아닌지
+- 보고 검증이 모순을 잡는지
+- CLI 에 새 플래그가 없는지
+
+### 3.3 문서
+
+- `gym/docs/discriminate.md` — 규약 정본
+- `mydocs/working/gym_discriminate.md` — 이 기록
+
+## 4. 의도적으로 하지 않은 일
+
+- pair 산출에 copy/garbage 를 얹지 않았다. 이슈가 고정한 종류는
+  answer sentinel · artifact copy · garbage artifact 다.
+- `--pack` / `--limit` 을 달지 않았다. 전수 감사가 점이다.
+- `schemaVersion` 을 1.1 로 올리지 않았다. 기존 키 의미가 그대로다.
+- `ok` 를 `toolFailed` 와 AND 하지 않았다. 도구가 죽은 것과 약한
+  오라클은 다른 신호다. 전자는 `toolFailed` 키로 남긴다.
+- `gym/README.md` 를 고치지 않았다. 이 가지의 허용 파일 밖이다.
+- `audit.py` 는 실행만 했고 수정하지 않았다.
+
+## 5. 위험과 남은 구멍
+
+1. **라이브 스윕은 바이너리가 필요하다.** 단위 시험은 러너를 목킹한다.
+   게이트 워크플로가 실제 `discriminate.py --bin` 을 돈다.
+2. **pair 과제는 sentinel 만 돈다.** 답 키가 없으면 빈 폴더를 채점한다.
+   파일 검사가 있으면 실패(판별력 있음)다. 파일 검사조차 없으면
+   빈 제출이 통과할 수 있다. 그 확장은 후속 이슈다.
+3. **입력 없는 copy 는 파일을 만들지 않는다.** 일부 연산자는 "파일
+   없음"을 실패로 접으므로 판별력 있음으로 집계된다. 이것이
+   false-pass 를 숨기지는 않는다.
+4. **열린 pack 확장 PR 과 겹치지 않으려면 pack 파일을 만지면 안
+   된다.** 이 가지는 도구·시험·문서만 만진다.
+
+## 6. 재현
+
+격리 worktree: `C:\Users\swsz9\rhwp-gym-discriminate`
+기준: `upstream/devel`
+브랜치: `feat/gym-discriminate-hardening`
+
+```bash
+python -m unittest scripts.tests.test_gym_discriminate
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+## 7. 시험 목록 (클래스)
+
+| 클래스 | 고정하는 것 |
+|---|---|
+| `DiscriminateTests` | devel 때부터 있던 다섯 계약 |
+| `CatalogContractTests` | 대조 id 세 개, 보고 키, 종료 코드 |
+| `SentinelContractTests` | sentinel 안정성, 흔한 진값과 불일치 |
+| `GarbageContractTests` | 1KiB, 널, JSON/XML/PDF 가 아님 |
+| `PathSafetyTests` | `..` / 절대 / 드라이브 / UNC / 홈 거절 |
+| `SubmitShapeTests` | answer·artifact·pair → 대조 튜플 |
+| `BuildNegativeAnswerTests` | 답만 쓰고 산출은 안 씀 |
+| `BuildNegativeCopyTests` | 입력 바이트 복사, 원본 무훼손, 입력 부재 |
+| `BuildNegativeGarbageTests` | garbage 바이트, 원본 불필요 |
+| `ScoreClassifyTests` | pass 해석, 치명 예외 재발생 |
+| `LabelAndAggregateTests` | 과제 라벨 중복 제거, 대조 라벨 유지 |
+| `ValidateReportTests` | ok ↔ falsePass 정직 |
+| `DiscriminateDiscoveryTests` | 깨진 JSON 건너뜀, 빈 gym ok |
+| `DiscriminateMatrixTests` | 세 종류의 실행 횟수와 false-pass 분리 |
+| `BuildThenScoreIntegrationTests` | 채점 직전에 파일이 실제로 그 바이트 |
+| `HumanReportTests` | 사람 출력 문장 |
+| `CliMainTests` | `--bin`/`--json` 만, 종료 0/1 |
+| `ThreeControlKindTableTests` | #5255 DoD 표 |
+
+## 8. 기존 다섯 시험과의 호환
+
+devel 시험이 가정하는 것:
+
+- `WRONG_SENTINEL` 문자열 그대로
+- `GARBAGE_BYTES` 상수로 비교
+- `build_negative(task, dir)` 기본 모드가 입력 복사
+- `build_negative(..., artifact_mode="garbage")`
+- `discriminate(bin, gym, neg)` 서명
+- `runner.score_task` 를 갈아끼우면 채점이 바뀜
+- artifact 한 과제의 `controlCount == 2`
+- garbage 만 통과하면 `falsePassControls == ["p1/T (garbage)"]`
+- `falsePass` 라벨은 `pack/task`
+
+이 가지는 서명을 늘리지 않고 반환 키만 추가했다. 기존 다섯 시험은
+그대로 통과해야 한다.
+
+## 9. 크기 게이트
+
+이슈 DoD: `additions >= 3000` vs `upstream/devel`. 허용 파일은 네 개다.
+
+- `gym/tools/discriminate.py`
+- `scripts/tests/test_gym_discriminate.py`
+- `gym/docs/discriminate.md`
+- `mydocs/working/gym_discriminate.md`
+
+`git add -A` 금지. 위 경로만 스테이징한다. 다른 열린 PR 파일
+(`trajectory.py`, `fuzz_corpus.py`, `gym/packs/automation`,
+`gym/packs/core-cli`, `gym/packs/casual-rides`) 은 워킹트리에
+나타나도 커밋에 넣지 않는다.
+
+## 10. 설계에서 버린 대안
+
+1. **네 번째 대조 `empty-file`.** 빈 파일은 `file_exists` 기본값에
+   걸린다. 형식 검사가 없어도 거부되므로 판별력 신호가 약하다.
+2. **네 번째 대조 `missing-file`.** 파일을 안 쓰는 것은 이미 입력
+   부재 copy 경로가 한다. 종류를 늘리면 카탈로그 시험이 깨진다.
+3. **artifact 에 `wrong-answer` 를 세 번째 대조로 추가.** 기존 시험
+   `controlCount == 2` 가 깨진다. 답 키는 copy/garbage 제출에도
+   sentinel 로 같이 쓰므로 세 번째 루프가 필요 없다.
+4. **보고 `schemaVersion=1.1`.** 필수 키 의미가 그대로라 올릴 이유가
+   없다. 부가 키는 `OPTIONAL_REPORT_KEYS` 로 남긴다.
+5. **`--out` 파일 쓰기.** 게이트는 stdout 의 사람 출력을 본다.
+   쓰기 경로를 늘리면 CLI 표면이 바뀐다.
+
+## 11. 로컬 명령 기록
+
+격리 worktree 에서 실행한 것:
+
+```
+python -m unittest scripts.tests.test_gym_discriminate
+python gym/tools/audit.py
+```
+
+`cargo fmt --all` 과 `cargo fmt --all -- --check` 는 돌리지 않았다.
+Rust 파일이 없다. 사용자 지시가 명시적으로 금지했다.
+
+단위 시험은 바이너리 없이 150건 전후가 통과해야 한다. `audit.py` 는
+devel 의 18 pack 정합을 그대로 통과해야 한다. pack JSON 을 이 가지가
+만지지 않으므로 audit 실패는 회귀가 아니라 작업 트리 오염이다.
+
+PR 본문은 한글, base 는 `devel`, `closes #5255`, `--body-file` 로
+보낸다. 제목은 도구와 세 대조를 드러낸다.
+
+닫는 문장: 음성 대조가 통과하면 과제가 틀린 것이 아니라 오라클이
+약한 것이다. 그 신호를 시험이 고정한다.
+
+이상.
+
+(이 기록은 작업 메모다. 규약 정본은 `gym/docs/discriminate.md`.)
+

--- a/scripts/tests/test_gym_discriminate.py
+++ b/scripts/tests/test_gym_discriminate.py
@@ -1,20 +1,31 @@
 """[discriminate] gym 판별력 감사 계약 — 음성 대조 구성 + false-pass 색출.
 
-핵심: 각 과제는 '일 안 한 제출'(음성 대조)을 거부해야 판별력이 있다. 음성 대조는
-오답 answer.json + 입력을 산출로 무편집 복사로 만든다. 음성이 통과하면 약한 오라클
-(false-pass, SWE-Bench 59.4% 결함과 같은 계열)로 잡는다. 채점은 목킹해 바이너리 없이 시험.
+핵심: 각 과제는 '일 안 한 제출'(음성 대조)을 거부해야 판별력이 있다. 음성 대조
+종류는 세 가지로 고정한다.
+
+- wrong-answer: 모든 답 키에 WRONG_SENTINEL
+- input-copy: artifact 산출 자리에 입력 바이트를 무편집 복사
+- garbage: 같은 자리에 GARBAGE_BYTES (1KiB 초과 synthetic)
+
+음성이 통과하면 약한 오라클(false-pass, SWE-Bench 59.4% 결함과 같은 계열)로
+잡는다. 채점은 목킹해 바이너리 없이 시험한다. 새 CLI/pack 은 없다.
 """
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
+import io
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "discriminate.py"
+SAMPLE = "samples/2010-01-06.hwp"  # REPO_ROOT 기준 실재 입력
 
 
 def load():
@@ -25,24 +36,55 @@ def load():
     return module
 
 
-SAMPLE = "samples/2010-01-06.hwp"  # REPO_ROOT 기준 실재 입력
-
-
 def _artifact_task():
     return {"id": "T", "input": SAMPLE, "submit": {"kind": "artifact", "files": ["out.svg"]},
             "checks": [{"op": "answer_eq", "answer": "pages",
                         "cmd": ["info", "{input}", "--json"], "path": "pageCount"}]}
 
 
-def _temp_gym(root, task):
-    td = os.path.join(root, "gym", "packs", "p1", "tasks")
-    os.makedirs(td)
-    with open(os.path.join(td, "T.json"), "w", encoding="utf-8") as fh:
+def _answer_task(tid="A", keys=None):
+    keys = list(keys or ["pages"])
+    checks = [{"op": "answer_eq", "answer": k, "cmd": ["info", "{input}", "--json"],
+               "path": "pageCount"} for k in keys]
+    return {"id": tid, "input": SAMPLE, "submit": {"kind": "answer", "files": ["answer.json"]},
+            "checks": checks}
+
+
+def _pair_task():
+    return {"id": "P", "input": SAMPLE, "submit": {"kind": "pair", "files": ["a.hwp", "b.hwp"]},
+            "checks": [{"op": "files_differ", "files": ["a.hwp", "b.hwp"]}]}
+
+
+def _temp_gym(root, task, pack="p1", name=None):
+    tid = task.get("id", "T")
+    name = name or f"{tid}.json"
+    td = os.path.join(root, "gym", "packs", pack, "tasks")
+    os.makedirs(td, exist_ok=True)
+    with open(os.path.join(td, name), "w", encoding="utf-8") as fh:
         json.dump(task, fh, ensure_ascii=False)
     return os.path.join(root, "gym")
 
 
+def _write(path, text="", binary=None):
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    if binary is not None:
+        with open(path, "wb") as fh:
+            fh.write(binary)
+    else:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+
+
+def _read(path, binary=False):
+    mode = "rb" if binary else "r"
+    kw = {} if binary else {"encoding": "utf-8"}
+    with open(path, mode, **kw) as fh:
+        return fh.read()
+
+
 class DiscriminateTests(unittest.TestCase):
+    """기존 계약 — 음성 구성과 false-pass 집계는 이 다섯 시험이 지킨다."""
+
     def test_build_negative_wrong_answer_and_noop_copy(self):
         mod = load()
         with tempfile.TemporaryDirectory() as d:
@@ -100,5 +142,1376 @@ class DiscriminateTests(unittest.TestCase):
             self.assertEqual(data, mod.GARBAGE_BYTES)
 
 
+class CatalogContractTests(unittest.TestCase):
+    """음성 대조 종류 세 가지를 시험이 고정한다."""
+
+    def test_control_kinds_are_exactly_three(self):
+        mod = load()
+        self.assertEqual(
+            mod.CONTROL_KINDS,
+            (mod.CONTROL_WRONG_ANSWER, mod.CONTROL_INPUT_COPY, mod.CONTROL_GARBAGE),
+        )
+        self.assertEqual(mod.CONTROL_KINDS, ("wrong-answer", "input-copy", "garbage"))
+        self.assertEqual(len(mod.CONTROL_KINDS), 3)
+        self.assertEqual(len(set(mod.CONTROL_KINDS)), 3)
+
+    def test_catalog_rows_match_ids_and_must_fail(self):
+        mod = load()
+        self.assertEqual(len(mod.CONTROL_CATALOG), 3)
+        ids = [row["id"] for row in mod.CONTROL_CATALOG]
+        self.assertEqual(ids, list(mod.CONTROL_KINDS))
+        for row in mod.CONTROL_CATALOG:
+            self.assertTrue(row["mustFail"])
+            self.assertIn(row["submit"], ("answer", "artifact"))
+            self.assertTrue(row["writes"])
+            self.assertTrue(row["payload"])
+            self.assertTrue(row["why"])
+
+    def test_answer_controls_only_sentinel(self):
+        mod = load()
+        self.assertEqual(mod.ANSWER_CONTROLS, ("wrong-answer",))
+        self.assertTrue(mod.is_answer_control("wrong-answer"))
+        self.assertFalse(mod.is_answer_control("garbage"))
+        self.assertFalse(mod.is_answer_control("input-copy"))
+
+    def test_artifact_controls_are_copy_and_garbage(self):
+        mod = load()
+        self.assertEqual(mod.ARTIFACT_CONTROLS, ("input-copy", "garbage"))
+        self.assertTrue(mod.is_artifact_control("input-copy"))
+        self.assertTrue(mod.is_artifact_control("garbage"))
+        self.assertFalse(mod.is_artifact_control("wrong-answer"))
+
+    def test_control_spec_and_unknown(self):
+        mod = load()
+        spec = mod.control_spec("garbage")
+        self.assertEqual(spec["payload"], "GARBAGE_BYTES")
+        self.assertIsNone(mod.control_spec("truncate"))
+        self.assertTrue(mod.is_known_control("wrong-answer"))
+        self.assertFalse(mod.is_known_control("missing-file"))
+        self.assertEqual(mod.control_ids(), mod.CONTROL_KINDS)
+
+    def test_report_kind_and_required_keys(self):
+        mod = load()
+        self.assertEqual(mod.REPORT_KIND, "gymDiscrimination")
+        self.assertEqual(mod.SCHEMA_VERSION, "1.0")
+        for key in (
+            "kind", "schemaVersion", "ok", "taskCount", "controlCount",
+            "discriminating", "falsePass", "falsePassControls",
+        ):
+            self.assertIn(key, mod.REPORT_KEYS)
+
+    def test_exit_codes_are_zero_and_one(self):
+        mod = load()
+        self.assertEqual(mod.EXIT_OK, 0)
+        self.assertEqual(mod.EXIT_FALSE_PASS, 1)
+        self.assertEqual(mod.exit_code({"ok": True}), 0)
+        self.assertEqual(mod.exit_code({"ok": False}), 1)
+        self.assertEqual(mod.exit_code({}), 1)
+
+    def test_negative_dirname_constant(self):
+        mod = load()
+        self.assertEqual(mod.NEGATIVE_DIRNAME, "_negative_control")
+        self.assertTrue(mod.default_neg_root(mod.GYM_ROOT).endswith("_negative_control"))
+
+
+class SentinelContractTests(unittest.TestCase):
+    def test_sentinel_text_is_stable(self):
+        mod = load()
+        self.assertEqual(mod.WRONG_SENTINEL, "__NEGATIVE_CONTROL_definitely_wrong__")
+        self.assertTrue(mod.WRONG_SENTINEL.startswith("__NEGATIVE_CONTROL_"))
+        self.assertIn("definitely_wrong", mod.WRONG_SENTINEL)
+
+    def test_sentinel_is_not_a_typical_gold_value(self):
+        mod = load()
+        for value in (0, 1, -1, 0.0, True, False, None, "", "0", "pages", "ok",
+                      [], {}, "true", "false", "null"):
+            self.assertFalse(mod.is_wrong_sentinel(value), msg=repr(value))
+        self.assertTrue(mod.is_wrong_sentinel(mod.WRONG_SENTINEL))
+
+    def test_sentinel_answers_sorts_keys(self):
+        mod = load()
+        payload = mod.sentinel_answers({"z", "a", "m"})
+        self.assertEqual(list(payload.keys()), ["a", "m", "z"])
+        self.assertTrue(all(v == mod.WRONG_SENTINEL for v in payload.values()))
+
+    def test_sentinel_answers_empty(self):
+        mod = load()
+        self.assertEqual(mod.sentinel_answers([]), {})
+        self.assertEqual(mod.sentinel_answers(set()), {})
+
+    def test_answer_keys_collects_only_nonempty_strings(self):
+        mod = load()
+        task = {
+            "checks": [
+                {"answer": "pages"},
+                {"answer": ""},
+                {"answer": 3},
+                {"op": "file_exists"},
+                "skip",
+                {"answer": "loss"},
+                {"answer": "pages"},
+            ]
+        }
+        self.assertEqual(mod.answer_keys(task), {"pages", "loss"})
+
+    def test_answer_keys_tolerates_broken_task(self):
+        mod = load()
+        self.assertEqual(mod.answer_keys({}), set())
+        self.assertEqual(mod.answer_keys({"checks": None}), set())
+        self.assertEqual(mod.answer_keys({"checks": "x"}), set())
+        self.assertEqual(mod.answer_keys(None), set())  # type: ignore[arg-type]
+
+
+class GarbageContractTests(unittest.TestCase):
+    def test_garbage_is_marker_times_repeat(self):
+        mod = load()
+        self.assertEqual(mod.GARBAGE_BYTES, mod.GARBAGE_MARKER * mod.GARBAGE_REPEAT)
+        self.assertEqual(mod.GARBAGE_REPEAT, 64)
+        self.assertTrue(mod.GARBAGE_MARKER.startswith(b"RHWP_GYM_GARBAGE_NEGATIVE_CONTROL"))
+        self.assertTrue(mod.GARBAGE_MARKER.endswith(b"\x00"))
+
+    def test_garbage_exceeds_one_kib(self):
+        mod = load()
+        self.assertGreaterEqual(mod.garbage_size(), mod.GARBAGE_MIN_SIZE)
+        self.assertGreaterEqual(mod.GARBAGE_MIN_SIZE, 1024)
+        self.assertTrue(mod.garbage_meets_minimum())
+        self.assertEqual(mod.garbage_size(), len(mod.GARBAGE_BYTES))
+
+    def test_garbage_payload_predicate(self):
+        mod = load()
+        self.assertTrue(mod.is_garbage_payload(mod.GARBAGE_BYTES))
+        self.assertFalse(mod.is_garbage_payload(mod.GARBAGE_BYTES + b"x"))
+        self.assertFalse(mod.is_garbage_payload(mod.GARBAGE_BYTES[:-1]))
+        self.assertFalse(mod.is_garbage_payload(b""))
+        self.assertFalse(mod.is_garbage_payload(mod.GARBAGE_MARKER))
+
+    def test_garbage_is_not_valid_utf8_document(self):
+        mod = load()
+        # 널 바이트가 있어 텍스트 문서로 쓸 수 없다. UTF-8 디코드 자체는 된다.
+        self.assertIn(b"\x00", mod.GARBAGE_BYTES)
+        text = mod.GARBAGE_BYTES.decode("utf-8")
+        self.assertIn("\x00", text)
+        self.assertTrue(text.startswith("RHWP_GYM_GARBAGE_NEGATIVE_CONTROL"))
+
+    def test_garbage_is_not_json_or_xml(self):
+        mod = load()
+        with self.assertRaises(ValueError):
+            json.loads(mod.GARBAGE_BYTES)
+        self.assertFalse(mod.GARBAGE_BYTES.lstrip().startswith(b"{"))
+        self.assertFalse(mod.GARBAGE_BYTES.lstrip().startswith(b"<"))
+        self.assertFalse(mod.GARBAGE_BYTES.lstrip().startswith(b"%PDF"))
+
+
+class PathSafetyTests(unittest.TestCase):
+    def test_normalize_rel_accepts_nested_posix(self):
+        mod = load()
+        self.assertEqual(mod.normalize_rel("out.svg"), "out.svg")
+        self.assertEqual(mod.normalize_rel("a/b/c.svg"), "a/b/c.svg")
+        self.assertEqual(mod.normalize_rel("./a/./b"), "a/b")
+        self.assertEqual(mod.normalize_rel("a\\b\\c"), "a/b/c")
+
+    def test_normalize_rel_rejects_escape(self):
+        mod = load()
+        for rel in ("../x", "a/../b", "/abs", "C:/abs", "C:\\abs", "~/.ssh",
+                    "//unc/share", "", ".", "..", None, 3, "  "):
+            self.assertIsNone(mod.normalize_rel(rel), msg=repr(rel))
+
+    def test_unsafe_rel_reason_catalog(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason(None), "not-str")
+        self.assertEqual(mod.unsafe_rel_reason(""), "empty")
+        self.assertEqual(mod.unsafe_rel_reason("/abs"), "absolute")
+        self.assertEqual(mod.unsafe_rel_reason("C:/x"), "drive")
+        self.assertEqual(mod.unsafe_rel_reason("../x"), "parent")
+        self.assertEqual(mod.unsafe_rel_reason("//unc/x"), "unc")
+        self.assertEqual(mod.unsafe_rel_reason("~/x"), "home")
+        self.assertIsNone(mod.unsafe_rel_reason("out.svg"))
+        for reason in ("empty", "not-str", "absolute", "drive", "parent", "unc", "home"):
+            self.assertIn(reason, mod.UNSAFE_REL_REASONS)
+
+    def test_is_safe_rel_and_join_sub(self):
+        mod = load()
+        self.assertTrue(mod.is_safe_rel("nested/out.svg"))
+        self.assertFalse(mod.is_safe_rel("../out.svg"))
+        with tempfile.TemporaryDirectory() as d:
+            path = mod.join_sub(d, "a/b.txt")
+            self.assertTrue(path.startswith(d))
+            self.assertTrue(path.endswith(os.path.join("a", "b.txt")))
+            with self.assertRaises(ValueError):
+                mod.join_sub(d, "../escape")
+
+
+class SubmitShapeTests(unittest.TestCase):
+    def test_submit_kind_variants(self):
+        mod = load()
+        self.assertEqual(mod.submit_kind(_artifact_task()), "artifact")
+        self.assertEqual(mod.submit_kind(_answer_task()), "answer")
+        self.assertEqual(mod.submit_kind(_pair_task()), "pair")
+        self.assertEqual(mod.submit_kind({}), "")
+        self.assertEqual(mod.submit_kind({"submit": "x"}), "")
+        self.assertTrue(mod.is_artifact_task(_artifact_task()))
+        self.assertTrue(mod.is_answer_task(_answer_task()))
+        self.assertTrue(mod.is_pair_task(_pair_task()))
+        self.assertFalse(mod.is_artifact_task(_answer_task()))
+
+    def test_controls_for_locks_three_kinds_to_submit(self):
+        mod = load()
+        self.assertEqual(mod.controls_for(_artifact_task()), ("input-copy", "garbage"))
+        self.assertEqual(mod.controls_for(_answer_task()), ("wrong-answer",))
+        self.assertEqual(mod.controls_for(_pair_task()), ("wrong-answer",))
+        self.assertEqual(mod.controls_for({}), ("wrong-answer",))
+        self.assertEqual(mod.controls_for({"submit": {"kind": "artifact"}}),
+                         ("input-copy", "garbage"))
+
+    def test_submit_files_dedup_and_skip_unsafe(self):
+        mod = load()
+        task = {"submit": {"kind": "artifact", "files": [
+            "out.svg", "out.svg", "../x", "nested/a.bin", "", None, 1,
+        ]}}
+        self.assertEqual(mod.submit_files(task), ["out.svg", "nested/a.bin"])
+        self.assertEqual(mod.submit_files({}), [])
+        self.assertEqual(mod.submit_files({"submit": {"files": "out.svg"}}), [])
+
+
+class BuildNegativeAnswerTests(unittest.TestCase):
+    def test_answer_task_writes_only_sentinel_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(_answer_task(keys=["pages", "loss"]), d)
+            path = os.path.join(d, "A", "answer.json")
+            self.assertTrue(os.path.isfile(path))
+            payload = json.loads(_read(path))
+            self.assertEqual(payload, {"loss": mod.WRONG_SENTINEL, "pages": mod.WRONG_SENTINEL})
+            self.assertEqual(built["answerKeys"], ["loss", "pages"])
+            self.assertEqual(built["files"], [])
+            self.assertFalse(os.path.exists(os.path.join(d, "A", "out.svg")))
+
+    def test_answer_task_without_keys_makes_empty_dir(self):
+        mod = load()
+        task = {"id": "Z", "submit": {"kind": "answer"}, "checks": [{"op": "file_exists", "file": "x"}]}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d)
+            self.assertIsNone(built["answerPath"])
+            self.assertEqual(os.listdir(os.path.join(d, "Z")), [])
+
+    def test_answer_json_is_utf8_without_ascii_escape(self):
+        mod = load()
+        task = _answer_task(keys=["한글키"])
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(task, d)
+            raw = _read(os.path.join(d, "A", "answer.json"))
+            self.assertIn("한글키", raw)
+            self.assertNotIn("\\u", raw)
+
+    def test_rebuild_replaces_previous_submission(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _write(os.path.join(d, "T", "stale.txt"), "old")
+            mod.build_negative(_answer_task(tid="T"), d)
+            self.assertFalse(os.path.exists(os.path.join(d, "T", "stale.txt")))
+            self.assertTrue(os.path.isfile(os.path.join(d, "T", "answer.json")))
+
+
+class BuildNegativeCopyTests(unittest.TestCase):
+    def test_input_copy_matches_repo_sample_bytes(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(_artifact_task(), d, artifact_mode="input-copy")
+            src = os.path.join(mod.REPO_ROOT, SAMPLE)
+            dst = os.path.join(d, "T", "out.svg")
+            self.assertEqual(_read(dst, binary=True), _read(src, binary=True))
+            self.assertEqual(built["files"][0]["action"], "copied")
+            self.assertNotEqual(_read(dst, binary=True), mod.GARBAGE_BYTES)
+
+    def test_input_copy_does_not_mutate_source(self):
+        mod = load()
+        src = os.path.join(mod.REPO_ROOT, SAMPLE)
+        before = _read(src, binary=True)
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(_artifact_task(), d, artifact_mode="input-copy")
+        self.assertEqual(_read(src, binary=True), before)
+
+    def test_nested_artifact_path_is_created(self):
+        mod = load()
+        task = {"id": "N", "input": SAMPLE, "submit": {"kind": "artifact", "files": ["deep/out.svg"]},
+                "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(task, d, artifact_mode="input-copy")
+            self.assertTrue(os.path.isfile(os.path.join(d, "N", "deep", "out.svg")))
+
+    def test_multiple_artifact_files_all_copied(self):
+        mod = load()
+        task = {"id": "M", "input": SAMPLE,
+                "submit": {"kind": "artifact", "files": ["a.bin", "b.bin"]}, "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d, artifact_mode="input-copy")
+            src = _read(os.path.join(mod.REPO_ROOT, SAMPLE), binary=True)
+            self.assertEqual(_read(os.path.join(d, "M", "a.bin"), binary=True), src)
+            self.assertEqual(_read(os.path.join(d, "M", "b.bin"), binary=True), src)
+            self.assertEqual([row["action"] for row in built["files"]], ["copied", "copied"])
+
+    def test_missing_input_skips_copy_without_raising(self):
+        mod = load()
+        task = {"id": "X", "input": "samples/no-such-file-for-discriminate.hwp",
+                "submit": {"kind": "artifact", "files": ["out.bin"]}, "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d, artifact_mode="input-copy")
+            self.assertEqual(built["files"][0]["action"], "skipped")
+            self.assertFalse(os.path.exists(os.path.join(d, "X", "out.bin")))
+            self.assertTrue(any("원본 없음" in e for e in built["errors"]))
+
+    def test_path_traversal_file_is_rejected(self):
+        mod = load()
+        task = {"id": "E", "input": SAMPLE,
+                "submit": {"kind": "artifact", "files": ["../escape.bin", "ok.bin"]},
+                "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d, artifact_mode="input-copy")
+            self.assertFalse(os.path.exists(os.path.join(d, "escape.bin")))
+            actions = {row["rel"]: row["action"] for row in built["files"]}
+            self.assertEqual(actions["../escape.bin"], "rejected")
+            self.assertEqual(actions["ok.bin"], "copied")
+            self.assertTrue(os.path.isfile(os.path.join(d, "E", "ok.bin")))
+
+    def test_unknown_artifact_mode_raises(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(ValueError) as ctx:
+                mod.build_negative(_artifact_task(), d, artifact_mode="truncate")
+            self.assertIn("truncate", str(ctx.exception))
+
+    def test_wrong_answer_mode_on_artifact_skips_files(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(_artifact_task(), d, artifact_mode="wrong-answer")
+            self.assertTrue(os.path.isfile(os.path.join(d, "T", "answer.json")))
+            self.assertFalse(os.path.exists(os.path.join(d, "T", "out.svg")))
+            self.assertEqual(built["files"], [])
+
+
+class BuildNegativeGarbageTests(unittest.TestCase):
+    def test_garbage_bytes_exact_and_not_input(self):
+        mod = load()
+        src = _read(os.path.join(mod.REPO_ROOT, SAMPLE), binary=True)
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(_artifact_task(), d, artifact_mode="garbage")
+            data = _read(os.path.join(d, "T", "out.svg"), binary=True)
+            self.assertEqual(data, mod.GARBAGE_BYTES)
+            self.assertNotEqual(data, src)
+            self.assertGreaterEqual(len(data), 1024)
+            self.assertEqual(built["files"][0]["action"], "garbage")
+
+    def test_garbage_does_not_need_source_file(self):
+        mod = load()
+        task = {"id": "G", "input": "samples/missing-for-garbage.hwp",
+                "submit": {"kind": "artifact", "files": ["out.bin"]}, "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d, artifact_mode="garbage")
+            self.assertEqual(built["files"][0]["action"], "garbage")
+            self.assertEqual(_read(os.path.join(d, "G", "out.bin"), binary=True), mod.GARBAGE_BYTES)
+
+    def test_garbage_on_nested_and_multiple_files(self):
+        mod = load()
+        task = {"id": "G2", "input": SAMPLE,
+                "submit": {"kind": "artifact", "files": ["x/a.bin", "y/b.bin"]}, "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(task, d, artifact_mode="garbage")
+            self.assertEqual(_read(os.path.join(d, "G2", "x", "a.bin"), binary=True), mod.GARBAGE_BYTES)
+            self.assertEqual(_read(os.path.join(d, "G2", "y", "b.bin"), binary=True), mod.GARBAGE_BYTES)
+
+    def test_garbage_rejects_traversal_like_copy(self):
+        mod = load()
+        task = {"id": "G3", "input": SAMPLE,
+                "submit": {"kind": "artifact", "files": ["../nope.bin"]}, "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d, artifact_mode="garbage")
+            self.assertEqual(built["files"][0]["action"], "rejected")
+            self.assertFalse(os.path.exists(os.path.join(d, "nope.bin")))
+
+
+class ScoreClassifyTests(unittest.TestCase):
+    def test_score_is_pass_only_true_pass(self):
+        mod = load()
+        self.assertTrue(mod.score_is_pass({"pass": True}))
+        self.assertFalse(mod.score_is_pass({"pass": False}))
+        self.assertFalse(mod.score_is_pass({}))
+        self.assertFalse(mod.score_is_pass(None))
+        self.assertFalse(mod.score_is_pass("pass"))
+        self.assertTrue(mod.score_is_pass({"pass": 1}))
+
+    def test_score_discriminates_is_negation(self):
+        mod = load()
+        self.assertFalse(mod.score_discriminates({"pass": True}))
+        self.assertTrue(mod.score_discriminates({"pass": False}))
+        self.assertTrue(mod.score_discriminates({}))
+
+    def test_normalize_score_non_dict(self):
+        mod = load()
+        got = mod.normalize_score("x")
+        self.assertFalse(got["pass"])
+        self.assertIn("dict", got["error"])
+        wrapped = mod.normalize_score({"pass": True, "id": "T", "error": "e"})
+        self.assertEqual(wrapped, {"pass": True, "error": "e", "id": "T"})
+
+    def test_score_task_safe_folds_value_error(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise ValueError("broken oracle")
+
+        got = mod.score_task_safe({}, "p", "bin", score_fn=boom)
+        self.assertFalse(got["pass"])
+        self.assertIn("ValueError", got["error"])
+
+    def test_score_task_safe_reraises_keyboardinterrupt(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise KeyboardInterrupt
+
+        with self.assertRaises(KeyboardInterrupt):
+            mod.score_task_safe({}, "p", "bin", score_fn=boom)
+
+    def test_score_task_safe_reraises_systemexit(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise SystemExit(2)
+
+        with self.assertRaises(SystemExit):
+            mod.score_task_safe({}, "p", "bin", score_fn=boom)
+
+    def test_is_fatal_exception(self):
+        mod = load()
+        self.assertTrue(mod.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(mod.is_fatal_exception(SystemExit()))
+        self.assertTrue(mod.is_fatal_exception(MemoryError()))
+        self.assertTrue(mod.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(mod.is_fatal_exception(ValueError("x")))
+        self.assertFalse(mod.is_fatal_exception(OSError("x")))
+
+
+class LabelAndAggregateTests(unittest.TestCase):
+    def test_false_pass_labels(self):
+        mod = load()
+        self.assertEqual(mod.false_pass_label("core-cli", "T01"), "core-cli/T01")
+        self.assertEqual(mod.false_pass_control_label("p", "T", "garbage"), "p/T (garbage)")
+        self.assertEqual(mod.parse_false_pass_label("p1/T"), ("p1", "T"))
+        self.assertIsNone(mod.parse_false_pass_label("nope"))
+        self.assertIsNone(mod.parse_false_pass_label(""))
+
+    def test_aggregate_empty_is_ok(self):
+        mod = load()
+        report = mod.aggregate_rows([], 0)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["taskCount"], 0)
+        self.assertEqual(report["controlCount"], 0)
+        self.assertEqual(report["discriminating"], 0)
+        self.assertEqual(report["kind"], "gymDiscrimination")
+        self.assertEqual(report["schemaVersion"], "1.0")
+
+    def test_aggregate_dedups_task_but_keeps_control_rows(self):
+        mod = load()
+        rows = [
+            {"pack": "p", "task": "T", "control": "input-copy", "discriminates": True},
+            {"pack": "p", "task": "T", "control": "garbage", "discriminates": False},
+        ]
+        report = mod.aggregate_rows(rows, 1)
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["falsePass"], ["p/T"])
+        self.assertEqual(report["falsePassControls"], ["p/T (garbage)"])
+        self.assertEqual(report["discriminating"], 0)
+        self.assertEqual(report["controlCount"], 2)
+
+    def test_unique_keep_order(self):
+        mod = load()
+        self.assertEqual(mod.unique_keep_order(["a", "b", "a", "c", "b"]), ["a", "b", "c"])
+
+
+class ValidateReportTests(unittest.TestCase):
+    def _good(self, mod):
+        return {
+            "kind": "gymDiscrimination",
+            "schemaVersion": "1.0",
+            "ok": True,
+            "taskCount": 1,
+            "controlCount": 1,
+            "discriminating": 1,
+            "falsePass": [],
+            "falsePassControls": [],
+            "results": [{"pack": "p", "task": "T", "control": "wrong-answer", "discriminates": True}],
+            "controlKinds": list(mod.CONTROL_KINDS),
+        }
+
+    def test_good_report_has_no_issues(self):
+        mod = load()
+        self.assertEqual(mod.validate_report(self._good(mod)), [])
+
+    def test_ok_true_with_false_pass_is_issue(self):
+        mod = load()
+        report = self._good(mod)
+        report["ok"] = True
+        report["falsePass"] = ["p/T"]
+        report["discriminating"] = 0
+        issues = mod.validate_report(report)
+        self.assertTrue(any("ok 가 참인데" in i for i in issues))
+
+    def test_ok_false_without_false_pass_is_issue(self):
+        mod = load()
+        report = self._good(mod)
+        report["ok"] = False
+        issues = mod.validate_report(report)
+        self.assertTrue(any("ok 가 거짓인데" in i for i in issues))
+
+    def test_unknown_control_in_results(self):
+        mod = load()
+        report = self._good(mod)
+        report["results"][0]["control"] = "truncate"
+        issues = mod.validate_report(report)
+        self.assertTrue(any("미지 대조" in i for i in issues))
+
+    def test_missing_required_key(self):
+        mod = load()
+        report = self._good(mod)
+        del report["falsePass"]
+        issues = mod.validate_report(report)
+        self.assertTrue(any("필수 키 없음: falsePass" in i for i in issues))
+
+    def test_non_dict_report(self):
+        mod = load()
+        self.assertEqual(mod.validate_report(None), ["보고가 dict 가 아니다"])
+
+    def test_control_count_must_match_results(self):
+        mod = load()
+        report = self._good(mod)
+        report["controlCount"] = 9
+        issues = mod.validate_report(report)
+        self.assertTrue(any("controlCount" in i for i in issues))
+
+    def test_discriminating_must_match_arithmetic(self):
+        mod = load()
+        report = self._good(mod)
+        report["discriminating"] = 99
+        issues = mod.validate_report(report)
+        self.assertTrue(any("discriminating" in i for i in issues))
+
+    def test_bad_false_pass_control_label(self):
+        mod = load()
+        report = self._good(mod)
+        report["ok"] = False
+        report["falsePass"] = ["p/T"]
+        report["falsePassControls"] = ["p/T garbage"]
+        report["discriminating"] = 0
+        issues = mod.validate_report(report)
+        self.assertTrue(any("falsePassControls 라벨" in i for i in issues))
+
+    def test_control_kinds_must_match_catalog(self):
+        mod = load()
+        report = self._good(mod)
+        report["controlKinds"] = ["wrong-answer"]
+        issues = mod.validate_report(report)
+        self.assertTrue(any("controlKinds" in i for i in issues))
+
+
+class DiscriminateDiscoveryTests(unittest.TestCase):
+    def test_empty_gym_is_ok(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            os.makedirs(os.path.join(gym, "packs"))
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["taskCount"], 0)
+            self.assertEqual(report["controlCount"], 0)
+            self.assertEqual(mod.validate_report(report), [])
+
+    def test_missing_packs_dir_is_empty_ok(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            os.makedirs(gym)
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["taskCount"], 0)
+
+    def test_skips_non_json_and_malformed(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, _answer_task())
+            tasks = os.path.join(gym, "packs", "p1", "tasks")
+            _write(os.path.join(tasks, "README.md"), "no")
+            _write(os.path.join(tasks, "broken.json"), "{")
+            _write(os.path.join(tasks, "array.json"), "[1]")
+            _write(os.path.join(tasks, "noid.json"), '{"checks":[]}')
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+            self.assertEqual(report["taskCount"], 1)
+            self.assertGreaterEqual(len(report["loadErrors"]), 3)
+            self.assertTrue(report["ok"])
+
+    def test_pack_without_tasks_dir_is_ignored(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            os.makedirs(os.path.join(gym, "packs", "empty"))
+            _write(os.path.join(gym, "packs", "empty", "pack.json"), "{}")
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+            self.assertEqual(report["taskCount"], 0)
+
+    def test_iter_pack_and_task_names_are_sorted(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            for name in ("zeta", "alpha"):
+                os.makedirs(os.path.join(d, name, "tasks"))
+            self.assertEqual(mod.iter_pack_ids(d), ["alpha", "zeta"])
+            tasks = os.path.join(d, "alpha", "tasks")
+            _write(os.path.join(tasks, "B.json"), "{}")
+            _write(os.path.join(tasks, "A.json"), "{}")
+            _write(os.path.join(tasks, "A.txt"), "x")
+            self.assertEqual(mod.iter_task_names(tasks), ["A.json", "B.json"])
+
+    def test_iter_pack_ids_missing_dir(self):
+        mod = load()
+        self.assertEqual(mod.iter_pack_ids(os.path.join("no", "such", "packs")), [])
+        self.assertEqual(mod.iter_task_names(os.path.join("no", "such", "tasks")), [])
+
+    def test_load_task_errors(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            bad = os.path.join(d, "x.json")
+            _write(bad, "{")
+            task, err = mod.load_task(bad)
+            self.assertIsNone(task)
+            self.assertIn("파싱 실패", err)
+            arr = os.path.join(d, "a.json")
+            _write(arr, "[1]")
+            task, err = mod.load_task(arr)
+            self.assertIsNone(task)
+            self.assertIn("객체가 아니다", err)
+
+    def test_task_id_of(self):
+        mod = load()
+        self.assertEqual(mod.task_id_of({"id": "T01"}), "T01")
+        self.assertIsNone(mod.task_id_of({"id": "  "}))
+        self.assertIsNone(mod.task_id_of({"id": 3}))
+        self.assertIsNone(mod.task_id_of({}))
+
+
+class DiscriminateMatrixTests(unittest.TestCase):
+    def test_answer_task_runs_only_wrong_answer_control(self):
+        mod = load()
+        seen = []
+
+        def score(_task, pack_dir, _bin):
+            seen.append(pack_dir.replace("\\", "/"))
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, _answer_task())
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+        self.assertEqual(report["controlCount"], 1)
+        self.assertEqual(report["results"][0]["control"], "wrong-answer")
+        self.assertEqual(len(seen), 1)
+        self.assertIn("/wrong-answer/", seen[0])
+        self.assertTrue(report["ok"])
+
+    def test_artifact_task_runs_copy_then_garbage(self):
+        mod = load()
+        order = []
+
+        def score(_task, pack_dir, _bin):
+            norm = pack_dir.replace("\\", "/")
+            if "/input-copy/" in norm:
+                order.append("input-copy")
+            if "/garbage/" in norm:
+                order.append("garbage")
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, _artifact_task())
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+        self.assertEqual(order, ["input-copy", "garbage"])
+        self.assertEqual([row["control"] for row in report["results"]],
+                         ["input-copy", "garbage"])
+        self.assertEqual(report["controlCount"], 2)
+
+    def test_copy_only_false_pass(self):
+        mod = load()
+
+        def score(_task, pack_dir, _bin):
+            return {"pass": "input-copy" in pack_dir}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate("bin", _temp_gym(d, _artifact_task()), os.path.join(d, "neg"))
+        self.assertEqual(report["falsePass"], ["p1/T"])
+        self.assertEqual(report["falsePassControls"], ["p1/T (input-copy)"])
+        self.assertFalse(report["ok"])
+
+    def test_both_artifact_controls_false_pass_dedup_task(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate("bin", _temp_gym(d, _artifact_task()), os.path.join(d, "neg"))
+        self.assertEqual(report["falsePass"], ["p1/T"])
+        self.assertEqual(
+            report["falsePassControls"],
+            ["p1/T (input-copy)", "p1/T (garbage)"],
+        )
+        self.assertEqual(report["discriminating"], 0)
+
+    def test_answer_sentinel_false_pass(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate("bin", _temp_gym(d, _answer_task()), os.path.join(d, "neg"))
+        self.assertEqual(report["falsePass"], ["p1/A"])
+        self.assertEqual(report["falsePassControls"], ["p1/A (wrong-answer)"])
+
+    def test_mixed_packs_keep_sorted_order(self):
+        mod = load()
+        seen = []
+
+        def score(task, pack_dir, _bin):
+            seen.append((task["id"], pack_dir.replace("\\", "/")))
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            _temp_gym(d, _answer_task(tid="B"), pack="zeta")
+            _temp_gym(d, _artifact_task(), pack="alpha")
+            gym = os.path.join(d, "gym")
+            report = mod.discriminate("bin", gym, os.path.join(d, "neg"))
+        self.assertEqual(report["taskCount"], 2)
+        self.assertEqual(report["controlCount"], 3)
+        self.assertEqual([row["pack"] for row in report["results"]], ["alpha", "alpha", "zeta"])
+        self.assertEqual(seen[0][0], "T")
+        self.assertEqual(seen[-1][0], "B")
+
+    def test_score_exception_is_not_false_pass(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise RuntimeError("oracle down")
+
+        mod.runner.score_task = boom
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate("bin", _temp_gym(d, _answer_task()), os.path.join(d, "neg"))
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["falsePass"], [])
+        self.assertTrue(report["scoreErrors"])
+        self.assertFalse(report["results"][0]["discriminates"] is True and report["results"][0].get("error") is None)
+        self.assertTrue(report["results"][0]["discriminates"])
+
+    def test_pair_task_uses_answer_control_only(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate("bin", _temp_gym(d, _pair_task()), os.path.join(d, "neg"))
+        self.assertEqual(report["controlCount"], 1)
+        self.assertEqual(report["results"][0]["control"], "wrong-answer")
+
+    def test_injected_score_fn_overrides_runner(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate(
+                "bin",
+                _temp_gym(d, _answer_task()),
+                os.path.join(d, "neg"),
+                score_fn=lambda *a, **k: {"pass": False},
+            )
+        self.assertTrue(report["ok"])
+
+
+class BuildThenScoreIntegrationTests(unittest.TestCase):
+    def test_answer_control_writes_sentinel_before_score(self):
+        mod = load()
+        seen = {}
+
+        def score(_task, pack_dir, _bin):
+            path = os.path.join(pack_dir, "A", "answer.json")
+            seen["payload"] = json.loads(_read(path))
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            mod.discriminate("bin", _temp_gym(d, _answer_task()), os.path.join(d, "neg"))
+        self.assertEqual(seen["payload"]["pages"], mod.WRONG_SENTINEL)
+
+    def test_copy_control_material_is_input_bytes(self):
+        mod = load()
+        src = _read(os.path.join(load().REPO_ROOT, SAMPLE), binary=True)
+        seen = {}
+
+        def score(_task, pack_dir, _bin):
+            if "input-copy" in pack_dir:
+                seen["copy"] = _read(os.path.join(pack_dir, "T", "out.svg"), binary=True)
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            mod.discriminate("bin", _temp_gym(d, _artifact_task()), os.path.join(d, "neg"))
+        self.assertEqual(seen["copy"], src)
+
+    def test_garbage_control_material_is_garbage_bytes(self):
+        mod = load()
+        seen = {}
+
+        def score(_task, pack_dir, _bin):
+            if "garbage" in pack_dir:
+                seen["g"] = _read(os.path.join(pack_dir, "T", "out.svg"), binary=True)
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            mod.discriminate("bin", _temp_gym(d, _artifact_task()), os.path.join(d, "neg"))
+        self.assertEqual(seen["g"], load().GARBAGE_BYTES)
+
+    def test_copy_and_garbage_are_different_bytes(self):
+        mod = load()
+        blobs = {}
+
+        def score(_task, pack_dir, _bin):
+            path = os.path.join(pack_dir, "T", "out.svg")
+            if not os.path.isfile(path):
+                return {"pass": False}
+            norm = pack_dir.replace("\\", "/")
+            if "/input-copy/" in norm:
+                blobs["input-copy"] = _read(path, binary=True)
+            elif "/garbage/" in norm:
+                blobs["garbage"] = _read(path, binary=True)
+            return {"pass": False}
+
+        mod.runner.score_task = score
+        with tempfile.TemporaryDirectory() as d:
+            mod.discriminate("bin", _temp_gym(d, _artifact_task()), os.path.join(d, "neg"))
+        self.assertIn("input-copy", blobs)
+        self.assertIn("garbage", blobs)
+        self.assertNotEqual(blobs["input-copy"], blobs["garbage"])
+
+
+class HumanReportTests(unittest.TestCase):
+    def test_ok_message(self):
+        mod = load()
+        text = mod.format_human_report({"ok": True, "taskCount": 12, "falsePass": []})
+        self.assertIn("12 과제", text)
+        self.assertIn("약한 오라클 0", text)
+        self.assertTrue(text.endswith("\n"))
+
+    def test_false_pass_message_lists_tasks(self):
+        mod = load()
+        text = mod.format_human_report({
+            "ok": False,
+            "falsePass": ["p/T", "q/U"],
+            "falsePassControls": ["p/T (garbage)"],
+        })
+        self.assertIn("2건", text)
+        self.assertIn("  - p/T", text)
+        self.assertIn("  - q/U", text)
+        self.assertIn("p/T (garbage)", text)
+        self.assertIn("일 안 한 제출이 통과한다", text)
+
+    def test_human_lines_match_join(self):
+        mod = load()
+        report = {"ok": True, "taskCount": 1}
+        self.assertEqual(mod.format_human_report(report), "\n".join(mod.human_lines(report)) + "\n")
+
+
+class CliMainTests(unittest.TestCase):
+    def test_parse_args_requires_bin(self):
+        mod = load()
+        with self.assertRaises(SystemExit):
+            mod.parse_args([])
+        ns = mod.parse_args(["--bin", "target/debug/rhwp"])
+        self.assertEqual(ns.bin, "target/debug/rhwp")
+        self.assertFalse(ns.json)
+        ns = mod.parse_args(["--bin", "rhwp", "--json"])
+        self.assertTrue(ns.json)
+
+    def test_parse_args_rejects_unknown_flag(self):
+        mod = load()
+        with self.assertRaises(SystemExit):
+            mod.parse_args(["--bin", "rhwp", "--pack", "x"])
+
+    def test_emit_json_and_human(self):
+        mod = load()
+        report = {
+            "kind": "gymDiscrimination", "schemaVersion": "1.0", "ok": True,
+            "taskCount": 0, "controlCount": 0, "discriminating": 0,
+            "falsePass": [], "falsePassControls": [],
+        }
+        buf = io.StringIO()
+        mod.emit_report(report, True, stream=buf)
+        parsed = json.loads(buf.getvalue())
+        self.assertEqual(parsed["kind"], "gymDiscrimination")
+        buf = io.StringIO()
+        mod.emit_report(report, False, stream=buf)
+        self.assertIn("약한 오라클 0", buf.getvalue())
+
+    def test_main_json_uses_run_audit(self):
+        mod = load()
+        fake = {
+            "kind": "gymDiscrimination", "schemaVersion": "1.0", "ok": True,
+            "taskCount": 2, "controlCount": 3, "discriminating": 2,
+            "falsePass": [], "falsePassControls": [],
+        }
+        buf = io.StringIO()
+        with mock.patch.object(mod.runner, "find_bin", return_value="rhwp"):
+            with mock.patch.object(mod, "run_audit", return_value=fake):
+                with mock.patch.object(sys, "stdout", buf):
+                    code = mod.main(["--bin", "rhwp", "--json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(buf.getvalue())["taskCount"], 2)
+
+    def test_main_returns_one_on_false_pass(self):
+        mod = load()
+        fake = {"ok": False, "taskCount": 1, "falsePass": ["p/T"], "falsePassControls": []}
+        buf = io.StringIO()
+        with mock.patch.object(mod.runner, "find_bin", return_value="rhwp"):
+            with mock.patch.object(mod, "run_audit", return_value=fake):
+                with mock.patch.object(sys, "stdout", buf):
+                    code = mod.main(["--bin", "rhwp"])
+        self.assertEqual(code, 1)
+        self.assertIn("p/T", buf.getvalue())
+
+    def test_run_audit_clears_neg_root(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, _answer_task())
+            neg = os.path.join(d, "neg")
+            stale = os.path.join(neg, "stale.txt")
+            _write(stale, "old")
+            mod.runner.score_task = lambda *a, **k: {"pass": False}
+            report = mod.run_audit("bin", gym_root=gym, neg_root=neg)
+            self.assertTrue(report["ok"])
+            self.assertFalse(os.path.isfile(stale))
+
+    def test_prepare_neg_root_recreates(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "neg")
+            _write(os.path.join(target, "x"), "1")
+            got = mod.prepare_neg_root(target)
+            self.assertEqual(got, target)
+            self.assertTrue(os.path.isdir(target))
+            self.assertEqual(os.listdir(target), [])
+
+
+class ResolveInputAndWriteHelpersTests(unittest.TestCase):
+    def test_resolve_input_path_relative_and_abs(self):
+        mod = load()
+        rel = mod.resolve_input_path({"input": SAMPLE})
+        self.assertTrue(rel.endswith(SAMPLE.replace("/", os.sep)))
+        self.assertTrue(os.path.isfile(rel))
+        self.assertEqual(mod.resolve_input_path({}), "")
+        self.assertEqual(mod.resolve_input_path({"input": 3}), "")
+        with tempfile.TemporaryDirectory() as d:
+            abs_in = os.path.join(d, "in.bin")
+            _write(abs_in, binary=b"abc")
+            self.assertEqual(mod.resolve_input_path({"input": abs_in}), abs_in)
+
+    def test_write_json_and_bytes_create_parents(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            jp = os.path.join(d, "a", "b.json")
+            bp = os.path.join(d, "a", "c.bin")
+            mod.write_json(jp, {"k": "한글"})
+            mod.write_bytes(bp, b"\x00\x01")
+            self.assertEqual(json.loads(_read(jp)), {"k": "한글"})
+            self.assertEqual(_read(bp, binary=True), b"\x00\x01")
+
+    def test_copy_file_overwrites(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "src.bin")
+            dst = os.path.join(d, "sub", "dst.bin")
+            _write(src, binary=b"one")
+            _write(dst, binary=b"two")
+            mod.copy_file(src, dst)
+            self.assertEqual(_read(dst, binary=True), b"one")
+
+    def test_write_answer_file_none_when_no_keys(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(mod.write_answer_file(d, []))
+            self.assertFalse(os.path.exists(os.path.join(d, "answer.json")))
+            path = mod.write_answer_file(d, ["k"])
+            self.assertTrue(os.path.isfile(path))
+
+
+class RunOneControlTests(unittest.TestCase):
+    def test_run_one_control_copy_row(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            row, build_err, score_err = mod.run_one_control(
+                _artifact_task(), "p1", "input-copy", d, "bin",
+                score_fn=lambda *a, **k: {"pass": False},
+            )
+        self.assertTrue(row["discriminates"])
+        self.assertEqual(row["control"], "input-copy")
+        self.assertEqual(build_err, [])
+        self.assertEqual(score_err, [])
+
+    def test_run_one_control_records_score_error(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise RuntimeError("x")
+
+        with tempfile.TemporaryDirectory() as d:
+            row, _b, score_err = mod.run_one_control(
+                _answer_task(), "p1", "wrong-answer", d, "bin", score_fn=boom,
+            )
+        self.assertTrue(score_err)
+        self.assertIn("RuntimeError", score_err[0])
+        self.assertTrue(row["discriminates"])
+
+    def test_make_result_row_extra(self):
+        mod = load()
+        row = mod.make_result_row("p", "T", "garbage", False, {"error": "e"})
+        self.assertEqual(row["pack"], "p")
+        self.assertEqual(row["error"], "e")
+        self.assertFalse(row["discriminates"])
+
+
+class EmptyReportAndDiscoverTests(unittest.TestCase):
+    def test_empty_report_validates(self):
+        mod = load()
+        report = mod.empty_report()
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertEqual(report["controlKinds"], list(mod.CONTROL_KINDS))
+
+    def test_discover_task_entries_reads_temp_gym(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, _answer_task())
+            entries, errs, tools = mod.discover_task_entries(gym)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["pack"], "p1")
+        self.assertEqual(entries[0]["task"]["id"], "A")
+        self.assertEqual(errs, [])
+        self.assertEqual(tools, [])
+
+    def test_control_pack_dir_layout(self):
+        mod = load()
+        path = mod.control_pack_dir("/neg", "garbage", "core-cli")
+        self.assertEqual(os.path.normpath(path), os.path.normpath(os.path.join("/neg", "garbage", "core-cli")))
+
+    def test_packs_dir_of(self):
+        mod = load()
+        self.assertTrue(mod.packs_dir_of("/tmp/gym").replace("\\", "/").endswith("gym/packs"))
+
+
+class ThreeControlKindTableTests(unittest.TestCase):
+    """이슈 #5255 DoD — 음성 대조 종류를 표로 고정."""
+
+    CASES = (
+        ("wrong-answer", "answer", "sentinel", True),
+        ("input-copy", "artifact", "input-bytes", True),
+        ("garbage", "artifact", "garbage-bytes", True),
+    )
+
+    def test_table_ids_are_the_only_kinds(self):
+        mod = load()
+        self.assertEqual(tuple(c[0] for c in self.CASES), mod.CONTROL_KINDS)
+
+    def test_table_must_fail_every_kind(self):
+        for _cid, _submit, _payload, must_fail in self.CASES:
+            self.assertTrue(must_fail)
+
+    def test_answer_kind_payload_is_sentinel_not_copy(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(_answer_task(), d, artifact_mode="wrong-answer")
+            payload = json.loads(_read(os.path.join(d, "A", "answer.json")))
+        self.assertEqual(payload["pages"], mod.WRONG_SENTINEL)
+        self.assertNotEqual(payload["pages"], SAMPLE)
+
+    def test_copy_kind_payload_is_input_not_garbage(self):
+        mod = load()
+        src = _read(os.path.join(mod.REPO_ROOT, SAMPLE), binary=True)
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(_artifact_task(), d, artifact_mode="input-copy")
+            data = _read(os.path.join(d, "T", "out.svg"), binary=True)
+        self.assertEqual(data, src)
+        self.assertNotEqual(data, mod.GARBAGE_BYTES)
+
+    def test_garbage_kind_payload_is_garbage_not_input(self):
+        mod = load()
+        src = _read(os.path.join(mod.REPO_ROOT, SAMPLE), binary=True)
+        with tempfile.TemporaryDirectory() as d:
+            mod.build_negative(_artifact_task(), d, artifact_mode="garbage")
+            data = _read(os.path.join(d, "T", "out.svg"), binary=True)
+        self.assertEqual(data, mod.GARBAGE_BYTES)
+        self.assertNotEqual(data, src)
+
+    def test_live_report_mentions_only_catalog_controls(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            _temp_gym(d, _answer_task(), pack="ans")
+            _temp_gym(d, _artifact_task(), pack="art")
+            report = mod.discriminate("bin", os.path.join(d, "gym"), os.path.join(d, "neg"))
+        kinds = {row["control"] for row in report["results"]}
+        self.assertTrue(kinds.issubset(set(mod.CONTROL_KINDS)))
+        self.assertEqual(kinds, {"wrong-answer", "input-copy", "garbage"})
+        self.assertEqual(mod.validate_report(report), [])
+
+
+class ArgparseSurfaceTests(unittest.TestCase):
+    def test_no_new_cli_flags(self):
+        mod = load()
+        parser = argparse.ArgumentParser()
+        # 재사용하지 않고 parse_args 의 플래그만 본다.
+        ns = mod.parse_args(["--bin", "x"])
+        self.assertEqual(sorted(vars(ns).keys()), ["bin", "json"])
+
+    def test_help_mentions_false_pass(self):
+        mod = load()
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdout", buf):
+            with self.assertRaises(SystemExit):
+                mod.parse_args(["--help"])
+        self.assertIn("false-pass", buf.getvalue().lower())
+
+
+class RepoLayoutSmokeTests(unittest.TestCase):
+    def test_tool_lives_in_gym_tools(self):
+        self.assertTrue(TOOL.is_file())
+        self.assertEqual(TOOL.name, "discriminate.py")
+
+    def test_module_constants_point_at_repo(self):
+        mod = load()
+        self.assertTrue(os.path.isdir(mod.GYM_ROOT))
+        self.assertTrue(os.path.isdir(mod.REPO_ROOT))
+        self.assertTrue(os.path.isfile(os.path.join(mod.REPO_ROOT, SAMPLE)))
+        self.assertTrue(mod.GYM_ROOT.endswith("gym") or mod.GYM_ROOT.replace("\\", "/").endswith("/gym"))
+
+    def test_docs_were_added_next_to_tool_contract(self):
+        root = TOOL.parents[2]
+        self.assertTrue((root / "gym" / "docs" / "discriminate.md").is_file())
+        self.assertTrue((root / "mydocs" / "working" / "gym_discriminate.md").is_file())
+
+
+class CatchableExceptionCatalogTests(unittest.TestCase):
+    def test_catchable_includes_os_and_json(self):
+        mod = load()
+        self.assertIn(OSError, mod.CATCHABLE_EXCEPTIONS)
+        self.assertIn(ValueError, mod.CATCHABLE_EXCEPTIONS)
+        self.assertIn(json.JSONDecodeError, mod.CATCHABLE_EXCEPTIONS)
+        for fatal in mod.FATAL_EXCEPTIONS:
+            self.assertNotIn(fatal, mod.CATCHABLE_EXCEPTIONS)
+
+    def test_score_task_safe_folds_oserror(self):
+        mod = load()
+        got = mod.score_task_safe({}, "p", "bin", score_fn=lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk")))
+        self.assertFalse(got["pass"])
+        self.assertIn("OSError", got["error"])
+
+
+class OptionalReportKeysTests(unittest.TestCase):
+    def test_optional_keys_are_named(self):
+        mod = load()
+        for key in (
+            "results", "loadErrors", "scoreErrors", "buildErrors",
+            "skipped", "toolFailed", "toolErrors", "controlKinds",
+        ):
+            self.assertIn(key, mod.OPTIONAL_REPORT_KEYS)
+
+    def test_aggregate_extras_override(self):
+        mod = load()
+        report = mod.aggregate_rows([], 0, {"toolFailed": True, "toolErrors": ["x"]})
+        self.assertTrue(report["toolFailed"])
+        self.assertEqual(report["toolErrors"], ["x"])
+        self.assertTrue(report["ok"])
+
+
+class ExtraHelperContractTests(unittest.TestCase):
+    def test_expected_control_count(self):
+        mod = load()
+        self.assertEqual(mod.expected_control_count(_artifact_task()), 2)
+        self.assertEqual(mod.expected_control_count(_answer_task()), 1)
+        self.assertEqual(mod.expected_control_count(_pair_task()), 1)
+        self.assertEqual(mod.expected_control_count({}), 1)
+
+    def test_row_is_false_pass(self):
+        mod = load()
+        self.assertTrue(mod.row_is_false_pass({"discriminates": False}))
+        self.assertFalse(mod.row_is_false_pass({"discriminates": True}))
+        self.assertTrue(mod.row_is_false_pass({}))
+        self.assertFalse(mod.row_is_false_pass(None))
+
+    def test_split_false_pass_control_label(self):
+        mod = load()
+        self.assertEqual(
+            mod.split_false_pass_control_label("serialization/SR05 (garbage)"),
+            ("serialization", "SR05", "garbage"),
+        )
+        self.assertIsNone(mod.split_false_pass_control_label("p/T"))
+        self.assertIsNone(mod.split_false_pass_control_label("p/T (truncate)"))
+        self.assertIsNone(mod.split_false_pass_control_label(""))
+
+    def test_format_json_report_roundtrip(self):
+        mod = load()
+        report = mod.empty_report()
+        text = mod.format_json_report(report)
+        self.assertTrue(text.endswith("\n"))
+        parsed = json.loads(text)
+        self.assertEqual(parsed["kind"], "gymDiscrimination")
+        self.assertEqual(mod.validate_report(parsed), [])
+
+    def test_control_spec_returns_copy(self):
+        mod = load()
+        spec = mod.control_spec("garbage")
+        spec["id"] = "mutated"
+        self.assertEqual(mod.control_spec("garbage")["id"], "garbage")
+
+    def test_submit_mapping_non_dict(self):
+        mod = load()
+        self.assertEqual(mod.submit_mapping(None), {})
+        self.assertEqual(mod.submit_mapping({"submit": []}), {})
+        self.assertEqual(mod.submit_mapping({"submit": {"kind": "artifact"}})["kind"], "artifact")
+
+    def test_write_artifact_file_actions(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(mod.REPO_ROOT, SAMPLE)
+            copied = os.path.join(d, "c.bin")
+            garb = os.path.join(d, "g.bin")
+            missing_dst = os.path.join(d, "m.bin")
+            self.assertEqual(mod.write_artifact_file(copied, src, "input-copy"), "copied")
+            self.assertEqual(mod.write_artifact_file(garb, src, "garbage"), "garbage")
+            self.assertEqual(mod.write_artifact_file(missing_dst, os.path.join(d, "no"), "input-copy"), "skipped")
+            self.assertEqual(mod.write_artifact_file(copied, src, "wrong-answer"), "rejected")
+            self.assertEqual(_read(garb, binary=True), mod.GARBAGE_BYTES)
+
+    def test_score_task_safe_folds_type_and_json(self):
+        mod = load()
+        typed = mod.score_task_safe({}, "p", "b", score_fn=lambda *_a, **_k: (_ for _ in ()).throw(TypeError("t")))
+        self.assertIn("TypeError", typed["error"])
+        jerr = mod.score_task_safe(
+            {}, "p", "b",
+            score_fn=lambda *_a, **_k: (_ for _ in ()).throw(json.JSONDecodeError("e", "{", 0)),
+        )
+        self.assertIn("JSONDecodeError", jerr["error"])
+
+    def test_validate_report_bad_false_pass_label(self):
+        mod = load()
+        report = {
+            "kind": "gymDiscrimination", "schemaVersion": "1.0", "ok": False,
+            "taskCount": 1, "controlCount": 0, "discriminating": 0,
+            "falsePass": ["nopath"], "falsePassControls": [],
+        }
+        issues = mod.validate_report(report)
+        self.assertTrue(any("falsePass 라벨" in i for i in issues))
+
+    def test_human_report_without_control_extra(self):
+        mod = load()
+        lines = mod.human_lines({"ok": False, "falsePass": ["p/T"], "falsePassControls": []})
+        self.assertTrue(any("p/T" in line for line in lines))
+        self.assertFalse(any(line.startswith("대조별") for line in lines))
+
+    def test_default_neg_root_joins_submissions(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            path = mod.default_neg_root(d)
+            self.assertEqual(path, os.path.join(d, "submissions", "_negative_control"))
+
+    def test_load_json_reads_utf8(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "t.json")
+            _write(path, '{"k":"한글"}')
+            self.assertEqual(mod.load_json(path), {"k": "한글"})
+
+    def test_build_negative_return_keys(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(_artifact_task(), d)
+        for key in ("taskId", "mode", "answerKeys", "answerPath", "files", "errors", "dir"):
+            self.assertIn(key, built)
+        self.assertEqual(built["mode"], "input-copy")
+        self.assertEqual(built["taskId"], "T")
+
+    def test_artifact_files_not_list_does_not_raise(self):
+        mod = load()
+        task = {"id": "Q", "input": SAMPLE, "submit": {"kind": "artifact", "files": "out.svg"},
+                "checks": []}
+        with tempfile.TemporaryDirectory() as d:
+            built = mod.build_negative(task, d)
+        self.assertEqual(built["files"], [])
+
+    def test_two_answer_tasks_false_pass_keep_order(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            _temp_gym(d, _answer_task(tid="B"), pack="p")
+            _temp_gym(d, _answer_task(tid="A"), pack="p")
+            report = mod.discriminate("bin", os.path.join(d, "gym"), os.path.join(d, "neg"))
+        self.assertEqual(report["falsePass"], ["p/A", "p/B"])
+        self.assertEqual(report["taskCount"], 2)
+
+    def test_windows_rel_normalizes_to_posix(self):
+        mod = load()
+        self.assertEqual(mod.normalize_rel("nested\\out.svg"), "nested/out.svg")
+        self.assertTrue(mod.is_safe_rel("nested\\out.svg"))
+
+    def test_emit_json_uses_format_json_report(self):
+        mod = load()
+        report = mod.empty_report()
+        buf = io.StringIO()
+        mod.emit_report(report, True, stream=buf)
+        self.assertEqual(buf.getvalue(), mod.format_json_report(report))
+
+    def test_garbage_min_size_constant(self):
+        mod = load()
+        self.assertEqual(mod.GARBAGE_MIN_SIZE, 1024)
+        self.assertGreater(len(mod.GARBAGE_MARKER) * mod.GARBAGE_REPEAT, 1024)
+
+    def test_report_keys_do_not_overlap_optional(self):
+        mod = load()
+        self.assertEqual(set(mod.REPORT_KEYS) & set(mod.OPTIONAL_REPORT_KEYS), set())
+
+    def test_fatal_tuple_has_four(self):
+        mod = load()
+        self.assertEqual(len(mod.FATAL_EXCEPTIONS), 4)
+
+    def test_join_sub_nested_dirs_under_root(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            path = mod.join_sub(d, "a/b/c.svg")
+            self.assertTrue(os.path.commonpath([d, path]) == os.path.abspath(d))
+
+    def test_answer_task_control_count_in_live_report(self):
+        mod = load()
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            report = mod.discriminate("bin", _temp_gym(d, _answer_task()), os.path.join(d, "neg"))
+        self.assertEqual(report["controlCount"], mod.expected_control_count(_answer_task()))
+
+    def test_split_label_roundtrip(self):
+        mod = load()
+        label = mod.false_pass_control_label("core-cli", "T01", "wrong-answer")
+        self.assertEqual(mod.split_false_pass_control_label(label),
+                         ("core-cli", "T01", "wrong-answer"))
+
+    def test_docs_mention_three_control_ids(self):
+        root = TOOL.parents[2]
+        text = (root / "gym" / "docs" / "discriminate.md").read_text(encoding="utf-8")
+        for token in ("wrong-answer", "input-copy", "garbage", "WRONG_SENTINEL", "GARBAGE_BYTES"):
+            self.assertIn(token, text)
+
+    def test_working_doc_points_at_issue(self):
+        root = TOOL.parents[2]
+        text = (root / "mydocs" / "working" / "gym_discriminate.md").read_text(encoding="utf-8")
+        self.assertIn("#5255", text)
+        self.assertIn("feat/gym-discriminate-hardening", text)
+        self.assertIn("audit.py", text)
+
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## 변경 요약

gym 판별력 감사(`discriminate.py`)의 음성 대조를 세 종류로 고정하고, 경로 안전·예외 접기·보고 정직 계약을 순수 함수와 시험으로 잠근다. 일 안 한 제출이 만점을 받는 약한 오라클을 과제 등재 전에 색출한다.

- `wrong-answer` — 모든 답 키에 `WRONG_SENTINEL`. `answer_eq` 가 거부해야 한다.
- `input-copy` — artifact 산출 자리에 입력을 무편집 복사. `differs_from_input` 이 거부해야 한다.
- `garbage` — 같은 자리에 1KiB 넘는 synthetic 바이트. 형식·핵심값 검사가 있어야 거부된다.
- 절대/부모/UNC 경로는 제출 폴더 밖에 쓰지 않는다. 입력 부재는 예외로 전수 감사를 죽이지 않는다.
- 채점 예외는 통과로 접지 않는다. 치명 예외(`KeyboardInterrupt` 등)는 다시 올린다.
- CLI 는 `--bin` / `--json` 만. 새 pack·새 rhwp CLI 없음. 열린 PR 파일은 만지지 않았다.

## 관련 이슈

closes #5255

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_discriminate -q` — 150 ran, 0 failed
- [x] `python gym/tools/audit.py` — 18 pack 통과
- [ ] **`cargo fmt --all -- --check` 통과** (이번 변경은 Python/문서만. 사용자 지시에 따라 생략)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [ ] `cargo test` 통과 (해당 없음)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 단위 시험은 바이너리 없이 돈다. 라이브 스윕은 기존과 같이 rhwp 가 필요하다.