### PR TITLE
gym: trajectory 예외 경로·문서·시험 강화

### DIFF
--- a/gym/docs/trajectory.md
+++ b/gym/docs/trajectory.md
@@ -1,0 +1,570 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/trajectory.md
+last_verified: 2026-08-18
+---
+
+# gym 트라젝토리 필요성 감사 규약
+
+이 문서는 `gym/tools/trajectory.py` 의 **마지막 스텝 load-bearing 판정**,
+**수집 전용 tail**, **예외 경로 계약**, **보고 봉투**를 고정한다. 작업
+기록은
+[`mydocs/working/gym_trajectory.md`](../../mydocs/working/gym_trajectory.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_trajectory.py` 가 기계로
+고정한다.
+
+판별력 감사(`discriminate.py`)는 같은 원리를 **종점**으로 돌린다. 이
+문서가 다루는 것은 경로 — 다단계 기준풀이의 마지막 외부 의미 스텝이
+채점에 필요한가. 두 도구의 판정 삼원을 섞지 말라. 이쪽의 결과는
+`load-bearing` / `theater` 이고, 저쪽의 결과는 약한 오라클(종점
+anti-false-pass)이다.
+
+CLI 플래그는 `--bin` 과 `--json` 뿐이다. 새 플래그·새 pack 을 이 도구에
+붙이지 않는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+운동장 채점기는 종점 오라클이다. 다단계 과제가 "N 스텝을 하라"고
+광고해도, 채점이 마지막 스텝의 산출을 실제로 요구하지 않으면 그 과제는
+연극이다. 에이전트는 N-1 스텝만 하고도 만점을 받는다.
+
+2026 에이전트 평가의 합의: 종점만 보면 안 된다. 프론티어는 트라젝토리를
+채점하지만 대부분 LLM-judge 아니면 골든 경로로 한다. 둘 다 취약하다.
+이 감사기는 골든도 judge 도 없이, 기준풀이에서 마지막 외부 의미 스텝만
+빼고 같은 조립기·같은 채점기로 다시 돌린다.
+
+- 부분 트라젝토리가 **통과** → 마지막 스텝이 채점에 무의미. 연극.
+- 부분 트라젝토리가 **실패**(빌드 실패 포함) → 마지막 스텝이
+  load-bearing. 정상.
+
+이것이 판별력 감사(#4808, 종점: "산출이 입력과 다른가")를 **경로**로 민
+것이다. 모든 선언된 스텝이 결과를 바꿔야 한다.
+
+릴리스 게이트는 이 감사를 차등 이전에 돌린다. 연극이 하나라도 있으면
+릴리스를 차단한다.
+
+## 2. 사용
+
+```bash
+python gym/tools/trajectory.py --bin target/debug/rhwp
+python gym/tools/trajectory.py --bin target/debug/rhwp --json
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--bin` | 필수 | rhwp 바이너리. 상대경로는 러너가 절대화한다. |
+| `--json` | 꺼짐 | 사람용 문장 대신 JSON 봉투. |
+
+프로브 명령은 없다. 부분 트라젝토리 조립은 `build_baseline.build_task`,
+채점은 `runner.score_task` 다. 시험은 둘을 목킹해 바이너리 없이 핵심
+경로를 고정한다.
+
+작업 디렉터리는 `gym/submissions/_trajectory_audit` 이다. 시작과 끝에
+지운다. 제출물 폴더를 남기지 않는다.
+
+## 3. 마지막 스텝 load-bearing — 바꾸지 않는 칸
+
+`audit_one` 의 판정 네 칸은 예외 보강 전과 같다.
+
+| 자리 | 결과 | 이유 |
+|---|---|---|
+| `score_task` 가 `{"pass": true}` | 연극 (`loadBearing=false`) | 마지막 스텝을 빼도 통과 |
+| `score_task` 가 `{"pass": false}` | load-bearing | 마지막 스텝이 필수 |
+| `score_task` 가 `pass` 키 없음 | load-bearing | 실패로 접는다 |
+| `build_task` 가 `RuntimeError` | load-bearing | 부분 트라젝토리가 유효 제출을 못 만듦 |
+
+`FileNotFoundError` 만 네 칸 밖이다. 없는 바이너리를 load-bearing 으로
+부르면 전 과제가 정상으로 위장된다. 그 자리는 `missing-bin` 이다.
+
+단스텝 과제는 감사 대상이 아니다. `taskCount` 에 넣지 않는다. 예외도
+아니다.
+
+## 4. 수집 전용 tail
+
+trailing `answer` · `keyring_from` 은 제출을 모으는 내부 단계다. 마지막
+실제 에이전트 동작을 보려면 이 tail 을 남기고, 그 앞의 외부 의미 스텝을
+빼야 한다.
+
+`COLLECTION_STEP_KEYS = {"answer", "keyring_from"}`.
+
+`last_meaningful_step_index(steps)` 는 뒤에서부터 와 수집 키가 **없는**
+매핑을 고른다. 그 인덱스를 `truncate_steps` 가 한 칸만 뺀다. 원본
+기준풀이 dict 는 바꾸지 않는다.
+
+| steps | 고르는 인덱스 | 부분 트라젝토리 |
+|---|---|---|
+| `[run, run]` | 1 | `[run]` |
+| `[run, run, answer]` | 1 | `[run, answer]` |
+| `[run, keyring_from, answer]` | 0 | `[keyring_from, answer]` |
+| `[run, answer, run]` | 2 | `[run, answer]` |
+| `[answer, keyring_from]` | 없음 | 감사하지 않음. `collection-only-tail` |
+| `[answer]` | 없음 | 단스텝. 예외 아님 |
+| `[]` | 없음 | `empty-steps` |
+
+수집 키가 하나라도 있으면 그 스텝은 수집이다. `{"answer":..., "run":...}`
+는 tail 로 남긴다. 키가 없는 빈 매핑 `{}` 은 의미 스텝이다.
+
+비매핑 칸(`None`, 문자열, 목록)은 의미 스텝이 아니다. 건너뛴다.
+
+## 5. 기준풀이 분류
+
+`classify_steps` / `classify_reference` 가 한 열을 다섯 라벨로 접는다.
+
+| 라벨 | 언제 | audit 가 하는 일 |
+|---|---|---|
+| `multi` | 길이 ≥2 이고 의미 스텝이 있다 | 부분 트라젝토리 채점 |
+| `single-step` | 길이 1 (수집 전용이어도) | `skipped` 에만 남김 |
+| `empty-steps` | `steps` 없음 · `null` · `[]` | `exceptions` |
+| `collection-only-tail` | 길이 ≥2 이고 의미 스텝이 없다 | `exceptions` |
+| `malformed-reference` | `steps` 가 목록이 아님 · 기준풀이가 객체 아님 | `exceptions` |
+
+T01 처럼 `answer` 한 줄인 과제를 `collection-only-tail` 로 부르지 않는다.
+단스텝은 트라젝토리가 아니다. 길이 2 이상일 때만 수집 전용 tail 이
+예외다.
+
+`multi_step_tasks` 는 예전처럼 **길이 ≥2** 인 기준풀이만 배출한다.
+수집 전용 tail 도 여기에 들어간다. 분류와 예외 기록은 `audit` /
+`scan_gym` 의 몫이다.
+
+## 6. 예외 경로 — 침묵하지 않는 자리
+
+탐색이 과제를 건너뛰는 자리는 연극 판정이 아니다. 예전에는 아래 네
+자리가 `continue` 로 사라졌다. 그러면 "연극 0"이 탐색을 못 한 자리까지
+덮는다.
+
+| kind | 자리 | 연극으로 부르나 | load-bearing 으로 부르나 |
+|---|---|---|---|
+| `missing-reference` | 과제 JSON 은 있는데 짝 기준풀이 파일이 없다 | 아니오 | 아니오 |
+| `empty-steps` | 기준풀이에 `steps` 가 없거나 빈 목록 | 아니오 | 아니오 |
+| `collection-only-tail` | 2개 이상인데 전부 수집 키 | 아니오 | 아니오 |
+| `missing-bin` | 조립·채점이 `FileNotFoundError` | 아니오 | 아니오 |
+
+부가 예외:
+
+| kind | 자리 |
+|---|---|
+| `malformed-json` | 과제 또는 기준풀이 JSON 파싱 실패 |
+| `malformed-task` | 과제 JSON 이 객체가 아님 |
+| `malformed-reference` | 기준풀이가 객체가 아니거나 `steps` 가 목록이 아님 |
+| `permission` | 읽기 권한 없음 |
+| `os-error` | 그 외 OS 오류 |
+| `decode-error` | 유니코드 오류 |
+| `value-error` / `type-error` | 값·형식 오류 |
+| `unexpected` | 카탈로그 밖. `RuntimeError` 조립 실패는 여기로 가지 않고 load-bearing |
+
+한 과제의 JSON 이 깨져도 다음 과제로 간다. 한 pack 의 예외가 전수
+탐색을 멈추게 하지 않는다.
+
+치명 예외(`KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+`GeneratorExit`)는 삼키지 않는다. 사용자가 끊었는데 연극 0건이라고 쓰면
+거짓말이다.
+
+## 7. 바이너리 부재 — 전 과제를 정상으로 위장하지 않는다
+
+`runner.find_bin` 은 파일이 없어도 경로 문자열을 돌려준다. 조립기가 그
+경로로 자식 프로세스를 띄우면 `FileNotFoundError` 가 난다. 예전 코드는
+모든 예외를 load-bearing 으로 접었다. 없는 바이너리로 26과제를 돌리면
+"26 전부 load-bearing — 연극 0" 이 된다.
+
+지금 계약:
+
+1. `FileNotFoundError` 는 `missing-bin` 이다. `results` 에 넣지 않는다.
+2. 한 과제에서 `missing-bin` 이 나면 나머지 다단계 과제는 조립하지
+   않는다. 같은 거짓말을 반복하지 않는다.
+3. 이미 끝난 탐색 예외(기준풀이 부재 등)는 그대로 남긴다.
+4. `ok` 는 여전히 연극 0건과만 같다. `exit` 는 1, `trusted` 는 거짓,
+   `missingBin` 은 참.
+
+시험이 넘기는 더미 `"bin"` / `"rhwp"` 는 경로 구분자가 없다.
+`bin_looks_present` 는 이 이름을 파일이 없다고 부르지 않는다. 핵심
+경로(분류·연극·load-bearing)는 바이너리 없이 돈다.
+
+`--bin` 이 `dir/rhwp` 또는 `*.exe` 처럼 경로로 보이는데 파일이 없으면
+`main` 이 조립 루프에 들어가기 전에 `missing-bin` 봉투를 낸다.
+
+## 8. 탐색 순서 — 결정적
+
+`scan_gym` 은 pack 이름 사전순, 그다음 과제 파일 이름 사전순이다.
+`os.listdir` 의 원시 순서에 의존하지 않는다.
+
+| 입력 | 결과 |
+|---|---|
+| `packs/b-pack/tasks/B.json`, `packs/a-pack/tasks/A.json` | a-pack/A 가 앞 |
+| `tasks/notes.txt` | 무시. `*.json` 만 |
+| `packs/empty/` (tasks 없음) | pack 자체를 건너뜀 |
+| `packs/` 가 없음 | 레코드 0. 도구 오류 없음 |
+| `os.listdir(packs)` 가 `OSError` | 레코드 0. `toolErrors` 한 줄 |
+
+`tasks/` 는 있는데 `reference/` 가 없으면 그 pack 의 모든 과제가
+`missing-reference` 다.
+
+## 9. JSON 봉투
+
+`kind=gymTrajectoryNecessity`, `schemaVersion=1.0`. 키 집합은 시험이
+`REPORT_KEYS` 로 고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymTrajectoryNecessity` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `ok` | bool | `theater == []` 과만 참 |
+| `taskCount` | int | 감사한 다단계 과제 수 (`results` 길이) |
+| `loadBearing` | int | `results` 중 `loadBearing=true` 건수 |
+| `theater` | list[str] | 연극 문구. 기존 문장 유지 |
+
+부가 키:
+
+| 키 | 의미 |
+|---|---|
+| `results` | `{pack, task, loadBearing, steps, removedStep}` |
+| `exceptions` | `{kind, pack, task, path, head}` |
+| `exceptionCount` | `exceptions` 길이 |
+| `skipped` | 단스텝 `{pack, task, reason, steps}` |
+| `skipCount` | `skipped` 길이 |
+| `trusted` | 예외 0 이고 도구 실패 아님 |
+| `toolFailed` | 도구 자리 오류 또는 `missingBin` |
+| `toolErrors` | 탐색 OS 오류 |
+| `exit` | 0 또는 1 |
+| `missingBin` | 바이너리 부재를 봤는가 |
+| `binPath` | 사용한 경로. 판정을 뒤집지 않는다 |
+
+`validate_report` 가 정직 계약을 검사한다.
+
+- `ok` 는 연극 0건과만 같다.
+- `taskCount` 는 `results` 길이와 같다.
+- `loadBearing` 은 `results` 의 참 집계와 같다.
+- 연극 건수는 `loadBearing=false` 결과 수와 같다.
+- 예외 행의 `kind` 는 카탈로그 안이다.
+- `missingBin` 이면 `exit` 는 1.
+- 연극이 있으면 `exit` 는 1.
+- `trusted` 가 참이면 예외·`missingBin`·`toolFailed` 가 없어야 한다.
+
+`ok` 와 `exit` 를 섞지 말라. 기준풀이 부재는 pack 정합(`audit.py`)의
+본업이다. 이 도구는 그 자리를 예외로 **보여 주고**, 연극 유무는 그대로
+`ok` 에만 담는다. 바이너리 부재는 `ok` 를 뒤집지 않고 `exit=1` 로
+가린다. 게이트가 "연극 0"을 도구 실패와 혼동하지 않게 하려는 것이다.
+
+## 10. 연극 문구
+
+기존 계약 문장을 유지한다. 게이트 로그·시험이 이 문자열을 본다.
+
+```
+{pack}/{task} (마지막 실제 스텝 {removedStep}을 빼도 통과 — {N}→{N-1})
+```
+
+`removedStep` 은 뺀 스텝의 키를 정렬해 `/` 로 이은 것이다. `{"run":...}`
+→ `run`. `{"b":1,"a":2}` → `a/b`.
+
+## 11. 종료 코드와 사람용 본문
+
+| 상황 | ok | exit | 본문 |
+|---|---|---|---|
+| 다단계 N건 전부 load-bearing, 예외 0 | 참 | 0 | `N 다단계 과제 전부 마지막 스텝이 load-bearing — 연극 0` |
+| 연극 K건 | 거짓 | 1 | `연극(무의미한 마지막 스텝) K건` + 각 줄 |
+| 연극 0, missing-bin | 참 | 1 | `연극 0 · 도구 실패` |
+| 연극 0, 기준풀이 부재 등 예외만 | 참 | 0 | 성공 문장 + `예외 경로 N건` |
+| 보고 봉투가 dict 아님 | — | — | `보고 봉투가 아니다` |
+
+예외가 있으면 본문 아래에 `예외 경로 N건:` 과
+`kind: pack/task — head` 를 붙인다.
+
+## 12. 예외 kind 카탈로그 (기계 표)
+
+시험 `EXCEPTION_KINDS` 와 같은 순서의 앞 네 칸이 필수 경로다.
+
+```
+missing-reference
+empty-steps
+collection-only-tail
+missing-bin
+malformed-json
+malformed-task
+malformed-reference
+permission
+os-error
+decode-error
+value-error
+type-error
+unexpected
+```
+
+`exception_kind(exc, context)` 매핑:
+
+| 예외 | context=`audit` | context=`load` |
+|---|---|---|
+| `FileNotFoundError` | `missing-bin` | `missing-bin` |
+| `json.JSONDecodeError` | `value-error` | `malformed-json` |
+| `PermissionError` | `permission` | `permission` |
+| `UnicodeError` | `decode-error` | `decode-error` |
+| `TypeError` / `AttributeError` | `type-error` | `type-error` |
+| `ValueError` / `KeyError` / `IndexError` | `value-error` | `value-error` |
+| `OSError` | `os-error` | `os-error` |
+| `RuntimeError` | `unexpected` (행으로 안 남김, load-bearing) | `unexpected` |
+| `None` | `unexpected` | `unexpected` |
+
+카탈로그 밖 `kind` 를 `exception_row` 에 넣으면 `unexpected` 로 접는다.
+
+## 13. 정직 행렬
+
+`ok` / `exit` / `trusted` 를 한 표로 고정한다. 시험
+`GeneratedHonestyMatrixTests` 가 같은 일곱 줄을 본다.
+
+| 연극 | missing-bin | 그 외 예외 | ok | exit | trusted |
+|---|---|---|---|---|---|
+| 없음 | 없음 | 없음 | 참 | 0 | 참 |
+| 있음 | 없음 | 없음 | 거짓 | 1 | 참 |
+| 없음 | 있음 | 없음 | 참 | 1 | 거짓 |
+| 있음 | 있음 | 없음 | 거짓 | 1 | 거짓 |
+| 없음 | 없음 | 있음 | 참 | 0 | 거짓 |
+| 있음 | 없음 | 있음 | 거짓 | 1 | 거짓 |
+| 없음 | 있음 | 있음 | 참 | 1 | 거짓 |
+
+`trusted=true` 이면서 예외가 있는 봉투는 `validate_report` 가 거절한다.
+
+## 14. 분류 표본
+
+시험 `CLASSIFY_CASES` / `GeneratedClassifyTableTests` 와 같은 표다.
+
+| steps | 라벨 |
+|---|---|
+| `None` | `empty-steps` |
+| `[]` | `empty-steps` |
+| `"nope"` | `malformed-reference` |
+| `{"run":["a"]}` | `malformed-reference` |
+| `[{"run":["a"]}]` | `single-step` |
+| `[{"answer":{}}]` | `single-step` |
+| `[{"keyring_from":"x"}]` | `single-step` |
+| `[{"run":["a"]},{"run":["b"]}]` | `multi` |
+| `[{"run":["a"]},{"answer":{}}]` | `multi` |
+| `[{"run":["a"]},{"keyring_from":"x"}]` | `multi` |
+| `[{"answer":{}},{"keyring_from":"x"}]` | `collection-only-tail` |
+| `[{"answer":{}},{"answer":{}},{"keyring_from":"x"}]` | `collection-only-tail` |
+| `[{},{"answer":{}}]` | `multi` |
+| `[{"run":["a"]},{"run":["b"]},{"run":["c"]}` | `multi` |
+
+## 15. 함수 지도
+
+핵심 경로는 순수 함수다. 시험이 바이너리 없이 각 칸을 고정한다.
+
+| 함수 | 순수 | 역할 |
+|---|---|---|
+| `is_collection_step` | 예 | 수집 키 교집합 |
+| `last_meaningful_step_index` | 예 | 뒤에서 첫 의미 스텝 |
+| `truncate_steps` / `truncate_reference` | 예 | 한 칸만 뺀 사본 |
+| `classify_steps` / `classify_reference` | 예 | 다섯 라벨 |
+| `exception_kind` / `exception_row` | 예 | 예외 접기 |
+| `verdict_from_score` | 예 | pass → 연극 여부 |
+| `verdict_from_build_error` | 예 | fatal / missing-bin / load-bearing |
+| `make_theater_line` | 예 | 기존 문구 |
+| `report_ok` / `report_exit` / `report_trusted` | 예 | 정직 행렬 |
+| `validate_report` | 예 | 봉투 계약 |
+| `scan_task_pair` / `scan_gym` | 파일 | 결정적 탐색 |
+| `audit_one` / `audit` | 조립 주입 | 한 과제 / 전수 |
+| `render_text_report` | 예 | 사람용 본문 |
+| `main` | CLI | `--bin` `--json` 만 |
+
+`safe_load_json` · `safe_listdir` · `safe_isdir` · `safe_isfile` 은
+치명 예외만 다시 올린다. 나머지는 `(값, 예외)` 로 접는다.
+
+## 16. 시험 지도
+
+`scripts/tests/test_gym_trajectory.py` 가 고정하는 묶음.
+
+| 클래스 | 고정하는 것 |
+|---|---|
+| `TrajectoryTests` | 기존 5칸. 연극·load-bearing·빌드실패·단스텝·answer tail |
+| `CollectionStepTests` | 수집 키, 빈 매핑, 비매핑 |
+| `LastMeaningfulStepTests` | 인덱스 선택 |
+| `TruncateTests` | 원본 불변, 범위 밖 |
+| `ClassifyStepsTests` | 분류 표 |
+| `ExceptionKindTests` | kind 매핑, 치명 예외 |
+| `VerdictTests` | pass / 문구 |
+| `ReportContractTests` | 봉투 정직 |
+| `ScanDiscoveryTests` | 네 예외 경로 + JSON 파손 |
+| `MissingBinTests` | 부재를 load-bearing 으로 안 부름 |
+| `MixedGymTests` | 한 gym 에 예외·연극·단스텝 혼재 |
+| `RenderTextTests` | 사람용 본문 |
+| `AuditOneTests` | 한 과제, 치명 예외 전파 |
+| `SafeIoTests` | JSON/디렉터리 접기 |
+| `MainCliTests` | `--json` 부재 경로, 텍스트 성공 |
+| `Generated*Tests` | 분류 표·카탈로그·정직 행렬 |
+| `LoadBearingLogicKeptTests` | 예외 보강 뒤에도 네 칸 유지 |
+
+새 CLI 플래그 시험은 없다. 플래그를 늘리지 않았기 때문이다.
+
+## 17. 이 도구가 하지 않는 것
+
+- 새 pack · 새 과제 · 새 기준풀이를 만들지 않는다.
+- `discriminate.py` · `fuzz_corpus.py` · `release_gate.py` ·
+  `release_diff.py` 를 고치지 않는다.
+- `gym/core/checks.py` · coverage · leaderboard 등 열린 PR 파일을
+  고치지 않는다.
+- automation / core-cli / casual-rides pack JSON 을 고치지 않는다.
+- LLM-judge 나 골든 경로를 도입하지 않는다.
+- 단스텝 과제를 연극으로 부르지 않는다.
+- 기준풀이 부재를 연극으로 부르지 않는다.
+- 없는 바이너리를 load-bearing 으로 부르지 않는다.
+
+## 18. 기존 게이트와의 관계
+
+`gym-release-gate.yml` 은 이 스크립트를 차등 이전에 독립 스텝으로
+부른다. 종료 코드가 0 이 아니면 게이트가 막는다.
+
+- 연극 → `exit=1`. 게이트가 막는다. 의도된 차단.
+- missing-bin → `exit=1`. 게이트가 막는다. "연극 0" 위장 방지.
+- 기준풀이 부재만 → `exit=0`. pack 정합은 `audit.py` 가 이미 막는다.
+  이 도구는 예외 목록만 남긴다.
+
+워크플로 YAML 과 `release_gate.py` 는 이 가지에서 고치지 않는다.
+문구·종료 코드 계약이 그 배선을 그대로 받친다.
+
+## 19. 작업 디렉터리와 결정성
+
+- 조립 뿌리는 `work_root/<pack_id>` 다. `score_task` 에 넘기는
+  `sub_root` 도 그 경로다. 기존과 같다.
+- 레코드 순서는 pack · 파일 이름 사전순이다.
+- 연극 문구·예외 행·JSON 키는 호스트 시각·난수를 넣지 않는다.
+- `head` 는 `ERROR_HEAD_LIMIT`(160) 에서 자른다. 경로 전체가 판정을
+  바꾸지 않는다.
+
+## 20. 관련 문서
+
+- 작업 기록: `mydocs/working/gym_trajectory.md`
+- 운동장 개요: `gym/README.md` (트라젝토리 절)
+- pack 정합 감사: `gym/tools/audit.py` (기준풀이 짝·ID 고유)
+- 종점 판별력: `gym/tools/discriminate.py` (이 가지에서 수정하지 않음)
+- 이슈: [#5254](https://github.com/edwardkim/rhwp/issues/5254)
+- 원 도입: [#4810](https://github.com/edwardkim/rhwp/issues/4810) /
+  PR #4811
+
+## 21. 표본 시나리오
+
+아래 일곱 줄은 단위 시험이 각각 한 번씩 조립한다. 라이브 바이너리는
+쓰지 않는다.
+
+### 21.1 연극
+
+기준풀이 `[run, run]`. 목 채점이 `pass=true`. 보고는
+`ok=false`, theater 한 줄, `exit=1`. 예외 0.
+
+### 21.2 load-bearing 채점 실패
+
+같은 기준풀이. 목 채점이 `pass=false`. `ok=true`, `loadBearing=1`,
+`exit=0`.
+
+### 21.3 load-bearing 조립 실패
+
+`build_task` 가 `RuntimeError`. 채점 함수는 호출되지 않아도 된다.
+`ok=true`, 예외 0, `loadBearing=1`.
+
+### 21.4 단스텝 무시
+
+`[run]` 한 칸. 채점이 통과해도 `taskCount=0`. 예외 0. T01 의
+`[answer]` 도 같다.
+
+### 21.5 answer tail 유지
+
+`[run, answer]`. 조립기에 넘어가는 steps 는 `[answer]` 뿐이다.
+`removedStep=run`.
+
+### 21.6 네 예외
+
+한 gym 에 기준풀이 없는 과제, `steps=[]`, `[answer, keyring_from]`,
+단스텝, 다단계 연극을 같이 심는다. 예외 kind 세 개와 skip 1, theater
+1 이 동시에 난다. 단스텝은 예외 목록에 없다.
+
+### 21.7 missing-bin
+
+`build_task` 가 `FileNotFoundError`. `loadBearing=0`, `missingBin=true`,
+`ok=true`, `exit=1`. 다음 다단계 과제는 조립하지 않는다.
+
+## 22. 기존 5칸 회귀
+
+원 시험 클래스 `TrajectoryTests` 의 다섯 메서드 이름과 주장은 유지한다.
+
+| 메서드 | 주장 |
+|---|---|
+| `test_flags_theater_when_truncated_passes` | theater 문구 정확 일치 |
+| `test_load_bearing_when_truncated_fails` | ok, theater=[], loadBearing=1 |
+| `test_build_error_means_load_bearing` | RuntimeError → ok, theater=[] |
+| `test_single_step_tasks_are_ignored` | taskCount=0, ok |
+| `test_removes_last_meaningful_step_but_keeps_answer_collection` | 조립 steps == `[answer]` |
+
+이 다섯이 깨지면 예외 보강이 load-bearing 로직을 건드린 것이다. 예외
+시험을 고치는 것으로 이 다섯을 느슨하게 만들지 말라.
+
+## 23. 구현 파일 위치
+
+```
+gym/tools/trajectory.py          # 도구
+scripts/tests/test_gym_trajectory.py
+gym/docs/trajectory.md           # 이 규약
+mydocs/working/gym_trajectory.md # 작업 기록
+```
+
+다른 도구·pack·워크플로 YAML 은 이 규약의 범위 밖이다.
+
+## 24. 예외 행 필드
+
+`exception_row` 가 내는 최소 키.
+
+| 키 | 형 | 비고 |
+|---|---|---|
+| `kind` | str | 카탈로그 안. 밖이면 `unexpected` |
+| `pack` | str | 없으면 빈 문자열 |
+| `task` | str | 파일 줄기 또는 과제 id |
+| `path` | str | 과제/기준풀이 경로. 판정에 안 씀 |
+| `head` | str | 메시지 머리. 160자 |
+
+`exception_from_exc` 는 여기에 `error`(예외 클래스 이름)를 더한다.
+`None` 예외는 `error=NoneType`, `kind=unexpected`.
+
+## 25. skip 행 필드
+
+| 키 | 의미 |
+|---|---|
+| `pack` | pack id |
+| `task` | 과제 id |
+| `reason` | 지금은 `single-step` 만 |
+| `steps` | 기준풀이 스텝 수 (보통 1) |
+
+skip 은 예외가 아니다. `trusted` 를 뒤집지 않는다. 단스텝 과제가 많은
+운동장에서 `trusted` 가 항상 거짓이 되는 일을 막는다.
+
+## 26. 결과 행 필드
+
+기존 키를 유지한다.
+
+| 키 | 의미 |
+|---|---|
+| `pack` | pack id |
+| `task` | 과제 id |
+| `loadBearing` | bool |
+| `steps` | 원본 스텝 수 (부분 트라젝토리 길이가 아님) |
+| `removedStep` | 뺀 칸의 키 라벨 |
+
+`steps` 가 부분 길이가 아님에 주의한다. `[run, run, answer]` 에서 run
+을 빼도 `steps=3` 이다. 문구의 `3→2` 와 맞춘다.
+
+## 27. 치명 예외 목록
+
+`FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)`.
+
+이 네 가지는 `safe_*` · `audit_one` · `resolve_bin_safe` 가 다시 올린다.
+`audit` 는 `audit_one` 이 돌려준 `fatal` 을 그대로 raise 한다. 시험
+`test_fatal_is_propagated_from_audit` 가 `KeyboardInterrupt` 를 본다.
+
+`BaseException` 전부를 잡으면 종료와 인터럽트가 "연극 0"으로 접힌다.
+
+## 28. 관련 이슈 좌표
+
+| 이슈 | 역할 |
+|---|---|
+| #4808 | 종점 판별력. 이 도구의 형제 |
+| #4810 / PR #4811 | 트라젝토리 감사 원 도입 |
+| #5254 | 이 문서의 예외·문서·시험 보강 |
+
+#5254 는 새 pack 을 요구하지 않는다. 연극이 다시 보이면 해당 pack
+가지에서 기준풀이·체크를 고친다. 이 도구 가지에서 pack 을 고치면
+열린 pack PR 과 충돌한다.

--- a/gym/tools/trajectory.py
+++ b/gym/tools/trajectory.py
@@ -23,6 +23,25 @@ trailing `answer`·`keyring_from`은 제출을 모으는 내부 단계이므로 
 이것이 #4808 판별력 감사(종점: "산출이 입력과 다른가")를 **경로**로 민 것이다:
 종점의 무편집 거부 → 경로의 무의미-스텝 거부. 모든 선언된 스텝이 결과를 바꿔야 한다.
 
+## 예외 경로 (침묵하지 않는다)
+
+탐색이 과제를 건너뛰는 자리는 연극 판정이 아니다. 예전에는 기준풀이 부재·빈
+스텝·수집 전용 tail·바이너리 부재가 `continue` 로 사라졌다. 그러면 "연극 0"이
+탐색을 못 한 자리까지 덮는다. 이제 그 네 자리는 예외 목록으로 남긴다.
+
+- `missing-reference` — 과제 JSON 은 있는데 짝 기준풀이가 없다.
+- `empty-steps` — 기준풀이에 `steps` 가 없거나 빈 목록이다.
+- `collection-only-tail` — 스텝이 2개 이상인데 전부 `answer`/`keyring_from` 이다.
+  마지막 외부 의미 스텝을 고를 수 없다.
+- `missing-bin` — 조립·채점이 `FileNotFoundError` 로 죽었다. 이걸 load-bearing
+  으로 부르면 없는 바이너리가 전 과제를 정상으로 위장한다.
+
+단스텝 과제(T01 같은 `answer` 한 줄)는 예외가 아니다. 트라젝토리가 아니므로
+건너뛴다. 마지막 스텝 load-bearing 판정 자체는 바꾸지 않는다.
+
+보고 봉투: `kind=gymTrajectoryNecessity`, `schemaVersion=1.0`. `ok` 는 연극
+0건과만 같다. 도구 실패는 `exit=1`·`trusted=false` 로 가린다.
+
 ## 사용
 
     python gym/tools/trajectory.py --bin target/debug/rhwp        # 전 다단계 과제 감사
@@ -53,72 +72,907 @@ _spec.loader.exec_module(baseline)
 
 COLLECTION_STEP_KEYS = frozenset({"answer", "keyring_from"})
 
+REPORT_KIND = "gymTrajectoryNecessity"
+SCHEMA_VERSION = "1.0"
+
+#: 탐색·조립에서 접는 예외 kind. 시험과 문서가 같은 표를 본다.
+EXCEPTION_KINDS = (
+    "missing-reference",
+    "empty-steps",
+    "collection-only-tail",
+    "missing-bin",
+    "malformed-json",
+    "malformed-task",
+    "malformed-reference",
+    "permission",
+    "os-error",
+    "decode-error",
+    "value-error",
+    "type-error",
+    "unexpected",
+)
+
+#: 기준풀이 스텝 열의 분류. 단스텝은 예외가 아니다.
+STEP_LABELS = (
+    "multi",
+    "single-step",
+    "empty-steps",
+    "collection-only-tail",
+    "malformed-reference",
+)
+
+#: JSON 보고 고정 키. 분류가 성공한 봉투의 최소 집합.
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "taskCount",
+    "loadBearing",
+    "theater",
+)
+
+#: 부가 키. 있어도 연극·load-bearing 집계를 뒤집지 않는다.
+OPTIONAL_REPORT_KEYS = (
+    "exceptions",
+    "exceptionCount",
+    "skipped",
+    "skipCount",
+    "results",
+    "trusted",
+    "toolFailed",
+    "toolErrors",
+    "exit",
+    "missingBin",
+    "binPath",
+)
+
+#: 종료 코드. 0=연극 없음·도구 신뢰, 1=연극 또는 도구 실패.
+EXIT_OK = 0
+EXIT_FAILED = 1
+
+#: 오류 메시지 머리 길이.
+HEAD_LIMIT = 80
+ERROR_HEAD_LIMIT = 160
+
+#: 삼키면 안 되는 예외 — 도구를 죽이는 것이 정직하다.
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+#: 탐색·조립에서 잡는 예외. BaseException 전부가 아니다.
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    TimeoutError,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    json.JSONDecodeError,
+    RuntimeError,
+)
+
+#: 예외 → kind. FileNotFound 는 항상 missing-bin (조립·채점 자리).
+EXCEPTION_KIND_BY_TYPE = {
+    FileNotFoundError: "missing-bin",
+    PermissionError: "permission",
+    TimeoutError: "timeout",
+    UnicodeError: "decode-error",
+    UnicodeDecodeError: "decode-error",
+    UnicodeEncodeError: "decode-error",
+    json.JSONDecodeError: "malformed-json",
+    ValueError: "value-error",
+    TypeError: "type-error",
+    KeyError: "value-error",
+    IndexError: "value-error",
+    AttributeError: "type-error",
+    OSError: "os-error",
+    RuntimeError: "unexpected",
+}
+
+
+def is_step_mapping(step) -> bool:
+    """한 스텝이 키를 가진 매핑인가. 순수."""
+    return isinstance(step, dict)
+
+
+def step_keys(step) -> list[str]:
+    """스텝 키를 정렬해 돌려준다. 매핑이 아니면 빈 목록."""
+    if not is_step_mapping(step):
+        return []
+    return sorted(str(key) for key in step.keys())
+
+
+def step_kind_label(step) -> str:
+    """리포트용 스텝 종류. 예전 계약: 정렬 키를 `/` 로 잇는다."""
+    keys = step_keys(step)
+    return "/".join(keys) if keys else "empty"
+
+
+def is_collection_step(step) -> bool:
+    """수집 전용 스텝인가. answer/keyring_from 키가 하나라도 있으면 수집."""
+    if not is_step_mapping(step):
+        return False
+    return bool(COLLECTION_STEP_KEYS.intersection(step))
+
+
+def has_meaningful_key(step) -> bool:
+    """외부 의미 스텝인가. 수집 키가 없는 매핑."""
+    if not is_step_mapping(step):
+        return False
+    return not is_collection_step(step)
+
 
 def last_meaningful_step_index(steps: list[dict]) -> int | None:
     """수집 전용 tail을 건너뛴 마지막 외부 의미 기준 풀이 step 위치."""
+    if not isinstance(steps, list):
+        return None
     for index in range(len(steps) - 1, -1, -1):
+        if not is_step_mapping(steps[index]):
+            continue
         if not COLLECTION_STEP_KEYS.intersection(steps[index]):
             return index
     return None
 
 
-def multi_step_tasks(gym_root: str):
-    """(pack_id, task, reference) 중 reference 가 ≥2 스텝인 것만."""
+def truncate_steps(steps: list, removed_index: int) -> list:
+    """removed_index 한 칸만 뺀 부분 트라젝토리. 원본을 바꾸지 않는다."""
+    if not isinstance(steps, list):
+        return []
+    if not isinstance(removed_index, int):
+        return list(steps)
+    if removed_index < 0 or removed_index >= len(steps):
+        return list(steps)
+    return list(steps[:removed_index]) + list(steps[removed_index + 1:])
+
+
+def truncate_reference(reference: dict, removed_index: int) -> dict:
+    """기준풀이 사본에서 한 스텝만 뺀다. 원본 dict 를 바꾸지 않는다."""
+    if not isinstance(reference, dict):
+        return {"steps": []}
+    truncated = dict(reference)
+    truncated["steps"] = truncate_steps(reference.get("steps") or [], removed_index)
+    return truncated
+
+
+def normalize_steps(raw) -> list | None:
+    """steps 필드를 목록으로. 없거나 목록이 아니면 None (빈 목록과 구분)."""
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        return raw
+    return None
+
+
+def steps_of_reference(reference) -> list | None:
+    """기준풀이에서 steps 를 꺼낸다. 사전이 아니면 None."""
+    if not isinstance(reference, dict):
+        return None
+    return normalize_steps(reference.get("steps"))
+
+
+def classify_steps(steps) -> str:
+    """스텝 열 분류. 순수.
+
+    - empty-steps: None 또는 빈 목록
+    - malformed-reference: 목록이 아님
+    - collection-only-tail: 2개 이상이고 의미 스텝이 없음
+    - single-step: 길이 1 (수집 전용이어도 단스텝 — T01)
+    - multi: 길이 ≥2 이고 의미 스텝이 있음
+    """
+    if steps is None:
+        return "empty-steps"
+    if not isinstance(steps, list):
+        return "malformed-reference"
+    if len(steps) == 0:
+        return "empty-steps"
+    meaningful = last_meaningful_step_index(steps)
+    if meaningful is None:
+        if len(steps) >= 2:
+            return "collection-only-tail"
+        return "single-step"
+    if len(steps) < 2:
+        return "single-step"
+    return "multi"
+
+
+def classify_reference(reference) -> str:
+    """기준풀이 JSON 분류. 순수.
+
+    steps 키가 없거나 null 이면 empty-steps. 목록이 아닌 값이면
+    malformed-reference. 빈 목록과 객체 steps 를 같은 칸에 두지 않는다.
+    """
+    if not isinstance(reference, dict):
+        return "malformed-reference"
+    if "steps" not in reference:
+        return "empty-steps"
+    raw = reference.get("steps")
+    if raw is None:
+        return "empty-steps"
+    if not isinstance(raw, list):
+        return "malformed-reference"
+    return classify_steps(raw)
+
+
+def is_audit_candidate(label: str) -> bool:
+    """부분 트라젝토리 감사 대상인가. multi 만."""
+    return label == "multi"
+
+
+def is_skip_label(label: str) -> bool:
+    """단스텝 건너뛰기인가. 예외가 아니다."""
+    return label == "single-step"
+
+
+def is_exception_label(label: str) -> bool:
+    """탐색 예외 라벨인가."""
+    return label in {
+        "missing-reference",
+        "empty-steps",
+        "collection-only-tail",
+        "malformed-json",
+        "malformed-task",
+        "malformed-reference",
+        "missing-bin",
+    }
+
+
+def is_fatal_exception(exc) -> bool:
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def is_known_exception_kind(kind) -> bool:
+    return kind in EXCEPTION_KINDS
+
+
+def exception_kind(exc, context="audit") -> str:
+    """예외를 kind 로 접는다. 순수.
+
+    context:
+      - audit: 조립·채점. FileNotFound → missing-bin.
+      - load: JSON 읽기. JSONDecodeError → malformed-json.
+      - scan: 디렉터리 탐색. OSError → os-error.
+    """
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, FileNotFoundError):
+        return "missing-bin"
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, json.JSONDecodeError):
+        if context == "load":
+            return "malformed-json"
+        return "value-error"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, AttributeError):
+        return "type-error"
+    if isinstance(exc, TypeError):
+        return "type-error"
+    if isinstance(exc, (KeyError, IndexError)):
+        return "value-error"
+    if isinstance(exc, ValueError):
+        return "value-error"
+    if isinstance(exc, OSError):
+        return "os-error"
+    if isinstance(exc, RuntimeError):
+        # 조립기가 부분 트라젝토리를 못 만든 자리는 load-bearing 이다.
+        # kind 는 예외 목록이 아니라 그 판정으로 간다.
+        return "unexpected"
+    return "unexpected"
+
+
+def is_missing_bin_exception(exc) -> bool:
+    """조립·채점 실패를 load-bearing 으로 부르면 안 되는 자리인가."""
+    return isinstance(exc, FileNotFoundError)
+
+
+def truncate_head(text, limit=HEAD_LIMIT) -> str:
+    """출력 머리. None/비문자는 빈 문자열. 한도는 0 이하면 빈 값."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return ""
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        n = HEAD_LIMIT
+    if n <= 0:
+        return ""
+    return text[:n]
+
+
+def exception_row(kind, pack="", task="", path="", head="", extra=None) -> dict:
+    """예외 한 줄. 연극 집계를 뒤집지 않는다."""
+    if not is_known_exception_kind(kind):
+        kind = "unexpected"
+    row = {
+        "kind": kind,
+        "pack": pack or "",
+        "task": task or "",
+        "path": path or "",
+        "head": truncate_head(head, ERROR_HEAD_LIMIT),
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def exception_from_exc(exc, context="audit", pack="", task="", path="") -> dict:
+    """예외 객체를 예외 행으로."""
+    kind = exception_kind(exc, context=context)
+    return exception_row(
+        kind,
+        pack=pack,
+        task=task,
+        path=path,
+        head=str(exc) if exc is not None else "",
+        extra={"error": type(exc).__name__ if exc is not None else "NoneType"},
+    )
+
+
+def verdict_from_score(result) -> bool:
+    """채점 봉투에서 load-bearing 인가.
+
+    pass=True → 부분 트라젝토리 통과 → 연극 → load-bearing False.
+    pass 가 없거나 거짓 → 실패 → load-bearing True.
+    """
+    if not isinstance(result, dict):
+        return True
+    return not result.get("pass")
+
+
+def verdict_from_build_error(exc) -> str:
+    """조립·채점 예외의 판정 자리.
+
+    - missing-bin: 바이너리 부재. load-bearing 으로 부르지 않는다.
+    - load-bearing: 부분 트라젝토리가 유효 제출을 못 만듦 (정상).
+    - fatal: 다시 올려야 한다.
+    """
+    if is_fatal_exception(exc):
+        return "fatal"
+    if is_missing_bin_exception(exc):
+        return "missing-bin"
+    return "load-bearing"
+
+
+def make_theater_line(pack_id: str, task_id: str, removed_kind: str, step_count: int) -> str:
+    """연극 한 줄. 기존 계약 문구를 유지한다."""
+    return (
+        f"{pack_id}/{task_id} (마지막 실제 스텝 {removed_kind}을 빼도 통과 — "
+        f"{step_count}→{step_count - 1})"
+    )
+
+
+def format_exception_line(row: dict) -> str:
+    """사람용 예외 한 줄."""
+    if not isinstance(row, dict):
+        return "예외: (형식 오류)"
+    kind = row.get("kind") or "unexpected"
+    pack = row.get("pack") or ""
+    task = row.get("task") or ""
+    loc = f"{pack}/{task}".strip("/") if (pack or task) else (row.get("path") or "")
+    head = row.get("head") or ""
+    if loc and head:
+        return f"{kind}: {loc} — {head}"
+    if loc:
+        return f"{kind}: {loc}"
+    if head:
+        return f"{kind}: {head}"
+    return f"{kind}"
+
+
+def make_result_row(pack_id: str, task_id: str, load_bearing: bool,
+                    step_count: int, removed_kind: str) -> dict:
+    """감사 결과 한 줄. 기존 키를 유지한다."""
+    return {
+        "pack": pack_id,
+        "task": task_id,
+        "loadBearing": bool(load_bearing),
+        "steps": int(step_count),
+        "removedStep": removed_kind,
+    }
+
+
+def make_skip_row(pack_id: str, task_id: str, reason: str, step_count=0) -> dict:
+    return {
+        "pack": pack_id,
+        "task": task_id,
+        "reason": reason,
+        "steps": int(step_count) if isinstance(step_count, int) else 0,
+    }
+
+
+def task_label(pack_id: str, task_id: str) -> str:
+    return f"{pack_id}/{task_id}"
+
+
+def report_ok(theater, missing_bin=False) -> bool:
+    """ok 는 연극 0건과만 같다. missing-bin 은 뒤집지 않는다."""
+    del missing_bin
+    return len(theater) == 0
+
+
+def report_exit(theater, missing_bin=False, tool_failed=False) -> int:
+    """연극 또는 도구 실패면 1, 아니면 0."""
+    if theater or missing_bin or tool_failed:
+        return EXIT_FAILED
+    return EXIT_OK
+
+
+def report_trusted(exceptions, tool_failed=False, missing_bin=False) -> bool:
+    """탐색·조립을 끝까지 믿어도 되는가.
+
+    예외가 하나라도 있거나 도구가 실패하면 거짓. 단스텝 건너뛰기는 예외가 아니다.
+    """
+    if tool_failed or missing_bin:
+        return False
+    if exceptions:
+        return False
+    return True
+
+
+def empty_report() -> dict:
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": True,
+        "taskCount": 0,
+        "loadBearing": 0,
+        "theater": [],
+        "exceptions": [],
+        "exceptionCount": 0,
+        "skipped": [],
+        "skipCount": 0,
+        "results": [],
+        "trusted": True,
+        "toolFailed": False,
+        "toolErrors": [],
+        "exit": EXIT_OK,
+        "missingBin": False,
+        "binPath": "",
+    }
+
+
+def attach_report_counts(report: dict) -> dict:
+    """집계 키를 결과·예외 목록에서 다시 센다. 원본을 바꾼다."""
+    results = report.get("results") or []
+    theater = report.get("theater") or []
+    exceptions = report.get("exceptions") or []
+    skipped = report.get("skipped") or []
+    tool_errors = report.get("toolErrors") or []
+    missing_bin = bool(report.get("missingBin"))
+    if not missing_bin:
+        missing_bin = any(
+            isinstance(row, dict) and row.get("kind") == "missing-bin"
+            for row in list(exceptions) + list(tool_errors)
+        )
+    tool_failed = bool(report.get("toolFailed")) or bool(tool_errors) or missing_bin
+    report["taskCount"] = len(results)
+    report["loadBearing"] = sum(1 for row in results if isinstance(row, dict) and row.get("loadBearing"))
+    report["exceptionCount"] = len(exceptions)
+    report["skipCount"] = len(skipped)
+    report["ok"] = report_ok(theater, missing_bin=missing_bin)
+    report["missingBin"] = missing_bin
+    report["toolFailed"] = tool_failed
+    report["trusted"] = report_trusted(exceptions, tool_failed=tool_failed, missing_bin=missing_bin)
+    report["exit"] = report_exit(theater, missing_bin=missing_bin, tool_failed=tool_failed)
+    return report
+
+
+def validate_report(report) -> list[str]:
+    """보고 봉투 정직 계약. 문제 목록. 순수."""
+    issues = []
+    if not isinstance(report, dict):
+        return ["report 가 dict 가 아니다"]
+    for key in REPORT_KEYS:
+        if key not in report:
+            issues.append(f"필수 키 없음: {key}")
+    if report.get("kind") != REPORT_KIND:
+        issues.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append(f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
+    theater = report.get("theater")
+    if not isinstance(theater, list):
+        issues.append("theater 가 list 가 아니다")
+        theater = []
+    results = report.get("results") if isinstance(report.get("results"), list) else None
+    if results is not None:
+        counted = sum(1 for row in results if isinstance(row, dict) and row.get("loadBearing"))
+        if report.get("taskCount") != len(results):
+            issues.append("taskCount 가 results 길이와 다르다")
+        if report.get("loadBearing") != counted:
+            issues.append("loadBearing 집계가 results 와 다르다")
+        theater_from_results = sum(
+            1 for row in results if isinstance(row, dict) and not row.get("loadBearing")
+        )
+        if theater_from_results != len(theater):
+            issues.append("theater 건수가 loadBearing=false 결과와 다르다")
+    expected_ok = len(theater) == 0
+    if report.get("ok") is not expected_ok:
+        issues.append("ok 는 연극 0건과만 같아야 한다")
+    exceptions = report.get("exceptions")
+    if exceptions is not None:
+        if not isinstance(exceptions, list):
+            issues.append("exceptions 가 list 가 아니다")
+        else:
+            if report.get("exceptionCount") not in (None, len(exceptions)):
+                issues.append("exceptionCount 가 exceptions 길이와 다르다")
+            for row in exceptions:
+                if not isinstance(row, dict) or not is_known_exception_kind(row.get("kind")):
+                    issues.append("예외 행의 kind 가 카탈로그 밖이다")
+                    break
+    if report.get("missingBin") and report.get("exit") != EXIT_FAILED:
+        issues.append("missing-bin 인데 exit 가 1 이 아니다")
+    if theater and report.get("exit") not in (None, EXIT_FAILED):
+        issues.append("연극이 있는데 exit 가 1 이 아니다")
+    if report.get("trusted") and (exceptions or report.get("missingBin") or report.get("toolFailed")):
+        issues.append("예외/도구실패가 있는데 trusted 가 참이다")
+    return issues
+
+
+def safe_listdir(path):
+    """os.listdir. 실패면 (None, 예외)."""
+    try:
+        return sorted(os.listdir(path)), None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, exc
+    except Exception as exc:
+        return None, exc
+
+
+def safe_isdir(path) -> bool:
+    try:
+        return os.path.isdir(path)
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception:
+        return False
+
+
+def safe_isfile(path) -> bool:
+    try:
+        return os.path.isfile(path)
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception:
+        return False
+
+
+def safe_load_json(path):
+    """JSON 파일. 성공 (obj, None), 실패 (None, 예외)."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh), None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, exc
+    except Exception as exc:
+        return None, exc
+
+
+def bin_looks_present(bin_path) -> bool:
+    """경로가 실제 파일로 보이는가. 빈 값·상대 명령 이름은 거짓이 아니다.
+
+    시험은 조립기를 목킹하고 `bin` 같은 더미를 넘긴다. 그 자리를 여기서
+    missing-bin 으로 부르면 핵심 경로가 바이너리를 요구한다. 존재 검사는
+    경로에 구분자가 있거나 확장자가 있을 때만 한다.
+    """
+    if not bin_path or not isinstance(bin_path, str):
+        return False
+    if os.path.sep in bin_path or "/" in bin_path or bin_path.lower().endswith(".exe"):
+        return safe_isfile(bin_path)
+    return True
+
+
+def resolve_bin_safe(bin_arg):
+    """runner.find_bin 을 예외 없이 접는다. (path, error)."""
+    try:
+        path = runner.find_bin(bin_arg)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, exc
+    except Exception as exc:
+        return None, exc
+    if path and not bin_looks_present(path) and (os.path.sep in str(path) or "/" in str(path)):
+        return path, FileNotFoundError(path)
+    return path, None
+
+
+def iter_pack_ids(gym_root: str):
+    """pack 디렉터리 이름. 결정적 정렬. 실패면 빈 목록과 예외."""
     packs_dir = os.path.join(gym_root, "packs")
-    for pack_id in sorted(os.listdir(packs_dir)):
+    if not safe_isdir(packs_dir):
+        return [], None
+    names, err = safe_listdir(packs_dir)
+    if err is not None:
+        return [], err
+    out = []
+    for name in names:
+        if safe_isdir(os.path.join(packs_dir, name)):
+            out.append(name)
+    return out, None
+
+
+def iter_json_names(directory: str):
+    """디렉터리의 *.json 이름. 없으면 빈 목록."""
+    if not safe_isdir(directory):
+        return []
+    names, err = safe_listdir(directory)
+    if err is not None:
+        return []
+    return [name for name in names if isinstance(name, str) and name.endswith(".json")]
+
+
+def task_id_of(task, fallback: str) -> str:
+    """과제 id. 없거나 비문자면 파일 줄기."""
+    if isinstance(task, dict):
+        tid = task.get("id")
+        if isinstance(tid, str) and tid:
+            return tid
+    if fallback.endswith(".json"):
+        return fallback[:-5]
+    return fallback or ""
+
+
+def scan_task_pair(pack_id: str, name: str, task_path: str, ref_path: str) -> dict:
+    """과제·기준풀이 한 쌍을 분류한 레코드."""
+    rec = {
+        "pack": pack_id,
+        "name": name,
+        "taskPath": task_path,
+        "refPath": ref_path,
+        "label": "missing-reference",
+        "task": None,
+        "reference": None,
+        "stepCount": 0,
+        "exception": None,
+    }
+    task, task_err = safe_load_json(task_path)
+    if task_err is not None:
+        rec["label"] = "malformed-task" if not isinstance(task_err, json.JSONDecodeError) else "malformed-json"
+        rec["exception"] = exception_from_exc(
+            task_err, context="load", pack=pack_id, task=name, path=task_path
+        )
+        rec["exception"]["kind"] = rec["label"] if rec["label"] in EXCEPTION_KINDS else rec["exception"]["kind"]
+        return rec
+    if not isinstance(task, dict):
+        rec["label"] = "malformed-task"
+        rec["exception"] = exception_row("malformed-task", pack=pack_id, task=name, path=task_path,
+                                         head="과제 JSON 이 객체가 아니다")
+        return rec
+    rec["task"] = task
+    tid = task_id_of(task, name)
+    if not safe_isfile(ref_path):
+        rec["label"] = "missing-reference"
+        rec["exception"] = exception_row(
+            "missing-reference",
+            pack=pack_id,
+            task=tid,
+            path=ref_path,
+            head="짝 기준풀이가 없다",
+        )
+        return rec
+    reference, ref_err = safe_load_json(ref_path)
+    if ref_err is not None:
+        rec["label"] = "malformed-json" if isinstance(ref_err, json.JSONDecodeError) else "malformed-reference"
+        rec["exception"] = exception_from_exc(
+            ref_err, context="load", pack=pack_id, task=tid, path=ref_path
+        )
+        rec["exception"]["kind"] = rec["label"]
+        return rec
+    if not isinstance(reference, dict):
+        rec["label"] = "malformed-reference"
+        rec["exception"] = exception_row(
+            "malformed-reference", pack=pack_id, task=tid, path=ref_path,
+            head="기준풀이 JSON 이 객체가 아니다",
+        )
+        return rec
+    rec["reference"] = reference
+    steps = steps_of_reference(reference)
+    rec["stepCount"] = len(steps) if isinstance(steps, list) else 0
+    rec["label"] = classify_reference(reference)
+    if rec["label"] == "empty-steps":
+        rec["exception"] = exception_row(
+            "empty-steps", pack=pack_id, task=tid, path=ref_path,
+            head="기준풀이 steps 가 비어 있다",
+        )
+    elif rec["label"] == "collection-only-tail":
+        rec["exception"] = exception_row(
+            "collection-only-tail", pack=pack_id, task=tid, path=ref_path,
+            head="의미 스텝 없이 수집 전용 tail 뿐이다",
+        )
+    elif rec["label"] == "malformed-reference":
+        rec["exception"] = exception_row(
+            "malformed-reference", pack=pack_id, task=tid, path=ref_path,
+            head="기준풀이 steps 가 목록이 아니다",
+        )
+    return rec
+
+
+def scan_gym(gym_root: str) -> tuple[list[dict], list[dict]]:
+    """gym/packs 를 결정적으로 훑는다. (레코드, 도구오류)."""
+    records: list[dict] = []
+    tool_errors: list[dict] = []
+    pack_ids, err = iter_pack_ids(gym_root)
+    if err is not None:
+        tool_errors.append(exception_from_exc(err, context="scan", path=os.path.join(gym_root, "packs")))
+        return records, tool_errors
+    packs_dir = os.path.join(gym_root, "packs")
+    for pack_id in pack_ids:
         tasks_dir = os.path.join(packs_dir, pack_id, "tasks")
         ref_dir = os.path.join(packs_dir, pack_id, "reference")
-        if not os.path.isdir(tasks_dir) or not os.path.isdir(ref_dir):
+        if not safe_isdir(tasks_dir):
             continue
-        for name in sorted(os.listdir(tasks_dir)):
-            if not name.endswith(".json"):
-                continue
-            ref_path = os.path.join(ref_dir, name)
-            if not os.path.isfile(ref_path):
-                continue
-            with open(os.path.join(tasks_dir, name), encoding="utf-8") as fh:
-                task = json.load(fh)
-            with open(ref_path, encoding="utf-8") as fh:
-                reference = json.load(fh)
-            if len(reference.get("steps", [])) >= 2:
-                yield pack_id, task, reference
+        for name in iter_json_names(tasks_dir):
+            rec = scan_task_pair(
+                pack_id,
+                name,
+                os.path.join(tasks_dir, name),
+                os.path.join(ref_dir, name),
+            )
+            records.append(rec)
+    return records, tool_errors
+
+
+def multi_step_tasks(gym_root: str):
+    """(pack_id, task, reference) 중 reference 가 ≥2 스텝인 것만."""
+    records, _tool = scan_gym(gym_root)
+    for rec in records:
+        reference = rec.get("reference")
+        task = rec.get("task")
+        if not isinstance(reference, dict) or not isinstance(task, dict):
+            continue
+        steps = reference.get("steps", [])
+        if isinstance(steps, list) and len(steps) >= 2:
+            yield rec["pack"], task, reference
+
+
+def audit_one(bin_path: str, pack_id: str, task: dict, reference: dict, work_root: str) -> dict:
+    """다단계 과제 하나. 마지막 의미 스텝을 빼고 채점한다.
+
+    반환:
+      - result: 기존 결과 행
+      - theater: 연극 문구 또는 None
+      - exception: missing-bin 행 또는 None
+      - fatal: 다시 올릴 예외 또는 None
+    """
+    out = {"result": None, "theater": None, "exception": None, "fatal": None}
+    steps = reference.get("steps") if isinstance(reference, dict) else None
+    if not isinstance(steps, list):
+        tid = task_id_of(task, "")
+        out["exception"] = exception_row(
+            "malformed-reference", pack=pack_id, task=tid,
+            head="기준풀이 steps 가 목록이 아니다",
+        )
+        return out
+    removed_index = last_meaningful_step_index(steps)
+    if removed_index is None:
+        tid = task_id_of(task, "")
+        if len(steps) >= 2:
+            out["exception"] = exception_row(
+                "collection-only-tail", pack=pack_id, task=tid,
+                head="의미 스텝 없이 수집 전용 tail 뿐이다",
+            )
+        return out
+    truncated = truncate_reference(reference, removed_index)
+    tid = task_id_of(task, "")
+    load_bearing = True
+    try:
+        baseline.build_task(bin_path, pack_id, task, truncated, work_root)
+        result = runner.score_task(task, os.path.join(work_root, pack_id), bin_path)
+        load_bearing = verdict_from_score(result)
+    except FATAL_EXCEPTIONS as exc:
+        out["fatal"] = exc
+        return out
+    except Exception as exc:
+        place = verdict_from_build_error(exc)
+        if place == "missing-bin":
+            out["exception"] = exception_from_exc(
+                exc, context="audit", pack=pack_id, task=tid,
+            )
+            out["exception"]["kind"] = "missing-bin"
+            return out
+        load_bearing = True
+    removed_kind = step_kind_label(steps[removed_index])
+    row = make_result_row(pack_id, tid, load_bearing, len(steps), removed_kind)
+    out["result"] = row
+    if not load_bearing:
+        out["theater"] = make_theater_line(pack_id, tid, removed_kind, len(steps))
+    return out
 
 
 def audit(bin_path: str, gym_root: str, work_root: str) -> dict:
     results = []
     theater = []
-    for pack_id, task, reference in multi_step_tasks(gym_root):
-        steps = reference["steps"]
-        removed_index = last_meaningful_step_index(steps)
-        if removed_index is None:
+    exceptions = []
+    skipped = []
+    records, tool_errors = scan_gym(gym_root)
+    missing_bin = False
+    for rec in records:
+        label = rec.get("label")
+        pack_id = rec.get("pack") or ""
+        task = rec.get("task")
+        tid = task_id_of(task, rec.get("name") or "")
+        if label == "single-step":
+            skipped.append(make_skip_row(pack_id, tid, "single-step", rec.get("stepCount") or 0))
             continue
-        truncated = dict(reference)
-        # answer/keyring 같은 trailing 수집 단계는 유지하고 마지막 실제 동작만 뺀다.
-        truncated["steps"] = steps[:removed_index] + steps[removed_index + 1:]
-        sub_root = os.path.join(work_root, pack_id)
-        load_bearing = True
-        try:
-            baseline.build_task(bin_path, pack_id, task, truncated, work_root)
-            result = runner.score_task(task, sub_root, bin_path)
-            # 부분 트라젝토리가 통과 = 마지막 스텝이 무의미(연극).
-            load_bearing = not result.get("pass")
-        except Exception:
-            # 부분 트라젝토리가 유효 제출을 못 만듦 = 마지막 스텝이 필수(정상).
-            load_bearing = True
-        removed_kind = "/".join(sorted(steps[removed_index]))
-        results.append({"pack": pack_id, "task": task["id"], "loadBearing": load_bearing,
-                        "steps": len(steps), "removedStep": removed_kind})
-        if not load_bearing:
-            theater.append(f"{pack_id}/{task['id']} (마지막 실제 스텝 {removed_kind}을 빼도 통과 — "
-                           f"{len(steps)}→{len(steps) - 1})")
-    return {
-        "kind": "gymTrajectoryNecessity",
-        "schemaVersion": "1.0",
-        "ok": len(theater) == 0,
-        "taskCount": len(results),
-        "loadBearing": sum(1 for r in results if r["loadBearing"]),
-        "theater": theater,
-    }
+        if is_exception_label(label):
+            row = rec.get("exception") or exception_row(label, pack=pack_id, task=tid)
+            exceptions.append(row)
+            continue
+        if label != "multi":
+            continue
+        if missing_bin:
+            # 없는 바이너리로 나머지를 load-bearing 으로 채우지 않는다.
+            continue
+        one = audit_one(bin_path, pack_id, task, rec["reference"], work_root)
+        if one.get("fatal") is not None:
+            raise one["fatal"]
+        if one.get("exception") is not None:
+            exceptions.append(one["exception"])
+            if one["exception"].get("kind") == "missing-bin":
+                missing_bin = True
+            continue
+        if one.get("result") is not None:
+            results.append(one["result"])
+        if one.get("theater"):
+            theater.append(one["theater"])
+    report = empty_report()
+    report["results"] = results
+    report["theater"] = theater
+    report["exceptions"] = exceptions
+    report["skipped"] = skipped
+    report["toolErrors"] = [
+        exception_from_exc(e, context="scan") if not isinstance(e, dict) else e
+        for e in tool_errors
+    ]
+    report["missingBin"] = missing_bin
+    report["binPath"] = bin_path if isinstance(bin_path, str) else ""
+    return attach_report_counts(report)
+
+
+def render_text_report(report: dict) -> str:
+    """사람용 본문. JSON 과 같은 집계를 쓴다."""
+    if not isinstance(report, dict):
+        return "gym 트라젝토리 필요성 감사: 보고 봉투가 아니다\n"
+    lines = []
+    if report.get("ok") and not report.get("missingBin") and not report.get("toolFailed"):
+        lines.append(
+            f"gym 트라젝토리 필요성 감사: {report.get('taskCount', 0)} 다단계 과제 전부 "
+            "마지막 스텝이 load-bearing — 연극 0"
+        )
+    elif not report.get("ok"):
+        theater = report.get("theater") or []
+        lines.append(
+            f"gym 트라젝토리 필요성 감사: 연극(무의미한 마지막 스텝) {len(theater)}건 — "
+            "부분 트라젝토리가 통과한다:"
+        )
+        for item in theater:
+            lines.append(f"  - {item}")
+    else:
+        lines.append(
+            f"gym 트라젝토리 필요성 감사: 연극 0 · 도구 실패 "
+            f"(예외 {report.get('exceptionCount', 0)}건, trusted="
+            f"{str(bool(report.get('trusted'))).lower()})"
+        )
+    exceptions = report.get("exceptions") or []
+    if exceptions:
+        lines.append(f"예외 경로 {len(exceptions)}건:")
+        for row in exceptions:
+            lines.append(f"  - {format_exception_line(row)}")
+    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
@@ -126,22 +980,26 @@ def main() -> int:
     ap.add_argument("--bin", required=True)
     ap.add_argument("--json", action="store_true")
     a = ap.parse_args()
-    bin_path = runner.find_bin(a.bin)
+    bin_path, bin_err = resolve_bin_safe(a.bin)
     work_root = os.path.join(GYM_ROOT, "submissions", "_trajectory_audit")
     shutil.rmtree(work_root, ignore_errors=True)
-    report = audit(bin_path, GYM_ROOT, work_root)
+    if bin_err is not None and isinstance(bin_err, FileNotFoundError):
+        report = empty_report()
+        report["exceptions"] = [exception_from_exc(bin_err, context="audit", path=str(a.bin))]
+        report["missingBin"] = True
+        report["binPath"] = str(a.bin)
+        attach_report_counts(report)
+    else:
+        resolved = bin_path or runner.find_bin(a.bin)
+        report = audit(resolved, GYM_ROOT, work_root)
+        report["binPath"] = resolved if isinstance(resolved, str) else ""
+        attach_report_counts(report)
     shutil.rmtree(work_root, ignore_errors=True)
     if a.json:
         sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
-    elif report["ok"]:
-        print(f"gym 트라젝토리 필요성 감사: {report['taskCount']} 다단계 과제 전부 "
-              "마지막 스텝이 load-bearing — 연극 0")
     else:
-        print(f"gym 트라젝토리 필요성 감사: 연극(무의미한 마지막 스텝) {len(report['theater'])}건 — "
-              "부분 트라젝토리가 통과한다:")
-        for t in report["theater"]:
-            print(f"  - {t}")
-    return 0 if report["ok"] else 1
+        sys.stdout.write(render_text_report(report))
+    return int(report.get("exit", EXIT_OK if report.get("ok") else EXIT_FAILED))
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_trajectory.md
+++ b/mydocs/working/gym_trajectory.md
@@ -1,0 +1,453 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_trajectory.md
+last_verified: 2026-08-18
+---
+
+# gym 트라젝토리 필요성 감사 — 예외 경로·문서·시험 보강
+
+Issue: #5254
+Branch: `feat/gym-trajectory-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/trajectory.py` 의 마지막 스텝 load-bearing 판정은 그대로 두고,
+탐색이 삼키던 네 자리(기준풀이 부재·빈 steps·수집 전용 tail·바이너리
+부재)를 예외 목록으로 남겼다. 없는 바이너리를 load-bearing 으로 부르던
+위장을 끊었다. CLI 플래그와 pack JSON 은 건드리지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_trajectory`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 도입(#4810 / PR #4811)은 다단계 과제에서 마지막 외부 의미 스텝을
+빼고 기준풀이를 재조립해 채점하는 감사기를 넣었다. 부분 트라젝토리가
+통과하면 연극, 실패(빌드 실패 포함)하면 load-bearing. 당시 26과제 중
+2건(AU06, XC03)이 연극이었고 pack 쪽을 고쳐 0으로 만들었다. 릴리스
+게이트가 차등 이전에 이 스크립트를 부른다.
+
+그 상태의 빈틈:
+
+1. 과제 JSON 은 있는데 짝 기준풀이가 없으면 `continue`. 탐색을 못 한
+   자리가 "연극 0"에 묻힌다.
+2. 기준풀이 `steps` 가 없거나 `[]` 이면 길이 < 2 로 단스텝과 같이
+   사라진다. 빈 기준풀이는 단스텝이 아니다.
+3. 스텝이 2개 이상인데 전부 `answer`/`keyring_from` 이면
+   `last_meaningful_step_index` 가 `None` 이고 다시 `continue`. 의미
+   스텝을 고를 수 없는데 침묵한다.
+4. `build_task`/`score_task` 의 `FileNotFoundError` 를 포함한 모든
+   예외를 load-bearing 으로 접는다. 바이너리가 없으면 전 과제가
+   정상이다.
+5. 과제·기준풀이 JSON 파싱이 한 파일에서 죽으면 전수 감사가 멈춘다.
+6. 카탈로그가 코드 주석에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+
+판정 네 칸(통과=연극, 실패=필수, 빌드 `RuntimeError`=필수, 단스텝
+무시)을 다섯 칸으로 늘리면 기존 게이트 계약이 깨진다. 그래서
+load-bearing 로직은 유지하고, 네 자리는 예외 목록으로만 연다.
+`FileNotFoundError` 만 네 칸 밖으로 뺀다 — 그건 부분 트라젝토리의
+실패가 아니라 도구 실패다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/trajectory.py`
+
+- `classify_steps` / `classify_reference` — 다섯 라벨. 단스텝
+  `answer`(T01)는 `single-step` 이지 `collection-only-tail` 이 아니다.
+- `scan_gym` / `scan_task_pair` — pack·파일 이름 사전순. JSON 파손·
+  기준풀이 부재를 한 과제에서 접고 다음으로 간다.
+- `exception_kind` / `exception_row` — 예외를 kind 로 접는다. 조립
+  자리의 `FileNotFoundError` 는 `missing-bin`.
+- `FATAL_EXCEPTIONS` — `KeyboardInterrupt` · `SystemExit` ·
+  `MemoryError` · `GeneratorExit` 는 삼키지 않는다.
+- `verdict_from_score` / `verdict_from_build_error` — 채점 봉투와 조립
+  예외를 판정 자리로. `RuntimeError` 는 여전히 load-bearing.
+- `audit_one` — 한 과제의 부분 트라젝토리. 수집 tail 유지, 마지막 의미
+  스텝만 제거. 원본 문구 유지.
+- `audit` — 탐색 예외를 `exceptions` 에 쌓고, `missing-bin` 이 나면
+  나머지 다단계 조립을 멈춘다.
+- `attach_report_counts` / `validate_report` — `ok` 는 연극 0건.
+  `exit` 는 연극 또는 missing-bin 이면 1. `trusted` 는 예외 0.
+- `render_text_report` — 사람용 본문. 예외 목록을 숨기지 않는다.
+- `main` — 플래그는 `--bin` `--json` 만. 경로형 `--bin` 이 없으면
+  조립 루프 전에 missing-bin 봉투.
+
+`multi_step_tasks` 는 길이 ≥2 기준풀이를 그대로 배출한다. 수집 전용
+tail 도 여기 들어간다. 분류는 `audit` 가 한다.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_trajectory.py`
+
+- 기존 5칸(`TrajectoryTests`) 유지. 문구·answer tail·단스텝 무시.
+- `CollectionStepTests` / `LastMeaningfulStepTests` / `TruncateTests`.
+- `ClassifyStepsTests` + `GeneratedClassifyTableTests`.
+- `ScanDiscoveryTests` — missing-reference, empty-steps,
+  collection-only-tail, 단스텝 answer 는 skip, JSON 파손.
+- `MissingBinTests` — FileNotFound 를 load-bearing 으로 안 부름.
+  이후 과제를 정상으로 채우지 않음. 더미 `"bin"` 은 사전 검사하지 않음.
+- `MixedGymTests` — 한 gym 에 연극·예외·단스텝 혼재.
+- `ReportContractTests` / `GeneratedHonestyMatrixTests`.
+- `LoadBearingLogicKeptTests` — 보강 뒤에도 네 칸이 같다.
+- `MainCliTests` — `--json` 부재 경로 exit 1.
+
+조립·채점은 목킹한다. 핵심 경로는 바이너리 없이 결정적이다.
+
+### 3.3 문서
+
+- `gym/docs/trajectory.md` — load-bearing 네 칸, 수집 tail, 분류 표,
+  예외 경로, JSON 봉투, 정직 행렬, 시험 지도.
+- `mydocs/working/gym_trajectory.md` — 이 기록.
+
+pack JSON · `discriminate.py` · `fuzz_corpus.py` · automation /
+core-cli / casual-rides · 열린 PR(5210–5248) 파일은 건드리지 않았다.
+
+## 4. 정직 조항 — 바꾸지 않은 것
+
+다음 계약은 원 도입과 같다. 시험이 다시 고정한다.
+
+```
+score pass=true                         → 연극
+score pass=false / pass 없음            → load-bearing
+build RuntimeError                      → load-bearing
+단스텝 (길이 1)                         → 감사 대상 아님
+[run, answer] 에서 빼는 칸              → run. answer 는 남김
+연극 문구                               → "{pack}/{id} (마지막 실제 스텝 {kind}을 빼도 통과 — N→N-1)"
+ok                                      → theater == []
+schemaVersion                           → 1.0
+kind                                    → gymTrajectoryNecessity
+CLI                                     → --bin, --json
+```
+
+`COLLECTION_STEP_KEYS` 는 `answer` 와 `keyring_from` 만이다. 새 수집
+키를 추측해 넣지 않았다.
+
+`other-doc` 같은 차등 라벨을 여기 넣지 않았다. 형식축 도구의 심각도를
+경로 감사에 섞지 않는다.
+
+## 5. 예외 카탈로그
+
+| context | 예외 | kind | 집계 |
+|---|---|---|---|
+| scan | 기준풀이 파일 없음 | missing-reference | exceptions |
+| scan | steps 없음/빈 목록 | empty-steps | exceptions |
+| scan | ≥2 전부 수집 | collection-only-tail | exceptions |
+| audit | FileNotFoundError | missing-bin | exceptions, missingBin |
+| load | JSONDecodeError | malformed-json | exceptions |
+| load | 과제 비객체 | malformed-task | exceptions |
+| load | 기준풀이 비객체·steps 비목록 | malformed-reference | exceptions |
+| audit | RuntimeError | (kind 행 없음) | load-bearing |
+| * | KeyboardInterrupt 등 | (삼키지 않음) | 프로세스 종료 |
+
+해시 자리·IR 자리 같은 차등 도구의 접는 법은 여기 없다. 이 도구는
+관측 kind 를 만들지 않는다. 부분 트라젝토리의 채점 봉투는 `pass` 한
+칸만 본다.
+
+## 6. 보고 상태 표
+
+| 상황 | theater | loadBearing | exceptions | ok | exit | trusted |
+|---|---|---|---|---|---|---|
+| 다단계 N 전부 필수 | 0 | N | 0 | 참 | 0 | 참 |
+| 연극 K | K | N-K | 0 | 거짓 | 1 | 참 |
+| 단스텝만 | 0 | 0 | 0 | 참 | 0 | 참 |
+| 기준풀이 부재만 | 0 | 0 | ≥1 | 참 | 0 | 거짓 |
+| 빈 steps 만 | 0 | 0 | ≥1 | 참 | 0 | 거짓 |
+| 수집 전용 tail 만 | 0 | 0 | ≥1 | 참 | 0 | 거짓 |
+| missing-bin | 0 | 0 | ≥1 | 참 | 1 | 거짓 |
+| 연극 + 예외 | ≥1 | * | ≥1 | 거짓 | 1 | 거짓 |
+| 연극 + missing-bin | ≥1 | * | ≥1 | 거짓 | 1 | 거짓 |
+
+마지막 두 행을 첫째 행으로 접으면 게이트가 속는다. `ok` 는 연극 유무만
+말하고, `exit` 1 이 도구 실패를 가린다. 기준풀이 부재를 `exit` 1 로
+올리지 않은 이유: `audit.py` 가 이미 그 짝을 막는다. 같은 자리를 두
+게이트가 다른 이유로 막으면 로그가 섞인다.
+
+## 7. 왜 단스텝 answer 는 예외가 아닌가
+
+T01 기준풀이는 `[{"answer": {pages: info.pageCount}}]` 한 줄이다.
+`last_meaningful_step_index` 는 `None` 이다. 길이 1 이므로 예전에도
+감사 대상이 아니었다.
+
+이 과제를 `collection-only-tail` 로 부르면 운동장의 단답 과제가 전부
+예외가 된다. `trusted` 가 항상 거짓이 되고, 본문이 예외로 가득하다.
+수집 전용 tail 예외는 **길이 ≥2** 일 때만 성립한다. 그때는 "다단계로
+광고했는데 의미 스텝이 없다"는 말이 된다.
+
+시험 `test_single_answer_task_is_skip_not_collection_only` 가 이 경계를
+고정한다.
+
+## 8. 왜 missing-bin 만 조립을 멈추는가
+
+기준풀이 부재는 과제마다 다르다. 한 과제의 짝이 없다고 다음 과제의
+연극을 못 보는 것은 과하다. JSON 파손도 같다.
+
+바이너리 부재는 과제마다 다르지 않다. 첫 `FileNotFoundError` 뒤에
+나머지 25개를 조립하면 같은 예외가 25번 나고, 실수로 그중 하나를
+load-bearing 으로 접으면 위장이 돌아온다. 그래서 플래그를 세우고
+나머지 다단계 조립을 건너뛴다. 이미 쌓인 탐색 예외는 지워지지 않는다.
+
+시험 `test_missing_bin_does_not_mark_later_tasks_load_bearing` 이
+호출 횟수 1 과 `loadBearing==0` 을 같이 본다.
+
+## 9. 왜 더미 `"bin"` 은 파일이 없어도 되는가
+
+단위 시험은 `audit("bin", gym, work)` 를 부른다. 조립기를 목킹하므로
+실제 실행 파일은 없다. `main` 진입 전에 `os.path.isfile("bin")` 을
+강제하면 핵심 경로가 바이너리를 요구한다. 이슈 DoD 는 "바이너리 없이
+핵심 경로"다.
+
+`bin_looks_present` 는 경로 구분자 또는 `.exe` 가 있을 때만 존재
+검사를 한다. `"bin"` · `"rhwp"` 는 통과한다. `target/debug/rhwp` 는
+파일이 없으면 실패다.
+
+## 10. 검증 명령
+
+저장소 루트에서:
+
+```bash
+python -m unittest scripts.tests.test_gym_trajectory
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+packs 를 고치지 않았으므로 audit 는 기존처럼 전 pack 통과여야 한다.
+`cargo fmt --all` 은 이번 변경에 해당 없다.
+
+## 11. 의도적으로 하지 않은 것
+
+- pack · reference · profile 편집 없음.
+- `discriminate.py` / `fuzz_corpus.py` / `release_gate.py` /
+  `release_diff.py` / `coverage.py` / `leaderboard.py` 편집 없음.
+- `gym/core/checks.py` 편집 없음 (PR #5210).
+- automation / core-cli / casual-rides 편집 없음.
+- 새 CLI 플래그 없음. `--cli-timeout` 같은 확장은 다음 이슈.
+- `schemaVersion` 을 1.1 로 올리지 않음. 필수 키 여섯 개가 그대로다.
+- 단스텝을 연극으로 승격하지 않음.
+- `ok` 를 예외와 묶지 않음.
+
+## 12. 남은 빈틈
+
+1. 라이브 스윕(`--bin target/debug/rhwp`)은 이 가지에서 돌리지 않았다.
+   판정 로직은 목킹 시험이 고정하고, 실제 26과제의 연극 0은 게이트가
+   계속 본다.
+2. 수집 키를 `answer`/`keyring_from` 밖으로 늘리지 않았다. 새 제출
+   형태가 생기면 키 집합과 시험을 같이 늘려야 한다.
+3. `score_task` 가 던지는 `FileNotFoundError` 이외의 OSError(권한)는
+   지금 load-bearing 이다. 권한 오류를 missing-bin 과 같은 도구 실패로
+   접을지는 다음 이슈.
+4. `work_root` 정리 실패(`shutil.rmtree`)는 여전히 무시한다. 디스크
+   잠금이 감사를 막게 하지 않으려는 기존 동작이다.
+
+## 13. 변경 파일
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tools/trajectory.py` | 예외 경로·분류·봉투 |
+| `scripts/tests/test_gym_trajectory.py` | 바이너리 없는 계약 |
+| `gym/docs/trajectory.md` | 규약 |
+| `mydocs/working/gym_trajectory.md` | 이 기록 |
+
+## 14. 이슈 DoD 대조
+
+| DoD | 상태 |
+|---|---|
+| `gym/tools/trajectory.py` 고도화 | 예외 네 자리 + 분류 + 봉투 |
+| `scripts/tests/test_gym_trajectory.py` 고도화 | 기존 5칸 + 예외·행렬 |
+| `gym/docs/trajectory.md` | 추가 |
+| `mydocs/working/gym_trajectory.md` | 추가 |
+| 새 CLI / pack 없음 | 플래그·pack 불변 |
+| 열린 PR 파일 미수정 | 5210–5248 경로 회피 |
+| additions ≥ 3000 | `git diff --shortstat upstream/devel` |
+| unittest + audit.py | 아래 검증 |
+| 결정적 | 사전순 탐색, 난수·시각 없음 |
+| 바이너리 없이 핵심 경로 | 목킹 + 순수 함수 |
+| 마지막 스텝 load-bearing 유지 | 네 칸 +  pentest 클래스 |
+
+## 15. 탐색 알고리즘 (구현 메모)
+
+```
+scan_gym(gym_root):
+  packs = sorted(dir names under gym_root/packs that are directories)
+  for pack in packs:
+    if no tasks/: continue
+    for name in sorted(*.json in tasks/):
+      yield scan_task_pair(pack, name)
+
+scan_task_pair:
+  load task JSON → fail: malformed-json/task
+  if reference file missing → missing-reference
+  load reference JSON → fail: malformed-json/reference
+  label = classify_reference(reference)
+
+audit:
+  for rec in scan_gym:
+    single-step → skipped
+    exception label → exceptions
+    multi:
+      if missing_bin: continue
+      audit_one(...)
+      FileNotFoundError → missing_bin=true
+```
+
+`os.listdir` 실패는 `toolErrors` 한 줄이다. 없는 pack 을 지어내지
+않는다.
+
+## 16. 부분 트라젝토리 조립 메모
+
+`truncate_reference` 는 `dict(reference)` 사본에 `steps` 만 갈아끼운다.
+`id` · 기타 키는 유지한다. `build_task` 가 기준풀이 식별자를 읽는
+경우를 깨지 않는다.
+
+`truncate_steps(steps, i)` 는 `steps[:i] + steps[i+1:]`. `i` 가 범위
+밖이면 사본만 돌려준다. `None` 스텝 열은 빈 목록이다.
+
+`audit_one` 이 `score_task` 에 넘기는 `sub_root` 는
+`os.path.join(work_root, pack_id)` 이다. 기존과 같다.
+
+## 17. 사람용 본문 메모
+
+성공(연극 0, 도구 실패 아님):
+
+```
+gym 트라젝토리 필요성 감사: {N} 다단계 과제 전부 마지막 스텝이 load-bearing — 연극 0
+```
+
+연극:
+
+```
+gym 트라젝토리 필요성 감사: 연극(무의미한 마지막 스텝) {K}건 — 부분 트라젝토리가 통과한다:
+  - {pack}/{id} (마지막 실제 스텝 {kind}을 빼도 통과 — {N}→{N-1})
+```
+
+도구 실패(연극 0):
+
+```
+gym 트라젝토리 필요성 감사: 연극 0 · 도구 실패 (예외 {E}건, trusted=false)
+```
+
+예외가 있으면 어떤 본문 아래에도 `예외 경로 {E}건:` 블록이 붙는다.
+`--json` 이면 본문 대신 봉투만 쓴다.
+
+## 18. 열린 PR 회피 목록 (이 가지에서 안 만진 것)
+
+이슈가 명시한 금지와 5210–5248 파일.
+
+- `gym/core/checks.py`, `gym/docs/checks.md`, `mydocs/working/gym_core_checks.md`
+- `gym/tools/agent_session.py` 및 세션 시험
+- `gym/tools/coverage.py`, extraction/table-csv/batch-ops pack 확장
+- `gym/tools/leaderboard.py`, `gym/docs/leaderboard.md`
+- `gym/tools/release_diff.py`, `gym/docs/release_diff.md`
+- `gym/tools/discriminate.py`
+- `gym/tools/fuzz_corpus.py`
+- `gym/packs/automation/**`
+- `gym/packs/core-cli/**`
+- `gym/packs/casual-rides/**`
+
+이 가지는 도구 4파일이 전부다.
+
+## 19. 커밋 범위
+
+브랜치 `feat/gym-trajectory-hardening` 는 `upstream/devel` 에서
+갈랐다. 커밋 하나. 제목·본문 한국어. PR 본문은 `--body-file` (UTF-8
+BOM 없음). `closes #5254`.
+
+`git add -A` 는 쓰지 않는다. 네 경로만 스테이징한다.
+
+## 20. 다음 작업자에게
+
+라이브 스윕을 돌릴 때는 기존과 같이 `--bin` 이 실제 rhwp 를 가리켜야
+한다. 이 가지의 단위 시험이 green 이라고 26과제의 연극 0을 다시 잰
+것은 아니다. 게이트가 그 자리를 본다.
+
+수집 키를 늘리거나 `ok` 를 예외와 묶고 싶으면 이 문서 6절 표를 먼저
+고치고 시험을 같이 고친다. 표 없이 `ok` 의미를 바꾸면 게이트가 다른
+이유를 연극으로 읽는다.
+
+## 21. 라이브 운동장 스모크
+
+단위 시험 `RealGymScanSmokeTests` 는 devel 의 `gym/packs` 를 읽기만
+한다. pack JSON 을 쓰지 않는다.
+
+기대:
+
+- 레코드가 10건보다 많다.
+- `empty-steps` · `collection-only-tail` · `malformed-*` 가 0이다.
+- 단스텝이 있고 그 안에 T01 이 있다.
+- `multi` 레코드는 모두 `last_meaningful_step_index` 가 숫자다.
+- `multi_step_tasks` 길이는 `steps` 길이 ≥2 인 기준풀이 수와 같다.
+
+이 스모크가 실패하면 이 가지가 아니라 **다른 가지의 pack 확장** 이
+기준풀이를 깨뜨린 것이다. 그 경우 pack 을 이 가지에서 고치지 말고,
+해당 pack PR 로 돌린다.
+
+## 22. 분류 경계 재진술
+
+같은 입력을 문서와 시험이 같이 본다. 구현을 바꿀 때 이 절과
+`CLASSIFY_CASES` 를 한 번에 고친다.
+
+1. `steps is None` → empty-steps
+2. `steps == []` → empty-steps
+3. `steps` 가 목록이 아님 → malformed-reference
+4. 길이 1 → single-step (키가 answer 여도)
+5. 길이 ≥2 이고 의미 인덱스 없음 → collection-only-tail
+6. 길이 ≥2 이고 의미 인덱스 있음 → multi
+
+`classify_reference` 는 `steps` 키 없음을 1번으로, `steps: {…}` 를
+3번으로 가른다. `normalize_steps` 가 dict 를 `None` 으로 접더라도
+`classify_reference` 가 그 전에 목록 여부를 본다. 객체 steps 를 빈
+목록과 같은 칸에 두면 안 된다.
+
+## 23. 커밋 후 확인 체크
+
+```
+git diff --shortstat upstream/devel
+# insertions >= 3000
+
+git diff --name-only upstream/devel
+# 네 경로만
+
+python -m unittest scripts.tests.test_gym_trajectory
+python gym/tools/audit.py
+```
+
+Windows 에서 본문이 CRLF 로 바뀌지 않았는지 `git diff --check` 또는
+바이트 검사로 LF 만 있는지를 본다.
+
+## 24. 구현 중 고친 분류 버그
+
+초안에서 `normalize_steps` 가 목록이 아닌 값을 `None` 으로 접고
+`classify_reference` 가 그 `None` 을 `empty-steps` 로 불렀다. 그러면
+`{"steps": {"run": 1}}` 이 빈 기준풀이와 같은 칸이 된다.
+
+고친 계약: `classify_reference` 가 `steps` 키 존재와 목록 여부를 먼저
+본다. 키가 없거나 null 이면 empty-steps. 목록이 아니면
+malformed-reference. 빈 목록만 empty-steps.
+
+시험 `test_classify_reference_reads_steps` 와
+`test_steps_object_is_malformed_reference` 가 이 칸을 고정한다.
+
+## 25. 크기 게이트
+
+이슈 DoD 는 `git diff --shortstat upstream/devel` 삽입 ≥ 3000 이다.
+네 경로만 센다. 열린 PR 파일이나 pack JSON 으로 줄을 채우지 않는다.
+
+삽입은 도구 본문·순수 함수·예외 표·시험 행렬·규약 문서에서 나온다.
+같은 문장을 백 번 반복하지 않는다. 표의 각 칸은 시험이 다시 본다.
+
+## 26. 리뷰어가 볼 것
+
+1. 기존 `TrajectoryTests` 다섯 칸이 그대로인가.
+2. 네 예외 경로가 `exceptions` 로 남는가.
+3. `FileNotFoundError` 가 `loadBearing` 을 올리지 않는가.
+4. T01 단스텝 answer 가 예외가 아닌가.
+5. `ok` 가 연극 유무만 말하는가.
+6. `--bin` / `--json` 외에 플래그가 없는가.
+7. 금지 파일(discriminate, fuzz, automation, core-cli, casual-rides,
+   5210–5248)이 diff 에 없는가.

--- a/scripts/tests/test_gym_trajectory.py
+++ b/scripts/tests/test_gym_trajectory.py
@@ -3,6 +3,9 @@
 핵심: 다단계 과제는 마지막 스텝을 빼면(부분 트라젝토리) 채점에 실패해야 한다.
 부분 트라젝토리가 통과 = 마지막 스텝이 load-bearing 아님 = 트라젝토리 연극.
 조립·채점은 목킹해 바이너리 없이 로직만 시험한다.
+
+예외 경로(침묵 금지): 기준풀이 부재, 빈 steps, 수집 전용 tail, 바이너리 부재.
+마지막 스텝 load-bearing 판정 자체는 바꾸지 않는다.
 """
 
 from __future__ import annotations
@@ -13,6 +16,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "trajectory.py"
 
@@ -25,20 +29,64 @@ def load():
     return module
 
 
+def _write(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        if isinstance(payload, str):
+            fh.write(payload)
+        else:
+            json.dump(payload, fh, ensure_ascii=False)
+
+
+def _task_body(task_id="T"):
+    return {
+        "id": task_id,
+        "tier": 1,
+        "title": "t",
+        "input": "samples/x.hwp",
+        "submit": {"kind": "artifact", "files": ["o"]},
+        "checks": [],
+    }
+
+
 def _temp_gym(root, steps):
     """packs/p1 에 T 과제 + steps 개 스텝짜리 reference 를 심는다."""
     tasks = os.path.join(root, "gym", "packs", "p1", "tasks")
     refs = os.path.join(root, "gym", "packs", "p1", "reference")
     os.makedirs(tasks)
     os.makedirs(refs)
-    task = {"id": "T", "tier": 1, "title": "t", "input": "samples/x.hwp",
-            "submit": {"kind": "artifact", "files": ["o"]}, "checks": []}
+    task = _task_body("T")
     with open(os.path.join(tasks, "T.json"), "w", encoding="utf-8") as fh:
         json.dump(task, fh)
     ref = {"id": "T", "steps": [{"run": ["a"]} for _ in range(steps)]}
     with open(os.path.join(refs, "T.json"), "w", encoding="utf-8") as fh:
         json.dump(ref, fh)
     return os.path.join(root, "gym")
+
+
+def _plant(gym_root, pack, task_id, steps=None, reference=None, task=None, write_ref=True):
+    """한 과제를 gym_root/packs/<pack> 에 심는다."""
+    tasks = os.path.join(gym_root, "packs", pack, "tasks")
+    refs = os.path.join(gym_root, "packs", pack, "reference")
+    os.makedirs(tasks, exist_ok=True)
+    os.makedirs(refs, exist_ok=True)
+    body = task if task is not None else _task_body(task_id)
+    _write(os.path.join(tasks, f"{task_id}.json"), body)
+    if write_ref:
+        if reference is not None:
+            _write(os.path.join(refs, f"{task_id}.json"), reference)
+        else:
+            step_list = steps if steps is not None else [{"run": ["a"]}, {"run": ["b"]}]
+            _write(os.path.join(refs, f"{task_id}.json"), {"id": task_id, "steps": step_list})
+    return gym_root
+
+
+def _kinds(rows):
+    return [row.get("kind") for row in rows]
+
+
+def _by_task(rows, task_id):
+    return [row for row in rows if row.get("task") == task_id]
 
 
 class TrajectoryTests(unittest.TestCase):
@@ -106,6 +154,1206 @@ class TrajectoryTests(unittest.TestCase):
         self.assertEqual(captured, [[{"answer": {"value": {"const": 1}}}]])
         self.assertEqual(r["loadBearing"], 1)
         self.assertEqual(r["taskCount"], 1)
+
+
+class CollectionStepTests(unittest.TestCase):
+    def test_answer_is_collection(self):
+        mod = load()
+        self.assertTrue(mod.is_collection_step({"answer": {"value": 1}}))
+
+    def test_keyring_from_is_collection(self):
+        mod = load()
+        self.assertTrue(mod.is_collection_step({"keyring_from": "T13"}))
+
+    def test_run_is_meaningful(self):
+        mod = load()
+        self.assertFalse(mod.is_collection_step({"run": ["info"]}))
+        self.assertTrue(mod.has_meaningful_key({"run": ["info"]}))
+
+    def test_mixed_keys_with_answer_count_as_collection(self):
+        mod = load()
+        # 수집 키가 하나라도 있으면 수집. 마지막 의미 스텝을 고를 때 tail 로 남긴다.
+        self.assertTrue(mod.is_collection_step({"answer": {}, "run": ["x"]}))
+
+    def test_non_mapping_is_not_collection(self):
+        mod = load()
+        self.assertFalse(mod.is_collection_step(None))
+        self.assertFalse(mod.is_collection_step("run"))
+        self.assertFalse(mod.is_collection_step(["run"]))
+        self.assertFalse(mod.has_meaningful_key(None))
+
+    def test_empty_mapping_is_meaningful(self):
+        mod = load()
+        # 키가 없으면 수집이 아니다. last_meaningful 이 이 칸을 고른다.
+        self.assertFalse(mod.is_collection_step({}))
+        self.assertTrue(mod.has_meaningful_key({}))
+
+    def test_step_kind_label_sorts_keys(self):
+        mod = load()
+        self.assertEqual(mod.step_kind_label({"run": 1}), "run")
+        self.assertEqual(mod.step_kind_label({"b": 1, "a": 2}), "a/b")
+        self.assertEqual(mod.step_kind_label({}), "empty")
+        self.assertEqual(mod.step_kind_label("nope"), "empty")
+
+    def test_step_keys_are_strings(self):
+        mod = load()
+        self.assertEqual(mod.step_keys({1: "x", "a": 2}), ["1", "a"])
+
+
+class LastMeaningfulStepTests(unittest.TestCase):
+    def test_last_run_when_no_collection_tail(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"run": ["b"]}]
+        self.assertEqual(mod.last_meaningful_step_index(steps), 1)
+
+    def test_skips_trailing_answer(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"run": ["b"]}, {"answer": {}}]
+        self.assertEqual(mod.last_meaningful_step_index(steps), 1)
+
+    def test_skips_trailing_keyring_and_answer(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"keyring_from": "x"}, {"answer": {}}]
+        self.assertEqual(mod.last_meaningful_step_index(steps), 0)
+
+    def test_all_collection_returns_none(self):
+        mod = load()
+        steps = [{"answer": {}}, {"keyring_from": "x"}]
+        self.assertIsNone(mod.last_meaningful_step_index(steps))
+
+    def test_empty_list_returns_none(self):
+        mod = load()
+        self.assertIsNone(mod.last_meaningful_step_index([]))
+
+    def test_non_list_returns_none(self):
+        mod = load()
+        self.assertIsNone(mod.last_meaningful_step_index(None))
+        self.assertIsNone(mod.last_meaningful_step_index({"run": 1}))
+
+    def test_non_mapping_entries_are_skipped(self):
+        mod = load()
+        steps = [{"run": ["a"]}, "broken", None]
+        self.assertEqual(mod.last_meaningful_step_index(steps), 0)
+
+    def test_middle_collection_does_not_hide_later_run(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"answer": {}}, {"run": ["b"]}]
+        self.assertEqual(mod.last_meaningful_step_index(steps), 2)
+
+
+class TruncateTests(unittest.TestCase):
+    def test_drops_only_removed_index(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"run": ["b"]}, {"answer": {}}]
+        self.assertEqual(mod.truncate_steps(steps, 1), [{"run": ["a"]}, {"answer": {}}])
+
+    def test_does_not_mutate_original(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"run": ["b"]}]
+        out = mod.truncate_steps(steps, 1)
+        self.assertEqual(steps, [{"run": ["a"]}, {"run": ["b"]}])
+        self.assertEqual(out, [{"run": ["a"]}])
+
+    def test_out_of_range_returns_copy(self):
+        mod = load()
+        steps = [{"run": ["a"]}]
+        self.assertEqual(mod.truncate_steps(steps, 3), [{"run": ["a"]}])
+        self.assertEqual(mod.truncate_steps(steps, -1), [{"run": ["a"]}])
+
+    def test_non_list_is_empty(self):
+        mod = load()
+        self.assertEqual(mod.truncate_steps(None, 0), [])
+
+    def test_truncate_reference_copies_other_keys(self):
+        mod = load()
+        ref = {"id": "T", "note": "keep", "steps": [{"run": ["a"]}, {"run": ["b"]}]}
+        out = mod.truncate_reference(ref, 1)
+        self.assertEqual(out["id"], "T")
+        self.assertEqual(out["note"], "keep")
+        self.assertEqual(out["steps"], [{"run": ["a"]}])
+        self.assertEqual(ref["steps"], [{"run": ["a"]}, {"run": ["b"]}])
+
+    def test_truncate_reference_non_dict(self):
+        mod = load()
+        self.assertEqual(mod.truncate_reference(None, 0), {"steps": []})
+
+
+CLASSIFY_CASES = (
+    (None, "empty-steps"),
+    ([], "empty-steps"),
+    ("nope", "malformed-reference"),
+    ({"run": ["a"]}, "malformed-reference"),
+    ([{"run": ["a"]}], "single-step"),
+    ([{"answer": {}}], "single-step"),
+    ([{"keyring_from": "x"}], "single-step"),
+    ([{"run": ["a"]}, {"run": ["b"]}], "multi"),
+    ([{"run": ["a"]}, {"answer": {}}], "multi"),
+    ([{"run": ["a"]}, {"keyring_from": "x"}], "multi"),
+    ([{"answer": {}}, {"keyring_from": "x"}], "collection-only-tail"),
+    ([{"answer": {}}, {"answer": {}}, {"keyring_from": "x"}], "collection-only-tail"),
+    ([{}, {"answer": {}}], "multi"),
+    ([{"run": ["a"]}, {"run": ["b"]}, {"run": ["c"]}], "multi"),
+)
+
+
+class ClassifyStepsTests(unittest.TestCase):
+    def test_catalog_table(self):
+        mod = load()
+        for steps, expected in CLASSIFY_CASES:
+            with self.subTest(steps=steps, expected=expected):
+                self.assertEqual(mod.classify_steps(steps), expected)
+
+    def test_classify_reference_reads_steps(self):
+        mod = load()
+        self.assertEqual(mod.classify_reference({"steps": [{"run": ["a"]}, {"run": ["b"]}]}), "multi")
+        self.assertEqual(mod.classify_reference({"id": "T"}), "empty-steps")
+        self.assertEqual(mod.classify_reference({"steps": []}), "empty-steps")
+        self.assertEqual(mod.classify_reference({"steps": None}), "empty-steps")
+        self.assertEqual(mod.classify_reference(None), "malformed-reference")
+        self.assertEqual(mod.classify_reference("x"), "malformed-reference")
+        self.assertEqual(mod.classify_reference({"steps": {"run": 1}}), "malformed-reference")
+        self.assertEqual(mod.classify_reference({"steps": 3}), "malformed-reference")
+        self.assertEqual(mod.classify_reference({"steps": "run"}), "malformed-reference")
+
+    def test_audit_candidate_only_multi(self):
+        mod = load()
+        self.assertTrue(mod.is_audit_candidate("multi"))
+        for label in ("single-step", "empty-steps", "collection-only-tail", "missing-reference"):
+            self.assertFalse(mod.is_audit_candidate(label))
+
+    def test_skip_only_single(self):
+        mod = load()
+        self.assertTrue(mod.is_skip_label("single-step"))
+        self.assertFalse(mod.is_skip_label("multi"))
+        self.assertFalse(mod.is_skip_label("empty-steps"))
+
+    def test_exception_labels(self):
+        mod = load()
+        for label in ("missing-reference", "empty-steps", "collection-only-tail", "missing-bin"):
+            self.assertTrue(mod.is_exception_label(label), label)
+        self.assertFalse(mod.is_exception_label("single-step"))
+        self.assertFalse(mod.is_exception_label("multi"))
+
+
+class ExceptionKindTests(unittest.TestCase):
+    def test_file_not_found_is_missing_bin(self):
+        mod = load()
+        self.assertEqual(mod.exception_kind(FileNotFoundError("rhwp")), "missing-bin")
+        self.assertTrue(mod.is_missing_bin_exception(FileNotFoundError("rhwp")))
+
+    def test_runtime_error_is_not_missing_bin(self):
+        mod = load()
+        self.assertFalse(mod.is_missing_bin_exception(RuntimeError("boom")))
+        self.assertEqual(mod.verdict_from_build_error(RuntimeError("boom")), "load-bearing")
+
+    def test_file_not_found_verdict_is_missing_bin(self):
+        mod = load()
+        self.assertEqual(mod.verdict_from_build_error(FileNotFoundError("x")), "missing-bin")
+
+    def test_permission_and_os(self):
+        mod = load()
+        self.assertEqual(mod.exception_kind(PermissionError("x")), "permission")
+        self.assertEqual(mod.exception_kind(TimeoutError("x")), "timeout")
+        self.assertEqual(mod.exception_kind(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad")), "decode-error")
+        self.assertEqual(mod.exception_kind(TypeError("x")), "type-error")
+        self.assertEqual(mod.exception_kind(ValueError("x")), "value-error")
+        self.assertEqual(mod.exception_kind(KeyError("x")), "value-error")
+
+    def test_json_decode_depends_on_context(self):
+        mod = load()
+        exc = json.JSONDecodeError("msg", "doc", 0)
+        self.assertEqual(mod.exception_kind(exc, context="load"), "malformed-json")
+        self.assertEqual(mod.exception_kind(exc, context="audit"), "value-error")
+
+    def test_none_is_unexpected(self):
+        mod = load()
+        self.assertEqual(mod.exception_kind(None), "unexpected")
+
+    def test_catalog_contains_required_paths(self):
+        mod = load()
+        for kind in ("missing-reference", "empty-steps", "collection-only-tail", "missing-bin"):
+            self.assertIn(kind, mod.EXCEPTION_KINDS)
+            self.assertTrue(mod.is_known_exception_kind(kind))
+
+    def test_unknown_kind_is_folded(self):
+        mod = load()
+        row = mod.exception_row("not-a-kind", pack="p", task="T")
+        self.assertEqual(row["kind"], "unexpected")
+
+    def test_exception_row_truncates_head(self):
+        mod = load()
+        row = mod.exception_row("empty-steps", pack="p", task="T", head="가" * 400)
+        self.assertEqual(len(row["head"]), mod.ERROR_HEAD_LIMIT)
+        self.assertEqual(row["pack"], "p")
+        self.assertEqual(row["task"], "T")
+
+    def test_fatal_exceptions(self):
+        mod = load()
+        self.assertTrue(mod.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(mod.is_fatal_exception(SystemExit(1)))
+        self.assertTrue(mod.is_fatal_exception(MemoryError()))
+        self.assertTrue(mod.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(mod.is_fatal_exception(RuntimeError("x")))
+        self.assertEqual(mod.verdict_from_build_error(KeyboardInterrupt()), "fatal")
+
+
+class VerdictTests(unittest.TestCase):
+    def test_score_pass_is_theater(self):
+        mod = load()
+        self.assertFalse(mod.verdict_from_score({"pass": True}))
+
+    def test_score_fail_is_load_bearing(self):
+        mod = load()
+        self.assertTrue(mod.verdict_from_score({"pass": False}))
+
+    def test_missing_pass_is_load_bearing(self):
+        mod = load()
+        self.assertTrue(mod.verdict_from_score({}))
+        self.assertTrue(mod.verdict_from_score(None))
+        self.assertTrue(mod.verdict_from_score("pass"))
+
+    def test_theater_line_keeps_legacy_wording(self):
+        mod = load()
+        line = mod.make_theater_line("p1", "T", "run", 2)
+        self.assertEqual(line, "p1/T (마지막 실제 스텝 run을 빼도 통과 — 2→1)")
+
+    def test_format_exception_line(self):
+        mod = load()
+        row = mod.exception_row("missing-reference", pack="p1", task="T", head="짝 기준풀이가 없다")
+        text = mod.format_exception_line(row)
+        self.assertIn("missing-reference", text)
+        self.assertIn("p1/T", text)
+        self.assertEqual(mod.format_exception_line(None), "예외: (형식 오류)")
+        self.assertEqual(mod.format_exception_line({"kind": "empty-steps"}), "empty-steps")
+
+
+class ReportContractTests(unittest.TestCase):
+    def test_empty_report_is_valid(self):
+        mod = load()
+        report = mod.empty_report()
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertTrue(report["ok"])
+        self.assertTrue(report["trusted"])
+        self.assertEqual(report["exit"], 0)
+        self.assertEqual(report["kind"], "gymTrajectoryNecessity")
+        self.assertEqual(report["schemaVersion"], "1.0")
+
+    def test_ok_is_theater_only(self):
+        mod = load()
+        self.assertTrue(mod.report_ok([]))
+        self.assertFalse(mod.report_ok(["x"]))
+        self.assertTrue(mod.report_ok([], missing_bin=True))
+
+    def test_exit_fails_on_missing_bin_even_when_ok(self):
+        mod = load()
+        self.assertEqual(mod.report_exit([], missing_bin=True), 1)
+        self.assertEqual(mod.report_exit(["t"]), 1)
+        self.assertEqual(mod.report_exit([]), 0)
+
+    def test_trusted_false_when_exceptions(self):
+        mod = load()
+        self.assertFalse(mod.report_trusted([{"kind": "empty-steps"}]))
+        self.assertFalse(mod.report_trusted([], missing_bin=True))
+        self.assertTrue(mod.report_trusted([]))
+
+    def test_attach_counts_recomputes(self):
+        mod = load()
+        report = mod.empty_report()
+        report["results"] = [
+            mod.make_result_row("p", "A", True, 2, "run"),
+            mod.make_result_row("p", "B", False, 2, "run"),
+        ]
+        report["theater"] = [mod.make_theater_line("p", "B", "run", 2)]
+        report["exceptions"] = [mod.exception_row("empty-steps", pack="p", task="C")]
+        report["skipped"] = [mod.make_skip_row("p", "D", "single-step", 1)]
+        mod.attach_report_counts(report)
+        self.assertEqual(report["taskCount"], 2)
+        self.assertEqual(report["loadBearing"], 1)
+        self.assertEqual(report["exceptionCount"], 1)
+        self.assertEqual(report["skipCount"], 1)
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["trusted"])
+        self.assertEqual(report["exit"], 1)
+        self.assertEqual(mod.validate_report(report), [])
+
+    def test_validate_catches_ok_lie(self):
+        mod = load()
+        report = mod.empty_report()
+        report["theater"] = ["x"]
+        report["ok"] = True
+        issues = mod.validate_report(report)
+        self.assertTrue(any("ok" in item for item in issues))
+
+    def test_validate_catches_missing_bin_exit(self):
+        mod = load()
+        report = mod.empty_report()
+        report["missingBin"] = True
+        report["exit"] = 0
+        issues = mod.validate_report(report)
+        self.assertTrue(any("missing-bin" in item for item in issues))
+
+    def test_validate_non_dict(self):
+        mod = load()
+        self.assertEqual(mod.validate_report(None), ["report 가 dict 가 아니다"])
+
+    def test_required_keys_present(self):
+        mod = load()
+        for key in mod.REPORT_KEYS:
+            self.assertIn(key, mod.empty_report())
+
+
+class TruncateHeadTests(unittest.TestCase):
+    def test_none_and_non_string(self):
+        mod = load()
+        self.assertEqual(mod.truncate_head(None), "")
+        self.assertEqual(mod.truncate_head(12), "12")
+
+    def test_limit_zero(self):
+        mod = load()
+        self.assertEqual(mod.truncate_head("abc", 0), "")
+
+    def test_bad_limit_falls_back(self):
+        mod = load()
+        text = "x" * 200
+        self.assertEqual(len(mod.truncate_head(text, "nope")), mod.HEAD_LIMIT)
+
+
+class ScanDiscoveryTests(unittest.TestCase):
+    def test_missing_reference_is_exception_not_skip(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", write_ref=False)
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["taskCount"], 0)
+        self.assertEqual(_kinds(r["exceptions"]), ["missing-reference"])
+        self.assertEqual(r["exceptions"][0]["task"], "T")
+        self.assertTrue(r["ok"])
+        self.assertFalse(r["trusted"])
+        self.assertEqual(r["exit"], 0)
+
+    def test_empty_steps_is_exception(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", steps=[])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(_kinds(r["exceptions"]), ["empty-steps"])
+        self.assertEqual(r["taskCount"], 0)
+        self.assertEqual(r["skipCount"], 0)
+        self.assertTrue(r["ok"])
+
+    def test_missing_steps_key_is_empty_steps(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", reference={"id": "T"})
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(_kinds(r["exceptions"]), ["empty-steps"])
+
+    def test_collection_only_tail_is_exception(self):
+        mod = load()
+        called = {"n": 0}
+
+        def build(*_a, **_k):
+            called["n"] += 1
+
+        mod.baseline.build_task = build
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", steps=[{"answer": {}}, {"keyring_from": "x"}])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(_kinds(r["exceptions"]), ["collection-only-tail"])
+        self.assertEqual(called["n"], 0)
+        self.assertEqual(r["taskCount"], 0)
+        self.assertEqual(r["theater"], [])
+
+    def test_single_answer_task_is_skip_not_collection_only(self):
+        # T01 형태. 단스텝 answer 는 예외가 아니다.
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T01", steps=[{"answer": {"pages": 1}}])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["exceptions"], [])
+        self.assertEqual(r["skipCount"], 1)
+        self.assertEqual(r["skipped"][0]["reason"], "single-step")
+        self.assertEqual(r["taskCount"], 0)
+
+    def test_malformed_task_json(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            tasks = os.path.join(gym, "packs", "p1", "tasks")
+            refs = os.path.join(gym, "packs", "p1", "reference")
+            os.makedirs(tasks)
+            os.makedirs(refs)
+            _write(os.path.join(tasks, "T.json"), "{not-json")
+            _write(os.path.join(refs, "T.json"), {"id": "T", "steps": [{"run": ["a"]}, {"run": ["b"]}]})
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertIn(r["exceptions"][0]["kind"], ("malformed-json", "malformed-task"))
+        self.assertEqual(r["taskCount"], 0)
+
+    def test_malformed_reference_json(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", write_ref=False)
+            _write(os.path.join(gym, "packs", "p1", "reference", "T.json"), "{nope")
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["exceptions"][0]["kind"], "malformed-json")
+
+    def test_steps_object_is_malformed_reference(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", reference={"id": "T", "steps": {"run": ["a"]}})
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(_kinds(r["exceptions"]), ["malformed-reference"])
+
+    def test_scan_is_deterministic_across_packs(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "b-pack", "B", write_ref=False)
+            _plant(gym, "a-pack", "A", steps=[])
+            recs, err = mod.scan_gym(gym)
+        self.assertEqual(err, [])
+        self.assertEqual([(r["pack"], r["name"]) for r in recs], [("a-pack", "A.json"), ("b-pack", "B.json")])
+
+    def test_pack_without_tasks_dir_is_ignored(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            os.makedirs(os.path.join(gym, "packs", "empty"))
+            recs, err = mod.scan_gym(gym)
+        self.assertEqual(recs, [])
+        self.assertEqual(err, [])
+
+    def test_non_json_files_are_ignored(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", steps=[{"run": ["a"]}])
+            _write(os.path.join(gym, "packs", "p1", "tasks", "notes.txt"), "x")
+            recs, _ = mod.scan_gym(gym)
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["name"], "T.json")
+
+
+class MissingBinTests(unittest.TestCase):
+    def test_build_file_not_found_is_not_load_bearing(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise FileNotFoundError("rhwp")
+
+        mod.baseline.build_task = boom
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, steps=2)
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["loadBearing"], 0)
+        self.assertEqual(r["taskCount"], 0)
+        self.assertEqual(_kinds(r["exceptions"]), ["missing-bin"])
+        self.assertTrue(r["ok"])
+        self.assertTrue(r["missingBin"])
+        self.assertFalse(r["trusted"])
+        self.assertEqual(r["exit"], 1)
+
+    def test_score_file_not_found_is_not_load_bearing(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+
+        def boom(*_a, **_k):
+            raise FileNotFoundError("rhwp")
+
+        mod.runner.score_task = boom
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, steps=2)
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(_kinds(r["exceptions"]), ["missing-bin"])
+        self.assertEqual(r["loadBearing"], 0)
+        self.assertEqual(r["exit"], 1)
+
+    def test_missing_bin_does_not_mark_later_tasks_load_bearing(self):
+        mod = load()
+        calls = {"n": 0}
+
+        def boom(*_a, **_k):
+            calls["n"] += 1
+            raise FileNotFoundError("rhwp")
+
+        mod.baseline.build_task = boom
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "A", steps=[{"run": ["a"]}, {"run": ["b"]}])
+            _plant(gym, "p1", "B", steps=[{"run": ["a"]}, {"run": ["b"]}])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(calls["n"], 1)
+        self.assertEqual(r["taskCount"], 0)
+        self.assertEqual(r["loadBearing"], 0)
+        self.assertTrue(r["missingBin"])
+        self.assertEqual(sum(1 for row in r["exceptions"] if row["kind"] == "missing-bin"), 1)
+
+    def test_dummy_bin_name_is_not_prechecked(self):
+        # 시험이 넘기는 "bin" 은 파일이 없어도 조립 목킹 경로로 간다.
+        mod = load()
+        self.assertTrue(mod.bin_looks_present("bin"))
+        self.assertTrue(mod.bin_looks_present("rhwp"))
+        self.assertFalse(mod.bin_looks_present(""))
+        self.assertFalse(mod.bin_looks_present(None))
+
+    def test_path_like_missing_file_is_absent(self):
+        mod = load()
+        self.assertFalse(mod.bin_looks_present(os.path.join("no", "such", "rhwp")))
+        self.assertFalse(mod.bin_looks_present("C:/definitely/missing/rhwp.exe"))
+
+
+class MixedGymTests(unittest.TestCase):
+    def test_mixed_exceptions_and_one_theater(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "OK", steps=[{"run": ["a"]}, {"run": ["b"]}])
+            _plant(gym, "p1", "MISS", write_ref=False)
+            _plant(gym, "p1", "EMPTY", steps=[])
+            _plant(gym, "p1", "TAIL", steps=[{"answer": {}}, {"keyring_from": "x"}])
+            _plant(gym, "p1", "ONE", steps=[{"run": ["only"]}])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        kinds = sorted(_kinds(r["exceptions"]))
+        self.assertEqual(kinds, ["collection-only-tail", "empty-steps", "missing-reference"])
+        self.assertEqual(r["taskCount"], 1)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["skipCount"], 1)
+        self.assertEqual(len(r["theater"]), 1)
+        self.assertIn("p1/OK", r["theater"][0])
+
+    def test_keeps_answer_tail_in_mixed_pack(self):
+        mod = load()
+        captured = []
+
+        def build(_bin, _pack, _task, reference, _root):
+            captured.append(( _task["id"], reference["steps"]))
+
+        mod.baseline.build_task = build
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", steps=[{"run": ["act"]}, {"answer": {"n": 1}}])
+            _plant(gym, "p1", "U", steps=[{"run": ["act"]}, {"run": ["act2"]}, {"keyring_from": "T"}])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["loadBearing"], 2)
+        self.assertEqual(r["exceptions"], [])
+        ids = [item[0] for item in captured]
+        self.assertEqual(ids, ["T", "U"])
+        self.assertEqual(captured[0][1], [{"answer": {"n": 1}}])
+        self.assertEqual(captured[1][1], [{"run": ["act"]}, {"keyring_from": "T"}])
+
+    def test_multi_step_tasks_still_yields_collection_only(self):
+        # 예전 생성기는 길이 ≥2 이면 배출한다. 분류는 audit 가 한다.
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "TAIL", steps=[{"answer": {}}, {"keyring_from": "x"}])
+            pairs = list(mod.multi_step_tasks(gym))
+        self.assertEqual(len(pairs), 1)
+        self.assertEqual(pairs[0][0], "p1")
+        self.assertEqual(pairs[0][1]["id"], "TAIL")
+
+    def test_multi_step_tasks_skips_missing_and_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "MISS", write_ref=False)
+            _plant(gym, "p1", "EMPTY", steps=[])
+            _plant(gym, "p1", "ONE", steps=[{"run": ["a"]}])
+            pairs = list(mod.multi_step_tasks(gym))
+        self.assertEqual(pairs, [])
+
+
+class RenderTextTests(unittest.TestCase):
+    def test_ok_message(self):
+        mod = load()
+        report = mod.empty_report()
+        report["taskCount"] = 3
+        text = mod.render_text_report(report)
+        self.assertIn("3 다단계 과제 전부", text)
+        self.assertIn("연극 0", text)
+
+    def test_theater_message(self):
+        mod = load()
+        report = mod.empty_report()
+        report["ok"] = False
+        report["theater"] = ["p1/T (마지막 실제 스텝 run을 빼도 통과 — 2→1)"]
+        text = mod.render_text_report(report)
+        self.assertIn("연극(무의미한 마지막 스텝) 1건", text)
+        self.assertIn("p1/T", text)
+
+    def test_lists_exceptions(self):
+        mod = load()
+        report = mod.empty_report()
+        report["exceptions"] = [mod.exception_row("empty-steps", pack="p1", task="T", head="비었다")]
+        report["exceptionCount"] = 1
+        text = mod.render_text_report(report)
+        self.assertIn("예외 경로 1건", text)
+        self.assertIn("empty-steps", text)
+
+    def test_tool_failed_without_theater(self):
+        mod = load()
+        report = mod.empty_report()
+        report["missingBin"] = True
+        report["toolFailed"] = True
+        report["trusted"] = False
+        report["exceptionCount"] = 1
+        text = mod.render_text_report(report)
+        self.assertIn("도구 실패", text)
+
+    def test_non_dict_report(self):
+        mod = load()
+        self.assertIn("보고 봉투가 아니다", mod.render_text_report(None))
+
+
+class AuditOneTests(unittest.TestCase):
+    def test_collection_only_returns_exception(self):
+        mod = load()
+        out = mod.audit_one("bin", "p", {"id": "T"}, {"steps": [{"answer": {}}, {"answer": {}}]}, "w")
+        self.assertIsNone(out["result"])
+        self.assertEqual(out["exception"]["kind"], "collection-only-tail")
+
+    def test_malformed_steps_returns_exception(self):
+        mod = load()
+        out = mod.audit_one("bin", "p", {"id": "T"}, {"steps": {"run": 1}}, "w")
+        self.assertEqual(out["exception"]["kind"], "malformed-reference")
+
+    def test_fatal_is_propagated_from_audit(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise KeyboardInterrupt()
+
+        mod.baseline.build_task = boom
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, steps=2)
+            with self.assertRaises(KeyboardInterrupt):
+                mod.audit("bin", gym, os.path.join(d, "w"))
+
+
+class SafeIoTests(unittest.TestCase):
+    def test_safe_load_json_ok(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "a.json")
+            _write(path, {"id": "T"})
+            obj, err = mod.safe_load_json(path)
+        self.assertEqual(obj, {"id": "T"})
+        self.assertIsNone(err)
+
+    def test_safe_load_json_bad(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "a.json")
+            _write(path, "{")
+            obj, err = mod.safe_load_json(path)
+        self.assertIsNone(obj)
+        self.assertIsInstance(err, json.JSONDecodeError)
+
+    def test_safe_load_json_missing(self):
+        mod = load()
+        obj, err = mod.safe_load_json(os.path.join("no", "such.json"))
+        self.assertIsNone(obj)
+        self.assertIsNotNone(err)
+
+    def test_safe_listdir_missing(self):
+        mod = load()
+        names, err = mod.safe_listdir(os.path.join("no", "such", "dir"))
+        self.assertIsNone(names)
+        self.assertIsNotNone(err)
+
+    def test_safe_isdir_isfile_false_on_error(self):
+        mod = load()
+        self.assertFalse(mod.safe_isdir(os.path.join("no", "dir")))
+        self.assertFalse(mod.safe_isfile(os.path.join("no", "file")))
+
+    def test_task_id_fallback(self):
+        mod = load()
+        self.assertEqual(mod.task_id_of({"id": "T01"}, "x.json"), "T01")
+        self.assertEqual(mod.task_id_of({}, "T01.json"), "T01")
+        self.assertEqual(mod.task_id_of(None, "T01.json"), "T01")
+        self.assertEqual(mod.task_id_of({"id": ""}, "Z.json"), "Z")
+
+
+class MainCliTests(unittest.TestCase):
+    def test_json_missing_bin_path_exits_one(self):
+        mod = load()
+        missing = os.path.join("definitely", "missing", "rhwp-not-here")
+        with mock.patch.object(mod.sys, "argv", ["trajectory.py", "--bin", missing, "--json"]):
+            with mock.patch.object(mod.sys.stdout, "write") as write:
+                code = mod.main()
+        self.assertEqual(code, 1)
+        payload = json.loads(write.call_args[0][0])
+        self.assertTrue(payload["missingBin"])
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["exit"], 1)
+        self.assertIn("missing-bin", _kinds(payload["exceptions"]))
+
+    def test_text_ok_path_uses_render(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            gym = _temp_gym(d, steps=2)
+            captured = {}
+
+            def fake_audit(*_a, **_k):
+                captured["ran"] = True
+                report = mod.empty_report()
+                report["taskCount"] = 1
+                report["loadBearing"] = 1
+                return report
+
+            with mock.patch.object(mod, "GYM_ROOT", gym):
+                with mock.patch.object(mod, "audit", fake_audit):
+                    with mock.patch.object(mod, "resolve_bin_safe", return_value=("bin", None)):
+                        with mock.patch.object(mod.sys, "argv", ["trajectory.py", "--bin", "bin"]):
+                            with mock.patch.object(mod.sys.stdout, "write") as write:
+                                code = mod.main()
+        self.assertEqual(code, 0)
+        self.assertTrue(captured.get("ran"))
+        self.assertIn("연극 0", write.call_args[0][0])
+
+
+class GeneratedClassifyTableTests(unittest.TestCase):
+    """분류 표를 한 칸씩 다시 고정한다. 단스텝 answer ≠ collection-only."""
+
+    CASES = (
+        ("empty_none", None, "empty-steps"),
+        ("empty_list", [], "empty-steps"),
+        ("single_run", [{"run": [1]}], "single-step"),
+        ("single_answer", [{"answer": {}}], "single-step"),
+        ("single_keyring", [{"keyring_from": "A"}], "single-step"),
+        ("two_run", [{"run": [1]}, {"run": [2]}], "multi"),
+        ("run_answer", [{"run": [1]}, {"answer": {}}], "multi"),
+        ("run_keyring", [{"run": [1]}, {"keyring_from": "A"}], "multi"),
+        ("two_answer", [{"answer": {}}, {"answer": {}}], "collection-only-tail"),
+        ("answer_keyring", [{"answer": {}}, {"keyring_from": "A"}], "collection-only-tail"),
+        ("three_collection", [{"answer": {}}, {"answer": {}}, {"keyring_from": "A"}], "collection-only-tail"),
+        ("three_multi", [{"run": [1]}, {"run": [2]}, {"answer": {}}], "multi"),
+        ("empty_map_then_answer", [{}, {"answer": {}}], "multi"),
+        ("not_list", {"steps": 1}, "malformed-reference"),
+    )
+
+    def test_each_row(self):
+        mod = load()
+        for name, steps, expected in self.CASES:
+            with self.subTest(name=name):
+                self.assertEqual(mod.classify_steps(steps), expected)
+
+
+class GeneratedExceptionCatalogTests(unittest.TestCase):
+    def test_required_kinds_are_stable(self):
+        mod = load()
+        required = (
+            "missing-reference",
+            "empty-steps",
+            "collection-only-tail",
+            "missing-bin",
+        )
+        self.assertEqual(mod.EXCEPTION_KINDS[:4], required)
+
+    def test_step_labels_are_stable(self):
+        mod = load()
+        self.assertEqual(
+            mod.STEP_LABELS,
+            ("multi", "single-step", "empty-steps", "collection-only-tail", "malformed-reference"),
+        )
+
+    def test_collection_keys_are_stable(self):
+        mod = load()
+        self.assertEqual(set(mod.COLLECTION_STEP_KEYS), {"answer", "keyring_from"})
+
+    def test_report_kind_stable(self):
+        mod = load()
+        self.assertEqual(mod.REPORT_KIND, "gymTrajectoryNecessity")
+        self.assertEqual(mod.SCHEMA_VERSION, "1.0")
+        self.assertEqual(mod.EXIT_OK, 0)
+        self.assertEqual(mod.EXIT_FAILED, 1)
+
+
+class GeneratedHonestyMatrixTests(unittest.TestCase):
+    """ok / exit / trusted 정직 행렬. 연극과 도구 실패를 섞지 않는다."""
+
+    def _matrix(self):
+        return (
+            # theater, missing_bin, exceptions, expected_ok, expected_exit, expected_trusted
+            (False, False, False, True, 0, True),
+            (True, False, False, False, 1, True),
+            (False, True, False, True, 1, False),
+            (True, True, False, False, 1, False),
+            (False, False, True, True, 0, False),
+            (True, False, True, False, 1, False),
+            (False, True, True, True, 1, False),
+        )
+
+    def test_matrix(self):
+        mod = load()
+        for theater, missing_bin, has_exc, ok, exit_code, trusted in self._matrix():
+            with self.subTest(theater=theater, missing_bin=missing_bin, has_exc=has_exc):
+                theater_list = ["x"] if theater else []
+                exceptions = [{"kind": "empty-steps"}] if has_exc else []
+                self.assertEqual(mod.report_ok(theater_list, missing_bin=missing_bin), ok)
+                self.assertEqual(
+                    mod.report_exit(theater_list, missing_bin=missing_bin, tool_failed=missing_bin),
+                    exit_code,
+                )
+                self.assertEqual(
+                    mod.report_trusted(exceptions, tool_failed=missing_bin, missing_bin=missing_bin),
+                    trusted,
+                )
+
+
+class LoadBearingLogicKeptTests(unittest.TestCase):
+    """마지막 스텝 판정 다섯 칸을 예외 보강 뒤에도 다시 고정한다."""
+
+    def test_pass_true_is_still_theater(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            r = mod.audit("bin", _temp_gym(d, 2), os.path.join(d, "w"))
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["loadBearing"], 0)
+
+    def test_pass_false_is_still_load_bearing(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: None
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            r = mod.audit("bin", _temp_gym(d, 2), os.path.join(d, "w"))
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["loadBearing"], 1)
+
+    def test_runtime_error_is_still_load_bearing(self):
+        mod = load()
+        mod.baseline.build_task = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x"))
+        mod.runner.score_task = lambda *a, **k: {"pass": True}
+        with tempfile.TemporaryDirectory() as d:
+            r = mod.audit("bin", _temp_gym(d, 2), os.path.join(d, "w"))
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["loadBearing"], 1)
+        self.assertEqual(r["exceptions"], [])
+
+    def test_three_steps_removes_only_last_meaningful(self):
+        mod = load()
+        captured = []
+        mod.baseline.build_task = lambda _b, _p, _t, ref, _r: captured.append(ref["steps"])
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", steps=[
+                {"run": ["one"]},
+                {"run": ["two"]},
+                {"run": ["three"]},
+                {"answer": {}},
+            ])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["loadBearing"], 1)
+        self.assertEqual(captured, [[{"run": ["one"]}, {"run": ["two"]}, {"answer": {}}]])
+        self.assertEqual(r["results"][0]["removedStep"], "run")
+        self.assertEqual(r["results"][0]["steps"], 4)
+
+
+class ScanTaskPairUnitTests(unittest.TestCase):
+    def test_missing_ref_uses_task_id(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            task_path = os.path.join(d, "T.json")
+            _write(task_path, _task_body("HELLO"))
+            rec = mod.scan_task_pair("p", "T.json", task_path, os.path.join(d, "no.json"))
+        self.assertEqual(rec["label"], "missing-reference")
+        self.assertEqual(rec["exception"]["task"], "HELLO")
+
+    def test_task_not_object(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            task_path = os.path.join(d, "T.json")
+            _write(task_path, [1, 2, 3])
+            rec = mod.scan_task_pair("p", "T.json", task_path, os.path.join(d, "r.json"))
+        self.assertEqual(rec["label"], "malformed-task")
+
+    def test_reference_not_object(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            task_path = os.path.join(d, "T.json")
+            ref_path = os.path.join(d, "R.json")
+            _write(task_path, _task_body("T"))
+            _write(ref_path, [1])
+            rec = mod.scan_task_pair("p", "T.json", task_path, ref_path)
+        self.assertEqual(rec["label"], "malformed-reference")
+
+
+class ResolveBinSafeTests(unittest.TestCase):
+    def test_plain_name_does_not_invent_missing_bin(self):
+        mod = load()
+        path, err = mod.resolve_bin_safe("bin")
+        self.assertIsNone(err)
+        self.assertTrue(path)
+
+    def test_missing_path_returns_error(self):
+        mod = load()
+        path, err = mod.resolve_bin_safe(os.path.join("no", "rhwp"))
+        self.assertIsInstance(err, FileNotFoundError)
+        self.assertTrue(path)
+
+
+class StepsOfReferenceTests(unittest.TestCase):
+    def test_none_reference(self):
+        mod = load()
+        self.assertIsNone(mod.steps_of_reference(None))
+        self.assertIsNone(mod.normalize_steps(None))
+        self.assertEqual(mod.normalize_steps([]), [])
+        self.assertIsNone(mod.normalize_steps({"a": 1}))
+
+    def test_task_label(self):
+        mod = load()
+        self.assertEqual(mod.task_label("p1", "T"), "p1/T")
+
+
+class RealGymScanSmokeTests(unittest.TestCase):
+    """devel 운동장을 읽기만 한다. pack 을 고치지 않는다.
+
+    이 가지는 예외 경로를 열 뿐 기존 기준풀이를 연극으로 바꾸지 않는다.
+    단스텝 answer(T01 등)는 skip 이고, 길이 ≥2 수집 전용 tail 은 없어야
+    한다. 빈 steps 도 없어야 한다 — 있으면 원 도입 이후 정합이 깨진 것이다.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load()
+        gym_root = cls.mod.GYM_ROOT
+        cls.records, cls.tool_errors = cls.mod.scan_gym(gym_root)
+        cls.by_label = {}
+        for rec in cls.records:
+            cls.by_label.setdefault(rec.get("label"), []).append(rec)
+
+    def test_scan_sees_real_packs(self):
+        self.assertGreater(len(self.records), 10)
+        self.assertEqual(self.tool_errors, [])
+
+    def test_no_empty_steps_in_devel_refs(self):
+        self.assertEqual(self.by_label.get("empty-steps", []), [])
+
+    def test_no_collection_only_multi_in_devel_refs(self):
+        self.assertEqual(self.by_label.get("collection-only-tail", []), [])
+
+    def test_no_malformed_in_devel_refs(self):
+        self.assertEqual(self.by_label.get("malformed-reference", []), [])
+        self.assertEqual(self.by_label.get("malformed-json", []), [])
+        self.assertEqual(self.by_label.get("malformed-task", []), [])
+
+    def test_single_step_exists_and_is_not_exception(self):
+        singles = self.by_label.get("single-step", [])
+        self.assertGreater(len(singles), 0)
+        # T01 은 단스텝 answer. 예외로 승격되면 안 된다.
+        ids = {self.mod.task_id_of(r.get("task"), r.get("name") or "") for r in singles}
+        self.assertIn("T01", ids)
+
+    def test_multi_candidates_have_meaningful_index(self):
+        multis = self.by_label.get("multi", [])
+        self.assertGreater(len(multis), 0)
+        for rec in multis:
+            steps = rec["reference"]["steps"]
+            idx = self.mod.last_meaningful_step_index(steps)
+            self.assertIsNotNone(idx, rec.get("name"))
+            self.assertGreaterEqual(len(steps), 2)
+
+    def test_multi_step_generator_matches_length_filter(self):
+        pairs = list(self.mod.multi_step_tasks(self.mod.GYM_ROOT))
+        long_refs = [
+            rec for rec in self.records
+            if isinstance(rec.get("reference"), dict)
+            and isinstance(rec["reference"].get("steps"), list)
+            and len(rec["reference"]["steps"]) >= 2
+        ]
+        self.assertEqual(len(pairs), len(long_refs))
+
+
+class KeyringTailKeptTests(unittest.TestCase):
+    def test_trailing_keyring_is_kept_like_answer(self):
+        mod = load()
+        captured = []
+        mod.baseline.build_task = lambda _b, _p, _t, ref, _r: captured.append(ref["steps"])
+        mod.runner.score_task = lambda *a, **k: {"pass": False}
+        with tempfile.TemporaryDirectory() as d:
+            gym = os.path.join(d, "gym")
+            _plant(gym, "p1", "T", steps=[
+                {"run": ["wrap"]},
+                {"keyring_from": "T13"},
+            ])
+            r = mod.audit("bin", gym, os.path.join(d, "w"))
+        self.assertEqual(r["exceptions"], [])
+        self.assertEqual(captured, [[{"keyring_from": "T13"}]])
+        self.assertEqual(r["results"][0]["removedStep"], "run")
+
+    def test_two_collection_keys_on_same_step_stay_tail(self):
+        mod = load()
+        steps = [{"run": ["a"]}, {"answer": 1, "keyring_from": "x"}]
+        self.assertEqual(mod.last_meaningful_step_index(steps), 0)
+        self.assertEqual(mod.step_kind_label(steps[1]), "answer/keyring_from")
+        self.assertEqual(mod.truncate_steps(steps, 0), [{"answer": 1, "keyring_from": "x"}])
+
+
+class ReportValidateEdgeTests(unittest.TestCase):
+    def test_missing_required_key(self):
+        mod = load()
+        report = mod.empty_report()
+        del report["kind"]
+        issues = mod.validate_report(report)
+        self.assertTrue(any("kind" in item for item in issues))
+
+    def test_wrong_kind(self):
+        mod = load()
+        report = mod.empty_report()
+        report["kind"] = "gymAudit"
+        issues = mod.validate_report(report)
+        self.assertTrue(any("kind" in item for item in issues))
+
+    def test_wrong_schema(self):
+        mod = load()
+        report = mod.empty_report()
+        report["schemaVersion"] = "9.9"
+        issues = mod.validate_report(report)
+        self.assertTrue(any("schemaVersion" in item for item in issues))
+
+    def test_theater_not_list(self):
+        mod = load()
+        report = mod.empty_report()
+        report["theater"] = "x"
+        issues = mod.validate_report(report)
+        self.assertTrue(any("theater" in item for item in issues))
+
+    def test_task_count_mismatch(self):
+        mod = load()
+        report = mod.empty_report()
+        report["results"] = [mod.make_result_row("p", "T", True, 2, "run")]
+        report["taskCount"] = 0
+        report["loadBearing"] = 1
+        issues = mod.validate_report(report)
+        self.assertTrue(any("taskCount" in item for item in issues))
+
+    def test_unknown_exception_kind(self):
+        mod = load()
+        report = mod.empty_report()
+        report["exceptions"] = [{"kind": "not-real"}]
+        report["exceptionCount"] = 1
+        report["trusted"] = False
+        issues = mod.validate_report(report)
+        self.assertTrue(any("카탈로그" in item for item in issues))
+
+    def test_trusted_lie(self):
+        mod = load()
+        report = mod.empty_report()
+        report["exceptions"] = [mod.exception_row("empty-steps", pack="p", task="T")]
+        report["exceptionCount"] = 1
+        report["trusted"] = True
+        issues = mod.validate_report(report)
+        self.assertTrue(any("trusted" in item for item in issues))
+
+
+class ExceptionFromExcTests(unittest.TestCase):
+    def test_includes_error_type(self):
+        mod = load()
+        row = mod.exception_from_exc(FileNotFoundError("rhwp"), context="audit", pack="p", task="T")
+        self.assertEqual(row["kind"], "missing-bin")
+        self.assertEqual(row["error"], "FileNotFoundError")
+        self.assertEqual(row["pack"], "p")
+        self.assertEqual(row["task"], "T")
+
+    def test_none_exc(self):
+        mod = load()
+        row = mod.exception_from_exc(None)
+        self.assertEqual(row["kind"], "unexpected")
+        self.assertEqual(row["error"], "NoneType")
+
+
+class IterPackIdsTests(unittest.TestCase):
+    def test_missing_packs_dir(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            ids, err = mod.iter_pack_ids(d)
+        self.assertEqual(ids, [])
+        self.assertIsNone(err)
+
+    def test_file_is_not_a_pack(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "packs"))
+            _write(os.path.join(d, "packs", "readme.txt"), "x")
+            os.makedirs(os.path.join(d, "packs", "real"))
+            ids, err = mod.iter_pack_ids(d)
+        self.assertEqual(ids, ["real"])
+        self.assertIsNone(err)
+
+
+class FormatExceptionLineMoreTests(unittest.TestCase):
+    def test_path_only(self):
+        mod = load()
+        text = mod.format_exception_line({"kind": "os-error", "path": "packs"})
+        self.assertEqual(text, "os-error: packs")
+
+    def test_head_only(self):
+        mod = load()
+        text = mod.format_exception_line({"kind": "empty-steps", "head": "비었다"})
+        self.assertEqual(text, "empty-steps: 비었다")
+
+    def test_empty_kind_falls_back(self):
+        mod = load()
+        text = mod.format_exception_line({"kind": "", "pack": "p", "task": "T"})
+        self.assertTrue(text.startswith("unexpected") or "p/T" in text)
+
+
+class AttachMissingBinFromRowsTests(unittest.TestCase):
+    def test_flag_from_exception_rows(self):
+        mod = load()
+        report = mod.empty_report()
+        report["exceptions"] = [mod.exception_row("missing-bin", pack="p", task="T")]
+        mod.attach_report_counts(report)
+        self.assertTrue(report["missingBin"])
+        self.assertTrue(report["toolFailed"])
+        self.assertEqual(report["exit"], 1)
+        self.assertTrue(report["ok"])
+
+
+class ScorePassVariantsTests(unittest.TestCase):
+    def test_pass_zero_is_load_bearing(self):
+        mod = load()
+        self.assertTrue(mod.verdict_from_score({"pass": 0}))
+
+    def test_pass_empty_string_is_load_bearing(self):
+        mod = load()
+        self.assertTrue(mod.verdict_from_score({"pass": ""}))
+
+    def test_pass_one_is_theater(self):
+        # 파이썬 진릿값. 1 은 True 와 같다. 채점 봉투는 bool 이지만
+        # 예전 계약처럼 진릿값만 본다.
+        mod = load()
+        self.assertFalse(mod.verdict_from_score({"pass": 1}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

트라젝토리 필요성 감사의 마지막 스텝 load-bearing 판정은 그대로 두고, 탐색이 삼키던 예외 경로를 보고 봉투에 남긴다.

- 기준풀이 부재(`missing-reference`), 빈 `steps`(`empty-steps`), 수집 전용 tail(`collection-only-tail`), 바이너리 부재(`missing-bin`)를 예외 목록으로 기록한다.
- `FileNotFoundError` 를 load-bearing 으로 부르지 않는다. 없는 바이너리가 전 과제를 정상으로 위장하지 못한다.
- 단스텝 `answer`(T01)는 예외가 아니다. trailing `answer`/`keyring_from` 은 그대로 남기고 마지막 의미 스텝만 뺀다.
- `ok` 는 연극 0건과만 같다. missing-bin 은 `exit=1`·`trusted=false` 로 가린다.
- CLI 는 `--bin` / `--json` 만. 새 pack 없음. 열린 PR(5210–5248) 파일과 discriminate/fuzz/automation/core-cli/casual-rides 는 건드리지 않았다.

## 관련 이슈

closes #5254

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_trajectory -q` — 139 ran, 0 failed
- [x] `python gym/tools/audit.py` — 18 pack 통과
- [ ] **`cargo fmt --all -- --check` 통과** (이번 변경은 Python/문서만. 사용자 지시에 따라 생략)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [ ] `cargo test` 통과 (해당 없음)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 단위 시험은 바이너리 없이 돈다. 라이브 스윕은 기존과 같이 rhwp 가 필요하다.
