### PR TITLE
feat(gym): release_gate 예외 경로와 판정 정직성 보강

### DIFF
--- a/gym/docs/release_gate.md
+++ b/gym/docs/release_gate.md
@@ -1,0 +1,734 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/release_gate.md
+last_verified: 2026-08-18
+---
+
+# gym 릴리스 게이트 규약
+
+이 문서는 `gym/tools/release_gate.py` 의 **판정 사원**, **예외 경로 계약**,
+**워크플로 전제**를 고정한다. 작업 기록은
+[`mydocs/working/gym_release_gate.md`](../../mydocs/working/gym_release_gate.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_release_gate_workflow.py` 와
+`scripts/tests/test_gym_release_gate_exceptions.py` 가 기계로 고정한다.
+
+릴리스 차등(`release_diff.py`)은 오라클이다. 게이트는 그 오라클을 읽어
+파이프라인 종료 코드로 묶는다. 오라클이 표면을 모르는데 안정이라고 쓰면
+게이트도 속는다. 그래서 `probe-failed` 는 삼원 밖에 두고 fail(1) 로 받는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+회귀 도구가 도구로만 있으면 사람이 기억해서 돌려야 한다. 릴리스 파이프라인에
+물리면 잊어도 돈다. 게이트가 묶는 것은 세 층이다.
+
+1. **종점 무결성** — `discriminate.py`. 일 안 한 제출이 만점을 받으면 벤치가
+   거짓이다. 워크플로가 게이트보다 먼저 돌리고, exit 1 이면 잡을 닫는다.
+2. **경로 무결성** — `trajectory.py`. 마지막 스텝을 빼도 통과하면 연극이다.
+   같은 자리에서 먼저 돈다.
+3. **시간축 차등 + 원장** — `release_diff.py` 와 `leaderboard.py verify`.
+   게이트 러너가 이 둘을 하나의 판정으로 접는다.
+
+이 도구는 새 CLI 를 열지 않는다. 새 pack 을 만들지 않는다. 차등 오라클의
+분류 삼원(stable / regression / surface-changed)을 네 값으로 늘리지 않는다.
+게이트가 더하는 것은 **파이프라인 판정**과 **예외를 위장하지 않는 접기**다.
+
+## 2. 사용
+
+```bash
+python gym/tools/release_gate.py --old <직전 태그 바이너리> --new target/debug/rhwp
+python gym/tools/release_gate.py --new target/debug/rhwp
+python gym/tools/release_gate.py --old old/rhwp --new new/rhwp --pack core-cli
+python gym/tools/release_gate.py --new target/debug/rhwp --no-leaderboard -o gate.json
+python gym/tools/release_gate.py --new target/debug/rhwp --github-summary
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--old` | (없음) | 직전 릴리스 rhwp. 없거나 파일이 없으면 차등 생략. |
+| `--new` | `find_bin` | 현재 rhwp. 없으면 fail. 생략이 아니다. |
+| `--agent` | `claude-fable-5` | 차등에 넘기는 제출물 루트. |
+| `--pack` | 전체 | 반복 지정 가능. 차등에 그대로 전달. |
+| `--no-leaderboard` | off | 원장 검증 생략. |
+| `--github-summary` | off | `GITHUB_STEP_SUMMARY` 에 표 추가. |
+| `-o` / `--out` | (없음) | 판정 JSON. UTF-8 · BOM 없음 · LF. |
+
+`--discriminate-fail`, `--preflight`, `--probe-failed` 같은 플래그는 없다.
+판별 실패는 워크플로가 게이트보다 먼저 막거나, 프로그래매틱 `preflight=`
+인자로만 넘긴다. CLI 표면을 늘리지 않는다.
+
+프로브 명령은 게이트가 부르지 않는다. 차등 도구가 `rhwp capabilities` 를
+부른다. 게이트는 그 보고의 `classification` 만 읽는다.
+
+## 3. 판정 사원
+
+게이트가 내는 판정은 넷이다. 차등 삼원과 1:1 이 아니다.
+
+| 판정 | exit | 언제 |
+|---|---|---|
+| `pass` | 0 | 차등 stable 또는 skipped(구 바이너리 없음) + 원장 무결 |
+| `fail` | 1 | 도구/전제 실패. 신 바이너리 부재, 보고 손상, probe-failed, 판별 실패 |
+| `review` | 2 | 차등 surface-changed. 사람 판정. **자동 차단 아님** |
+| `block` | 3 | 차등 regression, 또는 리더보드 체인 파손 |
+
+규칙:
+
+1. **regression 만 차단한다.** 표면 변경은 리뷰 신호다.
+2. **도구 실패는 분류가 아니다.** probe-failed 를 pass 로 부르면 거짓말이다.
+3. **구 바이너리 부재는 실패가 아니다.** 직전 태그를 안 빌드한 것과 현재
+   릴리스가 없는 것은 다르다.
+4. **신 바이너리 부재는 실패다.** skipped 로 위장하지 않는다.
+5. **판별 실패는 회귀가 아니다.** 오라클이 약한 것이지 관측이 갈린 것이 아니다.
+
+`ok` 는 `pass` 와만 참. `reviewRequired` 는 `review` 와만 참. `blocked` 는
+`block` 과만 참. `failed` 는 `fail` 과만 참. `validate_verdict` 가 이 표를
+검사한다.
+
+## 4. 차등 삼원을 게이트가 읽는 법
+
+차등 오라클의 `classify` 는 오직 세 값만 낸다. 게이트는 그 값을 판정으로
+옮긴다.
+
+| 차등 분류 | 표면 | 관측 분기 | 게이트 이유 | 판정 | exit |
+|---|---|---|---|---|---|
+| `stable` | 아니오 | 아니오 | `stable` | pass | 0 |
+| `regression` | 아니오 | 예 | `regression` | block | 3 |
+| `surface-changed` | 예 | 아니오 | `surface-changed` | review | 2 |
+| `surface-changed` | 예 | 예 | `surface-changed` | review | 2 |
+
+추가 상태 — 삼원이 아니다.
+
+| 차등 상태 | 게이트 이유 | 판정 | exit | 왜 |
+|---|---|---|---|---|
+| `skipped` (구 없음) | `missing-old-bin` | pass | 0 | 부재≠실패 |
+| `probe-failed` | `probe-failed` | fail | 1 | 표면을 모름 |
+| 보고 파일 없음 | `diff-report-missing` | fail | 1 | 오라클이 말을 안 함 |
+| 보고가 JSON 이 아님 | `diff-report-invalid` | fail | 1 | 오라클이 깨짐 |
+| 차등 도구 예외 | `diff-tool-error` | fail | 1 | 도구가 죽음 |
+
+오라클이 실수로 `classification=regression` 과 `surfaceChanged=true` 를 같이
+내면 게이트는 **review** 다. 표면이 회귀보다 앞선다는 #4661 정직 조항을
+게이트가 다시 적용한다. `surface_wins_over_regression` 이 그 자리이다.
+
+## 5. 예외 경로 — 이슈가 지목한 네 자리
+
+#5259 가 고정하라고 한 자리는 넷이다. 각각이 다른 종료 코드와 다른 이유다.
+한 칸으로 접으면 운영자가 다음 행동을 고르지 못한다.
+
+### 5.1 구 바이너리 부재 (`missing-old-bin`)
+
+직전 태그 바이너리를 안 빌드했거나 `--old` 를 안 줬다.
+
+- 차등 분류: `skipped`
+- 판정: `pass` (원장이 무결하면)
+- exit: 0
+- 워크플로: `if [ -f ./rhwp-old-bin ]` 가 거짓이면 `--old` 없이 게이트를 부른다
+
+부재를 실패로 위장하지 않는다. 첫 태그, 수동 실행에서 old_ref 를 비운 경우가
+정상 경로다.
+
+### 5.2 신 바이너리 부재 (`missing-new-bin`)
+
+현재 릴리스 실행 파일이 없다. `find_bin` 이 돌려준 경로가 디스크에 없다.
+
+- 차등: 돌리지 않는다
+- 원장: 돌리지 않는다
+- 판정: `fail`
+- exit: 1
+
+구 바이너리 부재와 대칭으로 생략하면, "지금 무엇을 릴리스하는가" 가 없는
+상태를 안정으로 위장한다. 그래서 이 자리만 fail 이다.
+
+빈 문자열 `--new ""` 도 같은 이유다. PATH 이름 `rhwp` 만 있고 파일이 없으면
+역시 fail 이다. 실행 파일을 알려면 `--new` 에 실제 경로를 준다.
+
+### 5.3 판별 감사 실패 (`discriminate-fail`)
+
+`discriminate.py` 가 0 이 아닌 종료 코드를 냈다. 일 안 한 제출이 만점을 받은
+과제(약한 오라클)가 하나라도 있다.
+
+- 워크플로: 게이트 스텝에 도달하지 않는다. 기본 `set -e` 로 잡이 실패한다.
+- 러너: `preflight={"tool":"discriminate.py","exit":1}` 을 받으면 `fail` / exit 1
+- **regression 으로 부르지 않는다.** 관측이 갈린 것이 아니다.
+- **surface-changed 로 부르지 않는다.** 명령 표면 문제가 아니다.
+- **pass 로 부르지 않는다.** 벤치가 거짓인데 릴리스를 통과시키면 안 된다.
+
+판별 실패가 회귀보다 앞선다. 오라클이 약하면 차등 숫자도 믿을 수 없다.
+`decide_verdict` 우선순위 0 이 이 자리다.
+
+게이트 CLI 에 `--discriminate` 를 달지 않는다. 워크플로가 이미 먼저 돌린다.
+두 번 돌리면 CI 가 두 배가 되고, 플래그를 늘리면 "새 CLI 없음" 계약을 깬다.
+
+### 5.4 표면 변경 대 회귀 (`surface-changed` vs `regression`)
+
+같은 "관측이 갈렸다" 라도 표면이 바뀌었으면 회귀가 아니다.
+
+| 표면 digest | 관측 분기 | 부르는 이름 | 사람 다음 행동 |
+|---|---|---|---|
+| 같음 | 없음 | stable | 없음. 릴리스해도 된다 |
+| 같음 | 있음 | regression | 막는다. 동작이 바뀌었다 |
+| 다름 | 없음 | surface-changed | 리뷰. 명령이 늘거나 빠졌다 |
+| 다름 | 있음 | surface-changed | 리뷰. 관측 변화는 표면 탓일 수 있다 |
+
+한컴 정답지가 없다. 게이트는 어느 쪽이 옳은지 말하지 않는다. 표면이 바뀐
+릴리스를 자동으로 막으면, 의도된 명령 추가가 전부 차단된다. 그래서 review
+이지 block 이 아니다.
+
+리더보드 체인 파손은 이 표 밖에 있다. 원장 무결은 사람 리뷰로 넘기지 않는다.
+surface-changed + 원장 파손 = block.
+
+## 6. 우선순위
+
+`decide_verdict` 가 이유 목록에서 하나를 고른다. 앞이 이긴다.
+
+| 순위 | 이유 | 판정 |
+|---|---|---|
+| 0 | `discriminate-fail` · `trajectory-fail` · `audit-fail` | fail |
+| 1 | `missing-new-bin` · `probe-failed` · `diff-report-*` · `diff-tool-error` · `leaderboard-error` | fail |
+| 2 | `regression` · `leaderboard-broken` | block |
+| 3 | `surface-changed` | review |
+| 4 | `stable` · `skipped` · `missing-old-bin` | pass |
+
+읽기:
+
+- 판별이 실패했는데 차등이 회귀여도 fail 이다. 오라클을 먼저 고친다.
+- 신 바이너리가 없는데 원장이 파손돼도 fail 이다. 비교 대상이 없다.
+- 표면이 바뀌었는데 원장이 파손되면 block 이다. 원장은 리뷰 대상이 아니다.
+- 구 바이너리만 없으면 pass 다. 원장이 파손되면 그때는 block.
+
+## 7. 이유 카탈로그
+
+`REASONS` 튜플과 문서·시험이 같은 표를 본다.
+
+| 이유 | 판정 | 한 줄 |
+|---|---|---|
+| `stable` | pass | 표면과 관측이 같다 |
+| `skipped` | pass | 차등을 돌리지 않았다 (구 없음과 동의) |
+| `missing-old-bin` | pass | 구 바이너리 없음. 차등 생략 |
+| `missing-new-bin` | fail | 신 바이너리 없음. 현재 릴리스 부재 |
+| `discriminate-fail` | fail | 약한 오라클. 차등 분류 아님 |
+| `trajectory-fail` | fail | 연극 과제. 차등 분류 아님 |
+| `audit-fail` | fail | 그 외 전제 감사 실패 |
+| `probe-failed` | fail | 표면을 못 잼. 삼원으로 위장 금지 |
+| `diff-report-missing` | fail | 차등 JSON 이 없다 |
+| `diff-report-invalid` | fail | 차등 JSON 이 깨졌다 |
+| `diff-tool-error` | fail | 차등 도구가 예외로 죽음 |
+| `surface-changed` | review | 명령 표면이 바뀜. 차단 아님 |
+| `regression` | block | 표면 같고 관측이 갈림 |
+| `leaderboard-broken` | block | 원장 체인 파손 |
+| `leaderboard-error` | fail | 원장 도구가 예외로 죽음 |
+| `write-error` | fail | 판정 파일을 못 씀 (종료 코드는 기존 판정 유지 가능) |
+| `unexpected` | fail | 카탈로그 밖 |
+
+`write-error` 는 `main` 이 판정을 이미 계산한 뒤에 난다. 디스크가 가득 찼다고
+회귀를 안정으로 바꾸지 않는다. 콘솔 종료 코드는 계산된 판정을 따른다.
+`-o` 파일이 비거나 부분만 쓰여 있으면 오류 기록을 봉투에 남긴다.
+
+## 8. 예외를 접는 자리
+
+감사기(이 게이트) 자신은 한 서브프로세스의 예외로 멈추지 않는다. 치명
+예외만 다시 올린다.
+
+| 자리 | 잡는 것 | 접는 곳 |
+|---|---|---|
+| `find_bin_safe` | OSError 등 | 바이너리 기록 status=error |
+| `path_exists_safe` | OSError | 없는 것으로 본다 |
+| `run_tool_safe` | timeout · missing-bin · OSError | 도구 오류 기록 |
+| `load_json_safe` | FileNotFound · JSONDecode · OSError | 보고 손상 이유 |
+| `remove_safe` | OSError | 무시. 판정을 바꾸지 않음 |
+| `write_verdict_safe` | OSError | `writeError` |
+| `write_github_summary` | OSError | 반환만. 판정 유지 |
+| `gate` 전제 | `preflight` 입력 | `fold_preflight` |
+
+삼키지 않는 것: `KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+`GeneratorExit`. 사용자가 끊었는데 안정 보고를 내면 거짓말이다.
+
+`exception_kind` 는 context 를 본다. 같은 `FileNotFoundError` 라도
+바이너리 자리면 `missing-bin`, 차등 보고 자리면 `diff-report-missing` 이다.
+
+## 9. JSON 봉투
+
+`kind=gymReleaseGate`, `schemaVersion=1.0`. 기존 필드 의미는 그대로다.
+#5259 가 이유를 가리키려고 칸을 더했다. 키 집합은 시험이 `VERDICT_KEYS` 로
+고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymReleaseGate` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `diff` | obj | 차등 요약 또는 skipped/unavailable |
+| `leaderboard` | obj | `{ok, exit}` 또는 `{ok: null, reason}` |
+| `verdict` | str | pass / review / block / fail |
+| `exit` | int | 0 / 1 / 2 / 3 |
+| `reason` | str | 이긴 이유 코드 |
+| `reasons` | list | 모인 이유. 우선순위 입력 |
+| `ok` | bool | pass 와만 참 |
+| `reviewRequired` | bool | review 와만 참 |
+| `blocked` | bool | block 과만 참 |
+| `failed` | bool | fail 과만 참 |
+| `old` / `new` | obj | `{role, given, resolved, status, reason}` |
+| `preflight` | obj | `{ok, audits, reasons, failed}` |
+| `errors` | list | 접힌 예외 기록 |
+
+`diff` 가 성공했을 때 들어 있는 칸:
+
+| 키 | 의미 |
+|---|---|
+| `classification` | 삼원 또는 skipped / probe-failed / unavailable |
+| `divergences` | 관측 분기 수 |
+| `surfaceChanged` | 표면이 달랐나 |
+| `tasksCompared` | 비교한 과제 수 |
+| `reasonCode` | 게이트가 읽은 이유 |
+| `toolExit` | 차등 도구의 종료 코드 |
+
+`validate_verdict` 가 정직 계약을 검사한다.
+
+- 사원일 때 `exit` · `ok` · `reviewRequired` · `blocked` · `failed` 가 표와
+  같아야 한다.
+- `pass` 인데 `reason` 이 `regression` / `surface-changed` /
+  `discriminate-fail` / `missing-new-bin` / `probe-failed` 이면 거짓말이다.
+- `review` 인데 `reason` 이 `surface-changed` 가 아니면 거짓말이다.
+- `block` 인데 `reason` 이 `regression` / `leaderboard-broken` 이 아니면
+  거짓말이다.
+- `fail` 인데 `reason` 이 `regression` 또는 `surface-changed` 이면 거짓말이다.
+- `probe-failed` 분류를 pass / review / block 으로 부르면 거짓말이다.
+
+## 10. 워크플로 계약
+
+독립 워크플로 `.github/workflows/gym-release-gate.yml`. 릴리스 본체
+(`release-binary.yml`)는 건드리지 않는다.
+
+순서:
+
+1. 현재 커밋에서 `cargo build --bin rhwp`
+2. **Discrimination audit** — `python3 gym/tools/discriminate.py --bin target/debug/rhwp`
+3. (old_ref 가 있을 때만) 구 태그 worktree 빌드 → `./rhwp-old-bin`
+4. **Trajectory necessity audit** — `python3 gym/tools/trajectory.py --bin target/debug/rhwp`
+5. **Run release gate** — old 파일이 있으면 `--old`, 항상 `--new`
+6. 판정 JSON 을 아티팩트로 업로드 (`if: always()`)
+
+고정하는 것:
+
+- `workflow_dispatch` + `push.tags: v*`
+- `permissions.contents: read` 만. write 권한 없음
+- 판별·트라젝토리가 게이트보다 먼저
+- 판별 스텝에 `--old` 없음 (현재 벤치만 본다)
+- 판별 스텝에 `continue-on-error` / `|| true` 없음
+- 게이트 스텝도 종료 코드를 삼키지 않음
+- old 파일이 없으면 `--old` 없이 게이트를 부름 (부재≠실패)
+- 업로드는 실패해도 돈다
+
+판별이 exit 1 을 내면 5번에 도달하지 않는다. 그게 `discriminate-fail` 의
+운영 경로다. 러너의 `preflight=` 는 같은 이유를 시험이 바이너리 없이
+재현하려고 둔 입구이지, 새 CLI 가 아니다.
+
+## 11. GitHub step summary
+
+`--github-summary` 이고 `GITHUB_STEP_SUMMARY` 가 있으면 표를 덧붙인다.
+환경 변수가 없으면 아무 것도 하지 않는다 (실패가 아니다).
+
+표 칸: 릴리스 차등, 리더보드 체인, 신/구 바이너리 상태, 전제 감사, 이유.
+
+이유별 주석:
+
+- `surface-changed` — 차단이 아니라 리뷰 신호
+- `discriminate-fail` — 회귀가 아니다. 약한 오라클
+- `missing-new-bin` — 차등 생략이 아니다
+- `probe-failed` — 표면을 모르면 분류하지 않는다
+- `regression` — 어느 쪽이 한컴과 맞는지는 말하지 않는다. 차단만 한다
+
+쓰기 실패는 판정을 바꾸지 않는다.
+
+## 12. 오검출 관문 요약
+
+게이트가 거짓말하지 않도록 지키는 문:
+
+1. **표면이 회귀보다 앞선다.** 오라클이 실수해도 게이트가 다시 적용한다.
+2. **도구 실패는 삼원이 아니다.** probe-failed / 보고 손상 / 도구 예외는
+   fail(1) 이다.
+3. **구 부재 ≠ 신 부재.** 한쪽만 skipped 다.
+4. **판별 실패 ≠ 회귀.** 오라클 결함과 동작 변화를 같은 exit 로 묶지 않는다.
+5. **원장 파손은 리뷰가 아니다.** surface-changed 여도 체인이 깨지면 block.
+6. **치명 예외는 삼키지 않는다.**
+7. **한 쓰기가 판정을 뒤집지 않는다.**
+8. **CLI 표면을 늘리지 않는다.** 전제는 워크플로와 `preflight=` 뿐이다.
+
+## 13. 시험이 고정하는 것
+
+```bash
+python -m unittest scripts.tests.test_gym_release_gate_workflow
+python -m unittest scripts.tests.test_gym_release_gate_exceptions
+```
+
+바이너리 없이 돈다. `run_tool` · `os.path.exists` · `runner.find_bin` 을
+목으로 갈아끼운다.
+
+고정하는 축:
+
+- 워크플로 존재, 본체 비침습, 수동+태그, 읽기 권한, 요약 플래그
+- 판별·트라젝토리가 게이트보다 앞섬
+- 판별 실패가 잡을 닫음 (`continue-on-error` 없음)
+- 러너 사원: stable→0, surface-changed→2, regression→3
+- 구 부재 → skipped / pass. 신 부재 → fail / 1
+- 판별 실패 → fail / 1. block/review 로 위장 금지
+- 표면 × 분기 × 전제 × 원장 생성 표. 위장 조합 없음
+- `probe-failed` / 깨진 JSON / 도구 OSError → fail
+- 원장 검증이 `--bin <new>` 를 그대로 씀
+- `validate_verdict` 정직 계약
+- `main` 의 exit 0/1
+- CLI 에 새 플래그 없음
+- 치명 예외 비삼킴
+- 문서 두 파일이 이유 코드를 포함
+
+## 14. 이 도구가 하지 않는 것
+
+- 새 CLI 플래그를 추가하지 않는다.
+- 새 gym pack 을 만들지 않는다.
+- `discriminate.py` · `trajectory.py` · `release_diff.py` · `fuzz_corpus.py`
+  를 고치지 않는다.
+- 자동화 pack · core-cli · casual-rides 과제 JSON 을 고치지 않는다.
+- 한컴 문서가 맞는지 틀리는지 말하지 않는다.
+- 어느 바이너리가 "더 옳은지" 고르지 않는다.
+- 표면이 바뀐 릴리스를 자동으로 막지 않는다.
+- 판별 실패를 회귀로 부르지 않는다.
+- 신 바이너리 부재를 차등 생략으로 부르지 않는다.
+- 치명 예외를 삼켜 성공인 척하지 않는다.
+- 릴리스 본체 워크플로에 침습하지 않는다.
+
+## 15. 관련 기둥
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 종점 무결성 | `discriminate.py` | 일 안 한 제출이 만점을 받나? |
+| 경로 무결성 | `trajectory.py` | 마지막 스텝을 빼도 통과하나? |
+| 도구 강건성 | `robustness.py` | 손상 입력에 rhwp 가 패닉·행 하나? |
+| 릴리스 차등 | `release_diff.py` | 두 바이너리가 같은 관측을 내나? |
+| 릴리스 게이트 | `release_gate.py` | 차등 + 원장을 파이프라인 판정으로 묶나? |
+
+차등은 오라클이다. 게이트는 오라클을 읽는다. 오라클이 표면을 모르는데
+안정이라고 쓰면 게이트도 속는다. 그래서 `probe-failed` 를 삼원 밖에 둔다.
+판별은 오라클의 오라클이다. 그게 실패하면 차등 숫자도 내려놓는다.
+
+## 16. 봉투 표본
+
+아래는 시험이 조립하는 최소 표본이다. 필드의 참/거짓이 판정과 어긋나면
+`validate_verdict` 가 거부한다.
+
+### 16.1 pass — stable
+
+```json
+{
+  "kind": "gymReleaseGate",
+  "schemaVersion": "1.0",
+  "diff": {
+    "classification": "stable",
+    "divergences": 0,
+    "surfaceChanged": false,
+    "tasksCompared": 91,
+    "reasonCode": "stable"
+  },
+  "leaderboard": {"ok": true, "exit": 0},
+  "verdict": "pass",
+  "exit": 0,
+  "reason": "stable",
+  "ok": true,
+  "reviewRequired": false,
+  "blocked": false,
+  "failed": false
+}
+```
+
+자기-대조(같은 바이너리를 `--old` 와 `--new` 에 넣음)는 이 모양이어야 한다.
+
+### 16.2 pass — 구 바이너리 없음
+
+```json
+{
+  "diff": {
+    "classification": "skipped",
+    "reason": "구 바이너리 없음 — 차등 생략(직전 태그 미빌드)",
+    "reasonCode": "missing-old-bin"
+  },
+  "leaderboard": {"ok": null, "reason": "커밋된 리더보드 없음 — 검증 생략"},
+  "verdict": "pass",
+  "exit": 0,
+  "reason": "missing-old-bin"
+}
+```
+
+첫 태그, 수동 실행에서 old_ref 를 비운 정상 경로다.
+
+### 16.3 fail — 신 바이너리 없음
+
+```json
+{
+  "diff": {
+    "classification": "unavailable",
+    "reasonCode": "missing-new-bin"
+  },
+  "new": {"status": "missing", "reason": "not-found"},
+  "verdict": "fail",
+  "exit": 1,
+  "reason": "missing-new-bin",
+  "ok": false,
+  "failed": true
+}
+```
+
+skipped 가 아니다. 현재 릴리스가 없다.
+
+### 16.4 fail — 판별 감사 실패
+
+```json
+{
+  "preflight": {
+    "ok": false,
+    "failed": true,
+    "reasons": ["discriminate-fail"],
+    "audits": [
+      {"tool": "discriminate", "exit": 1, "ok": false, "reason": "discriminate-fail"}
+    ]
+  },
+  "verdict": "fail",
+  "exit": 1,
+  "reason": "discriminate-fail",
+  "failed": true
+}
+```
+
+워크플로 경로에서는 이 봉투가 안 나올 수 있다 — 잡이 게이트 전에 죽는다.
+러너가 같은 이유를 재현할 수 있어야 시험이 위장을 잡는다.
+
+### 16.5 review — surface-changed
+
+```json
+{
+  "diff": {
+    "classification": "surface-changed",
+    "divergences": 70,
+    "surfaceChanged": true,
+    "reasonCode": "surface-changed"
+  },
+  "verdict": "review",
+  "exit": 2,
+  "reason": "surface-changed",
+  "reviewRequired": true,
+  "blocked": false
+}
+```
+
+관측이 70 갈려도 차단이 아니다. 명령 표면이 바뀐 릴리스다.
+
+### 16.6 block — regression
+
+```json
+{
+  "diff": {
+    "classification": "regression",
+    "divergences": 4,
+    "surfaceChanged": false,
+    "reasonCode": "regression"
+  },
+  "verdict": "block",
+  "exit": 3,
+  "reason": "regression",
+  "blocked": true,
+  "reviewRequired": false
+}
+```
+
+표면이 같은데 쪽수가 6→7 이면 순수 동작 변화다. 어느 쪽이 한컴과 맞는지는
+이 게이트가 말하지 않는다.
+
+### 16.7 fail — probe-failed
+
+```json
+{
+  "diff": {
+    "classification": "probe-failed",
+    "reasonCode": "probe-failed"
+  },
+  "verdict": "fail",
+  "exit": 1,
+  "reason": "probe-failed",
+  "failed": true,
+  "ok": false,
+  "reviewRequired": false,
+  "blocked": false
+}
+```
+
+표면을 모르면 분류하지 않는다. pass 도 review 도 block 도 아니다.
+
+### 16.8 block — 원장 파손
+
+```json
+{
+  "diff": {"classification": "skipped", "reasonCode": "missing-old-bin"},
+  "leaderboard": {"ok": false, "exit": 3},
+  "verdict": "block",
+  "exit": 3,
+  "reason": "leaderboard-broken"
+}
+```
+
+차등을 안 돌려도 원장이 깨지면 막는다.
+
+## 17. 운영자가 읽는 법
+
+종료 코드를 보고 다음 행동을 고른다.
+
+| exit | 하는 일 |
+|---|---|
+| 0 | 릴리스를 진행해도 된다. 구 바이너리가 없었으면 다음 태그부터 차등이 돈다. |
+| 1 | 도구/전제를 고친다. 약한 오라클이면 과제를 고친다. 바이너리 경로를 확인한다. 차등 보고가 깨졌으면 차등 도구를 본다. **동작을 되돌리는 자리가 아니다.** |
+| 2 | 변경 로그를 읽고 의도된 표면 변경인지 사람이 판정한다. 의도면 진행, 아니면 명령을 되돌린다. |
+| 3 | 관측이 갈렸거나 원장이 깨졌다. 릴리스를 막는다. 차등 JSON 의 `diffs` 또는 원장 verify 출력을 본다. |
+
+exit 1 과 exit 3 을 같은 "실패" 로 접으면, 약한 오라클과 쪽수 회귀를 같은
+티켓으로 보낸다. 그래서 사원이 넷이다.
+
+## 18. 로컬에서 재현하는 법
+
+바이너리 없이 계약을 확인한다.
+
+```bash
+python -m unittest scripts.tests.test_gym_release_gate_workflow -q
+python -m unittest scripts.tests.test_gym_release_gate_exceptions -q
+python gym/tools/audit.py
+```
+
+라이브 경로(실제 rhwp 두 개)는 기존과 같다.
+
+```bash
+python gym/tools/release_gate.py --old <구> --new target/debug/rhwp -o gate.json
+```
+
+`gate.json` 의 `verdict` / `exit` / `reason` 이 이 문서의 표와 같아야 한다.
+`validate_verdict` 를 파이썬에서 부르면 위장 조합을 기계가 거부한다.
+
+라이브 스윕은 이 가지의 완료 조건이 아니다. 단위 시험이 예외 경로를 고정하고,
+audit.py 가 pack 정합을 본다. 새 pack 이 없으므로 audit 는 기존과 같아야 한다.
+
+## 19. 변경을 열 때
+
+이 파일을 고치려면 같은 커밋에서 시험과 이유 카탈로그를 같이 고친다.
+
+- 새 이유 코드를 넣으면 `REASONS` · `VERDICT_BY_REASON` · `REASON_TEXT` ·
+  이 문서 7절 · 시험 표를 같이 늘린다.
+- 새 CLI 플래그를 넣지 않는다. 필요하면 이슈를 새로 연다.
+- 판정 사원에 다섯 번째 값을 넣지 않는다. 새 상황은 이유 코드로 접는다.
+- `discriminate.py` 를 이 가지에서 고치지 않는다. 종료 코드 계약만 읽는다.
+
+## 20. 용어
+
+| 말 | 뜻 |
+|---|---|
+| 삼원 | 차등 오라클의 stable / regression / surface-changed |
+| 사원 | 게이트의 pass / review / block / fail |
+| 전제 감사 | 게이트보다 먼저 도는 판별·트라젝토리 |
+| 약한 오라클 | 일 안 한 제출이 만점을 받는 과제 |
+| 연극 | 마지막 스텝을 빼도 통과하는 다단계 과제 |
+| 부재≠실패 | 구 바이너리가 없는 것을 오류로 부르지 않는 결 |
+| 정직 조항 | 무엇이 바뀌었나를 가리키고 어느 쪽이 옳은지는 말하지 않는다 |
+| 위장 | 한 이유를 다른 판정으로 부르는 것. 시험이 거부한다 |
+
+## 21. 결정 트리 (운영자가 따라가는 순서)
+
+게이트가 실제로 걷는 순서와 같다. 위에서 막히면 아래를 보지 않는다.
+
+```
+preflight.discriminate exit != 0 ?  → fail / discriminate-fail
+preflight.trajectory  exit != 0 ?  → fail / trajectory-fail
+new bin missing / empty / find_bin 실패 ? → fail / missing-new-bin
+old bin omitted or missing ?
+    yes → diff = skipped / missing-old-bin
+    no  → run release_diff.py
+          report missing ? → fail / diff-report-missing
+          report not JSON ? → fail / diff-report-invalid
+          classification == probe-failed ? → fail / probe-failed
+          surfaceChanged or classification == surface-changed ?
+              → reason = surface-changed
+          classification == regression ? → reason = regression
+          classification == stable ? → reason = stable
+          else → fail / unexpected
+ledger exists and verify_board ?
+    yes → leaderboard.py --bin <new> verify
+          도구 예외 ? → fail / leaderboard-error
+          exit != 0 ? → reason += leaderboard-broken
+decide_verdict(reasons) → pass | fail | review | block
+```
+
+이 트리를 코드가 아니라 글로 다시 쓴 이유는, YAML 과 러너와 시험이 같은
+질문을 다른 언어로 반복하지 않게 하기 위함이다. 새 예외를 넣을 때는 이
+트리의 한 갈래에 이름을 붙이고 `REASONS` 에 한 줄을 더한다.
+
+## 22. 위장 조합 거부 표
+
+`validate_verdict` 가 거부하는 조합이다.  greener 가 되려면 판정·이유·exit
+가 한 줄에 있어야 한다.
+
+| verdict | reason | exit | 허용 |
+|---|---|---|---|
+| pass | stable | 0 | 예 |
+| pass | missing-old-bin | 0 | 예 |
+| pass | skipped | 0 | 예 |
+| pass | regression | 0 | 아니오 |
+| pass | surface-changed | 0 | 아니오 |
+| pass | discriminate-fail | 0 | 아니오 |
+| pass | missing-new-bin | 0 | 아니오 |
+| pass | probe-failed | 0 | 아니오 |
+| review | surface-changed | 2 | 예 |
+| review | regression | 2 | 아니오 |
+| review | stable | 2 | 아니오 |
+| block | regression | 3 | 예 |
+| block | leaderboard-broken | 3 | 예 |
+| block | surface-changed | 3 | 아니오 |
+| block | discriminate-fail | 3 | 아니오 |
+| fail | missing-new-bin | 1 | 예 |
+| fail | discriminate-fail | 1 | 예 |
+| fail | probe-failed | 1 | 예 |
+| fail | diff-report-missing | 1 | 예 |
+| fail | diff-report-invalid | 1 | 예 |
+| fail | regression | 1 | 아니오 |
+| fail | surface-changed | 1 | 아니오 |
+| fail | stable | 1 | 아니오 (도구 실패가 아님) |
+
+`fail` + `stable` 은 표에서 거절로 적었다. 구현은 `reason` 이 `stable` 이면
+`decide_verdict` 가 pass 를 낸다. 사람이 봉투를 손으로 조립해 `fail` 과
+`stable` 을 붙이면 `validate_verdict` 가 `failed 는 fail 과만` 쪽보다
+이유 정합에서 먼저 걸린다. 시험이 그 손을 막는다.
+
+## 23. 워크플로 발췌와 러너 대응
+
+워크플로 한 줄이 러너의 어느 갈래인지.
+
+| YAML | 러너 |
+|---|---|
+| `if [ -f ./rhwp-old-bin ]` 참 | `gate(old, new, ...)` → 차등 실행 |
+| `if [ -f ./rhwp-old-bin ]` 거짓 | `gate(None, new, ...)` → missing-old-bin |
+| `python3 gym/tools/discriminate.py --bin target/debug/rhwp` 가 1 | 잡 종료. `preflight` 와 같은 이유 |
+| `python3 gym/tools/trajectory.py --bin target/debug/rhwp` 가 1 | 잡 종료. trajectory-fail |
+| `--github-summary` | `write_github_summary` |
+| `-o gate-verdict.json` | `write_verdict_safe` |
+| `if: always()` 업로드 | 판정이 fail/block 이어도 봉투를 남김 |
+| `contents: read` | 게이트는 쓰기를 요구하지 않음 |
+
+워크플로를 이 가지에서 고치지 않은 이유: 이미 판별·트라젝토리·old 생략이
+맞게 배선돼 있다. YAML 을 고치면 열린 계약 시험과 운영 습관을 흔든다.
+러너가 예외를 정직하게 접으면 YAML 은 그대로여도 DoD 가 닫힌다.
+
+## 24. 자기 점검 질문
+
+PR 리뷰어가 이 가지만 보고 물을 수 있는 질문.
+
+1. 신 바이너리가 없는데 exit 0 인 시험이 있는가? 있으면 위장이다.
+2. 판별 exit 1 을 block(3) 으로 읽는 분기가 있는가? 있으면 위장이다.
+3. surface-changed + divergences>0 가 block 인가? 이면 정직 조항을 깼다.
+4. `--preflight` 플래그가 argparse 에 생겼는가? 있으면 이슈 계약을 깼다.
+5. `discriminate.py` 의 한 줄이라도 이 diff 에 있는가? 있으면 금지 파일을
+   열었다.
+6. `git diff --shortstat upstream/devel` 의 insertions 가 3000 미만인가?
+   이면 DoD 미달이다. 빈 줄로 채우지 말고 표·표본·시험을 더한다.
+
+이 여섯이 모두 아니오/해당없음 이면 이 문서는 구현과 같다.

--- a/gym/tools/release_gate.py
+++ b/gym/tools/release_gate.py
@@ -1,4 +1,4 @@
-"""[#4662] 릴리스 게이트 러너 — 회귀 도구를 파이프라인 판정으로 묶는다.
+"""[#4662/#5259] 릴리스 게이트 러너 — 회귀 도구를 파이프라인 판정으로 묶는다.
 
 로컬에서도 CI 에서도 같은 판정을 낸다. 하는 일:
 
@@ -8,9 +8,15 @@
    자동 차단이 아니다(도구는 '무엇이 바뀌었나'를 가리키지 '어느 쪽이 옳은가'를
    판정하지 않는다 — #4661 정직 조항).
 
+판별 감사(discriminate.py) 실패는 차등 분류가 아니다. 약한 오라클은 벤치마크
+자체의 결함이라 워크플로가 게이트보다 먼저 exit 1 로 막는다. 러너는 그 종료
+코드를 받아도 regression(exit 3) 이나 surface-changed(exit 2) 로 위장하지 않는다.
+
 ## 종료 코드 (게이트 계약)
 
 - 0 = pass   — 차등 stable(또는 검사 대상 없음) + 리더보드 무결
+- 1 = fail   — 도구/전제 실패. 신 바이너리 부재, 차등 보고 손상, probe-failed,
+               판별 감사 실패. 삼원 분류로 위장하지 않는다
 - 2 = review — 차등 surface-changed. 표면이 바뀐 릴리스라 사람 판정 필요(차단 아님)
 - 3 = block  — 차등 regression, 또는 리더보드 체인 파손
 
@@ -18,8 +24,13 @@
 
 `--github-summary` 를 주면 GITHUB_STEP_SUMMARY 에 마크다운 표를 쓴다. old 바이너리가
 없으면(직전 태그 미빌드) 차등은 건너뛰고 리더보드 검증만 한다 — 부재를 실패로
-위장하지 않는 결 그대로 skipped 로 보고한다.
+위장하지 않는 결 그대로 skipped 로 보고한다. new 바이너리가 없으면 생략이 아니라
+fail 이다. 비교 대상이 없는 것과 현재 릴리스가 없는 것은 다르다.
+
+CLI 플래그는 그대로다. 새 pack 을 만들지 않는다.
 """
+
+from __future__ import annotations
 
 import argparse
 import io
@@ -40,6 +51,494 @@ from gym.core import runner  # noqa: E402
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+REPORT_KIND = "gymReleaseGate"
+SCHEMA_VERSION = "1.0"
+
+#: 게이트가 내는 네 판정. fail 은 삼원(차등 분류)이 아니다.
+VERDICTS = ("pass", "review", "block", "fail")
+EXIT_BY_VERDICT = {"pass": 0, "review": 2, "block": 3, "fail": 1}
+
+#: 차등 오라클의 삼원. probe-failed / skipped 는 이 튜플에 넣지 않는다.
+DIFF_CLASSIFICATIONS = ("stable", "regression", "surface-changed")
+DIFF_SKIPPED = "skipped"
+DIFF_PROBE_FAILED = "probe-failed"
+
+#: 게이트가 접는 이유 카탈로그. 시험·문서가 같은 표를 본다.
+REASONS = (
+    "stable",
+    "skipped",
+    "missing-old-bin",
+    "missing-new-bin",
+    "discriminate-fail",
+    "trajectory-fail",
+    "audit-fail",
+    "probe-failed",
+    "diff-report-missing",
+    "diff-report-invalid",
+    "diff-tool-error",
+    "surface-changed",
+    "regression",
+    "leaderboard-broken",
+    "leaderboard-error",
+    "write-error",
+    "unexpected",
+)
+
+#: 이유 → 판정. 우선순위는 decide_verdict 가 적용한다.
+VERDICT_BY_REASON = {
+    "stable": "pass",
+    "skipped": "pass",
+    "missing-old-bin": "pass",
+    "missing-new-bin": "fail",
+    "discriminate-fail": "fail",
+    "trajectory-fail": "fail",
+    "audit-fail": "fail",
+    "probe-failed": "fail",
+    "diff-report-missing": "fail",
+    "diff-report-invalid": "fail",
+    "diff-tool-error": "fail",
+    "surface-changed": "review",
+    "regression": "block",
+    "leaderboard-broken": "block",
+    "leaderboard-error": "fail",
+    "write-error": "fail",
+    "unexpected": "fail",
+}
+
+#: 워크플로가 게이트보다 먼저 돌리는 무결성 전제. 러너가 이 스크립트를
+#: 고치지 않는다 — 종료 코드만 읽는다.
+PREFLIGHT_TOOLS = ("discriminate.py", "trajectory.py")
+PREFLIGHT_REASON_BY_TOOL = {
+    "discriminate": "discriminate-fail",
+    "discriminate.py": "discriminate-fail",
+    "trajectory": "trajectory-fail",
+    "trajectory.py": "trajectory-fail",
+}
+
+#: 차등 보고에서 게이트가 읽는 키. 없어도 도구를 죽이지 않는다.
+DIFF_REPORT_KEYS = (
+    "classification",
+    "divergences",
+    "surfaceChanged",
+    "tasksCompared",
+)
+
+#: 판정 봉투 고정 키.
+VERDICT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "diff",
+    "leaderboard",
+    "verdict",
+    "exit",
+    "reason",
+    "reasons",
+    "ok",
+    "reviewRequired",
+    "blocked",
+    "failed",
+    "old",
+    "new",
+    "preflight",
+    "errors",
+)
+
+REASON_TEXT = {
+    "stable": "명령 표면과 관측이 같다",
+    "skipped": "구 바이너리 없음 — 차등 생략(직전 태그 미빌드)",
+    "missing-old-bin": "구 바이너리 없음 — 차등 생략(직전 태그 미빌드)",
+    "missing-new-bin": "신 바이너리가 없다 — 비교 대상이 아니라 현재 릴리스 부재",
+    "discriminate-fail": "판별 감사가 약한 오라클을 신고했다 — 차등 분류로 위장하지 않는다",
+    "trajectory-fail": "트라젝토리 감사가 연극 과제를 신고했다 — 차등 분류로 위장하지 않는다",
+    "audit-fail": "무결성 전제 감사가 실패했다",
+    "probe-failed": "차등이 표면을 재지 못했다 — stable/regression/surface-changed 로 위장하지 않는다",
+    "diff-report-missing": "차등 보고 파일이 없다",
+    "diff-report-invalid": "차등 보고를 읽지 못했다",
+    "diff-tool-error": "차등 도구가 보고 없이 실패했다",
+    "surface-changed": "명령 표면이 달라 사람 판정이 필요하다 — 자동 차단이 아니다",
+    "regression": "명령 표면은 같고 관측이 갈렸다 — 순수 동작 변화",
+    "leaderboard-broken": "리더보드 해시 체인이 파손됐다",
+    "leaderboard-error": "리더보드 검증 도구가 예외로 죽었다",
+    "write-error": "판정 봉투를 쓰지 못했다",
+    "unexpected": "카탈로그 밖 실패",
+}
+
+#: 삼키면 안 되는 예외 — 사용자가 끊었는데 안정 보고를 내면 거짓말이다.
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    TimeoutError,
+    subprocess.TimeoutExpired,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    json.JSONDecodeError,
+    RuntimeError,
+)
+
+ERROR_HEAD_LIMIT = 160
+
+EXCEPTION_KIND_BY_TYPE = {
+    FileNotFoundError: "missing-bin",
+    PermissionError: "permission",
+    TimeoutError: "timeout",
+    subprocess.TimeoutExpired: "timeout",
+    UnicodeError: "decode-error",
+    UnicodeDecodeError: "decode-error",
+    UnicodeEncodeError: "decode-error",
+    ValueError: "value-error",
+    TypeError: "type-error",
+    KeyError: "key-error",
+    IndexError: "index-error",
+    AttributeError: "attr-error",
+    OSError: "os-error",
+    json.JSONDecodeError: "invalid-json",
+    RuntimeError: "runtime-error",
+}
+
+
+def is_fatal_exception(exc):
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def truncate_head(text, limit=ERROR_HEAD_LIMIT):
+    """오류 머리. None/비문자는 빈 문자열. 한도는 0 이하면 빈 값."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except FATAL_EXCEPTIONS:
+            raise
+        except Exception:
+            return ""
+    if limit is None or limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[:limit]
+
+
+def exception_kind(exc, context="gate"):
+    """예외를 이유/오류 kind 로 접는다. 순수.
+
+    context:
+      - bin: 바이너리 존재 확인. FileNotFound → missing-bin
+      - diff-report: 차등 JSON. JSONDecodeError → invalid-json
+      - write: 판정 쓰기
+      - tool: 서브프로세스
+      - gate: 그 외
+    """
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, subprocess.TimeoutExpired) or isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, FileNotFoundError):
+        if context == "diff-report":
+            return "diff-report-missing"
+        if context == "bin":
+            return "missing-bin"
+        return "missing-bin"
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, json.JSONDecodeError):
+        return "invalid-json"
+    if isinstance(exc, (KeyError, IndexError, AttributeError)):
+        return "type-error" if isinstance(exc, AttributeError) else (
+            "key-error" if isinstance(exc, KeyError) else "index-error"
+        )
+    if isinstance(exc, TypeError):
+        return "type-error"
+    if isinstance(exc, ValueError):
+        return "value-error"
+    if isinstance(exc, OSError):
+        return "os-error"
+    if isinstance(exc, RuntimeError):
+        return "runtime-error"
+    return "unexpected"
+
+
+def exception_record(exc, context="gate", path=""):
+    """예외를 오류 한 줄로 접는다. 여기서 예외를 다시 올리지 않는다."""
+    return {
+        "context": context,
+        "kind": exception_kind(exc, context=context),
+        "error": type(exc).__name__ if exc is not None else "NoneType",
+        "head": truncate_head(str(exc) if exc is not None else ""),
+        "path": path or "",
+    }
+
+
+def normalize_tool_name(name):
+    """discriminate.py / discriminate / gym/tools/discriminate.py → discriminate."""
+    if not name:
+        return ""
+    base = os.path.basename(str(name).replace("\\", "/"))
+    lower = base.lower()
+    if lower.endswith(".py"):
+        lower = lower[:-3]
+    return lower
+
+
+def reason_for_audit(tool, code):
+    """전제 감사 종료 코드를 이유 코드로 접는다. 0 이면 None. 순수.
+
+    discriminate 실패는 regression 이 아니다. 오라클이 약한 것이지 바이너리
+    관측이 갈린 것이 아니다. 게이트는 이 값을 fail(1) 로만 묶는다.
+    """
+    try:
+        code_n = int(code)
+    except (TypeError, ValueError):
+        return "audit-fail"
+    if code_n == 0:
+        return None
+    name = normalize_tool_name(tool)
+    if name == "discriminate":
+        return "discriminate-fail"
+    if name == "trajectory":
+        return "trajectory-fail"
+    return "audit-fail"
+
+
+def fold_preflight(preflight):
+    """전제 감사 입력을 정규화한다. 순수.
+
+    받는 것:
+      - None / [] / {} → 전제 없음
+      - {tool, exit} 한 줄
+      - [{tool, exit}, ...]
+      - {audits: [...]} / {ok: False, reason: "..."}
+
+    내는 것: {ok, audits, reasons, failed}
+    """
+    empty = {"ok": True, "audits": [], "reasons": [], "failed": False}
+    if preflight is None:
+        return empty
+    rows = []
+    if isinstance(preflight, dict):
+        if "audits" in preflight and isinstance(preflight.get("audits"), list):
+            rows = list(preflight["audits"])
+        elif "tool" in preflight or "exit" in preflight:
+            rows = [preflight]
+        elif preflight.get("ok") is False:
+            reason = preflight.get("reason") or "audit-fail"
+            if reason not in REASONS:
+                reason = "audit-fail"
+            return {
+                "ok": False,
+                "audits": [dict(preflight)],
+                "reasons": [reason],
+                "failed": True,
+            }
+        else:
+            return empty
+    elif isinstance(preflight, (list, tuple)):
+        rows = list(preflight)
+    else:
+        return {
+            "ok": False,
+            "audits": [{"tool": "?", "exit": 1, "raw": truncate_head(str(preflight), 80)}],
+            "reasons": ["audit-fail"],
+            "failed": True,
+        }
+
+    audits = []
+    reasons = []
+    for row in rows:
+        if not isinstance(row, dict):
+            reasons.append("audit-fail")
+            audits.append({"tool": "?", "exit": 1, "ok": False})
+            continue
+        tool = row.get("tool") or row.get("name") or ""
+        code = row.get("exit")
+        if code is None:
+            code = 0 if row.get("ok") else 1
+        reason = reason_for_audit(tool, code)
+        item = {
+            "tool": normalize_tool_name(tool) or tool or "?",
+            "exit": code,
+            "ok": reason is None,
+        }
+        if reason:
+            item["reason"] = reason
+            reasons.append(reason)
+        audits.append(item)
+    return {
+        "ok": not reasons,
+        "audits": audits,
+        "reasons": reasons,
+        "failed": bool(reasons),
+    }
+
+
+def map_diff_classification(classification, surface_changed=None, divergences=None):
+    """차등 분류를 게이트 이유로 접는다. 순수.
+
+    surface-changed 는 관측 분기 유무와 무관하게 review 다.
+    regression 은 표면이 같을 때만 block 이다.
+    probe-failed / 알 수 없는 값은 fail 이지 pass 가 아니다.
+    """
+    cls = classification
+    if cls is None:
+        return "diff-report-invalid"
+    if not isinstance(cls, str):
+        return "diff-report-invalid"
+    cls = cls.strip()
+    if cls == DIFF_SKIPPED:
+        return "missing-old-bin"
+    if cls == DIFF_PROBE_FAILED:
+        return "probe-failed"
+    if cls == "surface-changed":
+        return "surface-changed"
+    if cls == "regression":
+        return "regression"
+    if cls == "stable":
+        return "stable"
+    if cls == "":
+        return "diff-report-invalid"
+    return "unexpected"
+
+
+def surface_wins_over_regression(classification, surface_changed, divergences):
+    """정직 조항 — 표면이 바뀌면 관측 분기를 회귀로 부르지 않는다. 순수.
+
+    차등 오라클이 이미 이 규칙을 지키지만, 게이트가 보고를 다시 읽을 때도
+    같은 규칙을 적용한다. 오라클이 실수로 regression + surfaceChanged=True 를
+    내도 게이트는 review 다.
+    """
+    if classification == "surface-changed":
+        return "surface-changed"
+    if surface_changed and classification == "regression":
+        return "surface-changed"
+    if surface_changed and classification == "stable":
+        return "surface-changed"
+    return map_diff_classification(classification, surface_changed, divergences)
+
+
+def decide_verdict(diff_reason, board_ok, preflight_reasons=None):
+    """이유들을 하나의 판정으로 접는다. 순수.
+
+    우선순위(앞이 이긴다):
+      1. 전제 감사 실패 (discriminate-fail 등) → fail
+      2. 신 바이너리 부재·도구 실패 → fail
+      3. regression 또는 리더보드 파손 → block
+      4. surface-changed → review
+      5. 그 외(stable / skipped / missing-old) → pass
+
+    리더보드 파손은 표면 변경보다 앞선다. 원장 무결은 사람 리뷰로 넘기지 않는다.
+    """
+    reasons = []
+    if preflight_reasons:
+        for r in preflight_reasons:
+            if r:
+                reasons.append(r)
+    if diff_reason:
+        reasons.append(diff_reason)
+    if board_ok is False:
+        reasons.append("leaderboard-broken")
+
+    rank = {
+        "discriminate-fail": 0,
+        "trajectory-fail": 0,
+        "audit-fail": 0,
+        "missing-new-bin": 1,
+        "probe-failed": 1,
+        "diff-report-missing": 1,
+        "diff-report-invalid": 1,
+        "diff-tool-error": 1,
+        "leaderboard-error": 1,
+        "write-error": 1,
+        "unexpected": 1,
+        "regression": 2,
+        "leaderboard-broken": 2,
+        "surface-changed": 3,
+        "stable": 4,
+        "skipped": 4,
+        "missing-old-bin": 4,
+    }
+    if not reasons:
+        reasons = ["stable"]
+    winner = min(reasons, key=lambda r: rank.get(r, 1))
+    verdict = VERDICT_BY_REASON.get(winner, "fail")
+    return {
+        "verdict": verdict,
+        "exit": EXIT_BY_VERDICT[verdict],
+        "reason": winner,
+        "reasons": list(reasons),
+        "ok": verdict == "pass",
+        "reviewRequired": verdict == "review",
+        "blocked": verdict == "block",
+        "failed": verdict == "fail",
+    }
+
+
+def empty_bin_record(role, given=None, status="missing", reason="empty"):
+    return {
+        "role": role,
+        "given": given,
+        "resolved": None,
+        "status": status,
+        "reason": reason,
+    }
+
+
+def find_bin_safe(path):
+    """runner.find_bin 을 예외 없이 접는다."""
+    try:
+        found = runner.find_bin(path)
+        return found, None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return path, exception_record(exc, context="bin", path=str(path) if path else "")
+    except Exception as exc:
+        return path, exception_record(exc, context="bin", path=str(path) if path else "")
+
+
+def path_exists_safe(path):
+    """os.path.exists 를 예외 없이 접는다. 모르면 없는 것으로 본다."""
+    if not path:
+        return False
+    try:
+        return os.path.exists(path)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS:
+        return False
+    except Exception:
+        return False
+
+
+def resolve_bin_record(path, role):
+    """바이너리 한 쪽의 존재 기록. 예외로 도구를 죽이지 않는다."""
+    if path is None:
+        return empty_bin_record(role, given=None, status="omitted", reason="empty")
+    if isinstance(path, str) and not path.strip():
+        return empty_bin_record(role, given=path, status="omitted", reason="empty")
+    resolved, err = find_bin_safe(path)
+    if err:
+        rec = empty_bin_record(role, given=path, status="error", reason=err.get("kind", "os-error"))
+        rec["resolved"] = resolved
+        rec["error"] = err
+        return rec
+    rec = {
+        "role": role,
+        "given": path,
+        "resolved": resolved,
+        "status": "present" if path_exists_safe(resolved) else "missing",
+        "reason": "ok" if path_exists_safe(resolved) else "not-found",
+    }
+    return rec
+
 
 def run_tool(script, args):
     """gym/tools 의 다른 러너를 서브프로세스로 부른다 — (exit, stdout)."""
@@ -48,74 +547,422 @@ def run_tool(script, args):
     return proc.returncode, proc.stdout.decode("utf-8", errors="replace")
 
 
-def gate(old_bin, new_bin, agent, packs, verify_board):
-    verdict = {"kind": "gymReleaseGate", "schemaVersion": "1.0",
-               "diff": None, "leaderboard": None}
+def run_tool_safe(script, args):
+    """run_tool 예외를 접는다. (exit, stdout, error_or_None)."""
+    try:
+        code, out = run_tool(script, args)
+        return code, out, None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return 1, "", exception_record(exc, context="tool", path=script)
+    except Exception as exc:
+        return 1, "", exception_record(exc, context="tool", path=script)
 
-    # 1) 릴리스 차등 — old 가 있어야 돈다.
-    if old_bin and os.path.exists(runner.find_bin(old_bin)):
-        out = os.path.join(runner.GYM, "release-gate-diff.json")
-        args = ["--old", old_bin, "--new", new_bin, "--agent", agent, "-o", out]
-        for p in packs or []:
-            args += ["--pack", p]
-        code, _ = run_tool("release_diff.py", args)
-        with io.open(out, encoding="utf-8") as fh:
-            report = json.load(fh)
-        os.remove(out)
-        verdict["diff"] = {
-            "classification": report["classification"],
-            "divergences": report["divergences"],
-            "surfaceChanged": report["surfaceChanged"],
-            "tasksCompared": report["tasksCompared"],
-        }
+
+def load_json_safe(path, context="diff-report"):
+    """JSON 파일을 예외 없이 읽는다. (obj, error_or_None)."""
+    if not path:
+        return None, {"kind": "diff-report-missing", "error": "empty-path", "head": "", "path": ""}
+    try:
+        if not os.path.exists(path):
+            return None, {
+                "kind": "diff-report-missing",
+                "error": "FileNotFoundError",
+                "head": path,
+                "path": path,
+            }
+        with io.open(path, encoding="utf-8") as fh:
+            return json.load(fh), None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, exception_record(exc, context=context, path=path)
+    except Exception as exc:
+        return None, exception_record(exc, context=context, path=path)
+
+
+def remove_safe(path):
+    """임시 보고 삭제. 실패해도 판정을 바꾸지 않는다."""
+    if not path:
+        return None
+    try:
+        if os.path.exists(path):
+            os.remove(path)
+        return None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return exception_record(exc, context="write", path=path)
+    except Exception as exc:
+        return exception_record(exc, context="write", path=path)
+
+
+def extract_diff_fields(report):
+    """차등 보고에서 게이트가 쓰는 칸만 꺼낸다. 순수.
+
+    키가 없어도 도구를 죽이지 않는다. 분류가 없으면 invalid.
+    """
+    if not isinstance(report, dict):
+        return None, {"kind": "diff-report-invalid", "error": "not-dict", "head": "", "path": ""}
+    classification = report.get("classification")
+    fields = {
+        "classification": classification,
+        "divergences": report.get("divergences"),
+        "surfaceChanged": report.get("surfaceChanged"),
+        "tasksCompared": report.get("tasksCompared"),
+    }
+    if "classificationReason" in report:
+        fields["classificationReason"] = report["classificationReason"]
+    if "probeFailed" in report:
+        fields["probeFailed"] = report["probeFailed"]
+    if "exit" in report:
+        fields["toolExit"] = report["exit"]
+    if classification is None:
+        return fields, {"kind": "diff-report-invalid", "error": "no-classification", "head": "", "path": ""}
+    return fields, None
+
+
+def skipped_diff(reason="missing-old-bin"):
+    return {
+        "classification": DIFF_SKIPPED,
+        "reason": REASON_TEXT.get(reason, REASON_TEXT["skipped"]),
+        "reasonCode": reason,
+    }
+
+
+def failed_diff(reason, extra=None):
+    row = {
+        "classification": reason if reason == DIFF_PROBE_FAILED else "unavailable",
+        "reason": REASON_TEXT.get(reason, reason),
+        "reasonCode": reason,
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def ledger_path():
+    return os.path.join(runner.GYM, "leaderboard", "ledger.ndjson")
+
+
+def run_release_diff(old_bin, new_bin, agent, packs):
+    """차등 도구를 부르고 보고를 읽는다. 예외로 게이트를 죽이지 않는다."""
+    out = os.path.join(runner.GYM, "release-gate-diff.json")
+    args = ["--old", str(old_bin), "--new", str(new_bin), "--agent", agent or "claude-fable-5",
+            "-o", out]
+    for p in packs or []:
+        args += ["--pack", p]
+    code, _stdout, tool_err = run_tool_safe("release_diff.py", args)
+    report, load_err = load_json_safe(out, context="diff-report")
+    remove_safe(out)
+    if tool_err and report is None:
+        return failed_diff("diff-tool-error", {"toolError": tool_err, "toolExit": code}), "diff-tool-error"
+    if load_err and report is None:
+        kind = load_err.get("kind")
+        reason = "diff-report-missing" if kind in ("diff-report-missing", "missing-bin") else "diff-report-invalid"
+        return failed_diff(reason, {"loadError": load_err, "toolExit": code}), reason
+    fields, field_err = extract_diff_fields(report)
+    if field_err:
+        return failed_diff("diff-report-invalid", {"loadError": field_err, "toolExit": code}), "diff-report-invalid"
+    reason = surface_wins_over_regression(
+        fields.get("classification"),
+        fields.get("surfaceChanged"),
+        fields.get("divergences"),
+    )
+    fields["reasonCode"] = reason
+    fields["toolExit"] = code
+    return fields, reason
+
+
+def run_leaderboard(new_bin):
+    """리더보드 verify. 예외로 게이트를 죽이지 않는다."""
+    code, out, err = run_tool_safe("leaderboard.py", ["--bin", new_bin, "verify"])
+    if err:
+        return {"ok": False, "exit": code, "error": err, "reasonCode": "leaderboard-error"}
+    return {"ok": code == 0, "exit": code, "reasonCode": None if code == 0 else "leaderboard-broken"}
+
+
+def empty_verdict():
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "diff": None,
+        "leaderboard": None,
+        "verdict": "fail",
+        "exit": 1,
+        "reason": "unexpected",
+        "reasons": [],
+        "ok": False,
+        "reviewRequired": False,
+        "blocked": False,
+        "failed": True,
+        "old": empty_bin_record("old"),
+        "new": empty_bin_record("new"),
+        "preflight": fold_preflight(None),
+        "errors": [],
+    }
+
+
+def attach_decision(verdict, decision):
+    verdict.update(decision)
+    return verdict
+
+
+def gate(old_bin, new_bin, agent, packs, verify_board, preflight=None):
+    """게이트 본체. 기존 위치 인자는 그대로다. preflight 는 선택.
+
+    preflight 는 CLI 플래그가 아니다. 워크플로가 이미 discriminate.py 를
+    게이트보다 먼저 돌리므로 main() 은 이 인자를 쓰지 않는다. 시험과
+    프로그래매틱 호출이 판별 실패를 차등 분류로 위장하지 않는지 고정한다.
+    """
+    verdict = empty_verdict()
+    errors = []
+    pre = fold_preflight(preflight)
+    verdict["preflight"] = pre
+
+    old_rec = resolve_bin_record(old_bin, "old")
+    new_rec = resolve_bin_record(new_bin, "new")
+    verdict["old"] = old_rec
+    verdict["new"] = new_rec
+
+    if new_rec.get("status") != "present":
+        verdict["diff"] = skipped_diff("missing-new-bin")
+        verdict["diff"]["classification"] = "unavailable"
+        verdict["leaderboard"] = {"ok": None, "reason": REASON_TEXT["missing-new-bin"]}
+        if new_rec.get("error"):
+            errors.append(new_rec["error"])
+        verdict["errors"] = errors
+        return attach_decision(verdict, decide_verdict(
+            "missing-new-bin", None, pre["reasons"]))
+
+    if pre["failed"]:
+        # 전제가 무너지면 차등을 돌려도 오라클을 믿을 수 없다. 그래도 신
+        # 바이너리는 있으므로 리더보드만 선택적으로 본다 — 파손이면 이유도
+        # 남긴다. 판정은 전제 실패(fail)가 이긴다.
+        if old_rec.get("status") == "present":
+            verdict["diff"] = skipped_diff(pre["reasons"][0] if pre["reasons"] else "audit-fail")
+            verdict["diff"]["classification"] = "unavailable"
+        else:
+            verdict["diff"] = skipped_diff("missing-old-bin")
+        if verify_board and path_exists_safe(ledger_path()):
+            # --bin 은 호출자가 준 new_bin 그대로. 해석 경로로 바꾸면
+            # 기존 계약(선택한 실행 파일로 원장 검증)이 깨진다.
+            board = run_leaderboard(new_bin)
+            verdict["leaderboard"] = board
+            board_ok = board.get("ok")
+        else:
+            verdict["leaderboard"] = {"ok": None, "reason": "커밋된 리더보드 없음 — 검증 생략"}
+            board_ok = None
+        verdict["errors"] = errors
+        extra = list(pre["reasons"])
+        if (verdict.get("leaderboard") or {}).get("reasonCode") == "leaderboard-error":
+            extra.append("leaderboard-error")
+            board_ok = None
+        return attach_decision(verdict, decide_verdict(
+            verdict["diff"].get("reasonCode"), board_ok, extra))
+
+    if old_rec.get("status") == "present":
+        fields, reason = run_release_diff(old_bin, new_bin, agent, packs)
+        verdict["diff"] = fields
     else:
-        verdict["diff"] = {"classification": "skipped",
-                           "reason": "구 바이너리 없음 — 차등 생략(직전 태그 미빌드)"}
+        reason = "missing-old-bin"
+        verdict["diff"] = skipped_diff("missing-old-bin")
 
-    # 2) 리더보드 해시 체인 — 커밋된 원장이 있으면.
-    if verify_board and os.path.exists(os.path.join(runner.GYM, "leaderboard", "ledger.ndjson")):
-        # 게이트가 판정한 현재 바이너리와 같은 실행 파일로 서명·앵커를 검증한다.
-        # 기본 탐색에 맡기면 CI/로컬의 target 배치에 따라 `rhwp`를 찾지 못해
-        # 정상 원장을 파손으로 오판할 수 있다.
-        code, out = run_tool("leaderboard.py", ["--bin", new_bin, "verify"])
-        verdict["leaderboard"] = {"ok": code == 0, "exit": code}
+    if verify_board and path_exists_safe(ledger_path()):
+        board = run_leaderboard(new_bin)
+        verdict["leaderboard"] = board
+        board_ok = board.get("ok")
+        if board.get("reasonCode") == "leaderboard-error":
+            errors.append(board.get("error"))
     else:
         verdict["leaderboard"] = {"ok": None, "reason": "커밋된 리더보드 없음 — 검증 생략"}
+        board_ok = None
 
-    # 3) 판정 — regression 만 차단.
-    cls = verdict["diff"]["classification"]
-    board_bad = verdict["leaderboard"].get("ok") is False
-    if cls == "regression" or board_bad:
-        verdict["verdict"], verdict["exit"] = "block", 3
-    elif cls == "surface-changed":
-        verdict["verdict"], verdict["exit"] = "review", 2
+    verdict["errors"] = errors
+    extra = list(pre["reasons"])
+    if (verdict.get("leaderboard") or {}).get("reasonCode") == "leaderboard-error":
+        extra.append("leaderboard-error")
+        board_ok = None
+    return attach_decision(verdict, decide_verdict(reason, board_ok, extra))
+
+
+def validate_verdict(verdict):
+    """판정 봉투의 정직 계약. 문제 문자열 목록(비면 통과)."""
+    issues = []
+    if not isinstance(verdict, dict):
+        return ["verdict 가 dict 가 아니다"]
+    for key in ("kind", "schemaVersion", "diff", "leaderboard", "verdict", "exit"):
+        if key not in verdict:
+            issues.append(f"키 없음: {key}")
+    if verdict.get("kind") != REPORT_KIND:
+        issues.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if verdict.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append(f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
+    v = verdict.get("verdict")
+    if v not in VERDICTS:
+        issues.append(f"알 수 없는 verdict: {v!r}")
     else:
-        verdict["verdict"], verdict["exit"] = "pass", 0
-    return verdict
+        if verdict.get("exit") != EXIT_BY_VERDICT[v]:
+            issues.append(f"exit 가 {v} 계약과 다르다")
+        if verdict.get("ok") is not None and verdict.get("ok") != (v == "pass"):
+            issues.append("ok 는 pass 와만 같아야 한다")
+        if verdict.get("reviewRequired") is not None and verdict.get("reviewRequired") != (v == "review"):
+            issues.append("reviewRequired 는 review 와만 같아야 한다")
+        if verdict.get("blocked") is not None and verdict.get("blocked") != (v == "block"):
+            issues.append("blocked 는 block 과만 같아야 한다")
+        if verdict.get("failed") is not None and verdict.get("failed") != (v == "fail"):
+            issues.append("failed 는 fail 과만 같아야 한다")
+    reason = verdict.get("reason")
+    if reason is not None and reason not in REASONS:
+        issues.append(f"알 수 없는 reason: {reason!r}")
+    if v == "review" and reason and reason != "surface-changed":
+        issues.append("review 인데 reason 이 surface-changed 가 아니다")
+    if v == "block" and reason not in (None, "regression", "leaderboard-broken"):
+        issues.append("block 인데 reason 이 regression/leaderboard-broken 이 아니다")
+    if v == "pass" and reason in ("regression", "surface-changed", "discriminate-fail",
+                                  "missing-new-bin", "probe-failed"):
+        issues.append(f"pass 로 {reason} 을 위장하면 안 된다")
+    if v == "fail" and reason == "regression":
+        issues.append("regression 을 fail 로 위장하면 안 된다 — block 이다")
+    if v == "fail" and reason == "surface-changed":
+        issues.append("surface-changed 를 fail 로 위장하면 안 된다 — review 이다")
+    if v == "block" and reason == "surface-changed":
+        issues.append("surface-changed 를 block 으로 위장하면 안 된다")
+    if v == "review" and reason == "regression":
+        issues.append("regression 을 review 로 위장하면 안 된다")
+    if v == "pass" and verdict.get("exit") not in (None, 0):
+        issues.append("pass 의 exit 는 0 이어야 한다")
+    if v == "review" and verdict.get("exit") not in (None, 2):
+        issues.append("review 의 exit 는 2 이어야 한다")
+    if v == "block" and verdict.get("exit") not in (None, 3):
+        issues.append("block 의 exit 는 3 이어야 한다")
+    if v == "fail" and verdict.get("exit") not in (None, 1):
+        issues.append("fail 의 exit 는 1 이어야 한다")
+    diff = verdict.get("diff")
+    if isinstance(diff, dict):
+        cls = diff.get("classification")
+        if cls == "regression" and v == "review":
+            issues.append("차등 regression 을 review 로 읽으면 안 된다")
+        if cls == "surface-changed" and v == "block" and reason != "leaderboard-broken":
+            issues.append("차등 surface-changed 를 block 으로 읽으면 안 된다")
+        if cls == "probe-failed" and v == "pass":
+            issues.append("probe-failed 를 pass 로 위장하면 안 된다")
+        if cls == "probe-failed" and v in ("review", "block"):
+            issues.append("probe-failed 를 삼원 판정으로 위장하면 안 된다")
+    return issues
+
+
+def write_verdict(verdict, path):
+    """UTF-8 · BOM 없음 · LF. 같은 입력이면 바이트가 같다."""
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(json.dumps(verdict, ensure_ascii=False, indent=2))
+        fh.write("\n")
+
+
+def write_verdict_safe(verdict, path):
+    """쓰기 예외를 접는다. 성공이면 None, 실패면 오류 기록."""
+    try:
+        write_verdict(verdict, path)
+        return None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return exception_record(exc, context="write", path=path)
+    except Exception as exc:
+        return exception_record(exc, context="write", path=path)
+
+
+def render_summary_lines(verdict):
+    """GitHub step summary / 콘솔이 공유하는 표. 순수."""
+    d = verdict.get("diff") or {}
+    b = verdict.get("leaderboard") or {}
+    pre = verdict.get("preflight") or {}
+    v = verdict.get("verdict", "?")
+    exit_code = verdict.get("exit", "?")
+    reason = verdict.get("reason", "")
+    lines = [
+        "## 운동장 릴리스 게이트",
+        "",
+        f"**판정: {v}** (exit {exit_code})",
+        "",
+        "| 검사 | 결과 |",
+        "|---|---|",
+    ]
+    diff_cell = d.get("classification", "?")
+    if "divergences" in d:
+        diff_cell += f" · 분기 {d.get('divergences')}"
+    elif d.get("reason"):
+        diff_cell += f" ({d.get('reason')})"
+    lines.append(f"| 릴리스 차등 | {diff_cell} |")
+    if b.get("ok") is True:
+        board_cell = "무결"
+    elif b.get("ok") is False:
+        board_cell = "파손!!"
+    else:
+        board_cell = b.get("reason", "생략")
+    lines.append(f"| 리더보드 체인 | {board_cell} |")
+    new_rec = verdict.get("new") or {}
+    old_rec = verdict.get("old") or {}
+    lines.append(f"| 신 바이너리 | {new_rec.get('status', '?')} |")
+    lines.append(f"| 구 바이너리 | {old_rec.get('status', '?')} |")
+    if pre.get("audits"):
+        audits = ", ".join(
+            f"{a.get('tool')}={'ok' if a.get('ok') else a.get('reason', 'fail')}"
+            for a in pre["audits"]
+        )
+        lines.append(f"| 전제 감사 | {audits} |")
+    if reason:
+        lines.append(f"| 이유 | {reason} — {REASON_TEXT.get(reason, '')} |")
+    lines.append("")
+    if d.get("classification") == "surface-changed" or reason == "surface-changed":
+        lines.append("> surface-changed 는 **차단이 아니라 리뷰 신호**다 — 명령 표면이 "
+                     "바뀐 릴리스라 관측 변화가 의도된 것일 수 있다. 사람이 판정한다.")
+    if reason == "discriminate-fail":
+        lines.append("> 판별 감사 실패는 **회귀가 아니다**. 일 안 한 제출이 만점을 받는 "
+                     "약한 오라클이다. 차등 삼원으로 위장하지 않는다.")
+    if reason == "missing-new-bin":
+        lines.append("> 신 바이너리 부재는 차등 생략이 아니다. 구 바이너리 부재만 skipped 다.")
+    if reason == "probe-failed":
+        lines.append("> 표면을 모르면 분류하지 않는다. probe-failed 를 pass/review/block 으로 "
+                     "부르지 않는다.")
+    if reason == "regression":
+        lines.append("> 표면이 같고 관측이 갈렸다. 어느 쪽이 한컴과 맞는지는 이 게이트가 "
+                     "말하지 않는다. 차단만 한다.")
+    return lines
 
 
 def write_github_summary(verdict):
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
-        return
-    d, b = verdict["diff"], verdict["leaderboard"]
-    lines = ["## 운동장 릴리스 게이트", "",
-             f"**판정: {verdict['verdict']}** (exit {verdict['exit']})", "",
-             "| 검사 | 결과 |", "|---|---|",
-             f"| 릴리스 차등 | {d['classification']}"
-             + (f" · 분기 {d.get('divergences')}" if 'divergences' in d else f" ({d.get('reason', '')})")
-             + " |",
-             f"| 리더보드 체인 | "
-             + ("무결" if b.get("ok") else ("파손!!" if b.get("ok") is False else b.get("reason", "")))
-             + " |", ""]
-    if d.get("classification") == "surface-changed":
-        lines.append("> surface-changed 는 **차단이 아니라 리뷰 신호**다 — 명령 표면이 "
-                     "바뀐 릴리스라 관측 변화가 의도된 것일 수 있다. 사람이 판정한다.")
-    with io.open(path, "a", encoding="utf-8") as fh:
-        fh.write("\n".join(lines) + "\n")
+        return None
+    lines = render_summary_lines(verdict)
+    try:
+        with io.open(path, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+        return None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return exception_record(exc, context="write", path=path)
+    except Exception as exc:
+        return exception_record(exc, context="write", path=path)
 
 
-def main():
+def print_console(verdict):
+    d = verdict.get("diff") or {}
+    print(f"릴리스 차등: {d.get('classification')}"
+          + (f" · 분기 {d.get('divergences')}" if "divergences" in d else ""))
+    b = verdict.get("leaderboard") or {}
+    print("리더보드 체인: "
+          + ("무결" if b.get("ok") else ("파손" if b.get("ok") is False else "생략")))
+    if verdict.get("reason") and verdict.get("reason") not in ("stable", "skipped", "missing-old-bin"):
+        print(f"이유: {verdict['reason']} — {REASON_TEXT.get(verdict['reason'], '')}")
+    print(f"게이트 판정: [{verdict.get('verdict')}] (exit {verdict.get('exit')})")
+
+
+def parse_args(argv=None):
+    """기존 CLI 그대로. 새 플래그를 추가하지 않는다."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--old", default=None, help="직전 릴리스 rhwp 바이너리(없으면 차등 생략)")
     ap.add_argument("--new", default=None, help="현재 rhwp 바이너리")
@@ -124,25 +971,28 @@ def main():
     ap.add_argument("--no-leaderboard", action="store_true", help="리더보드 검증 생략")
     ap.add_argument("--github-summary", action="store_true")
     ap.add_argument("-o", "--out", default=None)
-    a = ap.parse_args()
+    return ap.parse_args(argv)
 
-    new_bin = runner.find_bin(a.new)
+
+def main(argv=None):
+    a = parse_args(argv)
+    new_bin, find_err = find_bin_safe(a.new)
     verdict = gate(a.old, new_bin, a.agent, a.pack, not a.no_leaderboard)
+    if find_err and verdict.get("new", {}).get("status") != "present":
+        verdict.setdefault("errors", []).append(find_err)
 
     if a.out:
-        with io.open(a.out, "w", encoding="utf-8", newline="\n") as fh:
-            fh.write(json.dumps(verdict, ensure_ascii=False, indent=2))
+        write_err = write_verdict_safe(verdict, a.out)
+        if write_err:
+            verdict.setdefault("errors", []).append(write_err)
+            # 디스크가 가득 찼다고 회귀를 안정으로 바꾸지 않는다.
+            # 이미 계산한 판정을 유지하고 오류만 남긴다.
+            verdict["writeError"] = write_err
     if a.github_summary:
         write_github_summary(verdict)
 
-    d = verdict["diff"]
-    print(f"릴리스 차등: {d['classification']}"
-          + (f" · 분기 {d.get('divergences')}" if "divergences" in d else ""))
-    b = verdict["leaderboard"]
-    print("리더보드 체인: "
-          + ("무결" if b.get("ok") else ("파손" if b.get("ok") is False else "생략")))
-    print(f"게이트 판정: [{verdict['verdict']}] (exit {verdict['exit']})")
-    return verdict["exit"]
+    print_console(verdict)
+    return verdict.get("exit", 1)
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_release_gate.md
+++ b/mydocs/working/gym_release_gate.md
@@ -1,0 +1,374 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_release_gate.md
+last_verified: 2026-08-18
+---
+
+# gym 릴리스 게이트 — 예외 경로와 판정 정직성 보강
+
+Issue: #5259
+Branch: `feat/gym-release-gate-hardening`
+Date: 2026-08-18
+Worktree: `C:\Users\swsz9\rhwp-gym-release-gate` (isolation, `rhwp-desk*` 아님)
+
+## 1. 결론
+
+`gym/tools/release_gate.py` 의 기존 사원(pass / review / block)은 그대로 두고,
+도구·전제 실패를 `fail`(exit 1) 로 분리했다. 구 바이너리 부재는 계속 skipped /
+pass 다. 신 바이너리 부재, 판별 감사 실패, probe-failed, 깨진 차등 보고는
+stable 로 위장하지 않는다. surface-changed 는 review, regression 은 block.
+둘이 섞이면 표면이 이긴다.
+
+새 CLI 플래그는 없다. 새 pack 은 없다. `discriminate.py` · `trajectory.py` ·
+`release_diff.py` · `fuzz_corpus.py` · automation / core-cli / casual-rides 는
+이 가지에서 열지 않았다. 열린 PR 5210–5248 · 5266 의 파일도 열지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_release_gate_workflow`
+- `python -m unittest scripts.tests.test_gym_release_gate_exceptions`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 구현(#4662)은 차등 분류 세 값을 종료 코드 0/2/3 으로 묶고, 구 바이너리가
+없으면 차등을 생략했다. 워크플로가 판별·트라젝토리를 게이트보다 먼저 돌린다.
+대비 `upstream/devel` 의 러너는 약 150줄, 워크플로 시험은 약 147줄이었다.
+
+그 상태의 빈틈:
+
+1. **신 바이너리 부재를 검사하지 않는다.** `find_bin` 이 `rhwp` 라는 이름만
+   돌려줘도 차등·원장을 그대로 부른다. 구 부재와 같은 skipped/pass 로
+   떨어질 수 있다. 현재 릴리스가 없는 상태를 안정으로 위장한다.
+2. **`probe-failed` 를 pass 로 읽는다.** 차등이 표면을 못 재면 분류가
+   `probe-failed` 다. 러너는 `regression` / `surface-changed` 가 아니면
+   전부 pass 였다. 오라클이 말을 안 했는데 안정이다.
+3. **차등 보고가 없으면 게이트가 죽는다.** `json.load` 가 예외를 올린다.
+   깨진 JSON, 안 쓰인 `-o`, 권한 오류가 파이프라인을 트레이스백으로 끝낸다.
+   판정 봉투가 없다.
+4. **판별 실패를 러너가 모른다.** 워크플로가 먼저 막지만, 프로그래매틱
+   호출·재현 시험에서 그 이유를 차등 분류와 구분할 함수가 없다. 운영자가
+   exit 1 과 exit 3 을 같은 "실패" 로 접기 쉽다.
+5. **오라클이 `regression` + `surfaceChanged=true` 를 내도 게이트는 block
+   이다.** 표면이 앞선다는 정직 조항을 다시 적용하지 않는다.
+6. **카탈로그가 코드에만 있다.** 문서·시험이 같은 표를 공유하지 않는다.
+
+분류 함수를 네 값으로 늘리면 기존 게이트 계약
+(`stable→0`, `surface-changed→2`, `regression→3`)이 깨진다. 그래서 차등
+삼원은 유지하고, 도구/전제 실패만 사원의 네 번째 값 `fail` 로 받는다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/release_gate.py`
+
+- `VERDICTS` / `EXIT_BY_VERDICT` / `REASONS` / `VERDICT_BY_REASON` /
+  `REASON_TEXT` — 시험·문서가 같은 표를 본다.
+- `FATAL_EXCEPTIONS` — KeyboardInterrupt · SystemExit · MemoryError ·
+  GeneratorExit 는 삼키지 않는다.
+- `exception_kind` / `exception_record` — context 가 `diff-report` 이면
+  FileNotFound 는 `diff-report-missing`.
+- `reason_for_audit` / `fold_preflight` — 판별·트라젝토리 종료 코드를
+  이유 코드로 접는다. 0 이면 이유 없음.
+- `map_diff_classification` / `surface_wins_over_regression` — 삼원 +
+  skipped/probe-failed. 표면 플래그가 있으면 regression 을 review 로 되돌린다.
+- `decide_verdict` — 우선순위 0(전제) > 1(도구 실패) > 2(block) > 3(review)
+  > 4(pass).
+- `find_bin_safe` / `path_exists_safe` / `resolve_bin_record` — 바이너리
+  존재를 예외 없이 기록한다.
+- `run_tool_safe` / `load_json_safe` / `remove_safe` — 서브프로세스와
+  보고 읽기가 게이트를 죽이지 않는다.
+- `extract_diff_fields` — 분류 키가 없으면 invalid. dict 가 아니면 invalid.
+- `run_release_diff` / `run_leaderboard` — 오류를 이유 코드로 접는다.
+  원장 `--bin` 은 호출자가 준 `new_bin` 그대로다.
+- `gate(..., preflight=None)` — 기존 위치 인자 다섯 개는 그대로. 여섯 번째는
+  선택. CLI 플래그가 아니다.
+- 신 바이너리가 없으면 차등·원장을 부르지 않고 `fail`.
+- 전제가 실패하면 차등 숫자를 믿지 않고 `fail`. 원장만 선택적으로 본다.
+- `validate_verdict` — ok/review/blocked/failed/exit/reason 정직 계약.
+- `render_summary_lines` / `write_github_summary` — 이유별 주석.
+- `write_verdict_safe` — UTF-8 · BOM 없음 · LF. 쓰기 실패는 판정을 유지.
+- `parse_args` / `main` — 기존 플래그만. `main(argv)` 를 시험이 직접 부른다.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_release_gate_workflow.py`
+
+- 기존 워크플로 계약 9 + 러너 판정 6 을 유지.
+- `test_missing_old_binary_skips_diff_not_fail` 는 신 경로를 있다고 보고
+  구 부재만 분리한다. 예전처럼 `exists=False` 전역 목은 신 부재와 겹친다.
+- 판별이 `--old` 를 받지 않는지, `continue-on-error` 가 없는지, 업로드가
+  `always()` 인지, write 권한이 없는지를 고정.
+- 문서 두 파일이 이유 코드를 포함하는지 고정.
+
+`scripts/tests/test_gym_release_gate_exceptions.py` (신규)
+
+- 카탈로그·CLI 비확장·치명 예외 표지.
+- `reason_for_audit` — discriminate 실패는 regression 이 아님.
+- `fold_preflight` — None/한 줄/목록/쓰레기 입력.
+- `map_diff_classification` / `surface_wins_over_regression`.
+- `decide_verdict` 행렬 (구/신 부재, 판별, 표면, 회귀, 원장).
+- `validate_verdict` 위장 조합.
+- `gate` 라이브 목: 신 부재, 구 부재, 판별 실패가 회귀를 이김, 표면+분기,
+  오라클 실수(regression+surface), probe-failed, 깨진 JSON, 도구 OSError,
+  KeyboardInterrupt 비삼킴, 원장 예외 vs 원장 파손.
+- step summary 문구, 쓰기 형식, `main` exit 0/1.
+- 표면 × 분기 × 전제 × 원장 생성 표.
+
+### 3.3 문서
+
+- `gym/docs/release_gate.md` — 사원, 네 예외 경로, 우선순위, 이유 카탈로그,
+  JSON 봉투, 워크플로, 오검출 관문, 표본 8종.
+- `mydocs/working/gym_release_gate.md` — 이 기록.
+
+pack JSON 은 건드리지 않았다.
+
+## 4. 정직 조항 — 바꾸지 않은 것
+
+다음 계약은 #4662 와 같다. 시험이 다시 고정한다.
+
+```
+stable           → pass   / 0
+surface-changed  → review / 2
+regression       → block  / 3
+missing-old      → skip diff, pass (원장 무결 시)
+broken board     → block  / 3
+leaderboard --bin 은 게이트의 new_bin
+CLI: --old --new --agent --pack --no-leaderboard --github-summary -o
+```
+
+더한 것(기존과 모순되지 않음):
+
+```
+missing-new      → fail / 1
+discriminate-fail→ fail / 1
+probe-failed     → fail / 1
+bad diff report  → fail / 1
+surface flag + regression 분류 → review (표면이 이김)
+```
+
+`fail` 을 차등 `CLASSIFICATIONS` 에 넣지 않았다. 넣으면 오라클 계약을
+게이트가 침습한다. 오라클은 삼원, 게이트는 사원이다.
+
+## 5. 예외 카탈로그
+
+| context | 예외 | kind |
+|---|---|---|
+| bin | FileNotFoundError | missing-bin |
+| diff-report | FileNotFoundError | diff-report-missing |
+| * | PermissionError | permission |
+| * | TimeoutExpired / TimeoutError | timeout |
+| * | UnicodeError | decode-error |
+| * | JSONDecodeError | invalid-json |
+| * | KeyError / IndexError / AttributeError | key-error / index-error / type-error |
+| * | TypeError | type-error |
+| * | ValueError | value-error |
+| * | OSError | os-error |
+| * | RuntimeError | runtime-error |
+| * | 그 외 | unexpected |
+
+`reason_for_audit`:
+
+| tool | exit | reason |
+|---|---|---|
+| discriminate.py | 0 | (없음) |
+| discriminate.py | ≠0 | discriminate-fail |
+| trajectory.py | 0 | (없음) |
+| trajectory.py | ≠0 | trajectory-fail |
+| 그 외 | ≠0 | audit-fail |
+| 아무거나 | 비정수 | audit-fail |
+
+## 6. 우선순위 표 (운영)
+
+| 들어온 이유들 | 이긴 이유 | 판정 |
+|---|---|---|
+| stable | stable | pass |
+| missing-old-bin | missing-old-bin | pass |
+| missing-new-bin | missing-new-bin | fail |
+| discriminate-fail | discriminate-fail | fail |
+| discriminate-fail + regression | discriminate-fail | fail |
+| discriminate-fail + surface-changed | discriminate-fail | fail |
+| probe-failed | probe-failed | fail |
+| surface-changed | surface-changed | review |
+| surface-changed + 원장 파손 | leaderboard-broken | block |
+| regression | regression | block |
+| regression + 원장 파손 | regression (또는 broken, 둘 다 block) | block |
+| missing-old + 원장 파손 | leaderboard-broken | block |
+| 원장 도구 예외 | leaderboard-error | fail |
+
+이 표가 이슈 본문의 "Exception paths: missing old/new bin, discriminate fail,
+surface-changed vs regression" 을 닫는다.
+
+## 7. 열지 않은 파일
+
+사용자 지시와 열린 PR 충돌 방지.
+
+- `gym/tools/trajectory.py`
+- `gym/tools/discriminate.py`
+- `gym/tools/fuzz_corpus.py`
+- `gym/tools/release_diff.py` (PR #5248)
+- `gym/packs/automation/**` (PR #5266)
+- `gym/packs/core-cli/**`
+- `gym/packs/casual-rides/**`
+- `gym/core/checks.py` (PR #5210)
+- `gym/tools/coverage.py` / `gym/docs/coverage.md` (PR #5212)
+- `gym/docs/release_diff.md` (PR #5248)
+- `gym/docs/checks.md` · `agent_session.md` · `robustness.md` ·
+  `pack_health.md` · `differential.md` · `competitive_bench.md` ·
+  `from_e2e.md` · `leaderboard.md` (각 열린 PR)
+- `.github/workflows/gym-release-gate.yml` — 계약은 시험이 읽고, 파일은
+  그대로 둔다. 새 플래그·새 스텝을 넣지 않는다.
+
+연 파일:
+
+- `gym/tools/release_gate.py`
+- `scripts/tests/test_gym_release_gate_workflow.py`
+- `scripts/tests/test_gym_release_gate_exceptions.py` (신규)
+- `gym/docs/release_gate.md` (신규)
+- `mydocs/working/gym_release_gate.md` (신규)
+
+## 8. 기존 시험을 고친 이유
+
+`test_missing_old_binary_skips_diff_not_fail` 는 `os.path.exists` 를 전부
+거짓으로 목했다. 그 목은 신 바이너리도 없다고 말한다. 신 부재를 fail 로
+닫으면 이 시험이 구 부재를 더 이상 대변하지 못한다.
+
+고친 목:
+
+- `ledger.ndjson` 만 없다 (원장을 안 돌린다)
+- 그 외 경로는 있다 (신 바이너리 존재)
+- `old_bin=None` 이라 구는 omitted → skipped / pass
+
+신 부재는 `test_missing_new_fails` 가 따로 고정한다. 한 시험이 두 예외를
+동시에 목하면 어느 쪽이 이겼는지 알 수 없다.
+
+## 9. CLI 를 늘리지 않은 이유
+
+이슈 본문: "새 CLI/pack 없음."
+
+판별 실패를 CLI 로 받으려면 `--preflight` 또는 `--discriminate-report` 가
+필요하다. 워크플로는 이미 게이트 전에 판별을 돌린다. 플래그를 달면
+
+- 같은 감사를 두 번 돌리거나
+- 워크플로 YAML 을 고쳐 열린 계약 시험을 흔들거나
+- "새 CLI 없음" 을 깨게 된다.
+
+그래서 `gate(..., preflight=)` 는 파이썬 입구만 연다. `parse_args` 는
+기존 플래그만 안다. 시험이 `--discriminate-fail` / `--preflight` 를 주면
+`SystemExit` 이어야 한다.
+
+## 10. 스키마 1.0 을 유지한 이유
+
+칸을 더했지만 `schemaVersion` 은 `1.0` 이다. 기존 소비자가 `kind` 와
+`verdict` / `exit` / `diff.classification` 만 읽으면 그대로 동작한다.
+`reason` · `old` · `new` · `preflight` 는 부가다. 메이저 범프는 기존 칸의
+의미를 바꿀 때 한다. 이번에는 의미를 좁혀 위장을 제거했을 뿐이다.
+
+`fail` 판정은 예전 러너에 없었다. 예전에는 그 자리들이 pass 이거나
+트레이스백이었다. 소비자가 0/2/3 만 알고 있으면 1 은 "도구 실패" 로
+읽는 것이 Git 관례와 같다.
+
+## 11. 검증 실측
+
+작업 트리에서:
+
+```
+python -m unittest scripts.tests.test_gym_release_gate_workflow \
+                   scripts.tests.test_gym_release_gate_exceptions -q
+python gym/tools/audit.py
+```
+
+기대한 것:
+
+- 워크플로 + 예외 경로 시험 전부 통과
+- audit.py 전 pack 통과 (이 가지가 pack 을 안 건드렸으므로 devel 과 동일)
+
+`cargo fmt --all` · `cargo test` · `cargo clippy` 는 호출하지 않는다.
+Rust 파일이 없다.
+
+## 12. 크기 게이트
+
+이슈 DoD: `additions >= 3000`. 채우는 내용은 계약 표·예외 카탈로그·
+봉투 표본·생성 시험이다. 빈 줄이나 반복 문장으로 숫자를 만들지 않았다.
+
+삽입이 모이면 `git diff --shortstat upstream/devel` 의 insertions 가
+3000 이상이어야 PR 을 연다.
+
+## 13. PR
+
+- base: `devel`
+- head: `feat/gym-release-gate-hardening`
+- 제목·본문: 한국어
+- `closes #5259`
+- `--body-file` (UTF-8 BOM 없음)
+- `git add -A` 사용 안 함. 연 파일만 스테이징.
+
+## 14. 남은 빈틈 (이 가지의 밖)
+
+- 워크플로가 판별 실패 이유를 게이트 봉투에 남기지 않는다. 잡이 먼저
+  죽기 때문이다. 아티팩트에 판별 JSON 을 올리려면 YAML 을 고쳐야 하고,
+  그건 별 이슈다.
+- 라이브 바이너리 두 개로 게이트를 돌리는 스윕은 단위 시험이 대체한다.
+  CI 의 기존 워크플로가 그 경로다.
+- `trajectory-fail` 은 이유 코드와 우선순위만 있다. 이슈가 지목한 자리는
+  판별이다. 트라젝토리 도구 자체는 열지 않았다.
+- 차등 오라클의 `probe-failed` 보고 형식은 #5248 가지가 고정한다. 게이트는
+  `classification` 문자열만 읽는다.
+
+## 15. 한 줄
+
+게이트는 차등을 재판정하지 않는다. 차등이 말한 것을 파이프라인 종료 코드로
+옮기고, 말할 수 없는 자리(부재·전제 실패·보고 손상)를 안정으로 부르지
+않는다.
+
+## 16. 함수 목록 (러너)
+
+순수 또는 예외를 접는 함수만 적는다. `gate` / `main` 은 조합이다.
+
+| 함수 | 순수 | 역할 |
+|---|---|---|
+| `is_fatal_exception` | 예 | 삼키면 안 되는 예외 |
+| `truncate_head` | 예 | 오류 머리 |
+| `exception_kind` | 예 | 예외 → kind |
+| `exception_record` | 예 | 오류 한 줄 |
+| `normalize_tool_name` | 예 | 스크립트 경로 → 짧은 이름 |
+| `reason_for_audit` | 예 | 전제 종료 코드 → 이유 |
+| `fold_preflight` | 예 | 전제 입력 정규화 |
+| `map_diff_classification` | 예 | 차등 분류 → 이유 |
+| `surface_wins_over_regression` | 예 | 표면 플래그가 회귀를 이김 |
+| `decide_verdict` | 예 | 이유 목록 → 사원 |
+| `extract_diff_fields` | 예 | 보고에서 칸만 추출 |
+| `validate_verdict` | 예 | 정직 계약 |
+| `render_summary_lines` | 예 | step summary 문자열 |
+| `find_bin_safe` | 아니오 | find_bin 예외 접기 |
+| `path_exists_safe` | 아니오 | exists 예외 접기 |
+| `resolve_bin_record` | 아니오 | 바이너리 존재 기록 |
+| `run_tool` / `run_tool_safe` | 아니오 | 서브프로세스 |
+| `load_json_safe` | 아니오 | 보고 읽기 |
+| `run_release_diff` | 아니오 | 차등 + 보고 |
+| `run_leaderboard` | 아니오 | 원장 verify |
+| `write_verdict_safe` | 아니오 | 판정 쓰기 |
+| `gate` | 아니오 | 조합 |
+| `main` | 아니오 | CLI |
+
+순수 함수는 바이너리 없이 시험한다. 조합 함수는 `run_tool` 과 `exists` 를
+목으로 갈아끼운다.
+
+## 17. 기존 시험이 깨지지 않는 이유
+
+| 기존 시험 | 의존 | 유지 방법 |
+|---|---|---|
+| `test_stable_passes` | `_gate_with_diff("stable")` | exists=True, 보고 분류 그대로 pass |
+| `test_regression_blocks` | 같은 헬퍼 | reason=regression, block/3 |
+| `test_surface_changed_is_review_not_block` | 같은 헬퍼 | review/2. 분기 70 이어도 block 아님 |
+| `test_broken_leaderboard_blocks` | exists=True, run_tool=(3,…) | 원장 파손 → block/3 |
+| `test_leaderboard_uses_the_selected_new_binary` | `--bin` 인자 | 해석 경로가 아니라 호출자 `new_bin` |
+| `test_missing_old_binary_skips_diff_not_fail` | 예전 exists=False | 신 존재 목으로 분리 |
+| 워크플로 9종 | YAML 문자열 | YAML 을 이 가지에서 안 고침 |
+
+새 시험은 기존 이름을 바꾸지 않고 옆에서 더한다. `test_*workflow*.py`
+패턴은 ci.yml 배선(#4080)이 강제하므로 파일명을 유지한다.
+

--- a/scripts/tests/test_gym_release_gate_exceptions.py
+++ b/scripts/tests/test_gym_release_gate_exceptions.py
@@ -1,0 +1,1001 @@
+"""[#5259] 릴리스 게이트 예외 경로 — 부재·판별 실패·표면/회귀 분리.
+
+바이너리 없이 순수 함수와 목으로 고정한다. 이 파일이 지키는 것:
+
+- 구 바이너리 부재는 skipped / pass. 신 바이너리 부재는 fail(1).
+- 판별 감사 실패는 fail(1). regression(3) 이나 review(2) 로 위장하지 않는다.
+- surface-changed 는 review. regression 은 block. 둘이 섞이면 표면이 이긴다.
+- probe-failed / 보고 손상은 pass 가 아니다.
+- 치명 예외는 삼키지 않는다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATE_RUNNER = REPO_ROOT / "gym/tools/release_gate.py"
+GATE_WF = REPO_ROOT / ".github/workflows/gym-release-gate.yml"
+
+
+def load_rg():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location("gym_release_gate_exc", GATE_RUNNER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _exists_new_only(path):
+    text = str(path).replace("\\", "/")
+    if "ledger.ndjson" in text:
+        return False
+    if "old" in text.lower() and "rhwp-old" not in text.lower():
+        # 구 바이너리 후보만 숨기지 않는다 — 이 헬퍼는 신만 있다고 본다.
+        pass
+    return True
+
+
+def _exists_none(path):
+    return False
+
+
+def _exists_both_no_ledger(path):
+    text = str(path).replace("\\", "/")
+    if "ledger.ndjson" in text:
+        return False
+    return True
+
+
+class LoadMixin(unittest.TestCase):
+    def setUp(self):
+        self.rg = load_rg()
+
+
+class CatalogTests(LoadMixin):
+    def test_verdicts_and_exits_are_the_gate_contract(self):
+        self.assertEqual(self.rg.VERDICTS, ("pass", "review", "block", "fail"))
+        self.assertEqual(self.rg.EXIT_BY_VERDICT, {
+            "pass": 0, "review": 2, "block": 3, "fail": 1,
+        })
+
+    def test_diff_classifications_do_not_include_probe_failed(self):
+        self.assertEqual(self.rg.DIFF_CLASSIFICATIONS,
+                         ("stable", "regression", "surface-changed"))
+        self.assertNotIn("probe-failed", self.rg.DIFF_CLASSIFICATIONS)
+        self.assertNotIn("skipped", self.rg.DIFF_CLASSIFICATIONS)
+
+    def test_reasons_cover_the_issued_exception_paths(self):
+        for key in ("missing-old-bin", "missing-new-bin", "discriminate-fail",
+                    "surface-changed", "regression", "probe-failed"):
+            self.assertIn(key, self.rg.REASONS, key)
+
+    def test_verdict_by_reason_does_not_disguise(self):
+        m = self.rg.VERDICT_BY_REASON
+        self.assertEqual(m["missing-old-bin"], "pass")
+        self.assertEqual(m["missing-new-bin"], "fail")
+        self.assertEqual(m["discriminate-fail"], "fail")
+        self.assertEqual(m["surface-changed"], "review")
+        self.assertEqual(m["regression"], "block")
+        self.assertEqual(m["probe-failed"], "fail")
+        self.assertEqual(m["stable"], "pass")
+        self.assertNotEqual(m["discriminate-fail"], "block")
+        self.assertNotEqual(m["surface-changed"], "block")
+        self.assertNotEqual(m["regression"], "review")
+
+    def test_cli_flags_are_unchanged(self):
+        args = self.rg.parse_args([])
+        self.assertIsNone(args.old)
+        self.assertIsNone(args.new)
+        self.assertEqual(args.agent, "claude-fable-5")
+        self.assertIsNone(args.pack)
+        self.assertFalse(args.no_leaderboard)
+        self.assertFalse(args.github_summary)
+        self.assertIsNone(args.out)
+        with self.assertRaises(SystemExit):
+            self.rg.parse_args(["--discriminate-fail"])
+        with self.assertRaises(SystemExit):
+            self.rg.parse_args(["--preflight"])
+
+    def test_kind_and_schema_stay_on_v1(self):
+        self.assertEqual(self.rg.REPORT_KIND, "gymReleaseGate")
+        self.assertEqual(self.rg.SCHEMA_VERSION, "1.0")
+
+    def test_preflight_tools_match_workflow_scripts(self):
+        wf = GATE_WF.read_text(encoding="utf-8")
+        for script in self.rg.PREFLIGHT_TOOLS:
+            self.assertIn(script, wf, script)
+
+
+class ExceptionKindTests(LoadMixin):
+    def test_fatal_exceptions_are_marked(self):
+        self.assertTrue(self.rg.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(self.rg.is_fatal_exception(SystemExit(1)))
+        self.assertTrue(self.rg.is_fatal_exception(MemoryError()))
+        self.assertTrue(self.rg.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(self.rg.is_fatal_exception(FileNotFoundError("x")))
+        self.assertFalse(self.rg.is_fatal_exception(ValueError("x")))
+
+    def test_file_not_found_depends_on_context(self):
+        exc = FileNotFoundError("nope")
+        self.assertEqual(self.rg.exception_kind(exc, "bin"), "missing-bin")
+        self.assertEqual(self.rg.exception_kind(exc, "diff-report"), "diff-report-missing")
+        self.assertEqual(self.rg.exception_kind(exc, "gate"), "missing-bin")
+
+    def test_catalog_types(self):
+        cases = [
+            (PermissionError("p"), "permission"),
+            (TimeoutError("t"), "timeout"),
+            (subprocess.TimeoutExpired(cmd="x", timeout=1), "timeout"),
+            (UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad"), "decode-error"),
+            (json.JSONDecodeError("bad", "x", 0), "invalid-json"),
+            (TypeError("t"), "type-error"),
+            (ValueError("v"), "value-error"),
+            (OSError("o"), "os-error"),
+            (RuntimeError("r"), "runtime-error"),
+            (KeyError("k"), "key-error"),
+            (IndexError("i"), "index-error"),
+        ]
+        for exc, kind in cases:
+            self.assertEqual(self.rg.exception_kind(exc, "gate"), kind, kind)
+
+    def test_none_and_unknown_are_unexpected(self):
+        self.assertEqual(self.rg.exception_kind(None), "unexpected")
+        self.assertEqual(self.rg.exception_kind(RuntimeWarning("w")), "unexpected")
+
+    def test_truncate_head(self):
+        self.assertEqual(self.rg.truncate_head(None), "")
+        self.assertEqual(self.rg.truncate_head("ab", 0), "")
+        self.assertEqual(self.rg.truncate_head("abcd", 3), "abc")
+        self.assertEqual(self.rg.truncate_head("abcd", 10), "abcd")
+        self.assertEqual(self.rg.truncate_head(12), "12")
+
+    def test_exception_record_does_not_reraise(self):
+        rec = self.rg.exception_record(FileNotFoundError("z"), context="bin", path="p")
+        self.assertEqual(rec["kind"], "missing-bin")
+        self.assertEqual(rec["error"], "FileNotFoundError")
+        self.assertEqual(rec["path"], "p")
+        self.assertIn("z", rec["head"])
+
+
+class AuditReasonTests(LoadMixin):
+    def test_discriminate_zero_is_ok(self):
+        self.assertIsNone(self.rg.reason_for_audit("discriminate.py", 0))
+        self.assertIsNone(self.rg.reason_for_audit("discriminate", 0))
+
+    def test_discriminate_nonzero_is_discriminate_fail(self):
+        self.assertEqual(self.rg.reason_for_audit("discriminate.py", 1), "discriminate-fail")
+        self.assertEqual(self.rg.reason_for_audit("gym/tools/discriminate.py", 2),
+                         "discriminate-fail")
+        self.assertEqual(self.rg.reason_for_audit("DISCRIMINATE.PY", 1), "discriminate-fail")
+
+    def test_discriminate_fail_is_not_regression(self):
+        reason = self.rg.reason_for_audit("discriminate.py", 1)
+        self.assertNotEqual(reason, "regression")
+        self.assertNotEqual(reason, "surface-changed")
+        self.assertEqual(self.rg.VERDICT_BY_REASON[reason], "fail")
+        self.assertEqual(self.rg.EXIT_BY_VERDICT["fail"], 1)
+
+    def test_trajectory_nonzero_is_trajectory_fail(self):
+        self.assertEqual(self.rg.reason_for_audit("trajectory.py", 1), "trajectory-fail")
+        self.assertIsNone(self.rg.reason_for_audit("trajectory.py", 0))
+
+    def test_unknown_tool_nonzero_is_audit_fail(self):
+        self.assertEqual(self.rg.reason_for_audit("other.py", 1), "audit-fail")
+
+    def test_non_int_exit_is_audit_fail(self):
+        self.assertEqual(self.rg.reason_for_audit("discriminate.py", "nope"), "audit-fail")
+        self.assertEqual(self.rg.reason_for_audit("discriminate.py", None), "audit-fail")
+
+    def test_normalize_tool_name(self):
+        self.assertEqual(self.rg.normalize_tool_name("gym/tools/discriminate.py"),
+                         "discriminate")
+        self.assertEqual(self.rg.normalize_tool_name("discriminate.py"), "discriminate")
+        self.assertEqual(self.rg.normalize_tool_name(""), "")
+        self.assertEqual(self.rg.normalize_tool_name(None), "")
+
+
+class FoldPreflightTests(LoadMixin):
+    def test_none_and_empty_are_ok(self):
+        for raw in (None, [], {}, {"audits": []}):
+            folded = self.rg.fold_preflight(raw)
+            self.assertTrue(folded["ok"], raw)
+            self.assertFalse(folded["failed"], raw)
+            self.assertEqual(folded["reasons"], [])
+
+    def test_discriminate_row(self):
+        folded = self.rg.fold_preflight({"tool": "discriminate.py", "exit": 1})
+        self.assertFalse(folded["ok"])
+        self.assertEqual(folded["reasons"], ["discriminate-fail"])
+        self.assertEqual(folded["audits"][0]["tool"], "discriminate")
+
+    def test_list_of_audits(self):
+        folded = self.rg.fold_preflight([
+            {"tool": "discriminate.py", "exit": 0},
+            {"tool": "trajectory.py", "exit": 1},
+        ])
+        self.assertEqual(folded["reasons"], ["trajectory-fail"])
+        self.assertFalse(folded["ok"])
+
+    def test_ok_false_dict(self):
+        folded = self.rg.fold_preflight({"ok": False, "reason": "discriminate-fail"})
+        self.assertEqual(folded["reasons"], ["discriminate-fail"])
+        self.assertTrue(folded["failed"])
+
+    def test_garbage_input_is_audit_fail(self):
+        folded = self.rg.fold_preflight("not-a-structure")
+        self.assertTrue(folded["failed"])
+        self.assertEqual(folded["reasons"], ["audit-fail"])
+
+    def test_non_dict_row(self):
+        folded = self.rg.fold_preflight(["x"])
+        self.assertEqual(folded["reasons"], ["audit-fail"])
+
+
+class MapDiffTests(LoadMixin):
+    def test_three_way(self):
+        self.assertEqual(self.rg.map_diff_classification("stable"), "stable")
+        self.assertEqual(self.rg.map_diff_classification("regression"), "regression")
+        self.assertEqual(self.rg.map_diff_classification("surface-changed"), "surface-changed")
+
+    def test_skipped_and_probe_failed(self):
+        self.assertEqual(self.rg.map_diff_classification("skipped"), "missing-old-bin")
+        self.assertEqual(self.rg.map_diff_classification("probe-failed"), "probe-failed")
+
+    def test_invalid_values(self):
+        self.assertEqual(self.rg.map_diff_classification(None), "diff-report-invalid")
+        self.assertEqual(self.rg.map_diff_classification(""), "diff-report-invalid")
+        self.assertEqual(self.rg.map_diff_classification(3), "diff-report-invalid")
+        self.assertEqual(self.rg.map_diff_classification("mystery"), "unexpected")
+
+    def test_surface_wins_over_regression_flag(self):
+        # 오라클이 실수로 regression + surfaceChanged 를 내도 게이트는 review.
+        self.assertEqual(
+            self.rg.surface_wins_over_regression("regression", True, 4),
+            "surface-changed",
+        )
+        self.assertEqual(
+            self.rg.surface_wins_over_regression("stable", True, 0),
+            "surface-changed",
+        )
+        self.assertEqual(
+            self.rg.surface_wins_over_regression("regression", False, 4),
+            "regression",
+        )
+        self.assertEqual(
+            self.rg.surface_wins_over_regression("surface-changed", False, 0),
+            "surface-changed",
+        )
+
+
+class DecideVerdictTests(LoadMixin):
+    """우선순위 표 — 이슈가 지목한 네 예외 경로가 여기서 갈린다."""
+
+    CASES = (
+        # diff_reason, board_ok, preflight, verdict, exit, reason
+        ("stable", None, None, "pass", 0, "stable"),
+        ("missing-old-bin", None, None, "pass", 0, "missing-old-bin"),
+        ("skipped", None, None, "pass", 0, "skipped"),
+        ("missing-new-bin", None, None, "fail", 1, "missing-new-bin"),
+        ("discriminate-fail", None, None, "fail", 1, "discriminate-fail"),
+        ("probe-failed", None, None, "fail", 1, "probe-failed"),
+        ("diff-report-missing", None, None, "fail", 1, "diff-report-missing"),
+        ("diff-report-invalid", None, None, "fail", 1, "diff-report-invalid"),
+        ("surface-changed", None, None, "review", 2, "surface-changed"),
+        ("regression", None, None, "block", 3, "regression"),
+        ("stable", False, None, "block", 3, "leaderboard-broken"),
+        ("surface-changed", False, None, "block", 3, "leaderboard-broken"),
+        ("regression", False, None, "block", 3, "regression"),
+        ("stable", None, ["discriminate-fail"], "fail", 1, "discriminate-fail"),
+        ("regression", None, ["discriminate-fail"], "fail", 1, "discriminate-fail"),
+        ("surface-changed", None, ["discriminate-fail"], "fail", 1, "discriminate-fail"),
+        ("missing-new-bin", None, ["discriminate-fail"], "fail", 1, "discriminate-fail"),
+        ("missing-old-bin", True, None, "pass", 0, "missing-old-bin"),
+        ("stable", True, None, "pass", 0, "stable"),
+    )
+
+    def test_matrix(self):
+        for diff, board, pre, verdict, exit_code, reason in self.CASES:
+            with self.subTest(diff=diff, board=board, pre=pre):
+                d = self.rg.decide_verdict(diff, board, pre)
+                self.assertEqual(d["verdict"], verdict)
+                self.assertEqual(d["exit"], exit_code)
+                self.assertEqual(d["reason"], reason)
+                self.assertEqual(d["ok"], verdict == "pass")
+                self.assertEqual(d["reviewRequired"], verdict == "review")
+                self.assertEqual(d["blocked"], verdict == "block")
+                self.assertEqual(d["failed"], verdict == "fail")
+
+    def test_surface_changed_is_never_block_without_board(self):
+        d = self.rg.decide_verdict("surface-changed", None, None)
+        self.assertEqual(d["verdict"], "review")
+        self.assertNotEqual(d["verdict"], "block")
+        self.assertEqual(d["exit"], 2)
+
+    def test_regression_is_never_review(self):
+        d = self.rg.decide_verdict("regression", None, None)
+        self.assertEqual(d["verdict"], "block")
+        self.assertNotEqual(d["verdict"], "review")
+        self.assertEqual(d["exit"], 3)
+
+    def test_discriminate_fail_is_never_regression_or_review(self):
+        d = self.rg.decide_verdict("stable", None, ["discriminate-fail"])
+        self.assertEqual(d["verdict"], "fail")
+        self.assertEqual(d["exit"], 1)
+        self.assertNotEqual(d["reason"], "regression")
+        self.assertNotEqual(d["reason"], "surface-changed")
+
+    def test_missing_old_is_not_missing_new(self):
+        old = self.rg.decide_verdict("missing-old-bin", None, None)
+        new = self.rg.decide_verdict("missing-new-bin", None, None)
+        self.assertEqual(old["verdict"], "pass")
+        self.assertEqual(new["verdict"], "fail")
+        self.assertNotEqual(old["exit"], new["exit"])
+
+    def test_empty_reasons_default_to_stable(self):
+        d = self.rg.decide_verdict(None, None, None)
+        self.assertEqual((d["verdict"], d["exit"]), ("pass", 0))
+
+
+class ValidateVerdictTests(LoadMixin):
+    def _base(self, **over):
+        v = {
+            "kind": "gymReleaseGate",
+            "schemaVersion": "1.0",
+            "diff": {"classification": "stable"},
+            "leaderboard": {"ok": None},
+            "verdict": "pass",
+            "exit": 0,
+            "reason": "stable",
+            "ok": True,
+            "reviewRequired": False,
+            "blocked": False,
+            "failed": False,
+        }
+        v.update(over)
+        return v
+
+    def test_clean_pass(self):
+        self.assertEqual(self.rg.validate_verdict(self._base()), [])
+
+    def test_not_dict(self):
+        self.assertTrue(self.rg.validate_verdict("x"))
+
+    def test_wrong_kind(self):
+        issues = self.rg.validate_verdict(self._base(kind="nope"))
+        self.assertTrue(any("kind" in i for i in issues))
+
+    def test_pass_cannot_wear_regression(self):
+        issues = self.rg.validate_verdict(self._base(reason="regression"))
+        self.assertTrue(issues)
+
+    def test_review_must_be_surface_changed(self):
+        issues = self.rg.validate_verdict(self._base(
+            verdict="review", exit=2, reason="regression",
+            ok=False, reviewRequired=True, blocked=False, failed=False,
+        ))
+        self.assertTrue(any("review" in i for i in issues))
+
+    def test_block_cannot_be_surface_changed(self):
+        issues = self.rg.validate_verdict(self._base(
+            verdict="block", exit=3, reason="surface-changed",
+            ok=False, reviewRequired=False, blocked=True, failed=False,
+        ))
+        self.assertTrue(issues)
+
+    def test_fail_cannot_wear_regression(self):
+        issues = self.rg.validate_verdict(self._base(
+            verdict="fail", exit=1, reason="regression",
+            ok=False, reviewRequired=False, blocked=False, failed=True,
+        ))
+        self.assertTrue(any("regression" in i for i in issues))
+
+    def test_probe_failed_cannot_pass(self):
+        issues = self.rg.validate_verdict(self._base(
+            diff={"classification": "probe-failed"},
+        ))
+        self.assertTrue(any("probe-failed" in i for i in issues))
+
+    def test_exit_mismatch(self):
+        issues = self.rg.validate_verdict(self._base(exit=3))
+        self.assertTrue(any("exit" in i for i in issues))
+
+    def test_flags_must_match_verdict(self):
+        issues = self.rg.validate_verdict(self._base(ok=False))
+        self.assertTrue(any("ok" in i for i in issues))
+
+
+class MissingBinGateTests(LoadMixin):
+    def test_missing_new_fails(self):
+        with mock.patch("os.path.exists", return_value=False):
+            v = self.rg.gate(None, "missing-new", "agent", None, verify_board=False)
+        self.assertEqual(v["verdict"], "fail")
+        self.assertEqual(v["exit"], 1)
+        self.assertEqual(v["reason"], "missing-new-bin")
+        self.assertNotEqual(v["verdict"], "pass")
+        self.assertNotEqual(v["verdict"], "block")
+
+    def test_missing_new_does_not_run_diff(self):
+        called = []
+
+        def fake(script, args):
+            called.append(script)
+            return (0, "")
+
+        with mock.patch("os.path.exists", return_value=False), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            self.rg.gate("old", "new", "agent", None, verify_board=False)
+        self.assertEqual(called, [])
+
+    def test_missing_old_with_present_new_passes(self):
+        def exists(path):
+            text = str(path).replace("\\", "/")
+            return "ledger.ndjson" not in text
+
+        with mock.patch("os.path.exists", side_effect=exists):
+            v = self.rg.gate(None, "new", "agent", None, verify_board=False)
+        self.assertEqual(v["verdict"], "pass")
+        self.assertEqual(v["diff"]["classification"], "skipped")
+        self.assertEqual(v["reason"], "missing-old-bin")
+
+    def test_empty_new_is_missing(self):
+        with mock.patch("os.path.exists", return_value=True):
+            v = self.rg.gate(None, "", "agent", None, verify_board=False)
+        self.assertEqual(v["reason"], "missing-new-bin")
+        self.assertEqual(v["exit"], 1)
+
+    def test_none_new_is_missing_when_find_bin_yields_absent(self):
+        with mock.patch("os.path.exists", return_value=False):
+            v = self.rg.gate(None, None, "agent", None, verify_board=False)
+        self.assertEqual(v["reason"], "missing-new-bin")
+
+    def test_missing_old_given_path_skips(self):
+        def exists(path):
+            text = str(path).replace("\\", "/")
+            if "ledger.ndjson" in text:
+                return False
+            # 구 경로만 없다. 신 후보는 있다.
+            if text.endswith("/old") or text.endswith("\\old") or text.endswith("old-bin"):
+                return False
+            if text.replace("\\", "/").endswith("old"):
+                return False
+            return True
+
+        with mock.patch.object(self.rg.runner, "find_bin", side_effect=lambda p: p), \
+                mock.patch("os.path.exists", side_effect=exists):
+            v = self.rg.gate("old-bin", "new", "agent", None, verify_board=False)
+        self.assertEqual(v["diff"]["classification"], "skipped")
+        self.assertEqual(v["verdict"], "pass")
+
+
+class DiscriminateFailGateTests(LoadMixin):
+    def _present(self, path):
+        return "ledger.ndjson" not in str(path).replace("\\", "/")
+
+    def test_discriminate_fail_is_fail_not_block(self):
+        with mock.patch("os.path.exists", side_effect=self._present):
+            v = self.rg.gate(
+                None, "new", "agent", None, verify_board=False,
+                preflight={"tool": "discriminate.py", "exit": 1},
+            )
+        self.assertEqual(v["verdict"], "fail")
+        self.assertEqual(v["exit"], 1)
+        self.assertEqual(v["reason"], "discriminate-fail")
+        self.assertNotEqual(v["verdict"], "block")
+        self.assertNotEqual(v["verdict"], "review")
+        self.assertNotEqual(v["verdict"], "pass")
+
+    def test_discriminate_ok_does_not_change_stable(self):
+        with mock.patch("os.path.exists", side_effect=self._present):
+            v = self.rg.gate(
+                None, "new", "agent", None, verify_board=False,
+                preflight={"tool": "discriminate.py", "exit": 0},
+            )
+        self.assertEqual(v["verdict"], "pass")
+
+    def test_discriminate_fail_beats_regression(self):
+        def fake(script, args):
+            out = args[args.index("-o") + 1]
+            with io.open(out, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({
+                    "classification": "regression",
+                    "divergences": 4,
+                    "surfaceChanged": False,
+                    "tasksCompared": 10,
+                }))
+            return (3, "")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            v = self.rg.gate(
+                "old", "new", "agent", None, verify_board=False,
+                preflight={"tool": "discriminate.py", "exit": 1},
+            )
+        self.assertEqual(v["reason"], "discriminate-fail")
+        self.assertEqual(v["exit"], 1)
+
+    def test_discriminate_fail_beats_surface_changed(self):
+        with mock.patch("os.path.exists", side_effect=self._present):
+            v = self.rg.gate(
+                None, "new", "agent", None, verify_board=False,
+                preflight={"tool": "discriminate.py", "exit": 1},
+            )
+        self.assertEqual(v["reason"], "discriminate-fail")
+        self.assertEqual(v["exit"], 1)
+
+    def test_preflight_is_not_a_cli_flag(self):
+        with self.assertRaises(SystemExit):
+            self.rg.parse_args(["--preflight", "discriminate"])
+
+
+class SurfaceVsRegressionGateTests(LoadMixin):
+    def _gate(self, classification, divergences, surface, board=False, board_exit=0):
+        def fake(script, args):
+            if script == "leaderboard.py":
+                return (board_exit, "board")
+            out = args[args.index("-o") + 1]
+            with io.open(out, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({
+                    "classification": classification,
+                    "divergences": divergences,
+                    "surfaceChanged": surface,
+                    "tasksCompared": 91,
+                }))
+            return (0, "")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            return self.rg.gate("old", "new", "agent", ["core-cli"], verify_board=board)
+
+    def test_stable(self):
+        v = self._gate("stable", 0, False)
+        self.assertEqual((v["verdict"], v["exit"], v["reason"]), ("pass", 0, "stable"))
+        self.assertEqual(self.rg.validate_verdict(v), [])
+
+    def test_regression(self):
+        v = self._gate("regression", 4, False)
+        self.assertEqual((v["verdict"], v["exit"], v["reason"]), ("block", 3, "regression"))
+        self.assertEqual(self.rg.validate_verdict(v), [])
+
+    def test_surface_changed_zero_div(self):
+        v = self._gate("surface-changed", 0, True)
+        self.assertEqual((v["verdict"], v["exit"]), ("review", 2))
+        self.assertEqual(v["reason"], "surface-changed")
+
+    def test_surface_changed_with_divergences_still_review(self):
+        v = self._gate("surface-changed", 70, True)
+        self.assertEqual(v["verdict"], "review")
+        self.assertNotEqual(v["verdict"], "block")
+        self.assertEqual(v["exit"], 2)
+
+    def test_mislabelled_regression_with_surface_flag_is_review(self):
+        v = self._gate("regression", 4, True)
+        self.assertEqual(v["verdict"], "review")
+        self.assertEqual(v["reason"], "surface-changed")
+
+    def test_probe_failed_is_fail(self):
+        v = self._gate("probe-failed", 0, False)
+        self.assertEqual(v["verdict"], "fail")
+        self.assertEqual(v["exit"], 1)
+        self.assertEqual(v["reason"], "probe-failed")
+        self.assertNotEqual(v["verdict"], "pass")
+
+    def test_surface_plus_broken_board_blocks(self):
+        v = self._gate("surface-changed", 0, True, board=True, board_exit=3)
+        self.assertEqual(v["verdict"], "block")
+        self.assertEqual(v["reason"], "leaderboard-broken")
+
+    def test_regression_plus_broken_board_still_blocks(self):
+        v = self._gate("regression", 2, False, board=True, board_exit=3)
+        self.assertEqual(v["verdict"], "block")
+        self.assertIn(v["reason"], ("regression", "leaderboard-broken"))
+
+
+class DiffReportExceptionTests(LoadMixin):
+    def test_missing_report_is_fail(self):
+        def fake(script, args):
+            return (1, "no report")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake), \
+                mock.patch.object(self.rg, "load_json_safe",
+                                  return_value=(None, {"kind": "diff-report-missing"})):
+            v = self.rg.gate("old", "new", "agent", None, verify_board=False)
+        self.assertEqual(v["verdict"], "fail")
+        self.assertIn(v["reason"], ("diff-report-missing", "diff-tool-error"))
+
+    def test_invalid_json_is_fail(self):
+        def fake(script, args):
+            out = args[args.index("-o") + 1]
+            with io.open(out, "w", encoding="utf-8") as fh:
+                fh.write("{not json")
+            return (0, "")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            v = self.rg.gate("old", "new", "agent", None, verify_board=False)
+        self.assertEqual(v["verdict"], "fail")
+        self.assertEqual(v["reason"], "diff-report-invalid")
+
+    def test_report_without_classification_is_fail(self):
+        def fake(script, args):
+            out = args[args.index("-o") + 1]
+            with io.open(out, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({"divergences": 0}))
+            return (0, "")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            v = self.rg.gate("old", "new", "agent", None, verify_board=False)
+        self.assertEqual(v["reason"], "diff-report-invalid")
+        self.assertEqual(v["exit"], 1)
+
+    def test_run_tool_oserror_is_fail(self):
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=OSError("boom")):
+            v = self.rg.gate("old", "new", "agent", None, verify_board=False)
+        self.assertEqual(v["verdict"], "fail")
+        self.assertEqual(v["reason"], "diff-tool-error")
+
+    def test_keyboard_interrupt_is_not_swallowed(self):
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                self.rg.gate("old", "new", "agent", None, verify_board=False)
+
+    def test_system_exit_is_not_swallowed(self):
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=SystemExit(2)):
+            with self.assertRaises(SystemExit):
+                self.rg.gate("old", "new", "agent", None, verify_board=False)
+
+
+class LeaderboardExceptionTests(LoadMixin):
+    def test_leaderboard_oserror_is_fail(self):
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=OSError("dead")):
+            v = self.rg.gate(None, "new", "agent", None, verify_board=True)
+        # old omitted → skip diff. leaderboard throws → fail, not pass.
+        self.assertEqual(v["verdict"], "fail")
+        self.assertEqual(v["reason"], "leaderboard-error")
+
+    def test_leaderboard_nonzero_is_block(self):
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", return_value=(3, "broken")):
+            v = self.rg.gate(None, "new", "agent", None, verify_board=True)
+        self.assertEqual(v["exit"], 3)
+        self.assertEqual(v["reason"], "leaderboard-broken")
+
+    def test_verify_board_false_skips_even_if_ledger_exists(self):
+        called = []
+
+        def fake(script, args):
+            called.append(script)
+            return (0, "")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            v = self.rg.gate(None, "new", "agent", None, verify_board=False)
+        self.assertEqual(called, [])
+        self.assertEqual(v["verdict"], "pass")
+
+
+class SummaryAndWriteTests(LoadMixin):
+    def test_render_summary_mentions_surface_honesty(self):
+        v = {
+            "verdict": "review", "exit": 2, "reason": "surface-changed",
+            "diff": {"classification": "surface-changed", "divergences": 2},
+            "leaderboard": {"ok": None, "reason": "생략"},
+            "old": {"status": "present"}, "new": {"status": "present"},
+            "preflight": {"audits": []},
+        }
+        text = "\n".join(self.rg.render_summary_lines(v))
+        self.assertIn("리뷰 신호", text)
+        self.assertIn("surface-changed", text)
+
+    def test_render_summary_mentions_discriminate(self):
+        v = {
+            "verdict": "fail", "exit": 1, "reason": "discriminate-fail",
+            "diff": {"classification": "unavailable"},
+            "leaderboard": {"ok": None},
+            "old": {"status": "omitted"}, "new": {"status": "present"},
+            "preflight": {"audits": [{"tool": "discriminate", "ok": False,
+                                      "reason": "discriminate-fail"}]},
+        }
+        text = "\n".join(self.rg.render_summary_lines(v))
+        self.assertIn("약한 오라클", text)
+        self.assertIn("discriminate", text)
+
+    def test_render_summary_mentions_missing_new(self):
+        v = {
+            "verdict": "fail", "exit": 1, "reason": "missing-new-bin",
+            "diff": {"classification": "unavailable"},
+            "leaderboard": {"ok": None},
+            "old": {"status": "omitted"}, "new": {"status": "missing"},
+            "preflight": {},
+        }
+        text = "\n".join(self.rg.render_summary_lines(v))
+        self.assertIn("신 바이너리 부재", text)
+
+    def test_write_verdict_roundtrip(self):
+        payload = {"kind": "gymReleaseGate", "verdict": "pass", "exit": 0}
+        fd, path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            err = self.rg.write_verdict_safe(payload, path)
+            self.assertIsNone(err)
+            raw = Path(path).read_bytes()
+            self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+            self.assertNotIn(b"\r\n", raw)
+            back = json.loads(raw.decode("utf-8"))
+            self.assertEqual(back["verdict"], "pass")
+        finally:
+            os.remove(path)
+
+    def test_write_verdict_oserror(self):
+        err = self.rg.write_verdict_safe({"a": 1}, os.path.join("no-such-dir", "x.json"))
+        self.assertIsNotNone(err)
+        self.assertEqual(err["context"], "write")
+
+    def test_github_summary_noop_without_env(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
+            self.assertIsNone(self.rg.write_github_summary({
+                "verdict": "pass", "exit": 0, "diff": {}, "leaderboard": {},
+            }))
+
+    def test_github_summary_appends(self):
+        fd, path = tempfile.mkstemp(suffix=".md")
+        os.close(fd)
+        try:
+            Path(path).write_text("head\n", encoding="utf-8")
+            with mock.patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": path}):
+                self.rg.write_github_summary({
+                    "verdict": "review", "exit": 2, "reason": "surface-changed",
+                    "diff": {"classification": "surface-changed"},
+                    "leaderboard": {"ok": True},
+                    "old": {"status": "present"}, "new": {"status": "present"},
+                    "preflight": {},
+                })
+            text = Path(path).read_text(encoding="utf-8")
+            self.assertIn("head", text)
+            self.assertIn("운동장 릴리스 게이트", text)
+            self.assertIn("review", text)
+        finally:
+            os.remove(path)
+
+
+class MainEntryTests(LoadMixin):
+    def test_main_missing_new_exits_1(self):
+        with mock.patch("os.path.exists", return_value=False):
+            code = self.rg.main(["--new", "no-such-bin", "--no-leaderboard"])
+        self.assertEqual(code, 1)
+
+    def test_main_writes_out(self):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            def exists(p):
+                return "ledger.ndjson" not in str(p).replace("\\", "/")
+
+            with mock.patch("os.path.exists", side_effect=exists):
+                code = self.rg.main(["--new", "new", "--no-leaderboard", "-o", path])
+            self.assertEqual(code, 0)
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertEqual(data["kind"], "gymReleaseGate")
+            self.assertEqual(data["verdict"], "pass")
+        finally:
+            os.remove(path)
+
+    def test_main_no_new_cli_flags(self):
+        with self.assertRaises(SystemExit):
+            self.rg.main(["--help-discriminate"])
+
+
+class ExtractDiffFieldTests(LoadMixin):
+    def test_happy(self):
+        fields, err = self.rg.extract_diff_fields({
+            "classification": "stable",
+            "divergences": 0,
+            "surfaceChanged": False,
+            "tasksCompared": 3,
+        })
+        self.assertIsNone(err)
+        self.assertEqual(fields["classification"], "stable")
+
+    def test_not_dict(self):
+        fields, err = self.rg.extract_diff_fields([1])
+        self.assertIsNone(fields)
+        self.assertEqual(err["kind"], "diff-report-invalid")
+
+    def test_missing_classification(self):
+        fields, err = self.rg.extract_diff_fields({"divergences": 0})
+        self.assertIsNotNone(err)
+
+
+class FindBinSafeTests(LoadMixin):
+    def test_delegates(self):
+        with mock.patch.object(self.rg.runner, "find_bin", return_value="/abs/rhwp"):
+            found, err = self.rg.find_bin_safe("rhwp")
+        self.assertEqual(found, "/abs/rhwp")
+        self.assertIsNone(err)
+
+    def test_oserror(self):
+        with mock.patch.object(self.rg.runner, "find_bin", side_effect=OSError("x")):
+            found, err = self.rg.find_bin_safe("rhwp")
+        self.assertIsNotNone(err)
+        self.assertEqual(err["kind"], "os-error")
+
+    def test_keyboard_interrupt(self):
+        with mock.patch.object(self.rg.runner, "find_bin", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                self.rg.find_bin_safe("rhwp")
+
+
+class HonestyMatrixGeneratedTests(LoadMixin):
+    """표면 × 분기 × 전제 × 원장 의 생성 표. 위장 조합이 없는지 전수."""
+
+    def test_no_disguise_in_generated_table(self):
+        surfaces = (False, True)
+        divergences = (0, 3)
+        pres = (None, ["discriminate-fail"])
+        boards = (None, True, False)
+        for surface in surfaces:
+            for div in divergences:
+                for pre in pres:
+                    for board in boards:
+                        if surface:
+                            cls = "surface-changed"
+                        elif div:
+                            cls = "regression"
+                        else:
+                            cls = "stable"
+                        reason = self.rg.surface_wins_over_regression(cls, surface, div)
+                        d = self.rg.decide_verdict(reason, board if board is not True else None,
+                                                   pre)
+                        if pre:
+                            self.assertEqual(d["verdict"], "fail", (cls, pre, board))
+                            self.assertEqual(d["exit"], 1)
+                            continue
+                        if board is False:
+                            self.assertEqual(d["verdict"], "block", (cls, board))
+                            continue
+                        if surface:
+                            self.assertEqual(d["verdict"], "review", (cls, div))
+                            self.assertEqual(d["exit"], 2)
+                        elif div:
+                            self.assertEqual(d["verdict"], "block")
+                            self.assertEqual(d["exit"], 3)
+                        else:
+                            self.assertEqual(d["verdict"], "pass")
+                            self.assertEqual(d["exit"], 0)
+
+
+class ResolveBinRecordTests(LoadMixin):
+    def test_none_is_omitted(self):
+        rec = self.rg.resolve_bin_record(None, "old")
+        self.assertEqual(rec["status"], "omitted")
+        self.assertEqual(rec["role"], "old")
+
+    def test_blank_is_omitted(self):
+        rec = self.rg.resolve_bin_record("   ", "new")
+        self.assertEqual(rec["status"], "omitted")
+
+    def test_present_when_exists(self):
+        with mock.patch.object(self.rg.runner, "find_bin", return_value="/abs/rhwp"), \
+                mock.patch("os.path.exists", return_value=True):
+            rec = self.rg.resolve_bin_record("rhwp", "new")
+        self.assertEqual(rec["status"], "present")
+        self.assertEqual(rec["resolved"], "/abs/rhwp")
+
+    def test_missing_when_not_exists(self):
+        with mock.patch.object(self.rg.runner, "find_bin", return_value="/no/rhwp"), \
+                mock.patch("os.path.exists", return_value=False):
+            rec = self.rg.resolve_bin_record("rhwp", "new")
+        self.assertEqual(rec["status"], "missing")
+        self.assertEqual(rec["reason"], "not-found")
+
+    def test_find_bin_error(self):
+        with mock.patch.object(self.rg.runner, "find_bin", side_effect=OSError("x")):
+            rec = self.rg.resolve_bin_record("rhwp", "new")
+        self.assertEqual(rec["status"], "error")
+
+
+class ValidateDisguiseTableTests(LoadMixin):
+    """문서 22절의 허용/거절 표를 기계로 다시 읽는다."""
+
+    ALLOWED = (
+        ("pass", "stable", 0),
+        ("pass", "missing-old-bin", 0),
+        ("pass", "skipped", 0),
+        ("review", "surface-changed", 2),
+        ("block", "regression", 3),
+        ("block", "leaderboard-broken", 3),
+        ("fail", "missing-new-bin", 1),
+        ("fail", "discriminate-fail", 1),
+        ("fail", "probe-failed", 1),
+        ("fail", "diff-report-missing", 1),
+        ("fail", "diff-report-invalid", 1),
+    )
+    REJECTED = (
+        ("pass", "regression", 0),
+        ("pass", "surface-changed", 0),
+        ("pass", "discriminate-fail", 0),
+        ("pass", "missing-new-bin", 0),
+        ("pass", "probe-failed", 0),
+        ("review", "regression", 2),
+        ("block", "surface-changed", 3),
+        ("block", "discriminate-fail", 3),
+        ("fail", "regression", 1),
+        ("fail", "surface-changed", 1),
+    )
+
+    def _envelope(self, verdict, reason, exit_code):
+        return {
+            "kind": "gymReleaseGate",
+            "schemaVersion": "1.0",
+            "diff": {"classification": reason if reason != "leaderboard-broken" else "skipped"},
+            "leaderboard": {"ok": None},
+            "verdict": verdict,
+            "exit": exit_code,
+            "reason": reason,
+            "ok": verdict == "pass",
+            "reviewRequired": verdict == "review",
+            "blocked": verdict == "block",
+            "failed": verdict == "fail",
+        }
+
+    def test_allowed_rows_are_clean(self):
+        for verdict, reason, exit_code in self.ALLOWED:
+            issues = self.rg.validate_verdict(self._envelope(verdict, reason, exit_code))
+            self.assertEqual(issues, [], (verdict, reason, issues))
+
+    def test_rejected_rows_are_dirty(self):
+        for verdict, reason, exit_code in self.REJECTED:
+            issues = self.rg.validate_verdict(self._envelope(verdict, reason, exit_code))
+            self.assertTrue(issues, (verdict, reason))
+
+
+class PacksForwardedTests(LoadMixin):
+    def test_pack_flags_are_forwarded_to_release_diff(self):
+        seen = []
+
+        def fake(script, args):
+            seen.append((script, list(args)))
+            out = args[args.index("-o") + 1]
+            with io.open(out, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({
+                    "classification": "stable",
+                    "divergences": 0,
+                    "surfaceChanged": False,
+                    "tasksCompared": 1,
+                }))
+            return (0, "")
+
+        with mock.patch("os.path.exists", return_value=True), \
+                mock.patch.object(self.rg, "run_tool", side_effect=fake):
+            v = self.rg.gate("old", "new", "agent", ["core-cli", "security"],
+                             verify_board=False)
+        self.assertEqual(v["verdict"], "pass")
+        _script, args = seen[0]
+        self.assertIn("--pack", args)
+        self.assertIn("core-cli", args)
+        self.assertIn("security", args)
+        self.assertNotIn("automation", args)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/scripts/tests/test_gym_release_gate_workflow.py
+++ b/scripts/tests/test_gym_release_gate_workflow.py
@@ -73,6 +73,78 @@ class ReleaseGateWorkflowTests(unittest.TestCase):
         gate_at = self.wf.index("release_gate.py")
         self.assertLess(audit_at, gate_at, "트라젝토리 감사가 게이트보다 먼저 배선돼야 한다")
 
+    def test_discriminate_runs_on_the_new_binary_only(self):
+        """판별 감사는 현재 릴리스 바이너리만 본다. --old 를 넘기지 않는다.
+
+        약한 오라클은 '지금 벤치가 일을 거부하는가' 이지 '두 바이너리가
+        같은가' 가 아니다. 구 바이너리를 넣으면 차등과 겹친다.
+        """
+        # 감사 스텝 본문에 --old 가 없어야 한다. 게이트 스텝은 --old 를 쓴다.
+        audit_at = self.wf.index("Discrimination audit")
+        gate_at = self.wf.index("Run release gate")
+        audit_block = self.wf[audit_at:gate_at]
+        self.assertIn("discriminate.py", audit_block)
+        self.assertIn("target/debug/rhwp", audit_block)
+        self.assertNotIn("--old", audit_block)
+
+    def test_discriminate_failure_fails_the_job_before_gate(self):
+        """판별 실패는 워크플로 기본 동작으로 잡을 닫는다.
+
+        continue-on-error 가 있으면 exit 1 이 게이트까지 흘러가지 않고,
+        약한 오라클이 있는 릴리스가 차등만 통과해 나갈 수 있다.
+        """
+        audit_at = self.wf.index("Discrimination audit")
+        gate_at = self.wf.index("Run release gate")
+        audit_block = self.wf[audit_at:gate_at]
+        self.assertNotIn("continue-on-error", audit_block)
+        self.assertNotIn("|| true", audit_block)
+
+    def test_gate_step_does_not_swallow_nonzero(self):
+        """게이트 스텝도 종료 코드를 삼키지 않는다. review(2)/block(3) 이
+        워크플로 실패로 보여야 사람이 본다. fail(1) 도 같다.
+        """
+        gate_at = self.wf.index("Run release gate")
+        upload_at = self.wf.index("Upload verdict")
+        gate_block = self.wf[gate_at:upload_at]
+        self.assertNotIn("continue-on-error", gate_block)
+        self.assertNotIn("|| true", gate_block)
+
+    def test_upload_verdict_runs_even_when_gate_fails(self):
+        """판정이 fail/block 이어도 봉투를 올려야 리뷰어가 이유를 본다."""
+        self.assertIn("if: always()", self.wf)
+        self.assertIn("gate-verdict.json", self.wf)
+        self.assertIn("gym-release-gate-verdict", self.wf)
+
+    def test_old_ref_empty_skips_old_build_not_the_gate(self):
+        """old_ref 가 비면 구 바이너리 빌드만 생략한다. 게이트는 --new 만으로 돈다."""
+        self.assertIn("if: ${{ github.event.inputs.old_ref != '' }}", self.wf)
+        self.assertIn("--new target/debug/rhwp", self.wf)
+
+    def test_concurrency_cancels_in_progress(self):
+        self.assertIn("cancel-in-progress: true", self.wf)
+        self.assertIn("gym-release-gate-${{ github.ref }}", self.wf)
+
+    def test_does_not_add_write_permissions(self):
+        """게이트는 판정만 한다. pull-requests: write 같은 권한이 생기면 침습이다."""
+        self.assertNotIn("pull-requests: write", self.wf)
+        self.assertNotIn("contents: write", self.wf)
+        self.assertNotIn("id-token: write", self.wf)
+
+    def test_runner_docs_exist(self):
+        """#5259 문서 계약 — 규약과 작업 기록이 커밋되어 있어야 한다."""
+        docs = REPO_ROOT / "gym/docs/release_gate.md"
+        working = REPO_ROOT / "mydocs/working/gym_release_gate.md"
+        self.assertTrue(docs.is_file(), "gym/docs/release_gate.md 이 없다")
+        self.assertTrue(working.is_file(), "mydocs/working/gym_release_gate.md 이 없다")
+        text = docs.read_text(encoding="utf-8")
+        for needle in ("missing-old-bin", "missing-new-bin", "discriminate-fail",
+                       "surface-changed", "regression"):
+            self.assertIn(needle, text, needle)
+
+    def test_workflow_comment_states_honesty_clause(self):
+        self.assertIn("어느 쪽이 옳은가", self.wf)
+        self.assertIn("regression 만 차단", self.wf)
+
 
 class GateRunnerContractTests(unittest.TestCase):
     """러너의 판정 계약 — 종료 코드가 게이트 의미론과 일치하는지."""
@@ -136,11 +208,20 @@ class GateRunnerContractTests(unittest.TestCase):
 
     def test_missing_old_binary_skips_diff_not_fail(self):
         from unittest import mock
-        # old 경로가 없으면(find_bin 이 그대로 반환, exists=False) 차등은 skipped.
-        with mock.patch("os.path.exists", return_value=False):
+        # 구 바이너리 부재는 차등 생략이지 실패가 아니다.
+        # 신 바이너리까지 없다고 목하면 그 경로가 이긴다 — 이 시험은
+        # missing-old 만 분리한다. 신 경로는 있다고 본다.
+        def exists(path):
+            text = str(path).replace("\\", "/")
+            if "ledger.ndjson" in text:
+                return False
+            return True
+
+        with mock.patch("os.path.exists", side_effect=exists):
             v = self.rg.gate(None, "new", "agent", None, verify_board=False)
         self.assertEqual(v["diff"]["classification"], "skipped")
         self.assertEqual(v["verdict"], "pass")
+        self.assertEqual(v["reason"], "missing-old-bin")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

릴리스 게이트가 구/신 바이너리 부재, 판별 감사 실패, surface-changed/regression 을 같은 판정으로 접지 않도록 예외 경로를 닫는다. 새 CLI/pack 은 없다.

- 구 바이너리 부재는 차등 생략(pass). 신 바이너리 부재는 fail(1). 둘을 대칭으로 위장하지 않는다.
- 판별 감사 실패는 fail(1). regression(3) 이나 review(2) 로 부르지 않는다. 워크플로가 게이트보다 먼저 막는다.
- surface-changed 는 review. regression 은 block. 표면 플래그가 있으면 관측 분기를 회귀로 읽지 않는다.
- probe-failed / 깨진 차등 보고 / 도구 예외는 pass 가 아니라 fail 이다.
- CLI 플래그는 그대로다. discriminate.py, trajectory.py, fuzz_corpus.py, automation/core-cli/casual-rides, 열린 PR 파일은 열지 않았다.

## 관련 이슈

closes #5259

## 테스트

- [x] python -m unittest scripts.tests.test_gym_release_gate_workflow scripts.tests.test_gym_release_gate_exceptions -q — 123 ran, 0 failed
- [x] python gym/tools/audit.py — 18 pack 통과
- [ ] cargo fmt --all -- --check 통과 (이번 변경은 Python/문서만. 사용자 지시에 따라 생략)
- [ ] node scripts/rust-test-suite-manifest.mjs --check 통과 (해당 없음)
- [ ] node scripts/rust-unit-test-tiers.mjs --check 통과 (해당 없음)
- [ ] cargo test 통과 (해당 없음)
- [ ] cargo clippy -- -D warnings 통과 (해당 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 단위 시험은 바이너리 없이 돈다. 라이브 스윕은 기존 워크플로가 담당한다.
