### PR TITLE
docs: PR 전에 cargo fmt --all -- --check를 필수 관문으로 고정한다

### DIFF
--- a/.claude/skills/rhwp-contributor/SKILL.md
+++ b/.claude/skills/rhwp-contributor/SKILL.md
@@ -66,7 +66,8 @@ description: rhwp 저장소에 기여(이슈·코드 변경·문서·PR)할 때�
    봉투(JSON) 원문을 PR 본문에 붙이면 리뷰어가 재계산으로 검증할 수 있다.
 7. **처리 결과 문서** — 규모 있는 변경은 `mydocs/working/` 에 무엇을·왜·어떻게·
    검증 실측을 남긴다(스테이지 문서 관례).
-8. **PR** — [템플릿](../../../.github/pull_request_template.md) 체크리스트를 전부 채운다.
+8. **PR** — `cargo fmt --all -- --check` 가 통과한 뒤에만 연다.
+   [템플릿](../../../.github/pull_request_template.md) 체크리스트를 전부 채운다.
    제목·본문은 한국어. 관련 이슈를 `closes #` 로 연결한다.
 
 ## 하지 않는 것

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -79,7 +79,7 @@ git switch -c <work-branch> upstream/devel
 cargo build
 cargo test
 cargo build --release
-cargo fmt --check
+cargo fmt --all -- --check
 ```
 
 PR 전 전체 회귀 범위는 변경 위험도와 [PR 리뷰·통합 워크플로우](pr_review_workflow.md)에 따라 결정한다.


### PR DESCRIPTION
﻿## 변경 요약

PR을 열기 전에 `cargo fmt --all -- --check`를 통과해야 한다는 점을 지침에 더 분명히 넣었습니다.

- 기여자 스킬 8단계: `--check` 통과 후에만 PR
- 개발 환경 안내: `cargo fmt --check`를 `cargo fmt --all -- --check`로 교체 (CI Lint와 동일)

`CONTRIBUTING.md` 맨 위와 PR 템플릿 첫 체크박스는 이미 같은 명령을 요구합니다. `cargo fmt --check`만 돌리면 CI가 또 실패합니다.

## 관련 이슈

없음 (기여 게이트 보강)

## 테스트

- [x] `cargo fmt --all -- --check` — 문서만 변경. 워크트리에서 확인 예정
- [ ] 문서 경로만 변경
