### PR TITLE
feat(gym): fuzz_corpus 결정적 변형·예외 경로 강화 (#5256)

### DIFF
--- a/gym/docs/fuzz_corpus.md
+++ b/gym/docs/fuzz_corpus.md
@@ -1,0 +1,585 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/fuzz_corpus.md
+last_verified: 2026-08-18
+---
+
+# gym 코퍼스 퍼징 발견 엔진 규약
+
+이 문서는 `gym/tools/fuzz_corpus.py` 의 **결정적 손상 카탈로그**와 **예외
+경로 계약**을 고정한다. 구현은 [`gym/tools/fuzz_corpus.py`](../tools/fuzz_corpus.py),
+계약 시험은 [`scripts/tests/test_gym_fuzz_corpus.py`](../../scripts/tests/test_gym_fuzz_corpus.py)
+다. 작업 기록은 [`mydocs/working/gym_fuzz_corpus.md`](../../mydocs/working/gym_fuzz_corpus.md)
+를 본다.
+
+`robustness.py` 는 릴리스 **게이트**다. 이 도구는 그 앞단의 **발견 엔진**이다.
+무작위가 없고, 같은 입력은 같은 라벨·바이트를 낸다. 원본과 바이트가 같은
+무의미 변형은 버린다. 없는 바이너리·빈 코퍼스·읽기 실패는 DoS 로 위장하지
+않는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+gym 의 세 기둥은 과제의 채점과 도구의 수명을 지킨다.
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 종점 무결성 | `discriminate.py` (#4808) | 일 안 한 제출이 만점을 받나? |
+| 경로 무결성 | `trajectory.py` (#4810) | 마지막 스텝을 빼도 통과하나? |
+| 도구 강건성 | `robustness.py` (#4814 / #5218) | 손상 입력에 rhwp 가 패닉·행 하나? |
+| 발견 | `fuzz_corpus.py` (#4828 / #5256) | 전 코퍼스 × 다명령에서 고유 DoS 가 몇 곳인가? |
+
+게이트는 바운드된 부분집합으로 "패닉·행 0"을 강제한다. 발견 엔진은 전
+코퍼스를 여러 명령·여러 손상으로 exhaustive 하게 두들겨, 패닉을 **소스
+위치(file:line)별로 묶어** "고쳐야 할 고유 버그 목록"을 낸다. 게이트가
+회귀를 막고, 발견이 새 버그를 찾는다. 둘을 한 도구로 합치면 게이트가
+느려지거나 발견이 부분집합에 갇힌다.
+
+아무도 손으로 수백 문서를 수천 가지로 퍼징하지 않는다. 에이전트가 이걸
+돌려 rhwp 를 계속 경화한다. 이 캠페인의 실제 DoS(렌더러·파서 오버플로·
+무한루프·스택 오버플로)를 전부 이 엔진이 잡았다.
+
+발견 엔진 자신도 예외 경로에서 죽지 않는다. 없는 바이너리, 빈 코퍼스,
+읽을 수 없는 표본, 쓰기 실패, 프로브 시간초과·OS 오류는 분류해 보고하고
+중단하지 않는다. 도구가 죽으면 CI 가 붉어져 하네스 결함과 rhwp DoS 를
+구분할 수 없다.
+
+## 2. 사용
+
+```bash
+python gym/tools/fuzz_corpus.py --bin target/debug/rhwp
+python gym/tools/fuzz_corpus.py --bin <bin> --commands info,export-text
+python gym/tools/fuzz_corpus.py --bin <bin> --limit 40 --workers 8 --json
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--bin` | (필수) | rhwp 바이너리. `gym.core.runner.find_bin` 으로 해석한다. |
+| `--commands` | `info,export-text,export-structure,export-render-tree` | 쉼표구분 명령. 빈 토큰·중복은 버린다. |
+| `--limit` | 0 | 표본 수. 0 은 전수. 음수·변환 불능은 0. |
+| `--workers` | 8 | 병렬 워커. 비양수는 1. |
+| `--timeout` | 10 | 프로브 초. 비양수는 프로브가 `invalid-timeout` 으로 거절. |
+| `--json` | off | `gymFuzzCorpus` 봉투를 stdout 에 쓴다. |
+
+새 플래그는 없다. `--samples-dir` 를 넣지 않는다. 코퍼스는 항상
+`<repo>/samples` 다. 라이브러리 `fuzz()` 는 시험이 임시 디렉터리를 넘길
+수 있게 `samples_dir` 인자를 받는다.
+
+종료 코드:
+
+| exit | 의미 |
+|---|---|
+| 0 | 패닉 클러스터 0 · 행 클러스터 0 · 도구 실패 없음. |
+| 1 | 고유 패닉 또는 행이 하나라도 있다. |
+| 2 | 바이너리를 찾지 못했거나 도구가 코퍼스를 쓰지 못했다. |
+
+`ok` 는 패닉·행 부재 **그리고** `toolFailed` 가 거짓일 때만 true 다.
+빈 코퍼스는 DoS 가 아니다 — `emptyCorpus=true`, `ok=true`, exit 0.
+없는 바이너리는 DoS 가 아니다 — `missingBin=true`, `toolFailed=true`,
+`ok=false`, exit 2. "DoS 0" 이라고 쓰면 거짓말이다.
+
+읽기실패와 프로브오류는 **엔진 생존** 신호이지 rhwp DoS 가 아니다.
+`ok` 를 뒤집지 않는다. 다만 모든 프로브가 `missing-bin` 이면 바이너리가
+없는 것과 같으니 `toolFailed` 로 접는다.
+
+## 3. JSON 봉투 (`gymFuzzCorpus` 1.0)
+
+`kind=gymFuzzCorpus`, `schemaVersion=1.0`. 키 집합은 시험이 `REPORT_KEYS`
+로 고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymFuzzCorpus` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `ok` | bool | 패닉·행이 없고 `toolFailed` 가 거짓일 때만 true |
+| `samplesTested` | int | 실제로 고른 표본 수 |
+| `totalSamples` | int | 디렉터리의 `.hwp`/`.hwpx`/`.hml` 총수 |
+| `commands` | list[str] | 정규화된 명령 목록 |
+| `mutantsPerSample` | int | 4KiB 정상 입력 기준 변형 수 힌트 |
+| `runsChecked` | int | 프로브까지 도달한 실행 수 (변형 × 명령) |
+| `distinctPanicSites` | int | `panicClusters` 길이. 고유 버그 수. |
+| `panicClusters` | list[obj] | `{location, count, example}` 내림차순·위치 타이브레이크 |
+| `hangClusters` | list[obj] | `{command, count, samples, example}` 내림차순·명령 타이브레이크 |
+| `unreadables` | list[str] | 읽기/형태/변형 생성 실패 |
+| `probeErrors` | list[str] | 쓰기 실패·OS 오류·프로브 예외 |
+| `toolErrors` | list[str] | 바이너리 부재·코퍼스 나열 실패·스키마 위반 |
+| `emptyCorpus` | bool | 표본 총수가 0 이고 코퍼스를 읽었다 |
+| `missingBin` | bool | 바이너리 경로가 없거나 모든 프로브가 missing-bin |
+| `toolFailed` | bool | 도구가 발견을 수행하지 못했다 |
+| `inputShapes` | object | `empty`/`tiny`/`normal`/`huge` 카운트 |
+| `exit` | int | 0 / 1 / 2. `resolve_exit()` 와 같아야 한다. |
+
+`validate_report()` 가 이 계약을 다시 검사한다. 키가 빠지거나 `ok` 가
+패닉·행·toolFailed 와 어긋나거나 `distinctPanicSites` 가 클러스터 수와
+다르거나 `exit` 가 `resolve_exit` 와 다르면 위반 목록을 돌려준다.
+
+패닉 클러스터의 `location` 은 `panicked at file:line` 캡처이거나
+`stack-overflow` 이거나 `code{N}` 이다. 행 클러스터의 `command` 는
+시간초과가 난 rhwp 명령이다. `samples` 는 그 명령에서 행이 난 원본
+파일명의 정렬 유일 목록이다. `example` 은 `이름:라벨:명령` 태그 중
+클러스터에 처음 들어온 것이다.
+
+사람용 `format_human_report` 는 같은 사실을 빠뜨리지 않는다.
+
+- 도구 실패: `코퍼스 퍼징: 도구 실패 — …`
+- 빈 코퍼스: `코퍼스 퍼징: 빈 코퍼스 — 표본 0`
+- 깨끗함: `코퍼스 퍼징: 샘플 A/B × 명령 C × N 실행 — DoS 0`
+- DoS: `고유 패닉 X곳 · 행 클러스터 Y개` 와 `PANIC`/`HANG` 줄
+
+`--json` 을 안 줘도 리뷰어가 클러스터를 본다.
+
+## 4. 입력 형태
+
+위치 기반 변형은 입력 길이에 따라 다르게 동작한다. 엔진은 표본을 네
+형태로 접어 `inputShapes` 에 남긴다.
+
+| 형태 | 조건 | 변형 동작 |
+|---|---|---|
+| `empty` | `n==0` | `empty-to-nul` 한 건만. 위치 기반 변형 없음. |
+| `tiny` | `1 <= n <= 64` | 위치 기반은 가능하나 일부는 원본과 같아 버려진다. OLE 꼬리는 잘린 매직을 심는다. |
+| `normal` | `65 <= n < 1MiB` | 전체 카탈로그. 크기 증가 변형 포함. |
+| `huge` | `n >= 1MiB` | 크기 증가 변형(`splice-*`, `pad-eof`, `widen-gap`, `even-length-pad`)을 생략한다. |
+
+형태 분류는 `classify_input_shape()` 가 맡는다. 비-바이트는 `TypeError`
+다. 엔진은 그 예외를 `unreadables` 로 접고 다음 표본으로 간다.
+
+게이트(`robustness.py`)는 `.hwp` 만 고른다. 발견 엔진은 `.hwp` · `.hwpx`
+· `.hml` 을 고른다. HWPX 는 ZIP 이고 HML 은 텍스트다. 형식 축을 빼면
+ZIP 조건부 가족과 HWP3 서명을 놓친다. 대소문자는 무시한다(`X.HWP` 도
+표본이다). `.txt` 는 제외한다.
+
+## 5. 결정성 규칙
+
+1. 입력은 bytes-like 만 받는다. `str`/`int`/`None` 을 조용히 인코딩하지 않는다.
+2. 같은 바이트열은 같은 `(라벨, 바이트)` 순서를 낸다. 난수·시각·entropy 없음.
+3. `add()` 는 `mut == data` 이면 버린다. 무의미 변형이 프로브 예산을 먹지 않는다.
+4. 라벨은 가족 안에서 유일하다. 같은 바이트가 나와도 라벨이 다르면 둘 다 남긴다.
+5. 조건부 가족(ZIP/HWP3)은 매직이 있을 때만 켠다. 없을 때는 inject 쪽이 켠다.
+6. 거대 입력은 크기 증가 변형을 건너뛴다. 발견은 헤더/절단/길이로도 충분하다.
+7. 원 라벨(`truncN` / `flipN` / `biglenN`)은 유지한다. 이미 이 태그로 잡은
+   재현체를 깨지 않기 위해서다. 확대 가족은 뒤에 덧붙인다.
+
+표본 선택은 파일명을 정렬한 뒤 stride 로 `limit` 개를 뽑는다. `limit<=0`
+이면 전수다. 디렉터리를 읽을 수 없으면 빈 목록을 돌려 엔진이 죽지 않게
+한다. stride 반올림 중복은 순서를 유지한 채 제거한다. 같은 디렉터리·같은
+limit 은 같은 목록을 낸다.
+
+명령 목록은 `parse_commands` 가 정규화한다. 빈 토큰과 중복을 버리고
+순서는 유지한다. 전부 비면 기본 명령으로 돌아간다. 기본을 비우면
+"명령 0 × 실행 0 — DoS 0" 이 되어 거짓 음성이 난다.
+
+워커 수는 클러스터 내용을 바꾸지 않는다. `workers=1` 과 `workers=4` 는
+같은 `distinctPanicSites` 와 같은 location 을 낸다. `as_completed` 의
+완료 순서는 비결정이지만, 클러스터 키는 집합이고 정렬 키는
+`(-count, location|command)` 다. 예제의 태그는 "처음 들어온 것"이라
+워커가 많으면 예제 문자열만 갈릴 수 있다. 위치와 건수는 갈리지 않는다.
+
+## 6. 분류기
+
+### 6.1 패닉 (`classify`)
+
+기존 계약은 그대로다. 시험 `test_classify_distinguishes_panic_from_clean`
+이 고정한다.
+
+| 입력 | 결과 |
+|---|---|
+| `panicked at src/x.rs:42:9` | `("panic", "src/x.rs:42")` |
+| `stack overflow` | `("panic", "stack-overflow")` |
+| `code==101` (빈 출력) | `("panic", "code101")` |
+| 음수 코드 (Windows AV) | `("panic", "code-1073741819")` |
+| `code>=132` | `("panic", "code{N}")` |
+| `code==1` 깨끗한 CLI 오류 | `(None, None)` |
+| `code==0` 정상 | `(None, None)` |
+
+`panicked at file:line` 정규식이 먼저다. 위치가 있으면 그 위치가
+클러스터 키다. 위치가 없고 `stack overflow` 가 있으면 그 버킷. 그 다음이
+어보트 코드다. 깨끗한 비-0 실패를 패닉으로 오판하지 않는다.
+
+`err` 가 `None` 이거나 비문자면 빈 문자열로 접는다. `code` 가 int 가
+아니면 `>=132` 분기를 타지 않는다. `101` 과 문자열 비교는 하지 않는다.
+
+`is_panic_code` 는 `classify` 의 패닉 여부만 본다. hang 은 이 함수가
+내지 않는다.
+
+### 6.2 행
+
+`classify_timeout(timed_out)` 이 true 일 때만 행이다.
+
+- `True`
+- `subprocess.TimeoutExpired`
+- `TimeoutError`
+- `OSError` 이면서 `errno` 가 `ETIMEDOUT` 또는 `ETIME`
+- 소문자 표식: `timeout`, `timed out`, `time-out`, `time expired`, `deadline exceeded`
+
+`False`/`None`/그 외 예외/`ValueError("timeout in name only")` 는 행이
+아니다. 시그널 종료(`-9`)는 **패닉 쪽**이다. 일부 환경은 시간초과를
+SIGKILL 로 돌려주지만, 이 엔진은 `TimeoutExpired` 만을 행의 권위로 둔다.
+시그널을 행으로 접으면 실제 크래시가 행으로 위장된다.
+
+`probe` 가 `TimeoutExpired` 를 받으면 `("hang", cmd)` 를 낸다. 버킷은
+명령이다. 같은 명령의 행을 한 클러스터로 묶는다.
+
+### 6.3 프로브 접기
+
+`classify_probe_outcome(kind, bucket)`:
+
+| 결과 | 조건 | 보고 |
+|---|---|---|
+| `hang` | `kind=="hang"` 또는 timeout 분류 | `hangClusters` |
+| `panic` | `kind=="panic"` | `panicClusters` |
+| `error` | `kind=="error"` 또는 bucket 이 예외 kind | `probeErrors` |
+| `clean` | `kind in (None, "clean", "ok")` | 카운트만 |
+| `error` | 그 외 | `probeErrors` |
+
+우선순위는 행 > 패닉 > 오류 > 깨끗함 이다. 프로브가 timeout 을 이미
+선언했기 때문이다. `permission` 같은 오류를 행 클러스터에 넣지 않는다.
+넣으면 "고쳐야 할 DoS" 목록이 권한 오류로 더러워진다.
+
+## 7. 예외 경로 — 엔진이 죽지 않는 계약
+
+발견 엔진 자신이 예외로 죽으면 게이트 앞단이 "DoS 0" 이라는 거짓 음성을
+못 내고, 반대로 CI 가 붉어져 rhwp 결함과 하네스 결함을 구분할 수 없다.
+그래서 모든 I/O·형식·프로브 경로는 분류 가능한 문자열로 접힌다.
+
+이슈 #5256 이 명시한 세 자리는 필수다.
+
+| 경로 | 함수 | 접는 곳 | 보고 키 | exit |
+|---|---|---|---|---|
+| 없는 바이너리 | `find_bin_safe` / `probe` | `missing-bin` | `missingBin` · `toolFailed` · `toolErrors` | 2 |
+| 빈 코퍼스 | `select_samples` / `fuzz` | 표본 0 | `emptyCorpus` | 0 |
+| 읽기 실패 | `read_sample` | `(None, 이유)` | `unreadables` | (ok 유지) |
+
+나머지 자리도 같은 규칙이다.
+
+| 경로 | 함수 | 접는 곳 | 보고 키 |
+|---|---|---|---|
+| 비-바이트 입력 | `coerce_bytes` | `TypeError` | 호출 측. 엔진은 `unreadables` |
+| 형태 분류 실패 | `classify_input_shape` | `TypeError` | `unreadables` |
+| 한도/초/워커 변환 실패 | `normalize_*` | 0 또는 1 | 전수 / 프로브 거절 / 워커 1 |
+| 디렉터리 읽기 실패 | `list_sample_names` | `(None, 이유)` | `toolErrors` 또는 `emptyCorpus` |
+| 변형 생성 `TypeError` | `deterministic_mutants` | 엔진 루프 | `unreadables` |
+| 변형 쓰기 실패 | `write_mutant` | 이유 문자열 | `probeErrors` |
+| timeout <= 0 | `probe` | `invalid-timeout` | `probeErrors` |
+| 빈 바이너리 경로 | `probe` / `fuzz` | `missing-bin` | `missingBin` |
+| 빈 명령 | `probe` | `value-error` | `probeErrors` |
+| `TimeoutExpired` | `probe` | `("hang", cmd)` | `hangClusters` |
+| `FileNotFoundError` | `probe` | `missing-bin` | `probeErrors` (전량이면 toolFailed) |
+| `PermissionError` | `probe` | `permission` | `probeErrors` |
+| 그 외 프로브 예외 | `probe` | `exception_kind` | `probeErrors` |
+| 임시 디렉터리 실패 | `main` | 이유 문자열 | `toolErrors` · exit 2 |
+| `fuzz` 폭주 | `main` | 이유 문자열 | `toolErrors` · exit 2 |
+| 바이너리 탐색 실패 | `main` | stderr + JSON | exit 2 |
+
+`read_sample` / `write_mutant` / `probe` / `fuzz` / `main` 은 맨 바깥에서
+`Exception` 을 삼킨다. `# noqa: BLE001` 주석이 "엔진 생존이 우선"임을
+남긴다. 삼킨 예외는 메시지로 남기므로 침묵 삼킴이 아니다.
+
+치명 예외(`KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+`GeneratorExit`)는 삼키지 않는다. 사용자가 끊었는데 DoS 0 이라고 쓰면
+거짓말이다. `is_fatal_exception` 이 그 네 가지를 가린다.
+`exception_kind` 는 치명 여부를 바꾸지 않는다 — 호출자가 raise 한다.
+
+시험은 이 표의 각 칸을 목킹으로 고정한다. 바이너리 없이 돌아간다.
+
+### 7.1 없는 바이너리
+
+`runner.find_bin` 은 없는 경로도 문자열로 돌려준다. `find_bin_safe` 가
+`os.path.exists` 로 한 번 더 본다. 없거나 빈 경로면
+`(None, "missing-bin: …")` 이다. `main` 은 이 자리에서 `fuzz` 를 부르지
+않고 exit 2 를 낸다. JSON 이면 봉투를 stdout 에, 사람이면 요약을
+stderr 에 쓴다.
+
+`fuzz("", …)` 는 라이브러리 경로다. 빈 경로는 즉시 `missingBin` 이다.
+존재하는 것처럼 보이는 가짜 경로로 `probe` 를 부르면 `FileNotFoundError`
+가 `missing-bin` 으로 접힌다. 모든 프로브가 그 kind 이고 패닉·행이
+없으면 `toolFailed` 다. "프로브는 돌았으니 DoS 0" 이라고 쓰면 거짓말이다.
+
+### 7.2 빈 코퍼스
+
+`samples` 에 `.hwp`/`.hwpx`/`.hml` 이 없으면 `emptyCorpus=true` 다.
+`.txt` 만 있는 디렉터리도 빈 코퍼스다. 표본 0 은 발견할 DoS 가 없다는
+뜻이지 도구 실패가 아니다. `ok=true`, exit 0. 사람용 문구는
+`빈 코퍼스 — 표본 0` 이다. `DoS 0` 이라고 쓰면 전수를 돈 것처럼 보인다.
+
+디렉터리 자체가 없으면 `list_sample_names` 가 `empty-corpus` 또는
+`os-error` 로 접는다. `fuzz` 는 예외를 올리지 않는다.
+
+### 7.3 읽기 실패
+
+한 파일이 `PermissionError` / `FileNotFoundError` / 그 외 `OSError` 로
+안 읽히면 `unreadables` 에 `이름: unreadable: …` 를 남기고 다음 표본으로
+간다. 나머지 표본은 그대로 프로브한다. `ok` 는 패닉·행만 본다. 한 파일이
+잠겨 있다고 전 코퍼스 발견을 멈추지 않는다.
+
+`deterministic_mutants` 가 `TypeError` 를 내면 그것도 `unreadables` 다.
+변형을 못 만든 표본은 프로브하지 않는다.
+
+## 8. 변형 카탈로그
+
+카탈로그는 `MUTANT_CATALOG` 다. `mutant_catalog()` 가 사본을 돌려
+시험·문서가 같은 표를 본다. 무작위 필드가 없다.
+
+아래 표의 `when` 은 생성 조건이다. 조건이 맞아도 원본과 바이트가 같으면
+`add()` 가 버린다. 원 라벨은 게이트의 `truncate@P%` 와 달리 `truncP` 다.
+이미 이 태그로 열린 이슈·재현체를 깨지 않기 위해서다.
+
+### 8.1 empty
+
+| id | when | 하는 일 |
+|---|---|---|
+| `empty-to-nul` | `n==0` | NUL 한 바이트. 빈 입력의 유일한 변형. |
+
+### 8.2 truncate
+
+| id | when | 하는 일 |
+|---|---|---|
+| `truncP` | `n>0` | 앞 `max(1, n*P/100)` 바이트만 남긴다. P ∈ {1,5,10,25,50,75,95,99} |
+| `chop-last` | `n>=2` | 마지막 1바이트를 자른다. 오프바이원 레코드 끝. |
+| `cut-first` | `n>=1` | 선두 1바이트를 버린다. 매직이 한 칸 밀린 파일. |
+| `odd-length-chop` | 짝수이고 `n>=2` | 짝수 길이를 홀수로 만들어 UTF-16 워드 정렬을 깨뜨린다. |
+| `shrink-gap` | `n>=8` | 1/4 지점의 4바이트를 삭제해 뒤 레코드를 당긴다. |
+
+잘린 OLE/ZIP 은 중앙 디렉터리·FAT 가 없는 복합문서를 재현한다. 첫 주행이
+잡은 HWP3 line-spacing 패닉도 짧은 본문에서 터졌다. `trunc5/25/50/75/95`
+는 원 라벨이다. `trunc1/10/99` 는 확대분이다.
+
+### 8.3 flip
+
+| id | when | 하는 일 |
+|---|---|---|
+| `flipP` | `n>0` | 위치 `min(n-1, n*P/100)` 한 바이트를 XOR 0xFF. P ∈ {0,10,25,30,50,70,75,90,99} |
+
+원 라벨은 `flip10/30/50/70/90` 이다. 가장자리(`0`, `99`)와 사분면
+(`25`, `75`)을 보탠다. 1바이트 입력에서는 모든 플립이 같은 바이트를
+건드리지만 라벨은 남는다.
+
+### 8.4 length
+
+| id | when | 하는 일 |
+|---|---|---|
+| `biglenP` | `n>=4` | 위치에 `0x7FFFFFFF` (u32 LE). P ∈ {10,40,70}. 원 라벨. |
+| `length-zero30` | `n>=4` | `0x00000000`. 빈 레코드 조기 종료. |
+| `length-one60` | `n>=4` | `0x00000001`. 오프바이원 슬라이스. |
+| `i32-min20` | `n>=4` | `0x80000000`. 음수 길이. |
+| `u16-max12` | `n>=14` | 오프셋 12 의 u16 을 `0xFFFF`. |
+
+길이 필드는 할당 폭주와 정수 오버플로의 입구다. 양수 포화·0·1·음수
+최소를 모두 심어야 파서의 범위 검사가 한 갈래만 통과하는 일을 막는다.
+
+### 8.5 header
+
+| id | when | 하는 일 |
+|---|---|---|
+| `zero-header` | `n>0` | 선두 최대 512바이트를 0 으로 지운다. |
+| `header-smash` | `n>0` | 선두 최대 64바이트를 `DEADBEEF` 반복으로 덮는다. |
+| `rotate-header` | `n>=2` | 선두 8바이트를 한 칸 왼쪽 순환. |
+| `increment-header` | `n>0` | 선두 8바이트에 1 을 더한다(랩어라운드). |
+| `nibble-swap-head` | `n>0` | 선두 32바이트의 니블을 맞바꾼다. |
+
+`zero-header` 와 `header-smash` 를 나눈 이유: 매직이 없는 것과 매직이
+다른 손상인 것을 구분해야 파서의 형식 판별 분기를 따로 두드릴 수 있다.
+
+### 8.6 ole
+
+| id | when | 하는 일 |
+|---|---|---|
+| `ole-trunc-tail` | `n>64` | 꼬리 64바이트를 자른다. CFB 디렉터리/FAT 가 잘린 복합문서. |
+| `ole-trunc-tail` | `n<=64` | 꼬리 `k` 바이트를 잘린 OLE 매직으로 바꾼다. |
+| `ole-magic-poison` | `n>0` | 선두에 OLE 매직 XOR 0xFF 를 덮는다. |
+| `ole-sector-shift-poison` | `n>=32` | 오프셋 30 의 섹터 시프트를 `0xFFFF` 로. |
+| `ole-mini-fat-poison` | `n>=72` | 오프셋 60 의 MiniFAT 시작 섹터를 `0xFFFFFFFF` 로. |
+
+HWP5 는 CFB(OLE) 다. 섹터 시프트와 MiniFAT 는 할당 폭주·무한 루프의
+고전 위치다. 게이트와 같은 오프셋을 쓰면 게이트가 놓친 명령 축(export-*)
+에서 같은 손상을 다시 볼 수 있다.
+
+### 8.7 run
+
+| id | when | 하는 일 |
+|---|---|---|
+| `ff-run` | `n>0` | 1/3 지점에 최대 128바이트의 `0xFF` 런. |
+| `aa-run` | `n>0` | 선두 1/4 에 `0xAA` 런. |
+| `nul-mid` | `n>0` | 한가운데 최대 64바이트를 NUL. UTF-16 종료 위조. |
+| `00-run` | `n>0` | 2/3 지점에 NUL 런. 레코드 조기 종료. |
+| `55-run` | `n>0` | 선두 1/5 에 `0x55` 런. |
+
+런 패턴을 나눈 이유: `0xFF` 는 부호 없는 포화, `0x00` 은 종료,
+`0xAA`/`0x55` 는 교차 비트다. 한 패턴만 보면 파서의 다른 정수 해석을
+놓친다.
+
+### 8.8 unicode
+
+| id | when | 하는 일 |
+|---|---|---|
+| `utf16-nul-sprinkle` | `n>=2` | 20/40/60/80% 짝수 오프셋에 U+0000. |
+| `utf16-bom-inject` | `n>=2` | 선두에 UTF-16LE BOM(`FF FE`). |
+| `utf8-overlong` | `n>=2` | 1/5 지점에 overlong NUL(`C0 80`). |
+| `ascii-ctrl-sprinkle` | `n>0` | 15/35/55/75% 에 SOH(0x01). |
+| `path-sep-sprinkle` | `n>0` | 18/42/66/88% 에 `/` 와 `\\` 를 교차. |
+
+HWP 본문은 UTF-16LE 가 기본이다. NUL 뿌림은 문자열 절단을, BOM 은
+인코딩 오인을, overlong 은 UTF-8 검증을, 경로 구분자는 스트림 이름
+해석을 두드린다.
+
+### 8.9 zip
+
+| id | when | 하는 일 |
+|---|---|---|
+| `zip-local-header-flip` | `PK\\x03\\x04` 존재 | 그 4바이트만 XOR 0xFF. |
+| `zip-magic-inject` | 로컬 헤더 없음, `n>=4` | 선두에 로컬 헤더 매직을 심는다. |
+| `zip-cd-magic-flip` | `PK\\x01\\x02` 존재 | 중앙 디렉터리 매직만 플립. |
+| `zip-eocd-flip` | `PK\\x05\\x06` 존재 | EOCD 매직만 플립. |
+
+HWPX 는 ZIP 이다. 로컬 헤더·중앙 디렉터리·EOCD 를 따로 두드려야
+아카이브 탐색의 세 입구를 모두 본다. inject 는 비-ZIP(HWP5) 을 ZIP 으로
+오인하게 한다.
+
+### 8.10 permute
+
+| id | when | 하는 일 |
+|---|---|---|
+| `reverse-prefix` | `n>=2` | 선두 16바이트를 뒤집는다. |
+| `swap-ends` | `n>=16` | 선두 8과 꼬리 8을 맞바꾼다. |
+| `slide-window-left` | `n>=8` | 선두 32바이트를 한 바이트 왼쪽. |
+| `slide-window-right` | `n>=8` | 선두 32바이트를 한 바이트 오른쪽. |
+| `repeat-mid-block` | `n>=32` | 한가운데 32바이트를 바로 앞에 복사. |
+
+매직 순서와 필드 정렬을 깨뜨린다. 바이트 값 오염(flip/run)과 다른 축이다.
+
+### 8.11 stripe
+
+| id | when | 하는 일 |
+|---|---|---|
+| `high-bit-stripe` | `n>0` | 16바이트마다 상위 비트. |
+| `low-bit-stripe` | `n>0` | 16바이트마다 최하위 비트 반전. |
+| `xor-stride7` | `n>0` | 7바이트마다 `0xA5` XOR. |
+| `interleave-zero-head` | `n>0` | 선두 32의 홀수 인덱스를 0. |
+| `duplicate-prefix` | `n>=16` | 선두 8을 바로 다음에 복제. |
+| `tail-over-head` | `n>=32` | 꼬리 16을 선두에 덮음. |
+| `invert-tail-64` | `n>0` | 꼬리 최대 64바이트 비트 반전. |
+| `complement-mid-32` | `n>0` | 한가운데 최대 32바이트 비트 반전. |
+| `bit-rotate-head` | `n>0` | 선두 16바이트를 1비트 왼쪽 회전. |
+| `decrement-tail` | `n>0` | 꼬리 8바이트에서 1 을 뺀다. |
+
+주기적 오염은 레코드 정렬·체크섬·부호 있는 길이를 흔든다. 한 자리만
+뒤집으면 그 필드만 본다.
+
+### 8.12 splice
+
+| id | when | 하는 일 |
+|---|---|---|
+| `splice-nul-mid` | `n>0` 이고 거대 아님 | 한가운데에 NUL 16바이트. |
+| `crlf-inject` | `n>0` 이고 거대 아님 | 한가운데에 CRLF. |
+| `pad-eof` | `n>0` 이고 거대 아님 | 끝에 SUB(0x1A). |
+| `widen-gap` | `n>0` 이고 거대 아님 | 1/4 지점에 NUL 4바이트. |
+| `even-length-pad` | 홀수이고 거대 아님 | 끝에 NUL 하나. UTF-16 워드 맞춤. |
+
+거대 입력에 바이트를 끼우면 사본이 커진다. 발견 엔진의 예산은 헤더·절단·
+길이에 쓰는 편이 낫다. 게이트와 같은 생략 규칙이다.
+
+### 8.13 hwp3
+
+| id | when | 하는 일 |
+|---|---|---|
+| `hwp3-sig-flip` | `HWP Document File` 존재 | 서명 첫 4바이트 XOR 0xFF. |
+| `hwp3-sig-inject` | 서명 없음, `n` 이 서명보다 김 | 선두에 HWP3 서명을 심는다. |
+
+HWP3 파서는 HWP5 와 다른 입구다. 첫 주행의 line-spacing i32 오버플로는
+이 형식에서 났다. 서명이 있는 파일만 flip 하고, 없는 파일에는 inject
+한다. 둘을 동시에 켜면 같은 바이트를 두 번 두드린다.
+
+## 9. 가족 매핑
+
+`mutant_family(label)` 이 라벨을 가족 id 로 접는다. 카탈로그 확장 시
+여기만 고친다. 빈 문자열·`None`·미지 라벨은 `other` 다. 시험이 전 라벨
+표를 고정한다.
+
+| 가족 | 라벨 접두/목록 |
+|---|---|
+| empty | `empty-to-nul` |
+| truncate | `trunc*`, `chop-last`, `cut-first`, `odd-length-chop`, `shrink-gap` |
+| flip | `flip*` |
+| length | `biglen*`, `length-zero*`, `length-one*`, `i32-min*`, `u16-max*` |
+| header | `zero-header`, `header-smash`, `rotate-header`, `increment-header`, `nibble-swap-head` |
+| ole | `ole-trunc-tail`, `ole-magic-poison`, `ole-sector-shift-poison`, `ole-mini-fat-poison` |
+| run | `ff-run`, `aa-run`, `nul-mid`, `00-run`, `55-run` |
+| unicode | `utf16-*`, `utf8-overlong`, `ascii-ctrl-sprinkle`, `path-sep-sprinkle` |
+| zip | `zip-*` |
+| permute | `reverse-prefix`, `swap-ends`, `slide-window-*`, `repeat-mid-block` |
+| stripe | `*-stripe`, `xor-stride7`, `interleave-zero-head`, `duplicate-prefix`, `tail-over-head`, `invert-tail-64`, `complement-mid-32`, `bit-rotate-head`, `decrement-tail` |
+| splice | `splice-nul-mid`, `crlf-inject`, `pad-eof`, `widen-gap`, `even-length-pad` |
+| hwp3 | `hwp3-sig-flip`, `hwp3-sig-inject` |
+
+## 10. 클러스터링
+
+발견 엔진의 산출은 "죽은 횟수"가 아니라 **고유 버그 목록**이다.
+
+같은 `src/parser/foo.rs:120` 에서 스무 표본이 죽으면 버그 하나다. 명령이
+`info` 든 `export-text` 든 위치가 같으면 한 클러스터다. 시험
+`test_fuzz_clusters_panics_by_location` 이 이 계약을 고정한다.
+
+행은 위치가 없다. timeout 은 명령을 버킷으로 쓴다. `info` 에서만 멈추고
+`export-text` 는 끝나는 경우가 있다. 명령을 섞으면 "어느 경로가 루프인가"
+가 사라진다.
+
+클러스터 정렬:
+
+- 패닉: `(-count, location)`
+- 행: `(-count, command)`
+
+건수가 같으면 위치가 사전순이다. 리포트 diff 가 워커 순서에 흔들리지
+않게 하기 위해서다.
+
+`distinctPanicSites` 는 `len(panicClusters)` 다. 이 숫자가 "고쳐야 할
+고유 버그 수"다. `runsChecked` 는 예산이고, `distinctPanicSites` 가
+일이다.
+
+## 11. 게이트와의 분업
+
+| | `robustness.py` | `fuzz_corpus.py` |
+|---|---|---|
+| 역할 | 릴리스 게이트 | 발견 엔진 |
+| 표본 | `.hwp` 부분집합 | `.hwp`/`.hwpx`/`.hml` 전수 가능 |
+| 명령 | `info --json` 하나 | 기본 4명령, 지정 가능 |
+| 산출 | 패닉/행 목록 | 위치별·명령별 클러스터 |
+| ok | 패닉·행 0 | 패닉·행 0 그리고 도구 실패 아님 |
+| 변형 라벨 | `truncate@25%` | `trunc25` (원 재현체 호환) |
+| 예외 | unreadables / probeErrors | 같은 접기 + missingBin / emptyCorpus |
+
+게이트가 실패한 변형을 발견 엔진이 다시 두드리는 것은 낭비처럼 보이지만,
+게이트는 `info` 만 본다. `export-render-tree` 에서만 죽는 버그는 게이트를
+통과한다. 발견 엔진이 그 축을 담당한다.
+
+반대로 발견 엔진이 잡은 버그는 고친 뒤 게이트의 부분집합에 넣어 회귀를
+막는다. 발견 → 수정 → 게이트. 이 고리가 이 도구의 존재 이유다.
+
+## 12. 시험이 고정하는 것
+
+`scripts/tests/test_gym_fuzz_corpus.py` 는 바이너리 없이 돈다. subprocess
+는 목킹한다.
+
+- 원 계약 5건: 결정적 변형, classify, select_samples, 위치 클러스터, 깨끗한
+  주행.
+- 확대 변형: 가족 매핑, 헤더/OLE/길이/런/유니코드/permute/stripe/splice
+  바이트 계약, ZIP/HWP3 조건부, 거대 입력 splice 생략, 원 라벨 생존.
+- 예외 경로: 없는 바이너리(exit 2), 빈 코퍼스(ok), 읽기 실패(unreadables),
+  쓰기 실패, 프로브 예외, TypeError 변형, 없는 디렉터리.
+- 봉투: `REPORT_KEYS`, `validate_report`, `ok`/`exit`/`emptyCorpus` 정직.
+- 정직: 프로브 오류는 행이 아니다. 도구 실패는 DoS 0 이 아니다. 치명
+  예외는 kind 로 위장하지 않는다.
+
+`python -m unittest scripts.tests.test_gym_fuzz_corpus` 가 전부 통과해야
+한다. `python gym/tools/audit.py` 는 pack 정합을 본다. 이 PR 은 pack 을
+건드리지 않으므로 감사는 기존과 같아야 한다.
+
+## 13. 하지 않는 것
+
+- 새 CLI 플래그, 새 pack, 새 gym 과제.
+- `random` / `secrets` / 시각 기반 시드. 재현이 안 되면 발견이 아니다.
+- `trajectory.py` · `discriminate.py` · automation / core-cli / casual-rides
+  pack. 다른 열린 PR 의 파일.
+- `cargo fmt --all`. Python·문서만 바꾼다.
+- 원 `classify` 계약 변경. `code==1` 깨끗한 실패를 패닉으로 승격하지 않는다.
+- 원 라벨 삭제. `trunc25` 를 `truncate@25%` 로 바꾸지 않는다.
+
+이 문서는 규약이다. 구현이 이 표와 다르면 구현이 틀린 것이다.

--- a/gym/tools/fuzz_corpus.py
+++ b/gym/tools/fuzz_corpus.py
@@ -3,15 +3,24 @@ DoS(패닉·무한루프)를 **근본원인별로 클러스터링**한다.
 
 ## 왜 이 도구인가 (강건성 감사와의 분업)
 
-`robustness.py`(#4814)는 릴리스 **게이트**다 — 바운드된 부분집합으로 "패닉·행 0"을
-강제해 회귀를 막는다. 이 도구는 그 앞단의 **발견 엔진**이다 — 전 코퍼스를 여러 명령·
-여러 손상으로 **exhaustive** 하게 두들겨 아직 안 고쳐진 DoS 를 찾아, 패닉을 **소스
-위치(file:line)별로 묶어** "고쳐야 할 고유 버그 목록"을 낸다. 아무도 손으로 수백
-문서를 수천 가지로 퍼징하지 않는다 — 에이전트가 이걸 돌려 rhwp 를 계속 경화한다.
+`robustness.py`(#4814 / #5218)는 릴리스 **게이트**다 — 바운드된 부분집합으로
+"패닉·행 0"을 강제해 회귀를 막는다. 이 도구는 그 앞단의 **발견 엔진**이다 —
+전 코퍼스를 여러 명령·여러 손상으로 **exhaustive** 하게 두들겨 아직 안 고쳐진
+DoS 를 찾아, 패닉을 **소스 위치(file:line)별로 묶어** "고쳐야 할 고유 버그
+목록"을 낸다. 아무도 손으로 수백 문서를 수천 가지로 퍼징하지 않는다 —
+에이전트가 이걸 돌려 rhwp 를 계속 경화한다.
 
-- 패닉: stderr 의 `panicked at file:line` → 그 위치로 클러스터. 스택 오버플로·시그널·
-  비-0 어보트도 별도 버킷.
-- 무한루프: timeout → 샘플별 버킷.
+- 패닉: stderr 의 `panicked at file:line` → 그 위치로 클러스터. 스택 오버플로·
+  시그널·비-0 어보트도 별도 버킷.
+- 무한루프: timeout → 명령별 버킷.
+- 도구 예외(없는 바이너리·빈 코퍼스·읽기 실패)는 DoS 로 위장하지 않는다.
+  분류해 보고하고 엔진은 산다.
+
+카탈로그·분류·봉투 계약은 `gym/docs/fuzz_corpus.md` 가 정본이다. 시험은
+`scripts/tests/test_gym_fuzz_corpus.py` 가 바이너리 없이 고정한다. 작업 기록은
+`mydocs/working/gym_fuzz_corpus.md`.
+
+무작위는 없다. 같은 바이트는 같은 (라벨, 바이트) 를 낸다.
 
 ## 사용
 
@@ -23,11 +32,13 @@ DoS(패닉·무한루프)를 **근본원인별로 클러스터링**한다.
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import re
 import subprocess
 import sys
+import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -41,31 +52,1189 @@ from core import runner  # noqa: E402
 DEFAULT_COMMANDS = ["info", "export-text", "export-structure", "export-render-tree"]
 PANIC_RE = re.compile(r"panicked at ([^\n]+?:\d+)")
 
+REPORT_KIND = "gymFuzzCorpus"
+SCHEMA_VERSION = "1.0"
+SAMPLE_EXTS = (".hwp", ".hwpx", ".hml")
+PROBE_HEAD = 160
+TINY_MAX = 64
+HUGE_MIN = 1_048_576
+RUST_ABORT = 101
+WINDOWS_EXCEPTION_MASK = 0xC0000000
+SIGNAL_FLOOR = 132
 
-def deterministic_mutants(data: bytes):
-    """결정적 손상 변형 — (라벨, 바이트). 무작위 없음(재현 가능)."""
+OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+ZIP_LOCAL = b"PK\x03\x04"
+ZIP_CD = b"PK\x01\x02"
+ZIP_EOCD = b"PK\x05\x06"
+HEADER_SMASH_PAT = b"\xde\xad\xbe\xef" * 16
+HWP3_SIG = b"HWP Document File"
+XOR_STRIDE_MASK = 0xA5
+LENGTH_BOMB_U32 = b"\xff\xff\xff\x7f"
+LENGTH_ZERO_U32 = b"\x00\x00\x00\x00"
+LENGTH_ONE_U32 = b"\x01\x00\x00\x00"
+I32_MIN_LE = b"\x00\x00\x00\x80"
+U16_MAX_LE = b"\xff\xff"
+UTF16_BOM_LE = b"\xff\xfe"
+UTF8_OVERLONG_NUL = b"\xc0\x80"
+CTRL_BYTE = 0x01
+STRIPE_STEP = 16
+XOR_STRIDE = 7
+
+# 종료 코드. 0=DoS 없음, 1=패닉/행 발견, 2=도구 실패(바이너리 부재 등).
+EXIT_OK = 0
+EXIT_DOS = 1
+EXIT_TOOL_FAILED = 2
+
+# JSON 보고 고정 키. 시험이 이 집합을 계약으로 고정한다.
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "samplesTested",
+    "totalSamples",
+    "commands",
+    "mutantsPerSample",
+    "runsChecked",
+    "distinctPanicSites",
+    "panicClusters",
+    "hangClusters",
+    "unreadables",
+    "probeErrors",
+    "toolErrors",
+    "emptyCorpus",
+    "missingBin",
+    "toolFailed",
+    "inputShapes",
+    "exit",
+)
+
+REPORT_LIST_KEYS = (
+    "commands",
+    "panicClusters",
+    "hangClusters",
+    "unreadables",
+    "probeErrors",
+    "toolErrors",
+)
+REPORT_INT_KEYS = (
+    "samplesTested",
+    "totalSamples",
+    "mutantsPerSample",
+    "runsChecked",
+    "distinctPanicSites",
+    "exit",
+)
+REPORT_BOOL_KEYS = ("ok", "emptyCorpus", "missingBin", "toolFailed")
+SHAPE_KEYS = ("empty", "tiny", "normal", "huge")
+
+# 패닉 문자열 표식. 소문자 비교. 깨끗한 CLI 오류 문구와 겹치지 않게 고른다.
+PANIC_MARKERS = (
+    "panicked",
+    "stack overflow",
+    "core dumped",
+    "fatal runtime error",
+    "sigsegv",
+    "sigabrt",
+    "sigill",
+    "sigbus",
+    "access violation",
+    "segmentation fault",
+    "illegal instruction",
+    "abort trap",
+)
+
+TIMEOUT_MARKERS = (
+    "timeout",
+    "timed out",
+    "time-out",
+    "time expired",
+    "deadline exceeded",
+)
+
+# 프로브가 내는 kind. hang 은 classify() 가 아니라 TimeoutExpired 가 낸다.
+OUTCOME_KINDS = ("panic", "hang", "error", None)
+
+# 프로브/도구 예외 kind. 시험과 문서가 같은 표를 본다.
+EXCEPTION_KINDS = (
+    "missing-bin",
+    "empty-corpus",
+    "unreadable",
+    "permission",
+    "timeout",
+    "os-error",
+    "type-error",
+    "value-error",
+    "decode-error",
+    "invalid-timeout",
+    "invalid-workers",
+    "probe-error",
+    "unexpected",
+)
+
+EXCEPTION_KIND_BY_TYPE = {
+    FileNotFoundError: "missing-bin",
+    PermissionError: "permission",
+    TimeoutError: "timeout",
+    subprocess.TimeoutExpired: "timeout",
+    UnicodeError: "decode-error",
+    UnicodeDecodeError: "decode-error",
+    UnicodeEncodeError: "decode-error",
+    ValueError: "value-error",
+    TypeError: "type-error",
+    KeyError: "value-error",
+    IndexError: "value-error",
+    AttributeError: "type-error",
+    OSError: "os-error",
+}
+
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    TimeoutError,
+    subprocess.TimeoutExpired,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    RuntimeError,
+)
+
+# 정상(비어 있지 않은) 입력에서 항상 나오기를 기대하는 원 라벨.
+# 원본과 바이트가 같아지면 add() 가 버리므로 극소 입력에서는 일부만 남는다.
+LEGACY_ALWAYS_LABELS = (
+    "trunc5",
+    "trunc25",
+    "trunc50",
+    "trunc75",
+    "trunc95",
+    "flip10",
+    "flip30",
+    "flip50",
+    "flip70",
+    "flip90",
+    "biglen10",
+    "biglen40",
+    "biglen70",
+)
+
+# 2KiB 정상 입력에서 추가로 항상 나오는 확대 라벨. ZIP 조건부 라벨은 제외.
+EXPANDED_ALWAYS_LABELS = (
+    "trunc1",
+    "trunc10",
+    "trunc99",
+    "flip0",
+    "flip25",
+    "flip75",
+    "flip99",
+    "chop-last",
+    "cut-first",
+    "zero-header",
+    "header-smash",
+    "rotate-header",
+    "increment-header",
+    "nibble-swap-head",
+    "ole-trunc-tail",
+    "ole-magic-poison",
+    "ole-sector-shift-poison",
+    "ff-run",
+    "aa-run",
+    "nul-mid",
+    "00-run",
+    "55-run",
+    "utf16-nul-sprinkle",
+    "utf16-bom-inject",
+    "utf8-overlong",
+    "ascii-ctrl-sprinkle",
+    "path-sep-sprinkle",
+    "zip-magic-inject",
+    "length-zero30",
+    "length-one60",
+    "i32-min20",
+    "u16-max12",
+    "reverse-prefix",
+    "swap-ends",
+    "high-bit-stripe",
+    "low-bit-stripe",
+    "xor-stride7",
+    "interleave-zero-head",
+    "duplicate-prefix",
+    "tail-over-head",
+    "invert-tail-64",
+    "complement-mid-32",
+    "bit-rotate-head",
+    "decrement-tail",
+    "slide-window-left",
+    "slide-window-right",
+    "repeat-mid-block",
+    "odd-length-chop",
+    "splice-nul-mid",
+    "crlf-inject",
+    "pad-eof",
+    "widen-gap",
+    "shrink-gap",
+    "hwp3-sig-inject",
+)
+
+FAMILY_IDS = (
+    "empty",
+    "truncate",
+    "flip",
+    "length",
+    "header",
+    "ole",
+    "run",
+    "unicode",
+    "zip",
+    "permute",
+    "stripe",
+    "splice",
+    "hwp3",
+)
+
+# 변형 가족 카탈로그 — 문서·시험이 같은 표를 본다. 무작위 필드 없음.
+MUTANT_CATALOG = (
+    {
+        "id": "empty-to-nul",
+        "family": "empty",
+        "when": "n==0",
+        "why": "빈 입력은 위치 기반 절단/플립을 할 수 없다. NUL 한 바이트로 고정한다.",
+    },
+    {
+        "id": "trunc",
+        "family": "truncate",
+        "when": "n>0",
+        "why": "잘린 복합문서·ZIP 중앙 디렉터리 부재를 재현한다. 원 라벨 truncN.",
+        "params": (1, 5, 10, 25, 50, 75, 95, 99),
+    },
+    {
+        "id": "chop-last",
+        "family": "truncate",
+        "when": "n>=2",
+        "why": "마지막 1바이트만 잘라 오프바이원 레코드 끝을 재현한다.",
+    },
+    {
+        "id": "cut-first",
+        "family": "truncate",
+        "when": "n>=1",
+        "why": "선두 1바이트를 버려 매직이 한 칸 밀린 파일을 재현한다.",
+    },
+    {
+        "id": "flip",
+        "family": "flip",
+        "when": "n>0",
+        "why": "헤더·본문·꼬리 근처 한 바이트를 뒤집어 매직/길이 필드를 오염한다.",
+        "params": (0, 10, 25, 30, 50, 70, 75, 90, 99),
+    },
+    {
+        "id": "biglen",
+        "family": "length",
+        "when": "n>=4",
+        "why": "추정 길이 필드에 0x7FFFFFFF 를 넣어 할당 폭주를 유도한다. 원 라벨.",
+        "params": (10, 40, 70),
+    },
+    {
+        "id": "zero-header",
+        "family": "header",
+        "when": "n>0",
+        "why": "선두 512바이트를 0 으로 지워 OLE/ZIP 매직을 없앤다.",
+    },
+    {
+        "id": "header-smash",
+        "family": "header",
+        "when": "n>0",
+        "why": "고정 DEADBEEF 패턴으로 헤더를 덮어 매직만 다른 손상과 구분한다.",
+    },
+    {
+        "id": "rotate-header",
+        "family": "header",
+        "when": "n>=2",
+        "why": "선두 8바이트를 한 칸 왼쪽으로 순환시켜 매직 순서를 깨뜨린다.",
+    },
+    {
+        "id": "increment-header",
+        "family": "header",
+        "when": "n>0",
+        "why": "선두 8바이트에 1 을 더해(랩어라운드) 매직을 미세 오염한다.",
+    },
+    {
+        "id": "nibble-swap-head",
+        "family": "header",
+        "when": "n>0",
+        "why": "선두 32바이트의 니블을 뒤집어 길이 필드의 상위/하위를 맞바꾼다.",
+    },
+    {
+        "id": "ole-trunc-tail",
+        "family": "ole",
+        "when": "n>0",
+        "why": "CFB 디렉터리/FAT 가 잘린 꼬리, 또는 잘린 OLE 매직을 심는다.",
+    },
+    {
+        "id": "ole-magic-poison",
+        "family": "ole",
+        "when": "n>0",
+        "why": "선두에 깨진 OLE 매직(원본 매직 XOR 0xFF)을 덮어쓴다.",
+    },
+    {
+        "id": "ole-sector-shift-poison",
+        "family": "ole",
+        "when": "n>=32",
+        "why": "CFB 섹터 시프트(오프셋 30)를 0xFFFF 로 바꿔 거대 섹터 할당을 유도한다.",
+    },
+    {
+        "id": "ole-mini-fat-poison",
+        "family": "ole",
+        "when": "n>=72",
+        "why": "CFB MiniFAT 시작 섹터(오프셋 60)를 0xFFFFFFFF 로 채운다.",
+    },
+    {
+        "id": "ff-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "본문 1/3 지점에 0xFF 런을 넣어 길이·유니코드 필드를 포화시킨다.",
+    },
+    {
+        "id": "aa-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "선두 1/4 에 0xAA 런을 넣어 0xFF 와 다른 비트 패턴을 본다.",
+    },
+    {
+        "id": "nul-mid",
+        "family": "run",
+        "when": "n>0",
+        "why": "한가운데 최대 64바이트를 NUL 로 지워 UTF-16 종료를 위조한다.",
+    },
+    {
+        "id": "00-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "2/3 지점에 NUL 런을 넣어 레코드 조기 종료를 위조한다.",
+    },
+    {
+        "id": "55-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "선두 1/5 에 0x55 런을 넣어 교차 비트 패턴을 본다.",
+    },
+    {
+        "id": "utf16-nul-sprinkle",
+        "family": "unicode",
+        "when": "n>=2",
+        "why": "짝수 오프셋에 U+0000 을 뿌려 UTF-16LE 본문 절단을 위조한다.",
+    },
+    {
+        "id": "utf16-bom-inject",
+        "family": "unicode",
+        "when": "n>=2",
+        "why": "선두에 UTF-16LE BOM 을 심어 인코딩 오인을 유도한다.",
+    },
+    {
+        "id": "utf8-overlong",
+        "family": "unicode",
+        "when": "n>=2",
+        "why": "1/5 지점에 overlong NUL(C0 80)을 심어 UTF-8 검증을 흔든다.",
+    },
+    {
+        "id": "ascii-ctrl-sprinkle",
+        "family": "unicode",
+        "when": "n>0",
+        "why": "고정 퍼센트 위치에 SOH(0x01)를 넣어 제어문자 경로를 본다.",
+    },
+    {
+        "id": "path-sep-sprinkle",
+        "family": "unicode",
+        "when": "n>0",
+        "why": "고정 위치에 경로 구분자(\\/)를 심어 경로 해석 오류를 유도한다.",
+    },
+    {
+        "id": "zip-local-header-flip",
+        "family": "zip",
+        "when": "ZIP 로컬 헤더가 있을 때",
+        "why": "HWPX 의 PK\\x03\\x04 만 뒤집어 아카이브 인식을 깨뜨린다.",
+    },
+    {
+        "id": "zip-magic-inject",
+        "family": "zip",
+        "when": "선두가 ZIP 로컬 헤더가 아닐 때",
+        "why": "비-ZIP 문서 선두에 PK 매직을 심어 형식 오인을 유도한다.",
+    },
+    {
+        "id": "zip-cd-magic-flip",
+        "family": "zip",
+        "when": "ZIP 중앙 디렉터리 매직이 있을 때",
+        "why": "PK\\x01\\x02 만 뒤집어 중앙 디렉터리 탐색을 깨뜨린다.",
+    },
+    {
+        "id": "zip-eocd-flip",
+        "family": "zip",
+        "when": "ZIP EOCD 매직이 있을 때",
+        "why": "PK\\x05\\x06 만 뒤집어 아카이브 끝 탐색을 깨뜨린다.",
+    },
+    {
+        "id": "length-zero",
+        "family": "length",
+        "when": "n>=4",
+        "why": "추정 길이 필드에 0 을 넣어 빈 레코드 조기 종료를 유도한다.",
+        "params": (30,),
+    },
+    {
+        "id": "length-one",
+        "family": "length",
+        "when": "n>=4",
+        "why": "추정 길이 필드에 1 을 넣어 오프바이원 슬라이스를 유도한다.",
+        "params": (60,),
+    },
+    {
+        "id": "i32-min",
+        "family": "length",
+        "when": "n>=4",
+        "why": "부호 있는 최소값(0x80000000)을 넣어 음수 길이 경로를 본다.",
+        "params": (20,),
+    },
+    {
+        "id": "u16-max",
+        "family": "length",
+        "when": "n>=14",
+        "why": "오프셋 12 의 u16 을 0xFFFF 로 채워 카운트 필드를 포화시킨다.",
+    },
+    {
+        "id": "reverse-prefix",
+        "family": "permute",
+        "when": "n>=2",
+        "why": "선두 16바이트를 뒤집어 매직 순서를 깨뜨린다.",
+    },
+    {
+        "id": "swap-ends",
+        "family": "permute",
+        "when": "n>=16",
+        "why": "선두 8바이트와 꼬리 8바이트를 맞바꾼다.",
+    },
+    {
+        "id": "slide-window-left",
+        "family": "permute",
+        "when": "n>=8",
+        "why": "선두 32바이트를 한 바이트 왼쪽으로 밀어 필드 정렬을 흔든다.",
+    },
+    {
+        "id": "slide-window-right",
+        "family": "permute",
+        "when": "n>=8",
+        "why": "선두 32바이트를 한 바이트 오른쪽으로 밀어 필드 정렬을 흔든다.",
+    },
+    {
+        "id": "repeat-mid-block",
+        "family": "permute",
+        "when": "n>=32",
+        "why": "한가운데 32바이트를 바로 앞에 복사해 레코드 중복을 위조한다.",
+    },
+    {
+        "id": "high-bit-stripe",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "16바이트마다 상위 비트를 켜 부호 있는 길이 해석을 흔든다.",
+    },
+    {
+        "id": "low-bit-stripe",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "16바이트마다 최하위 비트를 뒤집어 홀짝 플래그를 깨뜨린다.",
+    },
+    {
+        "id": "xor-stride7",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "7바이트마다 0xA5 를 XOR 해 주기적 체크섬·정렬을 흔든다.",
+    },
+    {
+        "id": "interleave-zero-head",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "선두 32바이트의 홀수 인덱스를 0 으로 지워 교차 필드를 끊는다.",
+    },
+    {
+        "id": "duplicate-prefix",
+        "family": "stripe",
+        "when": "n>=16",
+        "why": "선두 8바이트를 바로 다음에 복제해 이중 매직을 만든다.",
+    },
+    {
+        "id": "tail-over-head",
+        "family": "stripe",
+        "when": "n>=32",
+        "why": "꼬리 16바이트를 선두에 덮어 매직을 본문 잔해로 바꾼다.",
+    },
+    {
+        "id": "invert-tail-64",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "꼬리 최대 64바이트를 비트 반전한다.",
+    },
+    {
+        "id": "complement-mid-32",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "한가운데 최대 32바이트를 비트 반전한다.",
+    },
+    {
+        "id": "bit-rotate-head",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "선두 16바이트를 1비트 왼쪽으로 회전한다.",
+    },
+    {
+        "id": "decrement-tail",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "꼬리 8바이트에서 1 을 빼 체크섬·길이를 미세 오염한다.",
+    },
+    {
+        "id": "odd-length-chop",
+        "family": "truncate",
+        "when": "n>=2 이고 짝수",
+        "why": "짝수 길이를 홀수로 만들어 UTF-16 워드 정렬을 깨뜨린다.",
+    },
+    {
+        "id": "even-length-pad",
+        "family": "splice",
+        "when": "n 이 홀수이고 거대 아님",
+        "why": "홀수 길이에 NUL 하나를 붙여 UTF-16 워드로 맞춘다.",
+    },
+    {
+        "id": "splice-nul-mid",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "한가운데에 NUL 16바이트를 끼워 레코드 경계를 밀어낸다.",
+    },
+    {
+        "id": "crlf-inject",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "한가운데에 CRLF 를 끼워 텍스트/바이너리 경계 오인을 유도한다.",
+    },
+    {
+        "id": "pad-eof",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "파일 끝에 SUB(0x1A)를 붙여 구식 EOF 표식을 심는다.",
+    },
+    {
+        "id": "widen-gap",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "1/4 지점에 NUL 4바이트를 끼워 오프셋을 밀어낸다.",
+    },
+    {
+        "id": "shrink-gap",
+        "family": "truncate",
+        "when": "n>=8",
+        "why": "1/4 지점의 4바이트를 삭제해 뒤 레코드를 앞으로 당긴다.",
+    },
+    {
+        "id": "hwp3-sig-flip",
+        "family": "hwp3",
+        "when": "HWP3 서명이 있을 때",
+        "why": "HWP Document File 서명의 첫 4바이트만 뒤집어 HWP3 인식을 깨뜨린다.",
+    },
+    {
+        "id": "hwp3-sig-inject",
+        "family": "hwp3",
+        "when": "HWP3 서명이 없고 n 이 서명보다 길 때",
+        "why": "비-HWP3 선두에 HWP3 서명을 심어 형식 오인을 유도한다.",
+    },
+)
+
+
+def is_fatal_exception(exc) -> bool:
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def exception_kind(exc, context="probe") -> str:
+    """예외를 kind 로 접는다. 순수.
+
+    context:
+      - probe: 한 명령 실행. FileNotFound → missing-bin.
+      - read: 표본 읽기. FileNotFound → unreadable.
+      - write: 변형 쓰기. FileNotFound → os-error.
+      - select: 코퍼스 나열. FileNotFound → empty-corpus.
+      - find-bin: 바이너리 탐색. FileNotFound → missing-bin.
+    """
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, subprocess.TimeoutExpired) or isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, FileNotFoundError):
+        if context in ("read", "select"):
+            return "unreadable" if context == "read" else "empty-corpus"
+        return "missing-bin"
+    if isinstance(exc, PermissionError):
+        return "permission" if context != "read" else "unreadable"
+    if isinstance(exc, json.JSONDecodeError):
+        return "value-error"
+    for typ, kind in EXCEPTION_KIND_BY_TYPE.items():
+        if isinstance(exc, typ):
+            if context == "read" and kind in ("os-error", "permission", "missing-bin"):
+                return "unreadable"
+            if context == "select" and kind in ("os-error", "missing-bin"):
+                return "empty-corpus"
+            return kind
+    return "unexpected"
+
+
+def coerce_bytes(data) -> bytes:
+    """바이트열만 받는다. bytearray/memoryview 는 복사하고, 그 외는 TypeError.
+
+    발견 엔진이 str/int/None 을 조용히 인코딩하면 결정성이 깨진다. 호출자가
+    파일에서 읽은 바이트만 넘기도록 강제한다.
+    """
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, bytearray):
+        return bytes(data)
+    if isinstance(data, memoryview):
+        return data.tobytes()
+    raise TypeError(
+        "deterministic_mutants 는 bytes-like 만 받습니다"
+        f" (got {type(data).__name__})"
+    )
+
+
+def classify_input_shape(data) -> str:
+    """입력 형태 분류: empty / tiny / normal / huge. 비-바이트는 TypeError."""
+    payload = coerce_bytes(data)
+    n = len(payload)
+    if n == 0:
+        return "empty"
+    if n <= TINY_MAX:
+        return "tiny"
+    if n >= HUGE_MIN:
+        return "huge"
+    return "normal"
+
+
+def normalize_limit(limit) -> int:
+    """표본 수 한도. 변환 불능·음수는 0 (전수 또는 표본 없음은 호출 측)."""
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, n)
+
+
+def normalize_timeout(timeout) -> int:
+    """프로브 초. 변환 불능·비양수는 0 — 호출 측에서 거른다."""
+    try:
+        n = int(timeout)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def normalize_workers(workers) -> int:
+    """워커 수. 변환 불능·비양수는 1."""
+    try:
+        n = int(workers)
+    except (TypeError, ValueError):
+        return 1
+    return n if n > 0 else 1
+
+
+def parse_commands(raw) -> list:
+    """쉼표구분 명령 문자열/시퀀스를 정규화. 빈 토큰은 버린다. 순서는 유지."""
+    if raw is None:
+        return list(DEFAULT_COMMANDS)
+    if isinstance(raw, (list, tuple)):
+        tokens = [str(item).strip() for item in raw]
+    else:
+        tokens = [part.strip() for part in str(raw).split(",")]
+    out, seen = [], set()
+    for token in tokens:
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return out or list(DEFAULT_COMMANDS)
+
+
+def is_sample_name(name: str) -> bool:
+    """코퍼스 파일명인가. 확장자만 본다. 대소문자 무시."""
+    if not isinstance(name, str) or not name:
+        return False
+    lower = name.lower()
+    return lower.endswith(SAMPLE_EXTS)
+
+
+def mutant_family(label: str) -> str:
+    """라벨을 가족 id 로 접는다. 카탈로그 확장 시 여기만 고치면 된다."""
+    if not isinstance(label, str) or not label:
+        return "other"
+    if label == "empty-to-nul":
+        return "empty"
+    if (
+        label.startswith("trunc")
+        or label in ("chop-last", "cut-first", "odd-length-chop", "shrink-gap")
+    ):
+        return "truncate"
+    if label.startswith("flip"):
+        return "flip"
+    if (
+        label.startswith("biglen")
+        or label.startswith("length-zero")
+        or label.startswith("length-one")
+        or label.startswith("i32-min")
+        or label.startswith("u16-max")
+    ):
+        return "length"
+    if label in (
+        "zero-header",
+        "header-smash",
+        "rotate-header",
+        "increment-header",
+        "nibble-swap-head",
+    ):
+        return "header"
+    if label in (
+        "ole-trunc-tail",
+        "ole-magic-poison",
+        "ole-sector-shift-poison",
+        "ole-mini-fat-poison",
+    ):
+        return "ole"
+    if label in ("ff-run", "aa-run", "nul-mid", "00-run", "55-run"):
+        return "run"
+    if label in (
+        "utf16-nul-sprinkle",
+        "utf16-bom-inject",
+        "utf8-overlong",
+        "ascii-ctrl-sprinkle",
+        "path-sep-sprinkle",
+    ):
+        return "unicode"
+    if label in (
+        "zip-local-header-flip",
+        "zip-magic-inject",
+        "zip-cd-magic-flip",
+        "zip-eocd-flip",
+    ):
+        return "zip"
+    if label in (
+        "reverse-prefix",
+        "swap-ends",
+        "slide-window-left",
+        "slide-window-right",
+        "repeat-mid-block",
+    ):
+        return "permute"
+    if label in (
+        "high-bit-stripe",
+        "low-bit-stripe",
+        "xor-stride7",
+        "interleave-zero-head",
+        "duplicate-prefix",
+        "tail-over-head",
+        "invert-tail-64",
+        "complement-mid-32",
+        "bit-rotate-head",
+        "decrement-tail",
+    ):
+        return "stripe"
+    if label in ("splice-nul-mid", "crlf-inject", "pad-eof", "widen-gap", "even-length-pad"):
+        return "splice"
+    if label in ("hwp3-sig-flip", "hwp3-sig-inject"):
+        return "hwp3"
+    return "other"
+
+
+def mutant_catalog() -> tuple:
+    """변형 가족 카탈로그 사본. 시험·문서가 같은 표를 참조한다."""
+    return tuple(dict(row) for row in MUTANT_CATALOG)
+
+
+def catalog_ids() -> tuple:
+    """카탈로그 id 튜플. 시험이 누락 가족을 잡는다."""
+    return tuple(row["id"] for row in MUTANT_CATALOG)
+
+
+def catalog_families() -> tuple:
+    """카탈로그 가족 id 의 등장 순서 유일 목록."""
+    seen, out = set(), []
+    for row in MUTANT_CATALOG:
+        fam = row["family"]
+        if fam not in seen:
+            seen.add(fam)
+            out.append(fam)
+    return tuple(out)
+
+
+def probe_head(text, limit: int = PROBE_HEAD) -> str:
+    """프로브 출력 머리. None/비문자는 빈 문자열."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
+    if limit <= 0:
+        return ""
+    return text[:limit]
+
+
+def _rotl8(value: int, bits: int = 1) -> int:
+    bits &= 7
+    value &= 0xFF
+    return ((value << bits) | (value >> (8 - bits))) & 0xFF
+
+
+def _swap_nibbles(value: int) -> int:
+    value &= 0xFF
+    return ((value & 0x0F) << 4) | ((value & 0xF0) >> 4)
+
+
+def _add_wrap(value: int, delta: int) -> int:
+    return (value + delta) & 0xFF
+
+
+def _find_magic(data: bytes, magic: bytes) -> int:
+    if not magic:
+        return -1
+    return data.find(magic)
+
+
+def _xor_slice(data: bytearray, start: int, width: int) -> None:
+    end = min(len(data), start + width)
+    for i in range(max(0, start), end):
+        data[i] ^= 0xFF
+
+
+def deterministic_mutants(data):
+    """결정적 손상 변형 — (라벨, 바이트). 무작위 없음(재현 가능).
+
+    같은 입력 → 같은 라벨·바이트. 원본과 동일한 무의미 변형은 넣지 않는다.
+    비-바이트는 TypeError. 빈 입력은 empty-to-nul 한 건만.
+    원 라벨(truncN/flipN/biglenN)은 유지하고, 확대 가족을 뒤에 덧붙인다.
+    """
+    data = coerce_bytes(data)
     n = len(data)
+    if n == 0:
+        return [("empty-to-nul", b"\0")]
     out = []
-    for pct in (5, 25, 50, 75, 95):
-        out.append((f"trunc{pct}", data[: max(1, n * pct // 100)]))
-    for pct in (10, 30, 50, 70, 90):
+    huge = n >= HUGE_MIN
+
+    def add(label: str, mut: bytes) -> None:
+        if mut != data:
+            out.append((label, mut))
+
+    for pct in (1, 5, 10, 25, 50, 75, 95, 99):
+        add(f"trunc{pct}", data[: max(1, n * pct // 100)])
+    if n >= 2:
+        add("chop-last", data[:-1])
+    add("cut-first", data[1:])
+
+    for pct in (0, 10, 25, 30, 50, 70, 75, 90, 99):
         pos = min(n - 1, n * pct // 100)
         b = bytearray(data)
         b[pos] ^= 0xFF
-        out.append((f"flip{pct}", bytes(b)))
-    for pct in (10, 40, 70):  # 길이필드 추정 위치를 큰 값으로
-        pos = min(n - 4, n * pct // 100)
+        add(f"flip{pct}", bytes(b))
+
+    if n >= 4:
+        for pct in (10, 40, 70):
+            pos = min(n - 4, n * pct // 100)
+            b = bytearray(data)
+            b[pos : pos + 4] = LENGTH_BOMB_U32
+            add(f"biglen{pct}", bytes(b))
+        pos = min(n - 4, n * 30 // 100)
         b = bytearray(data)
-        b[pos:pos + 4] = b"\xff\xff\xff\x7f"
-        out.append((f"biglen{pct}", bytes(b)))
+        b[pos : pos + 4] = LENGTH_ZERO_U32
+        add("length-zero30", bytes(b))
+        pos = min(n - 4, n * 60 // 100)
+        b = bytearray(data)
+        b[pos : pos + 4] = LENGTH_ONE_U32
+        add("length-one60", bytes(b))
+        pos = min(n - 4, n * 20 // 100)
+        b = bytearray(data)
+        b[pos : pos + 4] = I32_MIN_LE
+        add("i32-min20", bytes(b))
+
+    if n >= 14:
+        b = bytearray(data)
+        b[12:14] = U16_MAX_LE
+        add("u16-max12", bytes(b))
+
+    b = bytearray(data)
+    for i in range(min(n, 512)):
+        b[i] = 0
+    add("zero-header", bytes(b))
+
+    smash_n = min(n, len(HEADER_SMASH_PAT))
+    b = bytearray(data)
+    b[:smash_n] = HEADER_SMASH_PAT[:smash_n]
+    add("header-smash", bytes(b))
+
+    if n >= 2:
+        pref = min(8, n)
+        b = bytearray(data)
+        head = bytes(data[:pref])
+        b[:pref] = head[1:] + head[:1]
+        add("rotate-header", bytes(b))
+
+    inc_n = min(8, n)
+    b = bytearray(data)
+    for i in range(inc_n):
+        b[i] = _add_wrap(data[i], 1)
+    add("increment-header", bytes(b))
+
+    nib_n = min(32, n)
+    b = bytearray(data)
+    for i in range(nib_n):
+        b[i] = _swap_nibbles(data[i])
+    add("nibble-swap-head", bytes(b))
+
+    if n > 64:
+        add("ole-trunc-tail", data[:-64])
+    else:
+        k = min(4, n)
+        add("ole-trunc-tail", data[:-k] + OLE_MAGIC[:k])
+
+    poison_n = min(n, len(OLE_MAGIC))
+    b = bytearray(data)
+    poisoned = bytes(x ^ 0xFF for x in OLE_MAGIC[:poison_n])
+    b[:poison_n] = poisoned
+    add("ole-magic-poison", bytes(b))
+
+    if n >= 32:
+        b = bytearray(data)
+        b[30:32] = U16_MAX_LE
+        add("ole-sector-shift-poison", bytes(b))
+    if n >= 72:
+        b = bytearray(data)
+        b[60:64] = b"\xff\xff\xff\xff"
+        add("ole-mini-fat-poison", bytes(b))
+
+    start = n // 3
+    run = min(128, max(1, n - start))
+    b = bytearray(data)
+    b[start : start + run] = b"\xff" * run
+    add("ff-run", bytes(b))
+
+    aa_n = min(n, max(1, n // 4))
+    b = bytearray(data)
+    b[:aa_n] = b"\xaa" * aa_n
+    add("aa-run", bytes(b))
+
+    mid = n // 2
+    nul_n = min(64, max(1, n - mid))
+    b = bytearray(data)
+    b[mid : mid + nul_n] = b"\x00" * nul_n
+    add("nul-mid", bytes(b))
+
+    two_third = (n * 2) // 3
+    zero_n = min(64, max(1, n - two_third))
+    b = bytearray(data)
+    b[two_third : two_third + zero_n] = b"\x00" * zero_n
+    add("00-run", bytes(b))
+
+    five_n = min(n, max(1, n // 5))
+    b = bytearray(data)
+    b[:five_n] = b"\x55" * five_n
+    add("55-run", bytes(b))
+
+    if n >= 2:
+        b = bytearray(data)
+        for pct in (20, 40, 60, 80):
+            pos = min(n - 2, n * pct // 100) & ~1
+            b[pos : pos + 2] = b"\x00\x00"
+        add("utf16-nul-sprinkle", bytes(b))
+        b = bytearray(data)
+        b[:2] = UTF16_BOM_LE
+        add("utf16-bom-inject", bytes(b))
+        over_at = min(n - 2, max(0, n // 5))
+        b = bytearray(data)
+        b[over_at : over_at + 2] = UTF8_OVERLONG_NUL
+        add("utf8-overlong", bytes(b))
+
+    b = bytearray(data)
+    for pct in (15, 35, 55, 75):
+        pos = min(n - 1, n * pct // 100)
+        b[pos] = CTRL_BYTE
+    add("ascii-ctrl-sprinkle", bytes(b))
+
+    b = bytearray(data)
+    seps = (0x2F, 0x5C)
+    for i, pct in enumerate((18, 42, 66, 88)):
+        pos = min(n - 1, n * pct // 100)
+        b[pos] = seps[i % 2]
+    add("path-sep-sprinkle", bytes(b))
+
+    idx = _find_magic(data, ZIP_LOCAL)
+    if idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, idx, len(ZIP_LOCAL))
+        add("zip-local-header-flip", bytes(b))
+    elif n >= len(ZIP_LOCAL):
+        b = bytearray(data)
+        b[: len(ZIP_LOCAL)] = ZIP_LOCAL
+        add("zip-magic-inject", bytes(b))
+
+    cd_idx = _find_magic(data, ZIP_CD)
+    if cd_idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, cd_idx, len(ZIP_CD))
+        add("zip-cd-magic-flip", bytes(b))
+
+    eocd_idx = _find_magic(data, ZIP_EOCD)
+    if eocd_idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, eocd_idx, len(ZIP_EOCD))
+        add("zip-eocd-flip", bytes(b))
+
+    if n >= 2:
+        pref = min(16, n)
+        b = bytearray(data)
+        b[:pref] = bytes(reversed(data[:pref]))
+        add("reverse-prefix", bytes(b))
+
+    if n >= 16:
+        b = bytearray(data)
+        b[:8], b[-8:] = data[-8:], data[:8]
+        add("swap-ends", bytes(b))
+
+    if n >= 8:
+        win = min(32, n)
+        chunk = bytearray(data[:win])
+        left = chunk[1:] + chunk[:1]
+        b = bytearray(data)
+        b[:win] = left
+        add("slide-window-left", bytes(b))
+        right = chunk[-1:] + chunk[:-1]
+        b = bytearray(data)
+        b[:win] = right
+        add("slide-window-right", bytes(b))
+
+    if n >= 32:
+        mid = n // 2
+        block = data[mid : mid + 32]
+        dest = max(0, mid - 32)
+        b = bytearray(data)
+        b[dest : dest + 32] = block
+        add("repeat-mid-block", bytes(b))
+
+    b = bytearray(data)
+    for i in range(0, n, STRIPE_STEP):
+        b[i] = data[i] | 0x80
+    add("high-bit-stripe", bytes(b))
+
+    b = bytearray(data)
+    for i in range(0, n, STRIPE_STEP):
+        b[i] = data[i] ^ 0x01
+    add("low-bit-stripe", bytes(b))
+
+    b = bytearray(data)
+    for i in range(0, n, XOR_STRIDE):
+        b[i] = data[i] ^ XOR_STRIDE_MASK
+    add("xor-stride7", bytes(b))
+
+    head_n = min(32, n)
+    b = bytearray(data)
+    for i in range(1, head_n, 2):
+        b[i] = 0
+    add("interleave-zero-head", bytes(b))
+
+    if n >= 16:
+        b = bytearray(data)
+        b[8:16] = data[:8]
+        add("duplicate-prefix", bytes(b))
+
+    if n >= 32:
+        b = bytearray(data)
+        b[:16] = data[-16:]
+        add("tail-over-head", bytes(b))
+
+    tail_n = min(64, n)
+    b = bytearray(data)
+    for i in range(n - tail_n, n):
+        b[i] = data[i] ^ 0xFF
+    add("invert-tail-64", bytes(b))
+
+    mid = n // 2
+    mid_n = min(32, max(1, n - mid))
+    b = bytearray(data)
+    for i in range(mid, mid + mid_n):
+        b[i] = data[i] ^ 0xFF
+    add("complement-mid-32", bytes(b))
+
+    rot_n = min(16, n)
+    b = bytearray(data)
+    for i in range(rot_n):
+        b[i] = _rotl8(data[i], 1)
+    add("bit-rotate-head", bytes(b))
+
+    dec_n = min(8, n)
+    b = bytearray(data)
+    for i in range(n - dec_n, n):
+        b[i] = _add_wrap(data[i], -1)
+    add("decrement-tail", bytes(b))
+
+    if n >= 2 and (n % 2 == 0):
+        add("odd-length-chop", data[:-1])
+
+    hwp3_idx = _find_magic(data, HWP3_SIG)
+    if hwp3_idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, hwp3_idx, min(4, len(HWP3_SIG)))
+        add("hwp3-sig-flip", bytes(b))
+    elif n >= len(HWP3_SIG):
+        b = bytearray(data)
+        b[: len(HWP3_SIG)] = HWP3_SIG
+        add("hwp3-sig-inject", bytes(b))
+
+    if not huge:
+        mid = n // 2
+        add("splice-nul-mid", data[:mid] + (b"\x00" * 16) + data[mid:])
+        add("crlf-inject", data[:mid] + b"\r\n" + data[mid:])
+        add("pad-eof", data + b"\x1a")
+        gap = n // 4
+        add("widen-gap", data[:gap] + (b"\x00" * 4) + data[gap:])
+        if n % 2 == 1:
+            add("even-length-pad", data + b"\x00")
+    if n >= 8:
+        gap = n // 4
+        end = min(n, gap + 4)
+        if end > gap:
+            add("shrink-gap", data[:gap] + data[end:])
+
     return out
 
 
+def list_sample_names(samples_dir: str):
+    """코퍼스 파일명을 정렬해 돌려준다. 디렉터리를 못 읽으면 (None, 이유)."""
+    try:
+        names = os.listdir(samples_dir)
+    except OSError as exc:
+        return None, f"{exception_kind(exc, 'select')}: {type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        return None, f"{exception_kind(exc, 'select')}: {type(exc).__name__}: {exc}"
+    everything = sorted(f for f in names if is_sample_name(f))
+    return everything, None
+
+
 def select_samples(samples_dir: str, limit: int):
-    everything = sorted(
-        f for f in os.listdir(samples_dir) if f.endswith((".hwp", ".hwpx", ".hml"))
-    )
-    if limit <= 0 or len(everything) <= limit:
+    """정렬된 .hwp/.hwpx/.hml 을 결정적 stride 로 limit 개 뽑는다.
+
+    디렉터리를 읽을 수 없으면 빈 목록을 돌려 발견 엔진이 예외로 죽지 않게 한다.
+    limit<=0 이면 전수. 변환 불능 limit 은 0 으로 접어 전수다.
+    """
+    limit = normalize_limit(limit)
+    everything, err = list_sample_names(samples_dir)
+    if everything is None:
+        return [], 0
+    if not everything or (limit <= 0):
+        return everything, len(everything)
+    if len(everything) <= limit:
         return everything, len(everything)
     stride = len(everything) / limit
     picked, seen = [], set()
@@ -78,70 +1247,294 @@ def select_samples(samples_dir: str, limit: int):
 
 
 def classify(code, err: str):
-    """(kind, bucket) — kind in {panic, hang, None}. bucket 은 클러스터 키."""
+    """(kind, bucket) — kind in {panic, hang, None}. bucket 은 클러스터 키.
+
+    기존 계약: `panicked at file:line` → 그 위치. 스택 오버플로·어보트 코드
+    (101)·음수·>=132 는 패닉. 깨끗한 비-0 실패는 (None, None).
+    hang 은 이 함수가 내지 않는다 — TimeoutExpired 가 낸다.
+    """
+    if err is None:
+        err = ""
+    elif not isinstance(err, str):
+        err = str(err)
     low = err.lower()
     m = PANIC_RE.search(err)
     if m:
         return "panic", m.group(1)
     if "stack overflow" in low:
         return "panic", "stack-overflow"
-    if "panicked" in low or code == 101 or (code is not None and (code < 0 or code >= 132)):
+    if "panicked" in low or code == RUST_ABORT or (
+        code is not None and isinstance(code, int) and (code < 0 or code >= SIGNAL_FLOOR)
+    ):
         return "panic", f"code{code}"
     return None, None
 
 
+def is_panic_code(code, err: str) -> bool:
+    """우아한 실패와 패닉을 가른다. classify 의 패닉 판정과 같다."""
+    kind, _ = classify(code, err)
+    return kind == "panic"
+
+
+def classify_timeout(timed_out) -> bool:
+    """행(timeout) 분류. True / TimeoutExpired / TimeoutError / 표식 문자열."""
+    if isinstance(timed_out, BaseException):
+        if isinstance(timed_out, (subprocess.TimeoutExpired, TimeoutError)):
+            return True
+        if isinstance(timed_out, OSError):
+            timed = {getattr(errno, name, None) for name in ("ETIMEDOUT", "ETIME")}
+            timed.discard(None)
+            return getattr(timed_out, "errno", None) in timed
+        return False
+    if isinstance(timed_out, str):
+        low = timed_out.lower()
+        return any(marker in low for marker in TIMEOUT_MARKERS)
+    return timed_out is True
+
+
+def classify_probe_outcome(kind, bucket) -> str:
+    """probe 가 낸 (kind, bucket) 을 hang / panic / error / clean 으로 접는다."""
+    if kind == "hang" or classify_timeout(kind):
+        return "hang"
+    if kind == "panic":
+        return "panic"
+    if kind == "error" or (isinstance(bucket, str) and bucket in EXCEPTION_KINDS):
+        return "error"
+    if kind in (None, "clean", "ok"):
+        return "clean"
+    return "error"
+
+
+def read_sample(path: str):
+    """샘플을 읽는다. 성공 시 (bytes, None), 실패 시 (None, 이유)."""
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(), None
+    except OSError as exc:
+        return None, f"{exception_kind(exc, 'read')}: {type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        return None, f"{exception_kind(exc, 'read')}: {type(exc).__name__}: {exc}"
+
+
+def write_mutant(path: str, mut: bytes):
+    """변형 바이트를 쓴다. 성공 시 None, 실패 시 이유 문자열."""
+    try:
+        payload = coerce_bytes(mut)
+    except TypeError as exc:
+        return f"type-error: {exc}"
+    try:
+        with open(path, "wb") as fh:
+            fh.write(payload)
+        return None
+    except OSError as exc:
+        return f"{exception_kind(exc, 'write')}: {type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        return f"{exception_kind(exc, 'write')}: {type(exc).__name__}: {exc}"
+
+
+def find_bin_safe(cli_arg):
+    """바이너리 경로를 찾는다. 성공 시 (path, None), 실패 시 (None, 이유)."""
+    try:
+        path = runner.find_bin(cli_arg)
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, f"{exception_kind(exc, 'find-bin')}: {type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        return None, f"{exception_kind(exc, 'find-bin')}: {type(exc).__name__}: {exc}"
+    if not path:
+        return None, "missing-bin: empty-path"
+    if not os.path.exists(path):
+        return None, f"missing-bin: not-found: {path}"
+    return path, None
+
+
 def probe(bin_path, cmd, mut_path, timeout):
+    """한 명령 × 한 변형을 실행 — (kind, bucket).
+
+    TimeoutExpired → ("hang", cmd). 없는 바이너리·권한·그 외 예외는
+    ("error", kind) 로 접고 엔진을 죽이지 않는다. 치명 예외는 삼키지 않는다.
+    """
+    seconds = normalize_timeout(timeout)
+    if seconds <= 0:
+        return "error", "invalid-timeout"
+    if not bin_path:
+        return "error", "missing-bin"
+    if not cmd:
+        return "error", "value-error"
     args = [bin_path, cmd, mut_path]
     if cmd == "convert":
         args.append(mut_path + ".out.hwpx")
     try:
-        p = subprocess.run(args, cwd=REPO_ROOT, capture_output=True, timeout=timeout)
+        p = subprocess.run(args, cwd=REPO_ROOT, capture_output=True, timeout=seconds)
         err = p.stderr.decode("utf-8", "replace") + p.stdout.decode("utf-8", "replace")
         return classify(p.returncode, err)
     except subprocess.TimeoutExpired:
         return "hang", cmd
+    except CATCHABLE_EXCEPTIONS as exc:
+        return "error", exception_kind(exc, "probe")
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        return "error", exception_kind(exc, "probe")
 
 
-def fuzz(bin_path, samples_dir, commands, limit, workers, timeout, work_dir):
-    picked, total = select_samples(samples_dir, limit)
-    jobs = []
-    for i, name in enumerate(picked):
-        data = Path(samples_dir, name).read_bytes()
-        for label, mut in deterministic_mutants(data):
-            jobs.append((i, name, label, mut))
+def empty_shape_counts() -> dict:
+    return {key: 0 for key in SHAPE_KEYS}
 
-    panic_clusters, hang_clusters = {}, {}
-    checked = 0
 
-    def run_one(job):
-        idx, name, label, mut = job
-        p = os.path.join(work_dir, f"m{idx}_{label}.hwp")
-        Path(p).write_bytes(mut)
-        try:
-            results = []
-            for cmd in commands:
-                kind, bucket = probe(bin_path, cmd, p, timeout)
-                if kind:
-                    results.append((kind, bucket, f"{name}:{label}:{cmd}"))
-            return results
-        finally:
-            try:
-                os.remove(p)
-            except OSError:
-                pass
+def empty_report(commands=None) -> dict:
+    """스키마를 만족하는 빈 보고. 예외 경로에서 엔진이 죽지 않게 쓴다."""
+    cmds = list(commands) if commands else []
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": True,
+        "samplesTested": 0,
+        "totalSamples": 0,
+        "commands": cmds,
+        "mutantsPerSample": 0,
+        "runsChecked": 0,
+        "distinctPanicSites": 0,
+        "panicClusters": [],
+        "hangClusters": [],
+        "unreadables": [],
+        "probeErrors": [],
+        "toolErrors": [],
+        "emptyCorpus": False,
+        "missingBin": False,
+        "toolFailed": False,
+        "inputShapes": empty_shape_counts(),
+        "exit": EXIT_OK,
+    }
 
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        for fut in as_completed([ex.submit(run_one, j) for j in jobs]):
-            checked += 1
-            for kind, bucket, tag in fut.result():
-                target = panic_clusters if kind == "panic" else hang_clusters
-                target.setdefault(bucket, []).append(tag)
 
-    panics = sorted(
+def _cluster_ok(report) -> bool:
+    return not report.get("panicClusters") and not report.get("hangClusters")
+
+
+def resolve_exit(report) -> int:
+    """보고에서 종료 코드를 계산한다. 순수."""
+    if report.get("toolFailed") or report.get("missingBin"):
+        return EXIT_TOOL_FAILED
+    if report.get("panicClusters") or report.get("hangClusters"):
+        return EXIT_DOS
+    return EXIT_OK
+
+
+def validate_report(report) -> list:
+    """보고 스키마 위반 목록. 비어 있으면 계약 충족."""
+    issues = []
+    if not isinstance(report, dict):
+        return ["report-not-dict"]
+    missing = [key for key in REPORT_KEYS if key not in report]
+    extra = [key for key in report if key not in REPORT_KEYS]
+    if missing:
+        issues.append("missing:" + ",".join(missing))
+    if extra:
+        issues.append("extra:" + ",".join(sorted(extra)))
+    if report.get("kind") != REPORT_KIND:
+        issues.append("kind")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append("schemaVersion")
+    for key in REPORT_BOOL_KEYS:
+        if not isinstance(report.get(key), bool):
+            issues.append(f"{key}-type")
+    for key in REPORT_INT_KEYS:
+        if not isinstance(report.get(key), int):
+            issues.append(f"{key}-type")
+        elif report.get(key) < 0:
+            issues.append(f"{key}-negative")
+    for key in REPORT_LIST_KEYS:
+        value = report.get(key)
+        if not isinstance(value, list):
+            issues.append(f"{key}-type")
+    shapes = report.get("inputShapes")
+    if not isinstance(shapes, dict):
+        issues.append("inputShapes-type")
+    else:
+        for key in SHAPE_KEYS:
+            if key not in shapes:
+                issues.append(f"inputShapes-missing-{key}")
+            elif not isinstance(shapes[key], int) or shapes[key] < 0:
+                issues.append(f"inputShapes-{key}")
+    panics = report.get("panicClusters")
+    if isinstance(panics, list):
+        for item in panics:
+            if not isinstance(item, dict):
+                issues.append("panicClusters-item-type")
+                break
+            if "location" not in item or "count" not in item or "example" not in item:
+                issues.append("panicClusters-item-keys")
+                break
+    hangs = report.get("hangClusters")
+    if isinstance(hangs, list):
+        for item in hangs:
+            if not isinstance(item, dict):
+                issues.append("hangClusters-item-type")
+                break
+            if "command" not in item or "count" not in item:
+                issues.append("hangClusters-item-keys")
+                break
+    if isinstance(report.get("ok"), bool):
+        expected_ok = _cluster_ok(report) and not report.get("toolFailed")
+        if report["ok"] != expected_ok:
+            issues.append("ok-mismatch")
+    if isinstance(report.get("emptyCorpus"), bool) and isinstance(report.get("totalSamples"), int):
+        if report["emptyCorpus"] and report["totalSamples"] != 0:
+            issues.append("emptyCorpus-mismatch")
+    if isinstance(report.get("exit"), int):
+        if report["exit"] != resolve_exit(report):
+            issues.append("exit-mismatch")
+    if isinstance(report.get("distinctPanicSites"), int) and isinstance(panics, list):
+        if report["distinctPanicSites"] != len(panics):
+            issues.append("distinctPanicSites-mismatch")
+    return issues
+
+
+def format_human_report(report: dict) -> str:
+    """사람용 요약. JSON 이 아닐 때 stdout 에 쓴다."""
+    if report.get("missingBin") or report.get("toolFailed"):
+        lines = ["코퍼스 퍼징: 도구 실패 — 바이너리 또는 코퍼스를 쓰지 못했다."]
+        for item in report.get("toolErrors", []):
+            lines.append(f"  TOOL {item}")
+        return "\n".join(lines)
+    if report.get("emptyCorpus"):
+        return "코퍼스 퍼징: 빈 코퍼스 — 표본 0 (.hwp/.hwpx/.hml 없음)"
+    if report.get("ok"):
+        return (
+            f"코퍼스 퍼징: 샘플 {report['samplesTested']}/{report['totalSamples']} × "
+            f"명령 {len(report.get('commands') or [])} × {report['runsChecked']} 실행 — DoS 0"
+            f" (읽기실패 {len(report.get('unreadables') or [])}"
+            f" · 프로브오류 {len(report.get('probeErrors') or [])})"
+        )
+    lines = [
+        f"코퍼스 퍼징: 고유 패닉 {report.get('distinctPanicSites', 0)}곳 · "
+        f"행 클러스터 {len(report.get('hangClusters') or [])}개 — 고쳐야 할 DoS:"
+    ]
+    for p in report.get("panicClusters") or []:
+        lines.append(f"  PANIC {p.get('location')}  ({p.get('count')}건)  예: {p.get('example')}")
+    for h in report.get("hangClusters") or []:
+        samples = h.get("samples") or []
+        lines.append(
+            f"  HANG  {h.get('command')}  ({h.get('count')}건, {len(samples)}샘플)  예: {h.get('example')}"
+        )
+    return "\n".join(lines)
+
+
+def _sort_panic_clusters(panic_clusters: dict) -> list:
+    return sorted(
         ({"location": loc, "count": len(c), "example": c[0]} for loc, c in panic_clusters.items()),
-        key=lambda x: -x["count"],
+        key=lambda x: (-x["count"], x["location"]),
     )
-    hangs = sorted(
+
+
+def _sort_hang_clusters(hang_clusters: dict) -> list:
+    return sorted(
         (
             {
                 "command": cmd,
@@ -151,24 +1544,206 @@ def fuzz(bin_path, samples_dir, commands, limit, workers, timeout, work_dir):
             }
             for cmd, c in hang_clusters.items()
         ),
-        key=lambda x: -x["count"],
+        key=lambda x: (-x["count"], x["command"]),
     )
-    return {
-        "kind": "gymFuzzCorpus",
-        "schemaVersion": "1.0",
-        "ok": not panics and not hangs,
-        "samplesTested": len(picked),
-        "totalSamples": total,
-        "commands": commands,
-        "mutantsPerSample": len(deterministic_mutants(b"x" * 4096)),
-        "runsChecked": checked * len(commands),
-        "distinctPanicSites": len(panics),
-        "panicClusters": panics,
-        "hangClusters": hangs,
-    }
 
 
-def main() -> int:
+def _mutants_per_sample_hint() -> int:
+    """보고용 변형 수 힌트. 4KiB 정상 입력 기준. 결정적.
+
+    시험이 `deterministic_mutants` 를 바꿔 끼워도 보고 조립이 죽지 않게
+    예외는 0 으로 접는다. 실제 표본의 변형 생성 실패는 unreadables 다.
+    """
+    try:
+        return len(deterministic_mutants(b"x" * 4096))
+    except Exception:  # noqa: BLE001 — 힌트일 뿐 엔진을 죽이지 않는다
+        return 0
+
+
+def _finish_report(report, picked, total, commands, panic_clusters, hang_clusters,
+                   unreadables, probe_errors, tool_errors, shapes, checked,
+                   missing_bin=False, tool_failed=False, empty_corpus=False):
+    panics = _sort_panic_clusters(panic_clusters)
+    hangs = _sort_hang_clusters(hang_clusters)
+    report.update(
+        {
+            "samplesTested": len(picked),
+            "totalSamples": total,
+            "commands": list(commands),
+            "mutantsPerSample": _mutants_per_sample_hint(),
+            "runsChecked": checked,
+            "distinctPanicSites": len(panics),
+            "panicClusters": panics,
+            "hangClusters": hangs,
+            "unreadables": list(unreadables),
+            "probeErrors": list(probe_errors),
+            "toolErrors": list(tool_errors),
+            "emptyCorpus": bool(empty_corpus),
+            "missingBin": bool(missing_bin),
+            "toolFailed": bool(tool_failed or missing_bin),
+            "inputShapes": shapes,
+        }
+    )
+    report["ok"] = _cluster_ok(report) and not report["toolFailed"]
+    report["exit"] = resolve_exit(report)
+    return report
+
+
+def fuzz(bin_path, samples_dir, commands, limit, workers, timeout, work_dir):
+    """코퍼스 × 명령 × 변형을 두들겨 gymFuzzCorpus 봉투를 낸다.
+
+    예외 경로(없는 디렉터리·빈 코퍼스·읽기 실패·쓰기 실패·프로브 예외)에서도
+    엔진은 죽지 않는다. 패닉/행만 ok 를 뒤집고, 도구 실패(missingBin)는
+    toolFailed 로 따로 표시한다.
+    """
+    commands = parse_commands(commands)
+    workers = normalize_workers(workers)
+    report = empty_report(commands)
+    unreadables, probe_errors, tool_errors = [], [], []
+    shapes = empty_shape_counts()
+    panic_clusters, hang_clusters = {}, {}
+    picked, total = [], 0
+
+    if not bin_path:
+        tool_errors.append("missing-bin: empty-path")
+        return _finish_report(
+            report, picked, total, commands, panic_clusters, hang_clusters,
+            unreadables, probe_errors, tool_errors, shapes, 0,
+            missing_bin=True, tool_failed=True,
+        )
+
+    try:
+        picked, total = select_samples(samples_dir, limit)
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        tool_errors.append(f"select_samples: {type(exc).__name__}: {exc}")
+        return _finish_report(
+            report, [], 0, commands, panic_clusters, hang_clusters,
+            unreadables, probe_errors, tool_errors, shapes, 0,
+            tool_failed=True,
+        )
+
+    names, list_err = list_sample_names(samples_dir)
+    if list_err is not None and names is None:
+        # 디렉터리 자체 부재는 빈 코퍼스와 구분한다.
+        tool_errors.append(list_err)
+        empty = "empty-corpus" in list_err or "unreadable" in list_err
+        return _finish_report(
+            report, [], 0, commands, panic_clusters, hang_clusters,
+            unreadables, probe_errors, tool_errors, shapes, 0,
+            tool_failed=not empty, empty_corpus=empty,
+        )
+
+    if total == 0:
+        return _finish_report(
+            report, picked, total, commands, panic_clusters, hang_clusters,
+            unreadables, probe_errors, tool_errors, shapes, 0,
+            empty_corpus=True,
+        )
+
+    jobs = []
+    for i, name in enumerate(picked):
+        data, read_err = read_sample(os.path.join(samples_dir, name))
+        if read_err is not None or data is None:
+            unreadables.append(f"{name}: {read_err or 'unreadable'}")
+            continue
+        try:
+            shape = classify_input_shape(data)
+        except TypeError as exc:
+            unreadables.append(f"{name}: type-error: {exc}")
+            continue
+        shapes[shape] = shapes.get(shape, 0) + 1
+        try:
+            mutants = deterministic_mutants(data)
+        except TypeError as exc:
+            unreadables.append(f"{name}: type-error: {exc}")
+            continue
+        except Exception as exc:  # noqa: BLE001
+            if is_fatal_exception(exc):
+                raise
+            unreadables.append(f"{name}: {type(exc).__name__}: {exc}")
+            continue
+        for label, mut in mutants:
+            jobs.append((i, name, label, mut))
+
+    checked = 0
+    missing_bin_hits = 0
+
+    def run_one(job):
+        idx, name, label, mut = job
+        p = os.path.join(work_dir, f"m{idx}_{label}.hwp")
+        write_err = write_mutant(p, mut)
+        if write_err is not None:
+            return "write-error", write_err, f"{name}:{label}"
+        try:
+            results = []
+            for cmd in commands:
+                try:
+                    kind, bucket = probe(bin_path, cmd, p, timeout)
+                except Exception as exc:  # noqa: BLE001
+                    if is_fatal_exception(exc):
+                        raise
+                    results.append(("error", exception_kind(exc, "probe"), f"{name}:{label}:{cmd}"))
+                    continue
+                if kind:
+                    results.append((kind, bucket, f"{name}:{label}:{cmd}"))
+            return "ok", results, None
+        finally:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    if not jobs:
+        return _finish_report(
+            report, picked, total, commands, panic_clusters, hang_clusters,
+            unreadables, probe_errors, tool_errors, shapes, 0,
+            empty_corpus=False,
+        )
+
+    def absorb(status, payload, tag):
+        nonlocal checked, missing_bin_hits
+        if status == "write-error":
+            probe_errors.append(f"{tag}: {payload}")
+            return
+        checked += 1
+        for kind, bucket, item_tag in payload:
+            outcome = classify_probe_outcome(kind, bucket)
+            if outcome == "panic":
+                panic_clusters.setdefault(bucket, []).append(item_tag)
+            elif outcome == "hang":
+                hang_clusters.setdefault(bucket, []).append(item_tag)
+            elif outcome == "error":
+                probe_errors.append(f"{item_tag}: {bucket}")
+                if bucket == "missing-bin":
+                    missing_bin_hits += 1
+
+    if workers <= 1:
+        for job in jobs:
+            absorb(*run_one(job))
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            for fut in as_completed([ex.submit(run_one, j) for j in jobs]):
+                try:
+                    absorb(*fut.result())
+                except Exception as exc:  # noqa: BLE001
+                    if is_fatal_exception(exc):
+                        raise
+                    probe_errors.append(f"worker: {type(exc).__name__}: {exc}")
+
+    missing_bin = missing_bin_hits > 0 and not panic_clusters and not hang_clusters
+    if missing_bin:
+        tool_errors.append("missing-bin: probe FileNotFound")
+    return _finish_report(
+        report, picked, total, commands, panic_clusters, hang_clusters,
+        unreadables, probe_errors, tool_errors, shapes,
+        checked * len(commands),
+        missing_bin=missing_bin, tool_failed=missing_bin,
+    )
+
+
+def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="gym 코퍼스 퍼징 발견 엔진 — DoS 를 근본원인별로 색출")
     ap.add_argument("--bin", required=True)
     ap.add_argument("--commands", default=",".join(DEFAULT_COMMANDS),
@@ -177,27 +1752,56 @@ def main() -> int:
     ap.add_argument("--workers", type=int, default=8)
     ap.add_argument("--timeout", type=int, default=10)
     ap.add_argument("--json", action="store_true")
-    a = ap.parse_args()
-    bin_path = runner.find_bin(a.bin)
-    commands = [c.strip() for c in a.commands.split(",") if c.strip()]
-    import tempfile
-
-    with tempfile.TemporaryDirectory() as work:
-        report = fuzz(bin_path, os.path.join(REPO_ROOT, "samples"), commands,
-                      a.limit, a.workers, a.timeout, work)
+    a = ap.parse_args(argv)
+    commands = parse_commands(a.commands)
+    bin_path, bin_err = find_bin_safe(a.bin)
+    if bin_err is not None or not bin_path:
+        report = empty_report(commands)
+        report["missingBin"] = True
+        report["toolFailed"] = True
+        report["ok"] = False
+        report["toolErrors"] = [bin_err or "missing-bin: empty-path"]
+        report["exit"] = EXIT_TOOL_FAILED
+        if a.json:
+            sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+        else:
+            print(format_human_report(report), file=sys.stderr)
+        return EXIT_TOOL_FAILED
+    samples_dir = os.path.join(REPO_ROOT, "samples")
+    try:
+        work_cm = tempfile.TemporaryDirectory()
+    except Exception as exc:  # noqa: BLE001
+        if is_fatal_exception(exc):
+            raise
+        report = empty_report(commands)
+        report["toolFailed"] = True
+        report["ok"] = False
+        report["toolErrors"] = [f"tempdir: {type(exc).__name__}: {exc}"]
+        report["exit"] = EXIT_TOOL_FAILED
+        if a.json:
+            sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+        else:
+            print(format_human_report(report), file=sys.stderr)
+        return EXIT_TOOL_FAILED
+    with work_cm as work:
+        try:
+            report = fuzz(bin_path, samples_dir, commands, a.limit, a.workers, a.timeout, work)
+        except Exception as exc:  # noqa: BLE001
+            if is_fatal_exception(exc):
+                raise
+            report = empty_report(commands)
+            report["toolFailed"] = True
+            report["ok"] = False
+            report["toolErrors"] = [f"fuzz: {type(exc).__name__}: {exc}"]
+            report["exit"] = EXIT_TOOL_FAILED
+    issues = validate_report(report)
+    if issues:
+        report.setdefault("toolErrors", []).append("schema: " + ";".join(issues))
     if a.json:
         sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
-    elif report["ok"]:
-        print(f"코퍼스 퍼징: 샘플 {report['samplesTested']}/{report['totalSamples']} × "
-              f"명령 {len(commands)} × {report['runsChecked']} 실행 — DoS 0")
     else:
-        print(f"코퍼스 퍼징: 고유 패닉 {report['distinctPanicSites']}곳 · "
-              f"행 클러스터 {len(report['hangClusters'])}개 — 고쳐야 할 DoS:")
-        for p in report["panicClusters"]:
-            print(f"  PANIC {p['location']}  ({p['count']}건)  예: {p['example']}")
-        for h in report["hangClusters"]:
-            print(f"  HANG  {h['command']}  ({h['count']}건, {len(h['samples'])}샘플)  예: {h['example']}")
-    return 0 if report["ok"] else 1
+        print(format_human_report(report))
+    return int(report.get("exit", EXIT_OK if report.get("ok") else EXIT_DOS))
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_fuzz_corpus.md
+++ b/mydocs/working/gym_fuzz_corpus.md
@@ -1,0 +1,267 @@
+---
+kind: investigation
+status: active
+canonical: gym/docs/fuzz_corpus.md
+last_verified: 2026-08-18
+---
+
+# gym 코퍼스 퍼징 발견 엔진 — 결정적 변형·예외 경로 보강
+
+Issue: #5256
+Branch: `feat/gym-fuzz-corpus-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/fuzz_corpus.py` 의 결정적 손상 변형을 확대하고, 발견 엔진
+자신의 예외 경로를 분류·보고하도록 닫았다. 무작위는 쓰지 않는다. 같은
+입력은 같은 라벨·바이트를 내고, 원본과 동일한 무의미 변형은 버린다.
+
+없는 바이너리·빈 코퍼스·읽기 실패는 DoS 로 위장하지 않는다. 엔진은
+예외로 죽지 않는다. 치명 예외(`KeyboardInterrupt` · `SystemExit` ·
+`MemoryError` · `GeneratorExit`)는 삼키지 않는다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_fuzz_corpus`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+건드리지 않은 것:
+
+- `gym/tools/trajectory.py` · `discriminate.py`
+- `gym/packs/automation` · `core-cli` · `casual-rides`
+- 다른 열린 PR 의 파일
+- 새 CLI 플래그, 새 pack, 새 과제
+- 원 `classify` 계약 (`code==1` 깨끗한 실패는 패닉이 아님)
+- 원 라벨 `truncN` / `flipN` / `biglenN`
+
+## 2. 배경
+
+원 도구(#4828 / PR #4829)는 전 코퍼스 × 다명령 × 결정적 변형을 병렬로
+두들겨 패닉을 `file:line` 으로 묶는 발견 엔진이다. `robustness.py` 가
+릴리스 게이트라면 이 도구는 그 앞단이다. 대비 `upstream/devel` 의 구현은
+약 210줄, 시험은 5건이었다.
+
+그 상태의 빈틈:
+
+1. 정상 입력의 기본 변형이 13건(trunc 5 + flip 5 + biglen 3). 헤더·OLE·
+   ZIP·유니코드·permute/stripe/splice 가 없다. 게이트(#5218)가 이미 그
+   가족을 두드리는데 발견 엔진이 더 얇으면, 게이트가 놓친 **명령 축**
+   (`export-render-tree` 등)에서 같은 손상을 다시 볼 수 없다.
+2. `probe` 가 `TimeoutExpired` 만 잡고, 없는 바이너리·권한·그 외 예외는
+   엔진을 죽일 수 있다. 발견 엔진이 죽으면 CI 가 붉어져 rhwp DoS 와
+   하네스 결함을 구분할 수 없다.
+3. `select_samples` 가 없는 디렉터리에서 `os.listdir` 예외를 그대로
+   올린다. 빈 코퍼스와 없는 디렉터리를 구분하는 깃발이 없다.
+4. 읽을 수 없는 표본이 전 주행을 멈춘다. 한 파일이 잠겨 있다고 나머지
+   수백 개를 안 두드린다.
+5. `as_completed` 의 완료 순서가 클러스터 `example` 을 흔든다. 위치
+   묶음 자체는 집합이라 안전하지만, 보고 diff 가 워커에 흔들린다.
+6. 카탈로그가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+7. JSON 봉투에 예외 자리가 없다. `ok=true` 가 "DoS 0" 인지 "못 돌렸다"
+   인지 구분할 수 없다.
+
+이슈 #5256 의 DoD 는 이 빈틈을 닫는 것이다. additions >= 3000.
+unittest + audit.py. 무작위 금지. 새 CLI/pack 없음.
+
+게이트 보강(#5218 / `feat/gym-robust-mutants`)의 예외 접기와 확대 변형을
+참고하되, 발견 엔진의 정체성은 유지했다.
+
+- 원 라벨 `trunc25` 를 `truncate@25%` 로 바꾸지 않는다. 이미 이 태그로
+  열린 재현체가 있다.
+- 명령은 여러 개다. 게이트는 `info` 하나다.
+- 산출은 위치별 클러스터다. 게이트는 평평한 패닉/행 목록이다.
+- 표본 확장자는 `.hwp`/`.hwpx`/`.hml` 이다. 게이트는 `.hwp` 만.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/fuzz_corpus.py`
+
+- `coerce_bytes` — bytes/bytearray/memoryview 만. 그 외 `TypeError`.
+- `classify_input_shape` — empty/tiny/normal/huge.
+- `normalize_limit` / `normalize_timeout` / `normalize_workers`.
+- `parse_commands` — 빈 토큰·중복 제거. 전부 비면 기본 명령.
+- `is_sample_name` — `.hwp`/`.hwpx`/`.hml`, 대소문자 무시.
+- `MUTANT_CATALOG` + `mutant_catalog` / `catalog_ids` / `catalog_families`
+  / `mutant_family`.
+- 확대 결정적 변형(아래 4절). 원 라벨은 앞에 남긴다.
+- `read_sample` / `write_mutant` — 실패를 문자열로.
+- `find_bin_safe` — `find_bin` + exists. 없으면 `missing-bin`.
+- `probe` — invalid-timeout, missing-bin, 빈 명령, `TimeoutExpired`,
+  `FileNotFoundError`, `PermissionError`, 그 외 예외를 `(error, kind)` 로.
+- `classify` 기존 계약 유지. `classify_timeout` / `classify_probe_outcome`
+  / `is_panic_code` 를 옆에 둔다.
+- `exception_kind` — context 가 probe/read/select/find-bin 이면
+  FileNotFound 의 kind 가 갈린다 (missing-bin / unreadable / empty-corpus).
+- `FATAL_EXCEPTIONS` — 삼키지 않는다.
+- `empty_report` / `validate_report` / `format_human_report` / `resolve_exit`.
+- `fuzz` 가 읽기실패·쓰기실패·프로브예외를 삼키고 보고에 남긴다.
+- 봉투에 `unreadables`, `probeErrors`, `toolErrors`, `emptyCorpus`,
+  `missingBin`, `toolFailed`, `inputShapes`, `exit` 를 추가.
+- 클러스터 정렬을 `(-count, location|command)` 로 고정.
+- `main` 은 바이너리 부재·임시 디렉터리 실패·fuzz 폭주를 exit 2 로.
+  JSON 은 stdout, 사람용 실패는 stderr.
+
+종료 코드: 0=깨끗, 1=DoS 발견, 2=도구 실패.
+
+`ok` = 패닉·행 부재 **그리고** `toolFailed` 가 거짓. 빈 코퍼스는 ok.
+없는 바이너리는 not ok.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_fuzz_corpus.py`
+
+- 기존 `FuzzCorpusTests` 5건 유지. 봉투에 키가 늘어도 그 5건은 같은
+  주장을 한다.
+- `ExpandedMutantContractTests` — 가족 매핑, 헤더/OLE/길이/런/유니코드/
+  permute/stripe/splice 바이트 계약, ZIP/HWP3 조건부, 거대 입력 splice
+  생략, 원 라벨 생존.
+- `ClassifyAndSelectTests` — None/비문자 err, timeout 표식, hwpx/hml
+  포함, 없는 디렉터리, 명령 정규화, stride 안정.
+- `ExceptionPathTests` — 없는 바이너리(exit 2 JSON/사람), 빈 코퍼스,
+  읽기 실패, 쓰기 실패, 프로브 예외, TypeError 변형, 없는 디렉터리,
+  `validate_report`, `format_human_report`, shape 집계, 워커 1=워커 4
+  클러스터.
+- `MainCliTests` — `main(["--bin", 없는경로, "--json"])` 이 2 를 내고
+  봉투를 쓴다. 있는 바이너리면 `fuzz` 를 부른다.
+- `GeneratedCatalogTableTests` / `HonestyTests` — 카탈로그 why 비지
+  않음, 예외 kind 에 panic/hang 없음, 프로브 오류는 행이 아님.
+
+subprocess 는 전부 목킹한다. 바이너리 없이 돈다.
+
+### 3.3 문서
+
+- `gym/docs/fuzz_corpus.md` — 분업, 사용, 봉투, 형태, 결정성, 분류,
+  예외 세 자리, 카탈로그 13가족, 클러스터링, 게이트 분업, 시험, 하지
+  않는 것.
+- `mydocs/working/gym_fuzz_corpus.md` — 이 기록.
+
+pack JSON 은 건드리지 않았다.
+
+## 4. 확대 변형
+
+원 13라벨은 그대로 산다.
+
+| 원 라벨 | 하는 일 |
+|---|---|
+| `trunc5/25/50/75/95` | 앞 N% 절단 |
+| `flip10/30/50/70/90` | 그 위치 1바이트 XOR 0xFF |
+| `biglen10/40/70` | 그 위치에 `0x7FFFFFFF` |
+
+뒤에 덧붙인 가족:
+
+- truncate 확대: `trunc1/10/99`, `chop-last`, `cut-first`,
+  `odd-length-chop`, `shrink-gap`
+- flip 확대: `flip0/25/75/99`
+- length 확대: `length-zero30`, `length-one60`, `i32-min20`, `u16-max12`
+- header: `zero-header`, `header-smash`, `rotate-header`,
+  `increment-header`, `nibble-swap-head`
+- ole: `ole-trunc-tail`, `ole-magic-poison`, `ole-sector-shift-poison`,
+  `ole-mini-fat-poison`
+- run: `ff-run`, `aa-run`, `nul-mid`, `00-run`, `55-run`
+- unicode: `utf16-nul-sprinkle`, `utf16-bom-inject`, `utf8-overlong`,
+  `ascii-ctrl-sprinkle`, `path-sep-sprinkle`
+- zip: 로컬/CD/EOCD flip 또는 magic inject
+- permute / stripe / splice / hwp3: 게이트와 같은 축, 라벨만 발견 엔진
+  표기
+
+2KiB 정상 입력에서 `LEGACY_ALWAYS_LABELS` + `EXPANDED_ALWAYS_LABELS` 가
+모두 나온다. ZIP 매직이 없으면 `zip-local-header-flip` 은 없고
+`zip-magic-inject` 가 있다. HWP3 서명이 없으면 inject, 있으면 flip.
+거대(1MiB+)는 splice 성장을 생략한다. 빈 입력은 `empty-to-nul` 한 건.
+
+무작위 필드가 없다. `os.urandom` / `random` / `time` 을 변형 생성에
+쓰지 않는다.
+
+## 5. 예외 카탈로그
+
+| context | 예외 | kind |
+|---|---|---|
+| probe / find-bin | FileNotFoundError | missing-bin |
+| read | FileNotFoundError / PermissionError / OSError | unreadable |
+| select | FileNotFoundError / OSError | empty-corpus |
+| * | PermissionError (probe/write) | permission |
+| * | TimeoutExpired / TimeoutError | timeout |
+| * | UnicodeError | decode-error |
+| * | TypeError | type-error |
+| * | ValueError / KeyError / IndexError | value-error |
+| * | OSError | os-error |
+| * | 그 외 | unexpected |
+
+`probe` 의 빈 경로·비양수 timeout·빈 명령은 예외가 나기 전에
+`missing-bin` / `invalid-timeout` / `value-error` 로 접는다.
+
+`fuzz("", …)` 는 프로브 전에 `missingBin` 이다. `fuzz(있는것처럼 보이는
+가짜, 빈 디렉터리)` 는 `emptyCorpus` 다. `fuzz(있는것처럼 보이는 가짜,
+표본은 있는데 probe 가 FileNotFound)` 는 전량이 missing-bin 이면
+`toolFailed` 다.
+
+이 세 자리가 이슈가 명한 예외 경로다. 시험이 각각 고정한다.
+
+## 6. 정직 조항 — 바꾸지 않은 것
+
+```
+classify(101, "panicked at src/x.rs:42:9") → ("panic", "src/x.rs:42")
+classify(134, "stack overflow")            → ("panic", "stack-overflow")
+classify(101, "")                          → ("panic", "code101")
+classify(-1073741819, "")                  → ("panic", "code-1073741819")
+classify(1, "오류: 유효하지 않은 파일")      → (None, None)
+classify(0, "정상")                         → (None, None)
+```
+
+- 같은 위치의 다른 명령 패닉은 한 클러스터
+- 행은 명령 버킷
+- `ok` 는 패닉·행이 없고 도구가 실패하지 않았을 때만 true
+- 빈 코퍼스는 ok (발견할 것이 없음)
+- 없는 바이너리는 not ok (발견을 못 함)
+- 프로브 오류는 hangClusters 에 넣지 않는다
+- `other-doc` 같은 새 심각도를 만들지 않았다. 발견 엔진의 심각도는
+  패닉/행/없음 세 칸이다. 도구 실패는 네 번째 칸이 아니라 **도구 상태**다.
+
+`probe-failed` 를 분류 삼원에 넣지 않은 이유와 같다. 분류는 rhwp 의
+동작이고, 도구 실패는 하네스의 동작이다. 둘을 섞으면 "고유 버그 목록"이
+"오늘 디스크가 가득 찼음" 과 같은 칸에 앉는다.
+
+## 7. 크기와 범위
+
+이 가지는 Python 도구·시험·문서만 만진다. `src/` 와 `tests/cases/` 와
+`gym/packs/` 는 그대로다. 그래서 `cargo fmt --all` 을 돌리지 않는다.
+unit-test-tiers / rust-test-suite-manifest 도 다시 생성하지 않는다.
+
+삽입이 두꺼운 이유:
+
+- 변형 카탈로그를 게이트와 같은 축으로 맞추되 원 라벨을 유지하려면
+  생성 함수와 시험 바이트 계약이 길어진다.
+- 예외 세 자리(없는 바이너리·빈 코퍼스·읽기 실패)를 거짓말 없이 접으려면
+  봉투 키와 validate 와 main 경로가 길어진다.
+- 문서가 카탈로그와 같은 표를 보지 않으면 다음 확장이 또 코드에만
+  남는다. #5256 이 docs 를 DoD 에 넣은 이유다.
+
+얇게 예외 세 줄만 잡으면 재현이 다시 깨진다. 이슈가 말한 그대로다:
+"코퍼스 퍼즈가 결정성과 예외 처리 없이 커지면 재현이 안 된다."
+
+## 8. 로컬 검증 실측
+
+작업 트리: `C:\Users\swsz9\rhwp-gym-fuzz-corpus`
+브랜치: `feat/gym-fuzz-corpus-hardening` ← `upstream/devel`
+
+```
+python -m unittest scripts.tests.test_gym_fuzz_corpus
+python gym/tools/audit.py
+```
+
+pack 을 안 바꿨으므로 audit 는 기존과 같아야 한다. fuzz_corpus 시험은
+바이너리 없이 목킹만 탄다.
+
+## 9. 다음에 하지 말 것
+
+- 원 라벨을 게이트 표기로 리네임하지 말 것.
+- `classify` 에 `core dumped` 를 패닉 표식으로 승격하려면 별도 이슈.
+  이번 가지는 원 계약을 유지한다. 깨끗한 실패와 겹칠 위험이 있다.
+- 새 `--samples-dir` 플래그를 넣지 말 것. 라이브러리 `fuzz()` 가 이미
+  받는다. CLI 표면을 늘리면 이슈 범위를 넘는다.
+- trajectory / discriminate / automation / core-cli / casual-rides 를
+  이 가지에서 고치지 말 것.

--- a/scripts/tests/test_gym_fuzz_corpus.py
+++ b/scripts/tests/test_gym_fuzz_corpus.py
@@ -1,16 +1,158 @@
 """[fuzz_corpus] gym 코퍼스 퍼징 발견 엔진 계약 — 결정적 변형·분류·근본원인 클러스터링.
 
 퍼징(subprocess)은 목킹해 바이너리 없이 로직만 시험한다.
+
+확대 계약:
+- 같은 입력은 같은 라벨·바이트를 낸다(무작위 없음).
+- 원본과 바이트가 같은 무의미 변형은 버린다.
+- 없는 바이너리·빈 코퍼스·읽기 실패에서도 엔진이 죽지 않는다.
+- JSON 봉투 키가 REPORT_KEYS 와 같고 ok 는 패닉·행 부재 및 toolFailed 와 일치한다.
+- 패닉은 file:line 으로 클러스터하고, 행은 명령으로 클러스터한다.
 """
 
 from __future__ import annotations
 
+import errno
 import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "fuzz_corpus.py"
+
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "samplesTested",
+    "totalSamples",
+    "commands",
+    "mutantsPerSample",
+    "runsChecked",
+    "distinctPanicSites",
+    "panicClusters",
+    "hangClusters",
+    "unreadables",
+    "probeErrors",
+    "toolErrors",
+    "emptyCorpus",
+    "missingBin",
+    "toolFailed",
+    "inputShapes",
+    "exit",
+)
+
+LEGACY_ALWAYS_LABELS = (
+    "trunc5",
+    "trunc25",
+    "trunc50",
+    "trunc75",
+    "trunc95",
+    "flip10",
+    "flip30",
+    "flip50",
+    "flip70",
+    "flip90",
+    "biglen10",
+    "biglen40",
+    "biglen70",
+)
+
+EXPANDED_ALWAYS_LABELS = (
+    "trunc1",
+    "trunc10",
+    "trunc99",
+    "flip0",
+    "flip25",
+    "flip75",
+    "flip99",
+    "chop-last",
+    "cut-first",
+    "zero-header",
+    "header-smash",
+    "rotate-header",
+    "increment-header",
+    "nibble-swap-head",
+    "ole-trunc-tail",
+    "ole-magic-poison",
+    "ole-sector-shift-poison",
+    "ff-run",
+    "aa-run",
+    "nul-mid",
+    "00-run",
+    "55-run",
+    "utf16-nul-sprinkle",
+    "utf16-bom-inject",
+    "utf8-overlong",
+    "ascii-ctrl-sprinkle",
+    "path-sep-sprinkle",
+    "zip-magic-inject",
+    "length-zero30",
+    "length-one60",
+    "i32-min20",
+    "u16-max12",
+    "reverse-prefix",
+    "swap-ends",
+    "high-bit-stripe",
+    "low-bit-stripe",
+    "xor-stride7",
+    "interleave-zero-head",
+    "duplicate-prefix",
+    "tail-over-head",
+    "invert-tail-64",
+    "complement-mid-32",
+    "bit-rotate-head",
+    "decrement-tail",
+    "slide-window-left",
+    "slide-window-right",
+    "repeat-mid-block",
+    "odd-length-chop",
+    "splice-nul-mid",
+    "crlf-inject",
+    "pad-eof",
+    "widen-gap",
+    "shrink-gap",
+    "hwp3-sig-inject",
+)
+
+FAMILY_IDS = (
+    "empty",
+    "truncate",
+    "flip",
+    "length",
+    "header",
+    "ole",
+    "run",
+    "unicode",
+    "zip",
+    "permute",
+    "stripe",
+    "splice",
+    "hwp3",
+)
+
+NORMAL_2K = bytes(range(256)) * 8  # 2KB, 짝수, ZIP/HWP3 서명 없음
+EXCEPTION_KINDS = (
+    "missing-bin",
+    "empty-corpus",
+    "unreadable",
+    "permission",
+    "timeout",
+    "os-error",
+    "type-error",
+    "value-error",
+    "decode-error",
+    "invalid-timeout",
+    "invalid-workers",
+    "probe-error",
+    "unexpected",
+)
 
 
 def load():
@@ -19,6 +161,29 @@ def load():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def labels_of(pairs):
+    return [label for label, _ in pairs]
+
+
+def as_map(pairs):
+    return {label: payload for label, payload in pairs}
+
+
+def _fuzz(mod, samples, commands, **kwargs):
+    work = kwargs.pop("work_dir", None)
+    if work is None:
+        raise AssertionError("work_dir 필요")
+    return mod.fuzz(
+        kwargs.pop("bin_path", "bin"),
+        samples,
+        commands,
+        kwargs.pop("limit", 0),
+        kwargs.pop("workers", 2),
+        kwargs.pop("timeout", 5),
+        work,
+    )
 
 
 class FuzzCorpusTests(unittest.TestCase):
@@ -94,6 +259,1068 @@ class FuzzCorpusTests(unittest.TestCase):
         self.assertTrue(r["ok"])
         self.assertEqual(r["panicClusters"], [])
         self.assertEqual(r["hangClusters"], [])
+
+
+class ExpandedMutantContractTests(unittest.TestCase):
+    def test_catalog_covers_declared_families(self):
+        mod = load()
+        catalog = mod.mutant_catalog()
+        self.assertGreaterEqual(len(catalog), 40)
+        ids = [row["id"] for row in catalog]
+        self.assertEqual(ids, list(mod.catalog_ids()))
+        self.assertEqual(len(ids), len(set(ids)))
+        families = {row["family"] for row in catalog}
+        for fam in FAMILY_IDS:
+            self.assertIn(fam, families)
+        self.assertEqual(set(mod.catalog_families()), families)
+        for row in catalog:
+            self.assertIn("id", row)
+            self.assertIn("family", row)
+            self.assertIn("when", row)
+            self.assertIn("why", row)
+            self.assertTrue(row["why"])
+
+    def test_mutant_family_mapping(self):
+        mod = load()
+        cases = {
+            "empty-to-nul": "empty",
+            "trunc25": "truncate",
+            "trunc5": "truncate",
+            "chop-last": "truncate",
+            "cut-first": "truncate",
+            "odd-length-chop": "truncate",
+            "shrink-gap": "truncate",
+            "flip0": "flip",
+            "flip90": "flip",
+            "biglen10": "length",
+            "length-zero30": "length",
+            "length-one60": "length",
+            "i32-min20": "length",
+            "u16-max12": "length",
+            "zero-header": "header",
+            "header-smash": "header",
+            "rotate-header": "header",
+            "increment-header": "header",
+            "nibble-swap-head": "header",
+            "ole-trunc-tail": "ole",
+            "ole-magic-poison": "ole",
+            "ole-sector-shift-poison": "ole",
+            "ole-mini-fat-poison": "ole",
+            "ff-run": "run",
+            "aa-run": "run",
+            "nul-mid": "run",
+            "00-run": "run",
+            "55-run": "run",
+            "utf16-nul-sprinkle": "unicode",
+            "utf16-bom-inject": "unicode",
+            "utf8-overlong": "unicode",
+            "ascii-ctrl-sprinkle": "unicode",
+            "path-sep-sprinkle": "unicode",
+            "zip-local-header-flip": "zip",
+            "zip-magic-inject": "zip",
+            "zip-cd-magic-flip": "zip",
+            "zip-eocd-flip": "zip",
+            "reverse-prefix": "permute",
+            "swap-ends": "permute",
+            "slide-window-left": "permute",
+            "slide-window-right": "permute",
+            "repeat-mid-block": "permute",
+            "high-bit-stripe": "stripe",
+            "low-bit-stripe": "stripe",
+            "xor-stride7": "stripe",
+            "interleave-zero-head": "stripe",
+            "duplicate-prefix": "stripe",
+            "tail-over-head": "stripe",
+            "invert-tail-64": "stripe",
+            "complement-mid-32": "stripe",
+            "bit-rotate-head": "stripe",
+            "decrement-tail": "stripe",
+            "splice-nul-mid": "splice",
+            "crlf-inject": "splice",
+            "pad-eof": "splice",
+            "widen-gap": "splice",
+            "even-length-pad": "splice",
+            "hwp3-sig-flip": "hwp3",
+            "hwp3-sig-inject": "hwp3",
+            "": "other",
+            "unknown-label": "other",
+        }
+        for label, family in cases.items():
+            self.assertEqual(mod.mutant_family(label), family, label)
+        self.assertEqual(mod.mutant_family(None), "other")
+
+    def test_legacy_labels_survive_on_normal_payload(self):
+        mod = load()
+        labels = labels_of(mod.deterministic_mutants(NORMAL_2K))
+        for name in LEGACY_ALWAYS_LABELS:
+            self.assertIn(name, labels, name)
+        for name in EXPANDED_ALWAYS_LABELS:
+            self.assertIn(name, labels, name)
+        self.assertNotIn("zip-local-header-flip", labels)
+        self.assertNotIn("empty-to-nul", labels)
+        self.assertIn("zip-magic-inject", labels)
+        self.assertIn("hwp3-sig-inject", labels)
+
+    def test_empty_input_has_a_deterministic_mutant(self):
+        mod = load()
+        self.assertEqual(mod.deterministic_mutants(b""), [("empty-to-nul", b"\0")])
+
+    def test_empty_and_tiny_inputs_still_work(self):
+        mod = load()
+        shapes = (
+            b"",
+            b"\x00",
+            b"\xff",
+            b"AB",
+            b"\x00" * 64,
+            b"\xff" * 128,
+            b"PK\x03\x04",
+            b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 80,
+        )
+        for data in shapes:
+            a = mod.deterministic_mutants(data)
+            b = mod.deterministic_mutants(data)
+            self.assertEqual(a, b, f"결정성 깨짐: {data[:16]!r}")
+            self.assertGreater(len(a), 0)
+            labels = []
+            for label, mut in a:
+                self.assertNotEqual(mut, data, f"{label} 이 원본과 같다")
+                labels.append(label)
+            self.assertEqual(labels, list(dict.fromkeys(labels)))
+
+    def test_coerce_bytes_accepts_bytes_like_only(self):
+        mod = load()
+        self.assertEqual(mod.coerce_bytes(b"ab"), b"ab")
+        self.assertEqual(mod.coerce_bytes(bytearray(b"ab")), b"ab")
+        self.assertEqual(mod.coerce_bytes(memoryview(b"ab")), b"ab")
+        for bad in ("ab", 12, None, ["x"], {"a": 1}):
+            with self.assertRaises(TypeError):
+                mod.coerce_bytes(bad)
+            with self.assertRaises(TypeError):
+                mod.deterministic_mutants(bad)
+            with self.assertRaises(TypeError):
+                mod.classify_input_shape(bad)
+
+    def test_classify_input_shape_buckets(self):
+        mod = load()
+        self.assertEqual(mod.classify_input_shape(b""), "empty")
+        self.assertEqual(mod.classify_input_shape(b"\x00"), "tiny")
+        self.assertEqual(mod.classify_input_shape(b"\x00" * 64), "tiny")
+        self.assertEqual(mod.classify_input_shape(b"\x00" * 65), "normal")
+        self.assertEqual(mod.classify_input_shape(NORMAL_2K), "normal")
+        self.assertEqual(mod.classify_input_shape(b"\x00" * mod.HUGE_MIN), "huge")
+
+    def test_header_smash_uses_fixed_pattern(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["header-smash"]
+        self.assertTrue(payload.startswith(mod.HEADER_SMASH_PAT))
+        self.assertEqual(payload[64:], NORMAL_2K[64:])
+
+    def test_zero_header_clears_first_512(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["zero-header"]
+        self.assertEqual(payload[:512], b"\x00" * 512)
+        self.assertEqual(payload[512:], NORMAL_2K[512:])
+
+    def test_ole_magic_poison_xors_signature(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["ole-magic-poison"]
+        expected = bytes(x ^ 0xFF for x in mod.OLE_MAGIC)
+        self.assertEqual(payload[:8], expected)
+        self.assertEqual(payload[8:], NORMAL_2K[8:])
+
+    def test_ole_sector_and_minifat_offsets(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertEqual(mapped["ole-sector-shift-poison"][30:32], b"\xff\xff")
+        self.assertEqual(mapped["ole-mini-fat-poison"][60:64], b"\xff\xff\xff\xff")
+        tiny = as_map(mod.deterministic_mutants(b"\x00" * 20))
+        self.assertNotIn("ole-sector-shift-poison", tiny)
+        self.assertNotIn("ole-mini-fat-poison", tiny)
+
+    def test_length_bombs_are_little_endian_constants(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        bomb10 = min(n - 4, n * 10 // 100)
+        self.assertEqual(mapped["biglen10"][bomb10 : bomb10 + 4], b"\xff\xff\xff\x7f")
+        zero30 = min(n - 4, n * 30 // 100)
+        self.assertEqual(mapped["length-zero30"][zero30 : zero30 + 4], b"\x00\x00\x00\x00")
+        one60 = min(n - 4, n * 60 // 100)
+        self.assertEqual(mapped["length-one60"][one60 : one60 + 4], b"\x01\x00\x00\x00")
+        i32 = min(n - 4, n * 20 // 100)
+        self.assertEqual(mapped["i32-min20"][i32 : i32 + 4], b"\x00\x00\x00\x80")
+        self.assertEqual(mapped["u16-max12"][12:14], b"\xff\xff")
+
+    def test_run_families_overwrite_expected_windows(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        start = n // 3
+        run = min(128, n - start)
+        self.assertEqual(mapped["ff-run"][start : start + run], b"\xff" * run)
+        aa_n = max(1, n // 4)
+        self.assertEqual(mapped["aa-run"][:aa_n], b"\xaa" * aa_n)
+        mid = n // 2
+        nul_n = min(64, n - mid)
+        self.assertEqual(mapped["nul-mid"][mid : mid + nul_n], b"\x00" * nul_n)
+        two_third = (n * 2) // 3
+        zero_n = min(64, n - two_third)
+        self.assertEqual(mapped["00-run"][two_third : two_third + zero_n], b"\x00" * zero_n)
+        five_n = max(1, n // 5)
+        self.assertEqual(mapped["55-run"][:five_n], b"\x55" * five_n)
+
+    def test_unicode_and_control_injections(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertEqual(mapped["utf16-bom-inject"][:2], b"\xff\xfe")
+        over_at = len(NORMAL_2K) // 5
+        self.assertEqual(mapped["utf8-overlong"][over_at : over_at + 2], b"\xc0\x80")
+        n = len(NORMAL_2K)
+        ctrl = mapped["ascii-ctrl-sprinkle"]
+        for pct in (15, 35, 55, 75):
+            self.assertEqual(ctrl[n * pct // 100], 0x01)
+        seps = mapped["path-sep-sprinkle"]
+        self.assertEqual(seps[n * 18 // 100], 0x2F)
+        self.assertEqual(seps[n * 42 // 100], 0x5C)
+
+    def test_permute_and_stripe_contracts(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertEqual(mapped["reverse-prefix"][:16], bytes(reversed(NORMAL_2K[:16])))
+        self.assertEqual(mapped["swap-ends"][:8], NORMAL_2K[-8:])
+        self.assertEqual(mapped["swap-ends"][-8:], NORMAL_2K[:8])
+        self.assertEqual(mapped["slide-window-left"][:32], NORMAL_2K[1:32] + NORMAL_2K[:1])
+        self.assertEqual(mapped["slide-window-right"][:32], NORMAL_2K[31:32] + NORMAL_2K[:31])
+        self.assertEqual(mapped["duplicate-prefix"][8:16], NORMAL_2K[:8])
+        self.assertEqual(mapped["tail-over-head"][:16], NORMAL_2K[-16:])
+        self.assertEqual(mapped["high-bit-stripe"][0] & 0x80, 0x80)
+        self.assertEqual(mapped["low-bit-stripe"][0], NORMAL_2K[0] ^ 0x01)
+        self.assertEqual(mapped["xor-stride7"][0], NORMAL_2K[0] ^ 0xA5)
+        self.assertEqual(mapped["interleave-zero-head"][1], 0)
+        self.assertEqual(mapped["increment-header"][0], (NORMAL_2K[0] + 1) & 0xFF)
+        self.assertEqual(mapped["decrement-tail"][-1], (NORMAL_2K[-1] - 1) & 0xFF)
+        self.assertEqual(mapped["bit-rotate-head"][0], ((NORMAL_2K[0] << 1) | (NORMAL_2K[0] >> 7)) & 0xFF)
+        self.assertEqual(mapped["nibble-swap-head"][0], ((NORMAL_2K[0] & 0x0F) << 4) | ((NORMAL_2K[0] & 0xF0) >> 4))
+        self.assertEqual(mapped["invert-tail-64"][-1], NORMAL_2K[-1] ^ 0xFF)
+        self.assertEqual(mapped["complement-mid-32"][len(NORMAL_2K) // 2], NORMAL_2K[len(NORMAL_2K) // 2] ^ 0xFF)
+        self.assertEqual(mapped["rotate-header"][:8], NORMAL_2K[1:8] + NORMAL_2K[:1])
+
+    def test_splice_grows_and_shrink_shortens(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        self.assertEqual(len(mapped["splice-nul-mid"]), n + 16)
+        self.assertEqual(mapped["splice-nul-mid"][n // 2 : n // 2 + 16], b"\x00" * 16)
+        self.assertEqual(len(mapped["crlf-inject"]), n + 2)
+        self.assertEqual(mapped["crlf-inject"][n // 2 : n // 2 + 2], b"\r\n")
+        self.assertEqual(mapped["pad-eof"][-1:], b"\x1a")
+        self.assertEqual(len(mapped["widen-gap"]), n + 4)
+        self.assertEqual(len(mapped["shrink-gap"]), n - 4)
+        self.assertEqual(len(mapped["chop-last"]), n - 1)
+        self.assertEqual(len(mapped["cut-first"]), n - 1)
+        self.assertEqual(mapped["cut-first"], NORMAL_2K[1:])
+        self.assertEqual(len(mapped["odd-length-chop"]) % 2, 1)
+        self.assertNotIn("even-length-pad", mapped)
+
+    def test_odd_payload_gets_even_pad_not_odd_chop(self):
+        mod = load()
+        data = b"\x11" * 65
+        labels = labels_of(mod.deterministic_mutants(data))
+        self.assertIn("even-length-pad", labels)
+        self.assertNotIn("odd-length-chop", labels)
+        mapped = as_map(mod.deterministic_mutants(data))
+        self.assertEqual(mapped["even-length-pad"], data + b"\x00")
+
+    def test_zip_conditional_families(self):
+        mod = load()
+        local_only = b"xxxx" + b"PK\x03\x04" + b"yyyy" * 20
+        local_map = as_map(mod.deterministic_mutants(local_only))
+        self.assertIn("zip-local-header-flip", local_map)
+        self.assertNotIn("zip-magic-inject", local_map)
+        self.assertNotIn("zip-cd-magic-flip", local_map)
+        self.assertNotIn("zip-eocd-flip", local_map)
+        idx = local_only.find(b"PK\x03\x04")
+        self.assertEqual(
+            local_map["zip-local-header-flip"][idx : idx + 4],
+            bytes(x ^ 0xFF for x in b"PK\x03\x04"),
+        )
+
+        full = b"PK\x03\x04" + b"body" * 8 + b"PK\x01\x02" + b"cd" * 4 + b"PK\x05\x06" + b"end" * 4
+        full_map = as_map(mod.deterministic_mutants(full))
+        self.assertIn("zip-local-header-flip", full_map)
+        self.assertIn("zip-cd-magic-flip", full_map)
+        self.assertIn("zip-eocd-flip", full_map)
+        self.assertNotIn("zip-magic-inject", full_map)
+        cd = full.find(b"PK\x01\x02")
+        eocd = full.find(b"PK\x05\x06")
+        self.assertEqual(full_map["zip-cd-magic-flip"][cd : cd + 4], bytes(x ^ 0xFF for x in b"PK\x01\x02"))
+        self.assertEqual(full_map["zip-eocd-flip"][eocd : eocd + 4], bytes(x ^ 0xFF for x in b"PK\x05\x06"))
+
+    def test_hwp3_conditional_families(self):
+        mod = load()
+        inject = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertIn("hwp3-sig-inject", inject)
+        self.assertTrue(inject["hwp3-sig-inject"].startswith(mod.HWP3_SIG))
+        signed = mod.HWP3_SIG + b"\x00" * 80
+        flipped = as_map(mod.deterministic_mutants(signed))
+        self.assertIn("hwp3-sig-flip", flipped)
+        self.assertNotIn("hwp3-sig-inject", flipped)
+        expected = bytes(x ^ 0xFF for x in mod.HWP3_SIG[:4]) + mod.HWP3_SIG[4:]
+        self.assertEqual(flipped["hwp3-sig-flip"][: len(mod.HWP3_SIG)], expected)
+
+    def test_huge_input_skips_growing_splices(self):
+        mod = load()
+        huge = bytes([0x5A]) * mod.HUGE_MIN
+        labels = labels_of(mod.deterministic_mutants(huge))
+        for name in ("splice-nul-mid", "crlf-inject", "pad-eof", "widen-gap", "even-length-pad"):
+            self.assertNotIn(name, labels, name)
+        for name in ("zero-header", "header-smash", "trunc50", "flip50", "shrink-gap"):
+            self.assertIn(name, labels, name)
+        self.assertEqual(mod.classify_input_shape(huge), "huge")
+
+    def test_tiny_ole_trunc_tail_plants_magic_prefix(self):
+        mod = load()
+        data = b"ABCD"
+        payload = as_map(mod.deterministic_mutants(data))["ole-trunc-tail"]
+        self.assertTrue(payload.endswith(mod.OLE_MAGIC[: min(4, len(data))]))
+
+    def test_utf16_sprinkle_uses_even_offsets(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["utf16-nul-sprinkle"]
+        n = len(NORMAL_2K)
+        for pct in (20, 40, 60, 80):
+            pos = min(n - 2, n * pct // 100) & ~1
+            self.assertEqual(payload[pos : pos + 2], b"\x00\x00")
+            self.assertEqual(pos % 2, 0)
+
+    def test_legacy_trunc_and_flip_byte_contracts(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        self.assertEqual(mapped["trunc25"], NORMAL_2K[: max(1, n * 25 // 100)])
+        self.assertEqual(mapped["trunc50"], NORMAL_2K[: max(1, n * 50 // 100)])
+        pos = min(n - 1, n * 30 // 100)
+        expected = bytearray(NORMAL_2K)
+        expected[pos] ^= 0xFF
+        self.assertEqual(mapped["flip30"], bytes(expected))
+
+    def test_module_constants_match_test_contract(self):
+        mod = load()
+        self.assertEqual(mod.LEGACY_ALWAYS_LABELS, LEGACY_ALWAYS_LABELS)
+        self.assertEqual(mod.EXPANDED_ALWAYS_LABELS, EXPANDED_ALWAYS_LABELS)
+        self.assertEqual(mod.REPORT_KIND, "gymFuzzCorpus")
+        self.assertEqual(mod.SCHEMA_VERSION, "1.0")
+        self.assertEqual(mod.TINY_MAX, 64)
+        self.assertEqual(mod.HUGE_MIN, 1_048_576)
+        self.assertEqual(mod.OLE_MAGIC, b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+        self.assertEqual(mod.ZIP_LOCAL, b"PK\x03\x04")
+        self.assertEqual(mod.SAMPLE_EXTS, (".hwp", ".hwpx", ".hml"))
+        self.assertEqual(mod.EXIT_OK, 0)
+        self.assertEqual(mod.EXIT_DOS, 1)
+        self.assertEqual(mod.EXIT_TOOL_FAILED, 2)
+
+
+class ClassifyAndSelectTests(unittest.TestCase):
+    def test_classify_accepts_none_and_non_str_err(self):
+        mod = load()
+        self.assertEqual(mod.classify(0, None), (None, None))
+        self.assertEqual(mod.classify(0, 12345), (None, None))
+        self.assertEqual(mod.classify(101, None)[0], "panic")
+        self.assertEqual(mod.classify(101, 0)[0], "panic")
+
+    def test_classify_panic_markers_without_location(self):
+        mod = load()
+        for marker in (
+            "core dumped",
+            "fatal runtime error",
+            "SIGSEGV",
+            "access violation",
+            "Segmentation Fault",
+        ):
+            # 위치 정규식이 없으면 어보트 코드/표식 버킷. 깨끗한 1 은 패닉이 아니다.
+            kind, bucket = mod.classify(0, marker)
+            self.assertIsNone(kind, marker)
+            self.assertIsNone(bucket, marker)
+        self.assertEqual(mod.classify(101, "fatal runtime error")[0], "panic")
+        self.assertTrue(mod.is_panic_code(101, ""))
+        self.assertFalse(mod.is_panic_code(1, "오류"))
+        self.assertFalse(mod.is_panic_code(0, "정상"))
+
+    def test_classify_timeout_strings_and_os_errnos(self):
+        mod = load()
+        self.assertTrue(mod.classify_timeout(True))
+        self.assertFalse(mod.classify_timeout(False))
+        self.assertFalse(mod.classify_timeout(None))
+        self.assertTrue(mod.classify_timeout(subprocess.TimeoutExpired("rhwp", 1)))
+        self.assertTrue(mod.classify_timeout(TimeoutError("late")))
+        self.assertTrue(mod.classify_timeout("Deadline Exceeded"))
+        self.assertTrue(mod.classify_timeout("process timed out"))
+        self.assertTrue(mod.classify_timeout("TIME-OUT"))
+        self.assertFalse(mod.classify_timeout("ok"))
+        self.assertFalse(mod.classify_timeout(RuntimeError("other")))
+        timed = OSError(getattr(errno, "ETIMEDOUT", 110), "late")
+        timed.errno = getattr(errno, "ETIMEDOUT", 110)
+        self.assertTrue(mod.classify_timeout(timed))
+        other = OSError(errno.ENOENT, "missing")
+        other.errno = errno.ENOENT
+        self.assertFalse(mod.classify_timeout(other))
+        self.assertFalse(mod.classify_timeout(ValueError("timeout in name only")))
+
+    def test_classify_probe_outcome_matrix(self):
+        mod = load()
+        self.assertEqual(mod.classify_probe_outcome("hang", "info"), "hang")
+        self.assertEqual(mod.classify_probe_outcome("panic", "src/x.rs:1"), "panic")
+        self.assertEqual(mod.classify_probe_outcome("error", "missing-bin"), "error")
+        self.assertEqual(mod.classify_probe_outcome(None, None), "clean")
+        self.assertEqual(mod.classify_probe_outcome("ok", None), "clean")
+        self.assertEqual(mod.classify_probe_outcome("clean", None), "clean")
+        self.assertEqual(mod.classify_probe_outcome("weird", "permission"), "error")
+
+    def test_select_samples_includes_hwpx_and_hml(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "a.hwp").write_bytes(b"x")
+            Path(d, "b.hwpx").write_bytes(b"x")
+            Path(d, "c.hml").write_bytes(b"x")
+            Path(d, "d.HWP").write_bytes(b"x")
+            Path(d, "note.md").write_bytes(b"x")
+            picked, total = mod.select_samples(d, 0)
+            self.assertEqual(total, 4)
+            self.assertEqual(picked, ["a.hwp", "b.hwpx", "c.hml", "d.HWP"])
+
+    def test_select_samples_oserror_and_bad_limit(self):
+        mod = load()
+        missing = os.path.join(tempfile.gettempdir(), "gym-fuzz-missing-dir-does-not-exist")
+        picked, total = mod.select_samples(missing, 8)
+        self.assertEqual(picked, [])
+        self.assertEqual(total, 0)
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "a.hwp").write_bytes(b"x")
+            Path(d, "b.hwp").write_bytes(b"x")
+            all_picked, count = mod.select_samples(d, 0)
+            self.assertEqual(all_picked, ["a.hwp", "b.hwp"])
+            self.assertEqual(count, 2)
+            empty2, count2 = mod.select_samples(d, "bad")
+            self.assertEqual(empty2, ["a.hwp", "b.hwp"])
+            self.assertEqual(count2, 2)
+            all2, _ = mod.select_samples(d, 99)
+            self.assertEqual(all2, ["a.hwp", "b.hwp"])
+
+    def test_is_sample_name_and_parse_commands(self):
+        mod = load()
+        self.assertTrue(mod.is_sample_name("x.hwp"))
+        self.assertTrue(mod.is_sample_name("X.HWPX"))
+        self.assertTrue(mod.is_sample_name("y.Hml"))
+        self.assertFalse(mod.is_sample_name("note.txt"))
+        self.assertFalse(mod.is_sample_name(""))
+        self.assertFalse(mod.is_sample_name(None))
+        self.assertEqual(mod.parse_commands(None), list(mod.DEFAULT_COMMANDS))
+        self.assertEqual(mod.parse_commands("info, export-text, info"), ["info", "export-text"])
+        self.assertEqual(mod.parse_commands(["a", " a ", "", "b"]), ["a", "b"])
+        self.assertEqual(mod.parse_commands(" , , "), list(mod.DEFAULT_COMMANDS))
+
+    def test_normalize_limit_timeout_workers(self):
+        mod = load()
+        self.assertEqual(mod.normalize_limit(8), 8)
+        self.assertEqual(mod.normalize_limit("3"), 3)
+        self.assertEqual(mod.normalize_limit(-4), 0)
+        self.assertEqual(mod.normalize_limit(None), 0)
+        self.assertEqual(mod.normalize_limit("nope"), 0)
+        self.assertEqual(mod.normalize_timeout(8), 8)
+        self.assertEqual(mod.normalize_timeout(0), 0)
+        self.assertEqual(mod.normalize_timeout(-1), 0)
+        self.assertEqual(mod.normalize_timeout("nope"), 0)
+        self.assertEqual(mod.normalize_workers(8), 8)
+        self.assertEqual(mod.normalize_workers(0), 1)
+        self.assertEqual(mod.normalize_workers(-2), 1)
+        self.assertEqual(mod.normalize_workers("nope"), 1)
+        self.assertEqual(mod.normalize_workers(None), 1)
+
+    def test_stride_selection_is_stable_across_limits(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(20):
+                Path(d, f"{i:02d}.hwp").write_bytes(b"x")
+            five, total = mod.select_samples(d, 5)
+            ten, _ = mod.select_samples(d, 10)
+            self.assertEqual(total, 20)
+            self.assertEqual(len(five), 5)
+            self.assertEqual(len(ten), 10)
+            self.assertEqual(mod.select_samples(d, 5)[0], five)
+
+
+class ExceptionPathTests(unittest.TestCase):
+    def test_exception_kind_catalog_and_context(self):
+        mod = load()
+        self.assertEqual(tuple(mod.EXCEPTION_KINDS), EXCEPTION_KINDS)
+        self.assertEqual(mod.exception_kind(None), "unexpected")
+        self.assertEqual(mod.exception_kind(FileNotFoundError("x"), "probe"), "missing-bin")
+        self.assertEqual(mod.exception_kind(FileNotFoundError("x"), "find-bin"), "missing-bin")
+        self.assertEqual(mod.exception_kind(FileNotFoundError("x"), "read"), "unreadable")
+        self.assertEqual(mod.exception_kind(FileNotFoundError("x"), "select"), "empty-corpus")
+        self.assertEqual(mod.exception_kind(PermissionError("x"), "probe"), "permission")
+        self.assertEqual(mod.exception_kind(PermissionError("x"), "read"), "unreadable")
+        self.assertEqual(mod.exception_kind(subprocess.TimeoutExpired("rhwp", 1)), "timeout")
+        self.assertEqual(mod.exception_kind(TimeoutError()), "timeout")
+        self.assertEqual(mod.exception_kind(UnicodeDecodeError("utf-8", b"x", 0, 1, "bad")), "decode-error")
+        self.assertEqual(mod.exception_kind(TypeError("t")), "type-error")
+        self.assertEqual(mod.exception_kind(ValueError("v")), "value-error")
+        self.assertEqual(mod.exception_kind(OSError(errno.EIO, "io")), "os-error")
+        self.assertEqual(mod.exception_kind(RuntimeError("x")), "unexpected")
+        self.assertTrue(mod.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(mod.is_fatal_exception(SystemExit(1)))
+        self.assertTrue(mod.is_fatal_exception(MemoryError()))
+        self.assertFalse(mod.is_fatal_exception(RuntimeError("x")))
+
+    def test_read_sample_missing_and_success(self):
+        mod = load()
+        data, err = mod.read_sample(os.path.join(tempfile.gettempdir(), "no-such-fuzz.hwp"))
+        self.assertIsNone(data)
+        self.assertIsInstance(err, str)
+        self.assertIn("unreadable", err)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "ok.hwp")
+            Path(path).write_bytes(b"abc")
+            payload, err2 = mod.read_sample(path)
+            self.assertEqual(payload, b"abc")
+            self.assertIsNone(err2)
+
+    def test_write_mutant_typeerror_and_oserror(self):
+        mod = load()
+        self.assertTrue(mod.write_mutant("ignored", "not-bytes").startswith("type-error"))
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "mut.hwp")
+            self.assertIsNone(mod.write_mutant(path, b"xyz"))
+            self.assertEqual(Path(path).read_bytes(), b"xyz")
+            self.assertIsNone(mod.write_mutant(path, bytearray(b"zz")))
+            missing_parent = os.path.join(d, "no-dir", "mut.hwp")
+            err = mod.write_mutant(missing_parent, b"x")
+            self.assertIsInstance(err, str)
+            self.assertTrue(err)
+
+    def test_probe_invalid_timeout_and_missing_bin(self):
+        mod = load()
+        self.assertEqual(mod.probe("bin", "info", "x.hwp", 0), ("error", "invalid-timeout"))
+        self.assertEqual(mod.probe("bin", "info", "x.hwp", -3), ("error", "invalid-timeout"))
+        self.assertEqual(mod.probe("", "info", "x.hwp", 5), ("error", "missing-bin"))
+        self.assertEqual(mod.probe(None, "info", "x.hwp", 5), ("error", "missing-bin"))
+        self.assertEqual(mod.probe("bin", "", "x.hwp", 5), ("error", "value-error"))
+
+    def test_probe_oserror_is_not_panic(self):
+        mod = load()
+        kind, bucket = mod.probe(
+            os.path.join(tempfile.gettempdir(), "no-such-rhwp-bin-xyz"),
+            "info",
+            os.path.join(tempfile.gettempdir(), "no-such.hwp"),
+            2,
+        )
+        self.assertEqual(kind, "error")
+        self.assertEqual(bucket, "missing-bin")
+        self.assertEqual(mod.classify_probe_outcome(kind, bucket), "error")
+
+    def test_probe_timeout_expired_is_hang(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise subprocess.TimeoutExpired("rhwp", 1)
+
+        with mock.patch("subprocess.run", side_effect=boom):
+            kind, bucket = mod.probe("rhwp", "info", "x.hwp", 1)
+        self.assertEqual(kind, "hang")
+        self.assertEqual(bucket, "info")
+
+    def test_probe_unexpected_exception_is_error(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise RuntimeError("broken pipe")
+
+        with mock.patch("subprocess.run", side_effect=boom):
+            kind, bucket = mod.probe("rhwp", "info", "x.hwp", 1)
+        self.assertEqual(kind, "error")
+        self.assertIn(bucket, ("unexpected", "probe-error", "os-error"))
+
+    def test_probe_permission_is_error(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise PermissionError("denied")
+
+        with mock.patch("subprocess.run", side_effect=boom):
+            kind, bucket = mod.probe("rhwp", "info", "x.hwp", 1)
+        self.assertEqual((kind, bucket), ("error", "permission"))
+
+    def test_probe_success_path_classifies_panic_from_output(self):
+        mod = load()
+
+        class Fake:
+            returncode = 0
+            stdout = b""
+            stderr = b"thread 'main' panicked at src/x.rs:10:1"
+
+        with mock.patch("subprocess.run", return_value=Fake()):
+            kind, bucket = mod.probe("rhwp", "info", "x.hwp", 1)
+        self.assertEqual(kind, "panic")
+        self.assertEqual(bucket, "src/x.rs:10")
+
+    def test_probe_convert_appends_output_path(self):
+        mod = load()
+        seen = {}
+
+        class Fake:
+            returncode = 0
+            stdout = b"ok"
+            stderr = b""
+
+        def fake_run(args, **_k):
+            seen["args"] = list(args)
+            return Fake()
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            kind, bucket = mod.probe("rhwp", "convert", "mut.hwp", 1)
+        self.assertEqual((kind, bucket), (None, None))
+        self.assertEqual(seen["args"][-1], "mut.hwp.out.hwpx")
+
+    def test_find_bin_safe_missing_and_empty(self):
+        mod = load()
+        path, err = mod.find_bin_safe(os.path.join(tempfile.gettempdir(), "no-such-rhwp-xyz"))
+        self.assertIsNone(path)
+        self.assertIsInstance(err, str)
+        self.assertIn("missing-bin", err)
+        with mock.patch.object(mod.runner, "find_bin", return_value=""):
+            path2, err2 = mod.find_bin_safe("x")
+        self.assertIsNone(path2)
+        self.assertIn("empty-path", err2)
+
+    def test_find_bin_safe_swallows_lookup_exception(self):
+        mod = load()
+        with mock.patch.object(mod.runner, "find_bin", side_effect=FileNotFoundError("gone")):
+            path, err = mod.find_bin_safe("x")
+        self.assertIsNone(path)
+        self.assertIn("missing-bin", err)
+
+    def test_fuzz_missing_bin_path_is_tool_failure(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            r = mod.fuzz("", d, ["info"], 0, 1, 5, work)
+        self.assertFalse(r["ok"])
+        self.assertTrue(r["missingBin"])
+        self.assertTrue(r["toolFailed"])
+        self.assertEqual(r["exit"], mod.EXIT_TOOL_FAILED)
+        self.assertTrue(r["toolErrors"])
+        self.assertEqual(mod.validate_report(r), [])
+
+    def test_fuzz_empty_corpus_is_not_dos(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "note.txt").write_text("x", encoding="utf-8")
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            r = mod.fuzz("bin", d, ["info"], 0, 1, 5, work)
+        self.assertTrue(r["ok"])
+        self.assertTrue(r["emptyCorpus"])
+        self.assertFalse(r["toolFailed"])
+        self.assertEqual(r["samplesTested"], 0)
+        self.assertEqual(r["totalSamples"], 0)
+        self.assertEqual(r["panicClusters"], [])
+        self.assertEqual(r["exit"], mod.EXIT_OK)
+        self.assertEqual(mod.validate_report(r), [])
+
+    def test_fuzz_missing_samples_dir_does_not_raise(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            missing = os.path.join(d, "no-samples")
+            r = mod.fuzz("bin", missing, ["info"], 8, 1, 5, work)
+        self.assertIsInstance(r, dict)
+        self.assertEqual(r["samplesTested"], 0)
+        self.assertTrue(r["toolErrors"] or r["emptyCorpus"])
+        self.assertEqual(r["panicClusters"], [])
+        self.assertEqual(r["hangClusters"], [])
+
+    def test_fuzz_records_unreadable_samples(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "ok.hwp").write_bytes(NORMAL_2K)
+            Path(d, "bad.hwp").write_bytes(NORMAL_2K)
+            real_read = mod.read_sample
+
+            def wrapped(path):
+                if path.endswith("bad.hwp"):
+                    return None, "unreadable: PermissionError: denied"
+                return real_read(path)
+
+            mod.read_sample = wrapped
+            mod.probe = lambda *_a, **_k: (None, None)
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 0, 1, 5, work)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["samplesTested"], 2)
+        self.assertEqual(len(report["unreadables"]), 1)
+        self.assertIn("bad.hwp", report["unreadables"][0])
+        self.assertGreater(report["runsChecked"], 0)
+        self.assertEqual(report["inputShapes"]["normal"], 1)
+
+    def test_fuzz_records_write_errors(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.write_mutant = lambda *_a, **_k: "os-error: OSError: disk full"
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 1, 1, 5, work)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["runsChecked"], 0)
+        self.assertGreater(len(report["probeErrors"]), 0)
+        self.assertTrue(any("disk full" in item for item in report["probeErrors"]))
+
+    def test_fuzz_records_probe_error_heads(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = lambda *_a, **_k: ("error", "missing-bin")
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 1, 1, 5, work)
+        self.assertFalse(report["ok"])
+        self.assertTrue(report["missingBin"])
+        self.assertTrue(report["toolFailed"])
+        self.assertEqual(report["panicClusters"], [])
+        self.assertEqual(report["hangClusters"], [])
+        self.assertGreater(len(report["probeErrors"]), 0)
+        self.assertEqual(report["exit"], mod.EXIT_TOOL_FAILED)
+
+    def test_fuzz_probe_raising_is_caught(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise RuntimeError("probe exploded")
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = boom
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 1, 1, 5, work)
+        self.assertTrue(report["ok"])
+        self.assertTrue(any("probe exploded" in item or "unexpected" in item for item in report["probeErrors"]))
+
+    def test_fuzz_mutant_typeerror_is_unreadable(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.deterministic_mutants = lambda *_a, **_k: (_ for _ in ()).throw(TypeError("bad"))
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 1, 1, 5, work)
+        self.assertTrue(report["ok"])
+        self.assertTrue(any("type-error" in item or "TypeError" in item for item in report["unreadables"]))
+        self.assertEqual(report["runsChecked"], 0)
+
+    def test_empty_report_validates(self):
+        mod = load()
+        report = mod.empty_report(["info"])
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertTrue(report["ok"])
+        self.assertEqual(set(report), set(REPORT_KEYS))
+        self.assertEqual(set(report), set(mod.REPORT_KEYS))
+        self.assertEqual(report["inputShapes"], {"empty": 0, "tiny": 0, "normal": 0, "huge": 0})
+        self.assertEqual(report["commands"], ["info"])
+
+    def test_validate_report_detects_schema_breaks(self):
+        mod = load()
+        self.assertEqual(mod.validate_report("nope"), ["report-not-dict"])
+        report = mod.empty_report()
+        report.pop("hangClusters")
+        issues = mod.validate_report(report)
+        self.assertTrue(any(item.startswith("missing:") for item in issues))
+        report = mod.empty_report()
+        report["extraKey"] = 1
+        issues = mod.validate_report(report)
+        self.assertTrue(any(item.startswith("extra:") for item in issues))
+        report = mod.empty_report()
+        report["kind"] = "other"
+        report["schemaVersion"] = "9"
+        report["ok"] = "yes"
+        report["samplesTested"] = -1
+        report["panicClusters"] = [1]
+        report["inputShapes"] = {"empty": 0}
+        issues = mod.validate_report(report)
+        self.assertIn("kind", issues)
+        self.assertIn("schemaVersion", issues)
+        self.assertIn("ok-type", issues)
+        self.assertIn("samplesTested-negative", issues)
+        self.assertIn("panicClusters-item-type", issues)
+        self.assertTrue(any(item.startswith("inputShapes-missing-") for item in issues))
+        report = mod.empty_report()
+        report["ok"] = False
+        self.assertIn("ok-mismatch", mod.validate_report(report))
+        report = mod.empty_report()
+        report["emptyCorpus"] = True
+        report["totalSamples"] = 3
+        self.assertIn("emptyCorpus-mismatch", mod.validate_report(report))
+
+    def test_format_human_report_ok_fail_and_exceptions(self):
+        mod = load()
+        ok = mod.empty_report(["info"])
+        text = mod.format_human_report(ok)
+        self.assertIn("DoS 0", text)
+        fail = mod.empty_report(["info"])
+        fail["ok"] = False
+        fail["distinctPanicSites"] = 1
+        fail["panicClusters"] = [{"location": "src/x.rs:1", "count": 2, "example": "a:trunc5:info"}]
+        fail["hangClusters"] = [{"command": "export-text", "count": 1, "samples": ["a.hwp"], "example": "a:flip10:export-text"}]
+        fail["exit"] = 1
+        text = mod.format_human_report(fail)
+        self.assertIn("PANIC src/x.rs:1", text)
+        self.assertIn("HANG  export-text", text)
+        empty = mod.empty_report()
+        empty["emptyCorpus"] = True
+        self.assertIn("빈 코퍼스", mod.format_human_report(empty))
+        missing = mod.empty_report()
+        missing["missingBin"] = True
+        missing["toolFailed"] = True
+        missing["ok"] = False
+        missing["toolErrors"] = ["missing-bin: not-found"]
+        missing["exit"] = 2
+        self.assertIn("도구 실패", mod.format_human_report(missing))
+
+    def test_resolve_exit_matrix(self):
+        mod = load()
+        report = mod.empty_report()
+        self.assertEqual(mod.resolve_exit(report), 0)
+        report["panicClusters"] = [{"location": "x", "count": 1, "example": "e"}]
+        self.assertEqual(mod.resolve_exit(report), 1)
+        report = mod.empty_report()
+        report["missingBin"] = True
+        report["toolFailed"] = True
+        self.assertEqual(mod.resolve_exit(report), 2)
+
+    def test_input_shape_counts_in_fuzz(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "empty.hwp").write_bytes(b"")
+            Path(d, "tiny.hwp").write_bytes(b"\x00" * 8)
+            Path(d, "normal.hwp").write_bytes(NORMAL_2K)
+            mod.probe = lambda *_a, **_k: (None, None)
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 0, 1, 5, work)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["inputShapes"]["empty"], 1)
+        self.assertEqual(report["inputShapes"]["tiny"], 1)
+        self.assertEqual(report["inputShapes"]["normal"], 1)
+        self.assertEqual(report["inputShapes"]["huge"], 0)
+        self.assertGreater(report["runsChecked"], 3)
+
+    def test_empty_sample_still_probes_single_mutant(self):
+        mod = load()
+        seen = []
+
+        def probe(_bin, cmd, path, _timeout):
+            seen.append(Path(path).read_bytes())
+            return None, None
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "empty.hwp").write_bytes(b"")
+            mod.probe = probe
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 1, 1, 5, work)
+        self.assertEqual(seen, [b"\x00"])
+        self.assertEqual(report["runsChecked"], 1)
+        self.assertEqual(report["inputShapes"]["empty"], 1)
+
+    def test_mixed_panic_and_hang_keep_ok_false(self):
+        mod = load()
+
+        def probe(_bin, cmd, _path, _timeout):
+            if cmd == "a":
+                return "panic", "src/x.rs:10"
+            if cmd == "b":
+                return "hang", "b"
+            return None, None
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = probe
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["a", "b"], 1, 1, 5, work)
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["distinctPanicSites"], 1)
+        self.assertEqual(len(report["hangClusters"]), 1)
+        self.assertEqual(report["exit"], mod.EXIT_DOS)
+        self.assertEqual(mod.validate_report(report), [])
+
+    def test_panic_clusters_sort_by_count_then_location(self):
+        mod = load()
+        calls = {"n": 0}
+
+        def probe(_bin, cmd, _path, _timeout):
+            calls["n"] += 1
+            if cmd == "a":
+                return "panic", "src/z.rs:1"
+            return "panic", "src/a.rs:1"
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = probe
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["a", "b"], 1, 1, 5, work)
+        locs = [c["location"] for c in report["panicClusters"]]
+        self.assertEqual(sorted(locs), ["src/a.rs:1", "src/z.rs:1"])
+        # 같은 count 이면 location 사전순.
+        if report["panicClusters"][0]["count"] == report["panicClusters"][1]["count"]:
+            self.assertEqual(locs, ["src/a.rs:1", "src/z.rs:1"])
+
+    def test_workers_one_matches_workers_many_clusters(self):
+        mod = load()
+
+        def probe(_bin, cmd, _path, _timeout):
+            if cmd == "info":
+                return "panic", "src/x.rs:9"
+            return None, None
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            mod.probe = probe
+            one = mod.fuzz("bin", d, ["info", "export-text"], 1, 1, 5, work)
+            many = mod.fuzz("bin", d, ["info", "export-text"], 1, 4, 5, work)
+        self.assertEqual(one["distinctPanicSites"], many["distinctPanicSites"])
+        self.assertEqual(one["panicClusters"][0]["location"], many["panicClusters"][0]["location"])
+        self.assertEqual(one["ok"], many["ok"])
+
+    def test_probe_head_truncates(self):
+        mod = load()
+        self.assertEqual(mod.probe_head(None), "")
+        self.assertEqual(mod.probe_head(1234), "1234")
+        self.assertEqual(mod.probe_head("abcdef", 3), "abc")
+        self.assertEqual(mod.probe_head("abcdef", 0), "")
+
+
+class MainCliTests(unittest.TestCase):
+    def test_main_missing_bin_exits_two_and_json(self):
+        mod = load()
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdout", buf):
+            code = mod.main([
+                "--bin",
+                os.path.join(tempfile.gettempdir(), "no-such-rhwp-bin-abc"),
+                "--json",
+            ])
+        self.assertEqual(code, 2)
+        report = json.loads(buf.getvalue())
+        self.assertTrue(report["missingBin"])
+        self.assertTrue(report["toolFailed"])
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["kind"], "gymFuzzCorpus")
+
+    def test_main_missing_bin_human_goes_to_stderr(self):
+        mod = load()
+        err = io.StringIO()
+        out = io.StringIO()
+        with mock.patch.object(sys, "stderr", err), mock.patch.object(sys, "stdout", out):
+            code = mod.main(["--bin", os.path.join(tempfile.gettempdir(), "no-such-rhwp-bin-abc")])
+        self.assertEqual(code, 2)
+        self.assertIn("도구 실패", err.getvalue())
+        self.assertEqual(out.getvalue(), "")
+
+    def test_main_invokes_fuzz_when_bin_exists(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            fake = os.path.join(d, "rhwp.exe" if os.name == "nt" else "rhwp")
+            Path(fake).write_bytes(b"x")
+            captured = {}
+
+            def fake_fuzz(*args, **kwargs):
+                captured["args"] = args
+                report = mod.empty_report(["info"])
+                report["ok"] = True
+                report["exit"] = 0
+                return report
+
+            buf = io.StringIO()
+            with mock.patch.object(mod, "fuzz", side_effect=fake_fuzz), mock.patch.object(sys, "stdout", buf):
+                code = mod.main(["--bin", fake, "--commands", "info", "--json", "--limit", "1"])
+            self.assertEqual(code, 0)
+            report = json.loads(buf.getvalue())
+            self.assertTrue(report["ok"])
+            self.assertEqual(captured["args"][2], ["info"])
+
+
+class GeneratedCatalogTableTests(unittest.TestCase):
+    """카탈로그 행마다 why/when 이 비지 않았는지 표로 고정한다."""
+
+    def test_every_catalog_row_has_nonempty_why(self):
+        mod = load()
+        for row in mod.mutant_catalog():
+            self.assertTrue(row["id"], row)
+            self.assertTrue(row["family"], row)
+            self.assertTrue(row["when"], row)
+            self.assertGreaterEqual(len(row["why"]), 8, row["id"])
+
+    def test_family_ids_match_catalog_families_constant(self):
+        mod = load()
+        self.assertEqual(tuple(mod.FAMILY_IDS), FAMILY_IDS)
+        self.assertEqual(set(mod.FAMILY_IDS), set(mod.catalog_families()))
+
+    def test_exception_kinds_have_no_panic_or_hang(self):
+        mod = load()
+        self.assertNotIn("panic", mod.EXCEPTION_KINDS)
+        self.assertNotIn("hang", mod.EXCEPTION_KINDS)
+        self.assertIn("missing-bin", mod.EXCEPTION_KINDS)
+        self.assertIn("empty-corpus", mod.EXCEPTION_KINDS)
+        self.assertIn("unreadable", mod.EXCEPTION_KINDS)
+
+
+class HonestyTests(unittest.TestCase):
+    def test_ok_is_false_when_only_tool_failed(self):
+        mod = load()
+        report = mod.empty_report(["info"])
+        report["toolFailed"] = True
+        report["missingBin"] = True
+        report["ok"] = False
+        report["exit"] = 2
+        report["toolErrors"] = ["missing-bin"]
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["panicClusters"], [])
+
+    def test_empty_corpus_does_not_claim_dos(self):
+        mod = load()
+        report = mod.empty_report(["info"])
+        report["emptyCorpus"] = True
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["exit"], 0)
+        self.assertEqual(mod.validate_report(report), [])
+
+    def test_probe_error_is_not_hang_cluster(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = lambda *_a, **_k: ("error", "permission")
+            work = os.path.join(d, "w")
+            os.mkdir(work)
+            report = mod.fuzz("bin", d, ["info"], 1, 1, 5, work)
+        self.assertEqual(report["hangClusters"], [])
+        self.assertEqual(report["panicClusters"], [])
+        self.assertTrue(report["probeErrors"])
+        self.assertTrue(report["ok"])
+
+    def test_fatal_exception_is_not_swallowed_by_exception_kind(self):
+        mod = load()
+        self.assertTrue(mod.is_fatal_exception(GeneratorExit()))
+        # exception_kind 는 치명 여부를 바꾸지 않는다 — 호출자가 raise 한다.
+        self.assertEqual(mod.exception_kind(GeneratorExit()), "unexpected")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

`gym/tools/fuzz_corpus.py` 발견 엔진을 결정적 변형·예외 경로까지 닫는다. 무작위는 쓰지 않는다. 같은 입력은 같은 라벨·바이트를 내고, 원본과 바이트가 같은 무의미 변형은 버린다.

원 라벨(`truncN` / `flipN` / `biglenN`)과 `classify` 계약은 유지한다. 뒤에 헤더·OLE·ZIP·유니코드·길이·permute/stripe/splice/HWP3 가족을 덧붙인다. 패닉은 `file:line` 으로, 행은 명령으로 클러스터한다.

예외 세 자리(이슈 DoD):

- **없는 바이너리** — `find_bin_safe` / `probe` 가 `missing-bin` 으로 접고 exit 2. "DoS 0" 으로 위장하지 않는다.
- **빈 코퍼스** — `.hwp`/`.hwpx`/`.hml` 이 없으면 `emptyCorpus=true`, ok, exit 0.
- **읽기 실패** — 그 표본만 `unreadables` 에 남기고 나머지를 계속 두드린다.

JSON 봉투(`kind=gymFuzzCorpus`, `schemaVersion=1.0`)에 `unreadables` · `probeErrors` · `toolErrors` · `emptyCorpus` · `missingBin` · `toolFailed` · `inputShapes` · `exit` 를 더한다. `ok` 는 패닉·행 부재 **그리고** 도구 실패가 아닐 때만 true 다.

새 CLI/pack 없음. `trajectory.py` · `discriminate.py` · automation / core-cli / casual-rides 는 건드리지 않았다.

규범: `gym/docs/fuzz_corpus.md`. 작업 기록: `mydocs/working/gym_fuzz_corpus.md`.

## 관련 이슈

closes #5256

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_fuzz_corpus` 통과 (78)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [ ] **`cargo fmt --all -- --check` 통과** — 이번 변경은 Python·문서만. 사용자 지시에 따라 실행하지 않음
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 해당 없음
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — 해당 없음
- [ ] `cargo test` — 해당 없음
- [ ] `cargo clippy -- -D warnings` — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 샘플당 변형이 13개에서 정상 2KiB 기준 60개 전후로 늘어 프로브 횟수가 증가한다. 런타임 rhwp 파싱 경로는 불변. 거대 입력은 splice 성장을 생략한다.
- 재현·측정: 바이너리 없이 unittest만 실행. 미측정(발견 엔진 로직 확대).
