### PR TITLE
feat(gym): expert-challenges XC06+ 보스 여정 확장

### DIFF
--- a/gym/packs/expert-challenges/README.md
+++ b/gym/packs/expert-challenges/README.md
@@ -1,0 +1,212 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/expert-challenges/README.md
+last_verified: 2026-08-18
+---
+
+# expert-challenges — 보스 어트랙션 (고난도 완주)
+
+## 왜 이 pack 인가
+
+놀이공원 한쪽 끝의 급류·자이로드롭이다. 검증 사다리의 여러 단을 **한 제출**에
+묶고, 어느 한 단계만 빠지면 최종 판정이 막힌다. 부분 점수가 없다.
+
+devel 에 이미 있던 XC01–XC05 는 개장 보스 다섯 대다.
+
+| ID | 개장 보스 | 이 확장이 복제하지 않는 지문 |
+|----|-----------|------------------------------|
+| XC01 | 사다리 완주 L5 | `conformance --level L5 --deep` + 원장 |
+| XC02 | 오염 리콜 드릴 | `unaffected==0` 과 `affected>=2` 동시 |
+| XC03 | 정산 완주 4관문 | capsuleOk · gateOk · ledgerOk · workorderOk |
+| XC04 | 계보 완주 3세대 | `lineage --deep` + `depth==3` |
+| XC05 | 감사 표준 L3 | `L3 --deep` + `audit-report` |
+
+이 확장(XC06–XC55)은 그 다섯 지문을 베끼지 않는다. 깊이 4·5, 중간 오염,
+분기 형제, L4 게이트(원장 없음), 청구 verdict 만, 끝칸+계보 동시처럼
+**다른 묶음**만 둔다. AU14+ 한 축 저티어 여정, WR 일일 3해시, T07 서식
+채움(`fields[0]==홍길동`)도 복제하지 않는다.
+
+권위 출처: `mydocs/manual/cli_commands.md` §계획 실행·증명·감사,
+스킬 `rhwp-work-receipt`, 에이전트 작업 표준 AW-L1~AW-L5.
+
+## 이 확장이 지키는 규칙
+
+1. **기존 명령만.** `pack.json` requires 는 `keygen` · `replay` · `run` ·
+   `anchor` · `settle` · `conformance` · `recall-scope` · `lineage` ·
+   `audit-report` · `export-tables` 이다. 서식 채움·필드 조사·inspect·scan
+   을 채점 명령으로 부르지 않는다.
+2. **기존 연산자만.** `gym/core/checks.py` REGISTRY 에 있는 것만 고른다.
+   `value_eq` · `value_ge` · `len_ge` · `file_exists` · `files_differ` ·
+   `differs_from_input` · `cell_text_eq` 가 전부다. 새 연산자를 만들지 않는다.
+3. **기존 표본만.** `samples/` 밖 파일을 만들지 않는다. table-001,
+   table-004, multi-table-001/002, inner-table-01, hwp_table_test,
+   table-complex, hwpx/basic-table-01 — 이미 있는 실문서를 보스 묶음으로
+   다시 묻는다.
+4. **라이브 오라클.** 해시·건수를 과제에 박제하지 않는다. 채점기가 같은
+   명령을 다시 돌려 봉투 필드를 읽는다.
+5. **T07 을 복제하지 않는다.** 서식 채움·첫 필드 홍길동은 core-cli 의
+   일이다. 이 pack 은 누름틀을 채우지 않는다.
+6. **XC01–XC05 를 복제하지 않는다.** 위 표의 지문을 그대로 옮기지 않는다.
+7. **AU14+ · WR01+ 를 복제하지 않는다.** 한 축 저티어 여정과 일일 영수증
+   3해시 answer.json 은 다른 pack 의 일이다.
+8. **runner 를 복사만 한다.** `pack.json` 의 `rhwpVersion` · `rhwpCommit` ·
+   `capabilitiesSha256` 을 바꾸지 않는다. 이 확장은 바이너리를 바꾸지 않는다.
+9. **원본을 덮지 않는다.** 산출은 제출 폴더의 `-o` / `--capsule` 뿐이다.
+
+## 명령 표면 (pack.json requires)
+
+| 명령 | 하는 일 | 이 확장에서 읽는 봉투 |
+|------|---------|------------------------|
+| `lineage` | 머리→뿌리 계보 | `valid` · `depth` (4 또는 5, 3 금지) |
+| `recall-scope` | 오염 후손 폐쇄 | `affected` (unaffected 와 묶지 않음) |
+| `conformance` | L2 / L4 자가진단 | `verdict` (L5·L3 --deep 콤보 금지) |
+| `settle verify` | 청구 3해시 | `verdict==ok` (4관문 path 금지) |
+| `settle record` | 원장 기입 | `file_exists` ledger (관문 path 없음) |
+| `audit-report` | 감사 보고서 | `lineage.valid` (L3 와 묶지 않음) |
+| `anchor verify` | 등재 | `logged` |
+| `export-tables` | 표 좌표 텍스트 | `cell_text_eq` |
+| `keygen` · `replay` · `run` | 기준풀이 산출 | 채점 명령이 아님 |
+
+`--deep` 은 4·5세대 계보와 L2/L4 재현에만 쓴다. 3세대 계보와 L3/L5
+완주에는 붙이지 않는다.
+
+## 함정 (실측, 과제에 녹여 둔 것)
+
+- **3대에서 멈추면 깊이 4가 아니다.** XC06·XC18 은 네 대를 잇는다.
+- **중간 세대를 오염으로 지목하면 뿌리와 건수가 다르다.** XC13·XC35·XC49.
+- **형제는 직선이 아니다.** XC15·XC44·XC52 는 같은 부모에서 갈라진다.
+- **L4 는 원장이 없다.** L5 로 올리면 `--ledger` 가 필수다 (XC16·XC50).
+- **얕은 L4 정책은 lineageValid** 다. reproduced 를 요구하면 재료 미지정으로
+  거부된다 (XC17).
+- **서로 무관한 캡슐은 리콜 영향권이 1** 이다. 부모 링크가 필요하다.
+- **비밀키를 제출하지 마라.** 키링에는 공개키만 넣는다.
+- **T07 금지.** 누름틀 값을 넣지 마라.
+
+## 과제 지도
+
+난도 4=고급 · 5=보스. XC01–XC05 는 그대로 둔다. 번호 구멍 없음 (1…55).
+
+### XC01–XC05 — 개장 보스 (devel 에 이미 있음)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC01 | 5 | L5 완주 | table-001 |
+| XC02 | 5 | 오염 무영향 0 + 영향 2+ | table-001 |
+| XC03 | 4 | 정산 4관문 + 원장 | table-001 |
+| XC04 | 4 | 3세대 lineage --deep | table-001 |
+| XC05 | 5 | L3 --deep + 감사 표준 | table-001 |
+
+### XC06–XC10 — 깊은·얕은 계보 (깊이 4·5, 3 금지)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC06 | 5 | 4세대 깊은 계보 | table-001 |
+| XC07 | 5 | 5세대 깊은 계보 | table-001 |
+| XC08 | 4 | 4세대 얕은 계보 | table-004 |
+| XC09 | 4 | 5세대 얕은 계보 | multi-table-001 |
+| XC10 | 4 | 내부표 4세대 유효만 (깊이 숫자 고정 없음) | inner-table-01 |
+
+### XC11–XC15 — 리콜 (unaffected 콤보 금지)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC11 | 5 | 4세대 뿌리 리콜 4건+ | table-001 |
+| XC12 | 5 | 5세대 뿌리 리콜 5건+ | table-004 |
+| XC13 | 5 | 중간 세대 오염 폐쇄 3건+ | multi-table-001 |
+| XC14 | 4 | 잎 캡슐만 회수 | inner-table-01 |
+| XC15 | 5 | 형제 분기 뿌리 리콜 3건+ | table-001 |
+
+### XC16–XC20 — L4 / L2 (L5·L3 콤보 금지)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC16 | 5 | L4 --deep 4세대 게이트 | table-001 |
+| XC17 | 4 | L4 얕은 4세대 (lineageValid 정책) | table-004 |
+| XC18 | 5 | L4 와 4세대 계보 동시 | multi-table-001 |
+| XC19 | 4 | L2 --deep 과 4세대 계보 | inner-table-01 |
+| XC20 | 5 | L4 와 4세대 리콜 동시 | table-001 |
+
+### XC21–XC25 — 서명·앵커·보고 (L3 콤보 금지)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC21 | 5 | 서명 4세대 깊은 계보 | hwp_table_test |
+| XC22 | 4 | 쌍 캡슐 각각 앵커 | table-004 |
+| XC23 | 5 | 4연속 앵커와 계보 | multi-table-001 |
+| XC24 | 4 | 감사보고와 4세대 계보 | table-001 |
+| XC25 | 4 | 감사보고와 4세대 리콜 | inner-table-01 |
+
+### XC26–XC30 — 정산 (4관문 금지)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC26 | 5 | 청구 verdict 와 4세대 계보 | table-001 |
+| XC27 | 4 | 원장 실재와 4세대 계보 | table-004 |
+| XC28 | 5 | 청구 verdict 와 4세대 리콜 | multi-table-001 |
+| XC29 | 5 | 청구 verdict 와 L4 | table-001 |
+| XC30 | 4 | 청구 검증과 4세대 유효 | hwpx/basic-table-01 |
+
+### XC31–XC40 — 표본을 옮긴 보스
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC31 | 5 | 표사 4세대 깊은 계보 | table-004 |
+| XC32 | 5 | 다중표 4세대 리콜 | multi-table-001 |
+| XC33 | 5 | 내부표 L4 깊은 게이트 | inner-table-01 |
+| XC34 | 5 | 표시험 5세대 깊은 계보 | hwp_table_test |
+| XC35 | 5 | 복합표 중간 오염 폐쇄 | table-complex |
+| XC36 | 5 | HWPX 4세대 깊은 계보 | hwpx/basic-table-01 |
+| XC37 | 5 | 표사 L4 깊은 4세대 | table-004 |
+| XC38 | 5 | 다중표2 5세대 리콜 | multi-table-002 |
+| XC39 | 5 | 내부표 정산과 4세대 | inner-table-01 |
+| XC40 | 4 | 표사 감사보고와 4세대 | table-004 |
+
+### XC41–XC45 — 끝칸·분기 산출
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC41 | 5 | 4세대 끝칸과 깊은 계보 | table-001 |
+| XC42 | 5 | 5세대 끝칸과 리콜 | table-004 |
+| XC43 | 5 | 표사 끝칸 서명 4세대 | table-004 |
+| XC44 | 4 | 분기 두 잎 산출 상이 | table-001 |
+| XC45 | 4 | 4세대 원본 차이와 계보 | multi-table-002 |
+
+### XC46–XC55 — 혼합 보스
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| XC46 | 4 | 독립 두 사슬 각각 유효 | table-001 |
+| XC47 | 5 | 쌍 사슬 L4 깊은 게이트 | inner-table-01 |
+| XC48 | 5 | 원장·보고·4세대 동시 | table-001 |
+| XC49 | 5 | 5세대 중간 오염과 계보 | hwp_table_test |
+| XC50 | 5 | L4 리콜 4세대 서명 완주 (L5 아님) | table-001 |
+| XC51 | 5 | 끝칸과 L4 4세대 동시 | multi-table-001 |
+| XC52 | 5 | 세 갈래 뿌리 리콜 | table-001 |
+| XC53 | 4 | L2 재현 5세대 끝칸 | table-complex |
+| XC54 | 5 | 5연속 앵커와 5세대 계보 | table-004 |
+| XC55 | 5 | 표사 정산 L4 4세대 | table-004 |
+
+## 재현
+
+기준 풀이 왕복은 저장소 단독으로 돈다.
+
+```text
+python gym/tools/build_baseline.py --agent baseline --pack expert-challenges
+python gym/score.py --agent baseline --pack expert-challenges
+python gym/tools/audit.py
+python scripts/tests/test_gym_packs.py
+python scripts/tests/test_gym_expert_challenges_pack.py
+```
+
+바이너리 없이 구조 감사와 pack 가드는 파일만으로 통과한다. 기준풀이 왕복은
+로컬 `rhwp` 가 있을 때 돌린다.
+
+## 이 확장이 하지 않는 것
+
+- 새 CLI · 새 연산자 · 새 표본 · 새 pack
+- `pack.json` runner 신원 변경
+- `gym/README.md` · `gym/PARK.md` · `profiles/*.json` 집계 갱신
+- 다른 pack 의 과제 파일
+- `cargo fmt --all` (JSON·문서·테스트만)
+- T07 / AU14+ / WR / XC01–XC05 복제

--- a/gym/packs/expert-challenges/reference/XC06.json
+++ b/gym/packs/expert-challenges/reference/XC06.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC06",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC06\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC06\"}]}",
+        "--capsule",
+        "{sub:spine/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC06\"}]}",
+        "--capsule",
+        "{sub:spine/g1.capsule.json}",
+        "--parent",
+        "{sub:spine/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC06\"}]}",
+        "--capsule",
+        "{sub:spine/g2.capsule.json}",
+        "--parent",
+        "{sub:spine/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC06\"}]}",
+        "--capsule",
+        "{sub:spine/g3.capsule.json}",
+        "--parent",
+        "{sub:spine/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC07.json
+++ b/gym/packs/expert-challenges/reference/XC07.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC07",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC07\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC07\"}]}",
+        "--capsule",
+        "{sub:tower/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC07\"}]}",
+        "--capsule",
+        "{sub:tower/g1.capsule.json}",
+        "--parent",
+        "{sub:tower/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC07\"}]}",
+        "--capsule",
+        "{sub:tower/g2.capsule.json}",
+        "--parent",
+        "{sub:tower/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC07\"}]}",
+        "--capsule",
+        "{sub:tower/g3.capsule.json}",
+        "--parent",
+        "{sub:tower/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC07\"}]}",
+        "--capsule",
+        "{sub:tower/g4.capsule.json}",
+        "--parent",
+        "{sub:tower/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC08.json
+++ b/gym/packs/expert-challenges/reference/XC08.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC08",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC08\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC08\"}]}",
+        "--capsule",
+        "{sub:rail/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC08\"}]}",
+        "--capsule",
+        "{sub:rail/g1.capsule.json}",
+        "--parent",
+        "{sub:rail/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC08\"}]}",
+        "--capsule",
+        "{sub:rail/g2.capsule.json}",
+        "--parent",
+        "{sub:rail/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC08\"}]}",
+        "--capsule",
+        "{sub:rail/g3.capsule.json}",
+        "--parent",
+        "{sub:rail/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC09.json
+++ b/gym/packs/expert-challenges/reference/XC09.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC09",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC09\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC09\"}]}",
+        "--capsule",
+        "{sub:climb/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC09\"}]}",
+        "--capsule",
+        "{sub:climb/g1.capsule.json}",
+        "--parent",
+        "{sub:climb/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC09\"}]}",
+        "--capsule",
+        "{sub:climb/g2.capsule.json}",
+        "--parent",
+        "{sub:climb/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC09\"}]}",
+        "--capsule",
+        "{sub:climb/g3.capsule.json}",
+        "--parent",
+        "{sub:climb/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC09\"}]}",
+        "--capsule",
+        "{sub:climb/g4.capsule.json}",
+        "--parent",
+        "{sub:climb/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC10.json
+++ b/gym/packs/expert-challenges/reference/XC10.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC10",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC10\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC10\"}]}",
+        "--capsule",
+        "{sub:beam/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC10\"}]}",
+        "--capsule",
+        "{sub:beam/g1.capsule.json}",
+        "--parent",
+        "{sub:beam/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC10\"}]}",
+        "--capsule",
+        "{sub:beam/g2.capsule.json}",
+        "--parent",
+        "{sub:beam/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC10\"}]}",
+        "--capsule",
+        "{sub:beam/g3.capsule.json}",
+        "--parent",
+        "{sub:beam/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC11.json
+++ b/gym/packs/expert-challenges/reference/XC11.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC11",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC11\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC11\"}]}",
+        "--capsule",
+        "{sub:web/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC11\"}]}",
+        "--capsule",
+        "{sub:web/g1.capsule.json}",
+        "--parent",
+        "{sub:web/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC11\"}]}",
+        "--capsule",
+        "{sub:web/g2.capsule.json}",
+        "--parent",
+        "{sub:web/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC11\"}]}",
+        "--capsule",
+        "{sub:web/g3.capsule.json}",
+        "--parent",
+        "{sub:web/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC12.json
+++ b/gym/packs/expert-challenges/reference/XC12.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC12",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC12\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC12\"}]}",
+        "--capsule",
+        "{sub:net/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC12\"}]}",
+        "--capsule",
+        "{sub:net/g1.capsule.json}",
+        "--parent",
+        "{sub:net/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC12\"}]}",
+        "--capsule",
+        "{sub:net/g2.capsule.json}",
+        "--parent",
+        "{sub:net/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC12\"}]}",
+        "--capsule",
+        "{sub:net/g3.capsule.json}",
+        "--parent",
+        "{sub:net/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC12\"}]}",
+        "--capsule",
+        "{sub:net/g4.capsule.json}",
+        "--parent",
+        "{sub:net/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC13.json
+++ b/gym/packs/expert-challenges/reference/XC13.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC13",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC13\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC13\"}]}",
+        "--capsule",
+        "{sub:mid/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC13\"}]}",
+        "--capsule",
+        "{sub:mid/g1.capsule.json}",
+        "--parent",
+        "{sub:mid/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC13\"}]}",
+        "--capsule",
+        "{sub:mid/g2.capsule.json}",
+        "--parent",
+        "{sub:mid/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC13\"}]}",
+        "--capsule",
+        "{sub:mid/g3.capsule.json}",
+        "--parent",
+        "{sub:mid/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC14.json
+++ b/gym/packs/expert-challenges/reference/XC14.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC14",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC14\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC14\"}]}",
+        "--capsule",
+        "{sub:tip/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC14\"}]}",
+        "--capsule",
+        "{sub:tip/g1.capsule.json}",
+        "--parent",
+        "{sub:tip/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC14\"}]}",
+        "--capsule",
+        "{sub:tip/g2.capsule.json}",
+        "--parent",
+        "{sub:tip/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC14\"}]}",
+        "--capsule",
+        "{sub:tip/g3.capsule.json}",
+        "--parent",
+        "{sub:tip/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC15.json
+++ b/gym/packs/expert-challenges/reference/XC15.json
@@ -1,0 +1,47 @@
+{
+  "id": "XC15",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o0.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"뿌리-XC15\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o0.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"뿌리-XC15\"}]}",
+        "--capsule",
+        "{sub:fork/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:left.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"좌잎-XC15\"}]}",
+        "--capsule",
+        "{sub:fork/left.capsule.json}",
+        "--parent",
+        "{sub:fork/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:right.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"우잎-XC15\"}]}",
+        "--capsule",
+        "{sub:fork/right.capsule.json}",
+        "--parent",
+        "{sub:fork/root.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC16.json
+++ b/gym/packs/expert-challenges/reference/XC16.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC16",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc16-l4",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC16\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC16\"}]}",
+        "--capsule",
+        "{sub:gate4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC16\"}]}",
+        "--capsule",
+        "{sub:gate4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:gate4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC16\"}]}",
+        "--capsule",
+        "{sub:gate4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:gate4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC16\"}]}",
+        "--capsule",
+        "{sub:gate4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:gate4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc16-l4"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC17.json
+++ b/gym/packs/expert-challenges/reference/XC17.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC17",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc17-l4s",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC17\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC17\"}]}",
+        "--capsule",
+        "{sub:gate4s/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC17\"}]}",
+        "--capsule",
+        "{sub:gate4s/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:gate4s/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC17\"}]}",
+        "--capsule",
+        "{sub:gate4s/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:gate4s/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC17\"}]}",
+        "--capsule",
+        "{sub:gate4s/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:gate4s/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc17-l4s"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4s/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4s/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4s/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:gate4s/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-계보",
+              "require": {
+                "lineageValid": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC18.json
+++ b/gym/packs/expert-challenges/reference/XC18.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC18",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc18-both",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC18\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC18\"}]}",
+        "--capsule",
+        "{sub:both/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC18\"}]}",
+        "--capsule",
+        "{sub:both/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:both/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC18\"}]}",
+        "--capsule",
+        "{sub:both/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:both/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC18\"}]}",
+        "--capsule",
+        "{sub:both/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:both/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc18-both"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:both/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:both/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:both/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:both/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC19.json
+++ b/gym/packs/expert-challenges/reference/XC19.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC19",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC19\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC19\"}]}",
+        "--capsule",
+        "{sub:l2deep/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC19\"}]}",
+        "--capsule",
+        "{sub:l2deep/g1.capsule.json}",
+        "--parent",
+        "{sub:l2deep/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC19\"}]}",
+        "--capsule",
+        "{sub:l2deep/g2.capsule.json}",
+        "--parent",
+        "{sub:l2deep/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC19\"}]}",
+        "--capsule",
+        "{sub:l2deep/g3.capsule.json}",
+        "--parent",
+        "{sub:l2deep/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC20.json
+++ b/gym/packs/expert-challenges/reference/XC20.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC20",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc20-l4r",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC20\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC20\"}]}",
+        "--capsule",
+        "{sub:l4rec/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC20\"}]}",
+        "--capsule",
+        "{sub:l4rec/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:l4rec/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC20\"}]}",
+        "--capsule",
+        "{sub:l4rec/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:l4rec/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC20\"}]}",
+        "--capsule",
+        "{sub:l4rec/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:l4rec/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc20-l4r"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:l4rec/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:l4rec/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:l4rec/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:l4rec/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC21.json
+++ b/gym/packs/expert-challenges/reference/XC21.json
@@ -1,0 +1,84 @@
+{
+  "id": "XC21",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc21-sig",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC21\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC21\"}]}",
+        "--capsule",
+        "{sub:sig4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC21\"}]}",
+        "--capsule",
+        "{sub:sig4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:sig4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC21\"}]}",
+        "--capsule",
+        "{sub:sig4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:sig4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC21\"}]}",
+        "--capsule",
+        "{sub:sig4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:sig4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc21-sig"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC22.json
+++ b/gym/packs/expert-challenges/reference/XC22.json
@@ -1,0 +1,82 @@
+{
+  "id": "XC22",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc22-pair",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:op.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"쌍갑-XC22\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:op.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"쌍갑-XC22\"}]}",
+        "--capsule",
+        "{sub:pair/p.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:oq.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 1, \"text\": \"쌍을-XC22\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:oq.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 1, \"text\": \"쌍을-XC22\"}]}",
+        "--capsule",
+        "{sub:pair/q.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc22-pair"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:pair/p.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:pair/q.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC23.json
+++ b/gym/packs/expert-challenges/reference/XC23.json
@@ -1,0 +1,99 @@
+{
+  "id": "XC23",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC23\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC23\"}]}",
+        "--capsule",
+        "{sub:log4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC23\"}]}",
+        "--capsule",
+        "{sub:log4/g1.capsule.json}",
+        "--parent",
+        "{sub:log4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC23\"}]}",
+        "--capsule",
+        "{sub:log4/g2.capsule.json}",
+        "--parent",
+        "{sub:log4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC23\"}]}",
+        "--capsule",
+        "{sub:log4/g3.capsule.json}",
+        "--parent",
+        "{sub:log4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC24.json
+++ b/gym/packs/expert-challenges/reference/XC24.json
@@ -1,0 +1,68 @@
+{
+  "id": "XC24",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC24\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC24\"}]}",
+        "--capsule",
+        "{sub:rep4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC24\"}]}",
+        "--capsule",
+        "{sub:rep4/g1.capsule.json}",
+        "--parent",
+        "{sub:rep4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC24\"}]}",
+        "--capsule",
+        "{sub:rep4/g2.capsule.json}",
+        "--parent",
+        "{sub:rep4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC24\"}]}",
+        "--capsule",
+        "{sub:rep4/g3.capsule.json}",
+        "--parent",
+        "{sub:rep4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:rep4}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC25.json
+++ b/gym/packs/expert-challenges/reference/XC25.json
@@ -1,0 +1,68 @@
+{
+  "id": "XC25",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC25\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC25\"}]}",
+        "--capsule",
+        "{sub:reprec/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC25\"}]}",
+        "--capsule",
+        "{sub:reprec/g1.capsule.json}",
+        "--parent",
+        "{sub:reprec/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC25\"}]}",
+        "--capsule",
+        "{sub:reprec/g2.capsule.json}",
+        "--parent",
+        "{sub:reprec/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC25\"}]}",
+        "--capsule",
+        "{sub:reprec/g3.capsule.json}",
+        "--parent",
+        "{sub:reprec/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:reprec}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC26.json
+++ b/gym/packs/expert-challenges/reference/XC26.json
@@ -1,0 +1,114 @@
+{
+  "id": "XC26",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC26\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC26\"}]}",
+        "--capsule",
+        "{sub:pay4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC26\"}]}",
+        "--capsule",
+        "{sub:pay4/g1.capsule.json}",
+        "--parent",
+        "{sub:pay4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC26\"}]}",
+        "--capsule",
+        "{sub:pay4/g2.capsule.json}",
+        "--parent",
+        "{sub:pay4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC26\"}]}",
+        "--capsule",
+        "{sub:pay4/g3.capsule.json}",
+        "--parent",
+        "{sub:pay4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc26-pay4",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:pay4/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC27.json
+++ b/gym/packs/expert-challenges/reference/XC27.json
@@ -1,0 +1,126 @@
+{
+  "id": "XC27",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC27\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC27\"}]}",
+        "--capsule",
+        "{sub:led4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC27\"}]}",
+        "--capsule",
+        "{sub:led4/g1.capsule.json}",
+        "--parent",
+        "{sub:led4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC27\"}]}",
+        "--capsule",
+        "{sub:led4/g2.capsule.json}",
+        "--parent",
+        "{sub:led4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC27\"}]}",
+        "--capsule",
+        "{sub:led4/g3.capsule.json}",
+        "--parent",
+        "{sub:led4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc27-led4",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:led4/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "settle",
+        "record",
+        "{sub:claim.json}",
+        "--ledger",
+        "{sub:ledger.ndjson}",
+        "--verdict",
+        "accepted",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC28.json
+++ b/gym/packs/expert-challenges/reference/XC28.json
@@ -1,0 +1,114 @@
+{
+  "id": "XC28",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC28\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC28\"}]}",
+        "--capsule",
+        "{sub:payrec/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC28\"}]}",
+        "--capsule",
+        "{sub:payrec/g1.capsule.json}",
+        "--parent",
+        "{sub:payrec/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC28\"}]}",
+        "--capsule",
+        "{sub:payrec/g2.capsule.json}",
+        "--parent",
+        "{sub:payrec/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC28\"}]}",
+        "--capsule",
+        "{sub:payrec/g3.capsule.json}",
+        "--parent",
+        "{sub:payrec/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc28-payrec",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:payrec/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC29.json
+++ b/gym/packs/expert-challenges/reference/XC29.json
@@ -1,0 +1,199 @@
+{
+  "id": "XC29",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc29-pl4",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC29\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC29\"}]}",
+        "--capsule",
+        "{sub:payl4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC29\"}]}",
+        "--capsule",
+        "{sub:payl4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:payl4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC29\"}]}",
+        "--capsule",
+        "{sub:payl4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:payl4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC29\"}]}",
+        "--capsule",
+        "{sub:payl4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:payl4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc29-pl4"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:payl4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:payl4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:payl4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:payl4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc29-payl4",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:payl4/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC30.json
+++ b/gym/packs/expert-challenges/reference/XC30.json
@@ -1,0 +1,114 @@
+{
+  "id": "XC30",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC30\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC30\"}]}",
+        "--capsule",
+        "{sub:claim4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC30\"}]}",
+        "--capsule",
+        "{sub:claim4/g1.capsule.json}",
+        "--parent",
+        "{sub:claim4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC30\"}]}",
+        "--capsule",
+        "{sub:claim4/g2.capsule.json}",
+        "--parent",
+        "{sub:claim4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC30\"}]}",
+        "--capsule",
+        "{sub:claim4/g3.capsule.json}",
+        "--parent",
+        "{sub:claim4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc30-claim4",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:claim4/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC31.json
+++ b/gym/packs/expert-challenges/reference/XC31.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC31",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC31\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC31\"}]}",
+        "--capsule",
+        "{sub:t004s/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC31\"}]}",
+        "--capsule",
+        "{sub:t004s/g1.capsule.json}",
+        "--parent",
+        "{sub:t004s/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC31\"}]}",
+        "--capsule",
+        "{sub:t004s/g2.capsule.json}",
+        "--parent",
+        "{sub:t004s/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC31\"}]}",
+        "--capsule",
+        "{sub:t004s/g3.capsule.json}",
+        "--parent",
+        "{sub:t004s/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC32.json
+++ b/gym/packs/expert-challenges/reference/XC32.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC32",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC32\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC32\"}]}",
+        "--capsule",
+        "{sub:mt1r/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC32\"}]}",
+        "--capsule",
+        "{sub:mt1r/g1.capsule.json}",
+        "--parent",
+        "{sub:mt1r/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC32\"}]}",
+        "--capsule",
+        "{sub:mt1r/g2.capsule.json}",
+        "--parent",
+        "{sub:mt1r/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC32\"}]}",
+        "--capsule",
+        "{sub:mt1r/g3.capsule.json}",
+        "--parent",
+        "{sub:mt1r/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC33.json
+++ b/gym/packs/expert-challenges/reference/XC33.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC33",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc33-inl4",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC33\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC33\"}]}",
+        "--capsule",
+        "{sub:inl4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC33\"}]}",
+        "--capsule",
+        "{sub:inl4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:inl4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC33\"}]}",
+        "--capsule",
+        "{sub:inl4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:inl4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC33\"}]}",
+        "--capsule",
+        "{sub:inl4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:inl4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc33-inl4"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:inl4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:inl4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:inl4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:inl4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC34.json
+++ b/gym/packs/expert-challenges/reference/XC34.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC34",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC34\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC34\"}]}",
+        "--capsule",
+        "{sub:tt5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC34\"}]}",
+        "--capsule",
+        "{sub:tt5/g1.capsule.json}",
+        "--parent",
+        "{sub:tt5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC34\"}]}",
+        "--capsule",
+        "{sub:tt5/g2.capsule.json}",
+        "--parent",
+        "{sub:tt5/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC34\"}]}",
+        "--capsule",
+        "{sub:tt5/g3.capsule.json}",
+        "--parent",
+        "{sub:tt5/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC34\"}]}",
+        "--capsule",
+        "{sub:tt5/g4.capsule.json}",
+        "--parent",
+        "{sub:tt5/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC35.json
+++ b/gym/packs/expert-challenges/reference/XC35.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC35",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC35\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC35\"}]}",
+        "--capsule",
+        "{sub:cxmid/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC35\"}]}",
+        "--capsule",
+        "{sub:cxmid/g1.capsule.json}",
+        "--parent",
+        "{sub:cxmid/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC35\"}]}",
+        "--capsule",
+        "{sub:cxmid/g2.capsule.json}",
+        "--parent",
+        "{sub:cxmid/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC35\"}]}",
+        "--capsule",
+        "{sub:cxmid/g3.capsule.json}",
+        "--parent",
+        "{sub:cxmid/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC35\"}]}",
+        "--capsule",
+        "{sub:cxmid/g4.capsule.json}",
+        "--parent",
+        "{sub:cxmid/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC36.json
+++ b/gym/packs/expert-challenges/reference/XC36.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC36",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC36\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwpx/basic-table-01.hwpx\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC36\"}]}",
+        "--capsule",
+        "{sub:hx4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC36\"}]}",
+        "--capsule",
+        "{sub:hx4/g1.capsule.json}",
+        "--parent",
+        "{sub:hx4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC36\"}]}",
+        "--capsule",
+        "{sub:hx4/g2.capsule.json}",
+        "--parent",
+        "{sub:hx4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC36\"}]}",
+        "--capsule",
+        "{sub:hx4/g3.capsule.json}",
+        "--parent",
+        "{sub:hx4/g2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC37.json
+++ b/gym/packs/expert-challenges/reference/XC37.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC37",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc37-t4l4",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC37\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC37\"}]}",
+        "--capsule",
+        "{sub:t4l4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC37\"}]}",
+        "--capsule",
+        "{sub:t4l4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:t4l4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC37\"}]}",
+        "--capsule",
+        "{sub:t4l4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:t4l4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC37\"}]}",
+        "--capsule",
+        "{sub:t4l4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:t4l4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc37-t4l4"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4l4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4l4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4l4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4l4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC38.json
+++ b/gym/packs/expert-challenges/reference/XC38.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC38",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-002.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC38\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-002.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC38\"}]}",
+        "--capsule",
+        "{sub:mt2r/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC38\"}]}",
+        "--capsule",
+        "{sub:mt2r/g1.capsule.json}",
+        "--parent",
+        "{sub:mt2r/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC38\"}]}",
+        "--capsule",
+        "{sub:mt2r/g2.capsule.json}",
+        "--parent",
+        "{sub:mt2r/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC38\"}]}",
+        "--capsule",
+        "{sub:mt2r/g3.capsule.json}",
+        "--parent",
+        "{sub:mt2r/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC38\"}]}",
+        "--capsule",
+        "{sub:mt2r/g4.capsule.json}",
+        "--parent",
+        "{sub:mt2r/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC39.json
+++ b/gym/packs/expert-challenges/reference/XC39.json
@@ -1,0 +1,114 @@
+{
+  "id": "XC39",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC39\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC39\"}]}",
+        "--capsule",
+        "{sub:inpay/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC39\"}]}",
+        "--capsule",
+        "{sub:inpay/g1.capsule.json}",
+        "--parent",
+        "{sub:inpay/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC39\"}]}",
+        "--capsule",
+        "{sub:inpay/g2.capsule.json}",
+        "--parent",
+        "{sub:inpay/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC39\"}]}",
+        "--capsule",
+        "{sub:inpay/g3.capsule.json}",
+        "--parent",
+        "{sub:inpay/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc39-inpay",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:inpay/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC40.json
+++ b/gym/packs/expert-challenges/reference/XC40.json
@@ -1,0 +1,68 @@
+{
+  "id": "XC40",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC40\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC40\"}]}",
+        "--capsule",
+        "{sub:t4rep/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC40\"}]}",
+        "--capsule",
+        "{sub:t4rep/g1.capsule.json}",
+        "--parent",
+        "{sub:t4rep/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC40\"}]}",
+        "--capsule",
+        "{sub:t4rep/g2.capsule.json}",
+        "--parent",
+        "{sub:t4rep/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC40\"}]}",
+        "--capsule",
+        "{sub:t4rep/g3.capsule.json}",
+        "--parent",
+        "{sub:t4rep/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:t4rep}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC41.json
+++ b/gym/packs/expert-challenges/reference/XC41.json
@@ -1,0 +1,65 @@
+{
+  "id": "XC41",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC41\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC41\"}]}",
+        "--capsule",
+        "{sub:cell4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC41\"}]}",
+        "--capsule",
+        "{sub:cell4/g1.capsule.json}",
+        "--parent",
+        "{sub:cell4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC41\"}]}",
+        "--capsule",
+        "{sub:cell4/g2.capsule.json}",
+        "--parent",
+        "{sub:cell4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC41\"}]}",
+        "--capsule",
+        "{sub:cell4/g3.capsule.json}",
+        "--parent",
+        "{sub:cell4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "copy": {
+        "from": "{sub:o4.hwp}",
+        "to": "{sub:leaf.hwp}"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC42.json
+++ b/gym/packs/expert-challenges/reference/XC42.json
@@ -1,0 +1,77 @@
+{
+  "id": "XC42",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC42\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC42\"}]}",
+        "--capsule",
+        "{sub:cell5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC42\"}]}",
+        "--capsule",
+        "{sub:cell5/g1.capsule.json}",
+        "--parent",
+        "{sub:cell5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC42\"}]}",
+        "--capsule",
+        "{sub:cell5/g2.capsule.json}",
+        "--parent",
+        "{sub:cell5/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC42\"}]}",
+        "--capsule",
+        "{sub:cell5/g3.capsule.json}",
+        "--parent",
+        "{sub:cell5/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC42\"}]}",
+        "--capsule",
+        "{sub:cell5/g4.capsule.json}",
+        "--parent",
+        "{sub:cell5/g3.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "copy": {
+        "from": "{sub:o5.hwp}",
+        "to": "{sub:leaf.hwp}"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC43.json
+++ b/gym/packs/expert-challenges/reference/XC43.json
@@ -1,0 +1,90 @@
+{
+  "id": "XC43",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc43-csig",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC43\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC43\"}]}",
+        "--capsule",
+        "{sub:csig4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC43\"}]}",
+        "--capsule",
+        "{sub:csig4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:csig4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC43\"}]}",
+        "--capsule",
+        "{sub:csig4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:csig4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC43\"}]}",
+        "--capsule",
+        "{sub:csig4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:csig4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc43-csig"
+      }
+    },
+    {
+      "copy": {
+        "from": "{sub:o4.hwp}",
+        "to": "{sub:leaf.hwp}"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC44.json
+++ b/gym/packs/expert-challenges/reference/XC44.json
@@ -1,0 +1,47 @@
+{
+  "id": "XC44",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o0.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"뿌리-XC44\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o0.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"뿌리-XC44\"}]}",
+        "--capsule",
+        "{sub:split/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:left.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"좌잎-XC44\"}]}",
+        "--capsule",
+        "{sub:split/left.capsule.json}",
+        "--parent",
+        "{sub:split/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:right.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"우잎-XC44\"}]}",
+        "--capsule",
+        "{sub:split/right.capsule.json}",
+        "--parent",
+        "{sub:split/root.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC45.json
+++ b/gym/packs/expert-challenges/reference/XC45.json
@@ -1,0 +1,65 @@
+{
+  "id": "XC45",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-002.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC45\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-002.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC45\"}]}",
+        "--capsule",
+        "{sub:diff4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC45\"}]}",
+        "--capsule",
+        "{sub:diff4/g1.capsule.json}",
+        "--parent",
+        "{sub:diff4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC45\"}]}",
+        "--capsule",
+        "{sub:diff4/g2.capsule.json}",
+        "--parent",
+        "{sub:diff4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC45\"}]}",
+        "--capsule",
+        "{sub:diff4/g3.capsule.json}",
+        "--parent",
+        "{sub:diff4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "copy": {
+        "from": "{sub:o4.hwp}",
+        "to": "{sub:leaf.hwp}"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC46.json
+++ b/gym/packs/expert-challenges/reference/XC46.json
@@ -1,0 +1,65 @@
+{
+  "id": "XC46",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:oa1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"갑뿌리-XC46\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:oa1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"갑뿌리-XC46\"}]}",
+        "--capsule",
+        "{sub:dual/a1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:oa1.hwp}\", \"output\": \"{sub:oa2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"갑잎-XC46\"}]}",
+        "--capsule",
+        "{sub:dual/a2.capsule.json}",
+        "--parent",
+        "{sub:dual/a1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:ob1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"을뿌리-XC46\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:ob1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"을뿌리-XC46\"}]}",
+        "--capsule",
+        "{sub:dual/b1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:ob1.hwp}\", \"output\": \"{sub:ob2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"을잎-XC46\"}]}",
+        "--capsule",
+        "{sub:dual/b2.capsule.json}",
+        "--parent",
+        "{sub:dual/b1.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC47.json
+++ b/gym/packs/expert-challenges/reference/XC47.json
@@ -1,0 +1,102 @@
+{
+  "id": "XC47",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc47-dl4",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:op.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"쌍갑-XC47\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:op.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"쌍갑-XC47\"}]}",
+        "--capsule",
+        "{sub:duall4/p.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:oq.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 1, \"text\": \"쌍을-XC47\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/inner-table-01.hwp\", \"output\": \"{sub:oq.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 1, \"text\": \"쌍을-XC47\"}]}",
+        "--capsule",
+        "{sub:duall4/q.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc47-dl4"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:duall4/p.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:duall4/q.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC48.json
+++ b/gym/packs/expert-challenges/reference/XC48.json
@@ -1,0 +1,135 @@
+{
+  "id": "XC48",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC48\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC48\"}]}",
+        "--capsule",
+        "{sub:mix3/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC48\"}]}",
+        "--capsule",
+        "{sub:mix3/g1.capsule.json}",
+        "--parent",
+        "{sub:mix3/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC48\"}]}",
+        "--capsule",
+        "{sub:mix3/g2.capsule.json}",
+        "--parent",
+        "{sub:mix3/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC48\"}]}",
+        "--capsule",
+        "{sub:mix3/g3.capsule.json}",
+        "--parent",
+        "{sub:mix3/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc48-mix3",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:mix3/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "settle",
+        "record",
+        "{sub:claim.json}",
+        "--ledger",
+        "{sub:ledger.ndjson}",
+        "--verdict",
+        "accepted",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "audit-report",
+        "{sub:mix3}",
+        "-o",
+        "{sub:report.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC49.json
+++ b/gym/packs/expert-challenges/reference/XC49.json
@@ -1,0 +1,71 @@
+{
+  "id": "XC49",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC49\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/hwp_table_test.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC49\"}]}",
+        "--capsule",
+        "{sub:m5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC49\"}]}",
+        "--capsule",
+        "{sub:m5/g1.capsule.json}",
+        "--parent",
+        "{sub:m5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC49\"}]}",
+        "--capsule",
+        "{sub:m5/g2.capsule.json}",
+        "--parent",
+        "{sub:m5/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC49\"}]}",
+        "--capsule",
+        "{sub:m5/g3.capsule.json}",
+        "--parent",
+        "{sub:m5/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC49\"}]}",
+        "--capsule",
+        "{sub:m5/g4.capsule.json}",
+        "--parent",
+        "{sub:m5/g3.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC50.json
+++ b/gym/packs/expert-challenges/reference/XC50.json
@@ -1,0 +1,144 @@
+{
+  "id": "XC50",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc50-boss",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC50\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC50\"}]}",
+        "--capsule",
+        "{sub:boss4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC50\"}]}",
+        "--capsule",
+        "{sub:boss4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:boss4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC50\"}]}",
+        "--capsule",
+        "{sub:boss4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:boss4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC50\"}]}",
+        "--capsule",
+        "{sub:boss4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:boss4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc50-boss"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:boss4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:boss4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:boss4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:boss4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC51.json
+++ b/gym/packs/expert-challenges/reference/XC51.json
@@ -1,0 +1,150 @@
+{
+  "id": "XC51",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc51-cl4",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC51\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/multi-table-001.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC51\"}]}",
+        "--capsule",
+        "{sub:cl4/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC51\"}]}",
+        "--capsule",
+        "{sub:cl4/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:cl4/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC51\"}]}",
+        "--capsule",
+        "{sub:cl4/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:cl4/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC51\"}]}",
+        "--capsule",
+        "{sub:cl4/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:cl4/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc51-cl4"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:cl4/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:cl4/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:cl4/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:cl4/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "copy": {
+        "from": "{sub:o4.hwp}",
+        "to": "{sub:leaf.hwp}"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC52.json
+++ b/gym/packs/expert-challenges/reference/XC52.json
@@ -1,0 +1,59 @@
+{
+  "id": "XC52",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o0.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"뿌리-XC52\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"{sub:o0.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"뿌리-XC52\"}]}",
+        "--capsule",
+        "{sub:tri/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:left.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"좌잎-XC52\"}]}",
+        "--capsule",
+        "{sub:tri/left.capsule.json}",
+        "--parent",
+        "{sub:tri/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:mid.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"가운잎-XC52\"}]}",
+        "--capsule",
+        "{sub:tri/mid.capsule.json}",
+        "--parent",
+        "{sub:tri/root.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o0.hwp}\", \"output\": \"{sub:right.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"우잎-XC52\"}]}",
+        "--capsule",
+        "{sub:tri/right.capsule.json}",
+        "--parent",
+        "{sub:tri/root.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC53.json
+++ b/gym/packs/expert-challenges/reference/XC53.json
@@ -1,0 +1,77 @@
+{
+  "id": "XC53",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC53\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-complex.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC53\"}]}",
+        "--capsule",
+        "{sub:l2c5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC53\"}]}",
+        "--capsule",
+        "{sub:l2c5/g1.capsule.json}",
+        "--parent",
+        "{sub:l2c5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC53\"}]}",
+        "--capsule",
+        "{sub:l2c5/g2.capsule.json}",
+        "--parent",
+        "{sub:l2c5/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC53\"}]}",
+        "--capsule",
+        "{sub:l2c5/g3.capsule.json}",
+        "--parent",
+        "{sub:l2c5/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC53\"}]}",
+        "--capsule",
+        "{sub:l2c5/g4.capsule.json}",
+        "--parent",
+        "{sub:l2c5/g3.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "copy": {
+        "from": "{sub:o5.hwp}",
+        "to": "{sub:leaf.hwp}"
+      }
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC54.json
+++ b/gym/packs/expert-challenges/reference/XC54.json
@@ -1,0 +1,121 @@
+{
+  "id": "XC54",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC54\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC54\"}]}",
+        "--capsule",
+        "{sub:log5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC54\"}]}",
+        "--capsule",
+        "{sub:log5/g1.capsule.json}",
+        "--parent",
+        "{sub:log5/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC54\"}]}",
+        "--capsule",
+        "{sub:log5/g2.capsule.json}",
+        "--parent",
+        "{sub:log5/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC54\"}]}",
+        "--capsule",
+        "{sub:log5/g3.capsule.json}",
+        "--parent",
+        "{sub:log5/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o4.hwp}\", \"output\": \"{sub:o5.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸5-XC54\"}]}",
+        "--capsule",
+        "{sub:log5/g4.capsule.json}",
+        "--parent",
+        "{sub:log5/g3.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log5/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log5/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log5/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log5/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:log5/g4.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/reference/XC55.json
+++ b/gym/packs/expert-challenges/reference/XC55.json
@@ -1,0 +1,199 @@
+{
+  "id": "XC55",
+  "steps": [
+    {
+      "run": [
+        "keygen",
+        "--key-id",
+        "gym-xc55-mix",
+        "--out",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC55\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-004.hwp\", \"output\": \"{sub:o1.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸1-XC55\"}]}",
+        "--capsule",
+        "{sub:t4mix/g0.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o1.hwp}\", \"output\": \"{sub:o2.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸2-XC55\"}]}",
+        "--capsule",
+        "{sub:t4mix/g1.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:t4mix/g0.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o2.hwp}\", \"output\": \"{sub:o3.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸3-XC55\"}]}",
+        "--capsule",
+        "{sub:t4mix/g2.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:t4mix/g1.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:o3.hwp}\", \"output\": \"{sub:o4.hwp}\", \"steps\": [{\"action\": \"set_cell\", \"table\": 0, \"row\": 0, \"col\": 0, \"text\": \"칸4-XC55\"}]}",
+        "--capsule",
+        "{sub:t4mix/g3.capsule.json}",
+        "--sign-key",
+        "{sub:agent.key.json}",
+        "--parent",
+        "{sub:t4mix/g2.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "keyring_from": {
+        "key": "{sub:agent.key.json}",
+        "out": "{sub:keyring.json}",
+        "keyId": "gym-xc55-mix"
+      }
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4mix/g0.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4mix/g1.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4mix/g2.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "anchor",
+        "add",
+        "{sub:t4mix/g3.capsule.json}",
+        "--log",
+        "{sub:anchor.ndjson}",
+        "--json"
+      ]
+    },
+    {
+      "write_json": {
+        "to": "{sub:policy.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "admissionPolicy",
+          "default": "deny",
+          "rules": [
+            {
+              "id": "R1-재현",
+              "require": {
+                "reproduced": {
+                  "eq": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:wo.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "kind": "workorder",
+          "workorderId": "xc55-t4mix",
+          "acceptancePolicy": {
+            "schemaVersion": "1.0",
+            "kind": "admissionPolicy",
+            "default": "deny",
+            "rules": [
+              {
+                "id": "R1-재현",
+                "require": {
+                  "reproduced": {
+                    "eq": true
+                  }
+                }
+              }
+            ]
+          },
+          "unitPrice": {
+            "amount": "1000",
+            "currency": "KRW",
+            "per": "capsule"
+          }
+        }
+      }
+    },
+    {
+      "write_json": {
+        "to": "{sub:gate.json}",
+        "body": {
+          "schemaVersion": "1.0",
+          "verdict": "allow",
+          "violations": []
+        }
+      }
+    },
+    {
+      "run": [
+        "settle",
+        "propose",
+        "--workorder",
+        "{sub:wo.json}",
+        "--capsule",
+        "{sub:t4mix/g3.capsule.json}",
+        "--gate-envelope",
+        "{sub:gate.json}",
+        "-o",
+        "{sub:claim.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC06.json
+++ b/gym/packs/expert-challenges/tasks/XC06.json
@@ -1,0 +1,57 @@
+{
+  "id": "XC06",
+  "tier": 5,
+  "title": "4세대 깊은 계보",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC06 — 4세대 깊은 계보.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n끊기지 않는 **4세대** 계보를 spine/ 에 제출하라(g0→g1→g2→g3). 막내 g3 에서 lineage --deep 을 걸면 사슬이 온전하고 깊이가 **4** 여야 한다. XC04 의 3세대와 깊이가 다르다.\n\n제출 폴더에 spine/g0.capsule.json · spine/g1.capsule.json · spine/g2.capsule.json · spine/g3.capsule.json 를 두어라.\n\n수행 힌트: replay --parent 로 네 대를 잇는다. 채점은 lineage g3 --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n3세대에서 멈추면 깊이가 4가 아니다. 부모 링크를 빠뜨리면 valid 가 깨진다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "spine/g0.capsule.json",
+      "spine/g1.capsule.json",
+      "spine/g2.capsule.json",
+      "spine/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:spine/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:spine/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "spine/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC07.json
+++ b/gym/packs/expert-challenges/tasks/XC07.json
@@ -1,0 +1,58 @@
+{
+  "id": "XC07",
+  "tier": 5,
+  "title": "5세대 깊은 계보",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC07 — 5세대 깊은 계보.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n끊기지 않는 **5세대** 계보를 tower/ 에 제출하라. 막내에서 lineage --deep 을 걸면 깊이 **5** 다.\n\n제출 폴더에 tower/g0.capsule.json · tower/g1.capsule.json · tower/g2.capsule.json · tower/g3.capsule.json · tower/g4.capsule.json 를 두어라.\n\n수행 힌트: replay --parent 다섯 번. 채점은 lineage --deep depth==5.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n4세대에서 멈추면 이 보스를 통과하지 못한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "tower/g0.capsule.json",
+      "tower/g1.capsule.json",
+      "tower/g2.capsule.json",
+      "tower/g3.capsule.json",
+      "tower/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 5세대",
+      "op": "value_eq",
+      "value": 5,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:tower/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:tower/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "tower/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC08.json
+++ b/gym/packs/expert-challenges/tasks/XC08.json
@@ -1,0 +1,55 @@
+{
+  "id": "XC08",
+  "tier": 4,
+  "title": "4세대 얕은 계보",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC08 — 4세대 얕은 계보.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 로 **4세대** 계보를 rail/ 에 제출하라. 채점은 lineage ( --deep 없음 ) 깊이 4. XC04 의 --deep 3세대와 다르다.\n\n제출 폴더에 rail/g0.capsule.json · rail/g1.capsule.json · rail/g2.capsule.json · rail/g3.capsule.json 를 두어라.\n\n수행 힌트: replay --parent. 채점은 lineage g3 --json (얕음).\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n--deep 을 붙여도 점수는 얕은 판정만 본다. 깊이가 4가 아니면 실패다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "rail/g0.capsule.json",
+      "rail/g1.capsule.json",
+      "rail/g2.capsule.json",
+      "rail/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:rail/g3.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:rail/g3.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "rail/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC09.json
+++ b/gym/packs/expert-challenges/tasks/XC09.json
@@ -1,0 +1,56 @@
+{
+  "id": "XC09",
+  "tier": 4,
+  "title": "5세대 얕은 계보",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC09 — 5세대 얕은 계보.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n다중표 표본으로 **5세대** 얕은 계보를 climb/ 에 제출하라. --deep 없이 깊이 5.\n\n제출 폴더에 climb/g0.capsule.json · climb/g1.capsule.json · climb/g2.capsule.json · climb/g3.capsule.json · climb/g4.capsule.json 를 두어라.\n\n수행 힌트: lineage 막내 --json, path depth==5.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n깊은 재현을 요구하지 않는다. 사슬 길이만 본다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "climb/g0.capsule.json",
+      "climb/g1.capsule.json",
+      "climb/g2.capsule.json",
+      "climb/g3.capsule.json",
+      "climb/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 5세대",
+      "op": "value_eq",
+      "value": 5,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:climb/g4.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:climb/g4.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "climb/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC10.json
+++ b/gym/packs/expert-challenges/tasks/XC10.json
@@ -1,0 +1,41 @@
+{
+  "id": "XC10",
+  "tier": 4,
+  "title": "내부표 4세대 사슬 유효",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC10 — 내부표 4세대 사슬 유효.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n내부표 표본으로 4세대 사슬을 beam/ 에 만들고, 막내 lineage --deep 의 **valid==true** 만 본다. 깊이 숫자를 3으로 고정하지 마라(XC04 금지).\n\n제출 폴더에 beam/g0.capsule.json · beam/g1.capsule.json · beam/g2.capsule.json · beam/g3.capsule.json 를 두어라.\n\n수행 힌트: lineage --deep path valid.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n깊이 3을 맞추려 3대만 내면 이 과제의 제출 파일 수가 모자란다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "beam/g0.capsule.json",
+      "beam/g1.capsule.json",
+      "beam/g2.capsule.json",
+      "beam/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "사슬 온전(깊이 숫자 고정 없음)",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:beam/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "beam/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC11.json
+++ b/gym/packs/expert-challenges/tasks/XC11.json
@@ -1,0 +1,43 @@
+{
+  "id": "XC11",
+  "tier": 5,
+  "title": "4세대 오염 전파",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC11 — 4세대 오염 전파.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 사슬 web/ 을 제출하고 뿌리 g0 을 오염으로 지목하라. 영향 캡슐이 **4건 이상**. XC02 처럼 unaffected==0 을 함께 묻지 않는다.\n\n제출 폴더에 web/g0.capsule.json · web/g1.capsule.json · web/g2.capsule.json · web/g3.capsule.json 를 두어라.\n\n수행 힌트: recall-scope --contaminated g0 --among web. path affected len_ge 4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n무관한 네 장을 내면 영향권이 1이다. 부모 링크가 필요하다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "web/g0.capsule.json",
+      "web/g1.capsule.json",
+      "web/g2.capsule.json",
+      "web/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:web/g0.capsule.json}",
+        "--among",
+        "{file:web}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "web/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC12.json
+++ b/gym/packs/expert-challenges/tasks/XC12.json
@@ -1,0 +1,44 @@
+{
+  "id": "XC12",
+  "tier": 5,
+  "title": "5세대 오염 전파",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC12 — 5세대 오염 전파.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 5세대 net/ 에서 뿌리를 오염으로 지목해 영향 **5건 이상**을 받아라. unaffected 축은 보지 않는다.\n\n제출 폴더에 net/g0.capsule.json · net/g1.capsule.json · net/g2.capsule.json · net/g3.capsule.json · net/g4.capsule.json 를 두어라.\n\n수행 힌트: recall-scope affected len_ge 5.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n4대에서 멈추면 5건이 안 나온다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "net/g0.capsule.json",
+      "net/g1.capsule.json",
+      "net/g2.capsule.json",
+      "net/g3.capsule.json",
+      "net/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 5건 이상",
+      "op": "len_ge",
+      "value": 5,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:net/g0.capsule.json}",
+        "--among",
+        "{file:net}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "net/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC13.json
+++ b/gym/packs/expert-challenges/tasks/XC13.json
@@ -1,0 +1,43 @@
+{
+  "id": "XC13",
+  "tier": 5,
+  "title": "중간 세대 오염 폐쇄",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC13 — 중간 세대 오염 폐쇄.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 mid/ 의 **둘째 세대 g1** 을 오염으로 지목하라. 후손 폐쇄집합이 **3건 이상**(g1+후손). 뿌리를 오염으로 내면 다른 과제다.\n\n제출 폴더에 mid/g0.capsule.json · mid/g1.capsule.json · mid/g2.capsule.json · mid/g3.capsule.json 를 두어라.\n\n수행 힌트: recall-scope --contaminated g1 --among mid.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n뿌리를 오염으로 내면 4건이 잡혀 이 과제의 지목이 아니다. 중간 세대를 겨냥하라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "mid/g0.capsule.json",
+      "mid/g1.capsule.json",
+      "mid/g2.capsule.json",
+      "mid/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 3건 이상",
+      "op": "len_ge",
+      "value": 3,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:mid/g1.capsule.json}",
+        "--among",
+        "{file:mid}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "mid/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC14.json
+++ b/gym/packs/expert-challenges/tasks/XC14.json
@@ -1,0 +1,43 @@
+{
+  "id": "XC14",
+  "tier": 4,
+  "title": "잎 캡슐만 회수",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC14 — 잎 캡슐만 회수.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 tip/ 의 **막내 g3** 만 오염으로 지목하라. 영향권은 잎 자신이라 **1건 이상**. 뿌리 리콜(XC02/AU10)과 반대 방향이다.\n\n제출 폴더에 tip/g0.capsule.json · tip/g1.capsule.json · tip/g2.capsule.json · tip/g3.capsule.json 를 두어라.\n\n수행 힌트: recall-scope --contaminated g3. affected len_ge 1.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n뿌리를 오염으로 내면 4건이 잡힌다. 이 보스는 잎만 회수한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "tip/g0.capsule.json",
+      "tip/g1.capsule.json",
+      "tip/g2.capsule.json",
+      "tip/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 1건 이상",
+      "op": "len_ge",
+      "value": 1,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:tip/g3.capsule.json}",
+        "--among",
+        "{file:tip}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "tip/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC15.json
+++ b/gym/packs/expert-challenges/tasks/XC15.json
@@ -1,0 +1,42 @@
+{
+  "id": "XC15",
+  "tier": 5,
+  "title": "형제 분기 뿌리 리콜",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC15 — 형제 분기 뿌리 리콜.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n뿌리 root 에서 두 자식 left·right 가 갈라지는 **분기 계보**를 fork/ 에 제출하라. 뿌리를 오염으로 지목하면 영향 **3건 이상**(root+left+right). 직선 3세대(XC04)가 아니다.\n\n제출 폴더에 fork/root.capsule.json · fork/left.capsule.json · fork/right.capsule.json 를 두어라.\n\n수행 힌트: replay --parent root 로 left 와 right. recall-scope --contaminated root.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n직선 사슬만 내면 형제가 없다. 두 자식이 같은 부모를 가리켜야 한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "fork/root.capsule.json",
+      "fork/left.capsule.json",
+      "fork/right.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 3건 이상",
+      "op": "len_ge",
+      "value": 3,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:fork/root.capsule.json}",
+        "--among",
+        "{file:fork}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "fork/left.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC16.json
+++ b/gym/packs/expert-challenges/tasks/XC16.json
@@ -1,0 +1,76 @@
+{
+  "id": "XC16",
+  "tier": 5,
+  "title": "L4 깊은 4세대 게이트",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC16 — L4 깊은 4세대 게이트.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 전부를 같은 키로 서명하고 앵커에 올린 뒤, 정책(재현 eq true)으로 **L4 --deep** 을 통과하라. L5 원장(XC01)과 L3+감사보고(XC05)는 하지 마라. ledger 를 넣지 마라.\n\n제출 폴더에 gate4/g0.capsule.json · gate4/g1.capsule.json · gate4/g2.capsule.json · gate4/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: keygen → replay --sign-key ×4 → anchor add ×4 → conformance --level L4 --deep --keyring --anchor-log --policy.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nL5 는 --ledger 가 필수다. 이 과제는 원장 없이 L4 게이트만 본다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "gate4/g0.capsule.json",
+      "gate4/g1.capsule.json",
+      "gate4/g2.capsule.json",
+      "gate4/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:gate4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:gate4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "gate4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC17.json
+++ b/gym/packs/expert-challenges/tasks/XC17.json
@@ -1,0 +1,75 @@
+{
+  "id": "XC17",
+  "tier": 4,
+  "title": "L4 얕은 4세대 게이트",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC17 — L4 얕은 4세대 게이트.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 4세대를 서명·앵커하고, 정책은 **lineageValid eq true** 다. **L4 얕은**( --deep 없음 ) conformant. 재현 재료를 요구하지 않는다.\n\n제출 폴더에 gate4s/g0.capsule.json · gate4s/g1.capsule.json · gate4s/g2.capsule.json · gate4s/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: conformance --level L4 --keyring --anchor-log --policy (no --deep).\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n정책이 reproduced 를 요구하면 얕은 L4 는 재료 미지정으로 거부된다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "gate4s/g0.capsule.json",
+      "gate4s/g1.capsule.json",
+      "gate4s/g2.capsule.json",
+      "gate4s/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 얕은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:gate4s}",
+        "--level",
+        "L4",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:gate4s/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "gate4s/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC18.json
+++ b/gym/packs/expert-challenges/tasks/XC18.json
@@ -1,0 +1,108 @@
+{
+  "id": "XC18",
+  "tier": 5,
+  "title": "L4와 4세대 계보 동시",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC18 — L4와 4세대 계보 동시.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n다중표 4세대를 서명·앵커한 뒤 **L4 --deep** 과 **lineage --deep 깊이 4** 를 한 제출에서 동시에 통과하라. L5 도 3세대도 아니다.\n\n제출 폴더에 both/g0.capsule.json · both/g1.capsule.json · both/g2.capsule.json · both/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: conformance L4 --deep 그리고 lineage 막내 --deep depth 4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n한 축만 맞추면 보스가 아니다. 게이트와 계보가 둘 다 막힌다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "both/g0.capsule.json",
+      "both/g1.capsule.json",
+      "both/g2.capsule.json",
+      "both/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:both/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:both/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:both}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:both/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "both/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC19.json
+++ b/gym/packs/expert-challenges/tasks/XC19.json
@@ -1,0 +1,75 @@
+{
+  "id": "XC19",
+  "tier": 4,
+  "title": "L2 재현과 4세대 계보",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC19 — L2 재현과 4세대 계보.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n내부표 4세대에 **L2 --deep**(재현) 과 계보 깊이 4 를 동시에 걸어라. 서명·앵커·L3/L5 는 범위 밖이다.\n\n제출 폴더에 l2deep/g0.capsule.json · l2deep/g1.capsule.json · l2deep/g2.capsule.json · l2deep/g3.capsule.json 를 두어라.\n\n수행 힌트: conformance --level L2 --deep 그리고 lineage --deep depth 4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nL3 이상을 치면 keyring/anchor 가 필요해 사용법 오류가 난다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "l2deep/g0.capsule.json",
+      "l2deep/g1.capsule.json",
+      "l2deep/g2.capsule.json",
+      "l2deep/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:l2deep/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:l2deep/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "L2 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:l2deep}",
+        "--level",
+        "L2",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "l2deep/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC20.json
+++ b/gym/packs/expert-challenges/tasks/XC20.json
@@ -1,0 +1,94 @@
+{
+  "id": "XC20",
+  "tier": 5,
+  "title": "L4와 4세대 리콜 동시",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC20 — L4와 4세대 리콜 동시.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n서명·앵커된 4세대로 **L4 --deep** 과 뿌리 리콜 영향 **4건 이상**을 동시에 받아라. unaffected 는 묻지 않는다. L5 원장은 넣지 마라.\n\n제출 폴더에 l4rec/g0.capsule.json · l4rec/g1.capsule.json · l4rec/g2.capsule.json · l4rec/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: conformance L4 --deep + recall-scope affected>=4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n리콜만 맞추고 서명을 빠뜨리면 L4 가 막힌다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "l4rec/g0.capsule.json",
+      "l4rec/g1.capsule.json",
+      "l4rec/g2.capsule.json",
+      "l4rec/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:l4rec/g0.capsule.json}",
+        "--among",
+        "{file:l4rec}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:l4rec}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:l4rec/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "l4rec/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC21.json
+++ b/gym/packs/expert-challenges/tasks/XC21.json
@@ -1,0 +1,57 @@
+{
+  "id": "XC21",
+  "tier": 5,
+  "title": "서명 4세대 깊은 계보",
+  "input": "samples/hwp_table_test.hwp",
+  "axis": "자동화",
+  "instructions": "XC21 — 서명 4세대 깊은 계보.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n표시험 표본을 같은 키로 서명한 4세대 sig4/ 를 제출하고, 막내 lineage --deep 깊이 4 를 받아라. 적합성 L3/L5 를 돌리지 마라.\n\n제출 폴더에 sig4/g0.capsule.json · sig4/g1.capsule.json · sig4/g2.capsule.json · sig4/g3.capsule.json 를 두어라.\n\n수행 힌트: keygen · replay --sign-key · lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n키링·앵커·적합성은 채점하지 않는다. 계보 깊이만 보스다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "sig4/g0.capsule.json",
+      "sig4/g1.capsule.json",
+      "sig4/g2.capsule.json",
+      "sig4/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:sig4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:sig4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "sig4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC22.json
+++ b/gym/packs/expert-challenges/tasks/XC22.json
@@ -1,0 +1,69 @@
+{
+  "id": "XC22",
+  "tier": 4,
+  "title": "쌍 캡슐 각각 앵커",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC22 — 쌍 캡슐 각각 앵커.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n같은 키로 서명한 **서로 다른** 두 캡슐 alpha·beta 를 pair/ 에 두고, 각각을 같은 앵커 로그에 등재하라. 채점은 두 캡슐 모두 logged==true. 계보로 잇지 마라.\n\n제출 폴더에 pair/p.capsule.json · pair/q.capsule.json · keyring.json · anchor.ndjson 를 두어라.\n\n수행 힌트: replay 두 번(다른 셀 문구) → anchor add 두 번 → anchor verify 각각.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n한 캡슐을 두 번 내면 files 가 같고 보스가 아니다. 두 산출이 달라야 한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "pair/p.capsule.json",
+      "pair/q.capsule.json",
+      "keyring.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "첫째 캡슐 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:pair/p.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "둘째 캡슐 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:pair/q.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "두 캡슐 바이트가 다름",
+      "op": "files_differ",
+      "files": [
+        "pair/p.capsule.json",
+        "pair/q.capsule.json"
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "pair/q.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC23.json
+++ b/gym/packs/expert-challenges/tasks/XC23.json
@@ -1,0 +1,82 @@
+{
+  "id": "XC23",
+  "tier": 5,
+  "title": "4연속 앵커와 계보",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC23 — 4연속 앵커와 계보.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 각 캡슐을 같은 앵커 로그에 순서대로 올리고, 막내 계보 --deep 깊이 4 와 막내 logged==true 를 동시에 받아라.\n\n제출 폴더에 log4/g0.capsule.json · log4/g1.capsule.json · log4/g2.capsule.json · log4/g3.capsule.json · anchor.ndjson 를 두어라.\n\n수행 힌트: anchor add ×4 + lineage --deep + anchor verify 막내.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n마지막만 등재하면 앞 세대가 로그에 없다. 네 번 add 하라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "log4/g0.capsule.json",
+      "log4/g1.capsule.json",
+      "log4/g2.capsule.json",
+      "log4/g3.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:log4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:log4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:log4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "log4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC24.json
+++ b/gym/packs/expert-challenges/tasks/XC24.json
@@ -1,0 +1,81 @@
+{
+  "id": "XC24",
+  "tier": 4,
+  "title": "감사보고와 4세대 계보",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC24 — 감사보고와 4세대 계보.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 rep4/ 에 대한 audit-report 를 발급하고, 막내 lineage --deep 깊이 4 를 동시에 통과하라. L3 --deep 적합성(XC05)은 하지 마라.\n\n제출 폴더에 rep4/g0.capsule.json · rep4/g1.capsule.json · rep4/g2.capsule.json · rep4/g3.capsule.json · report.json 를 두어라.\n\n수행 힌트: audit-report rep4 -o report.json 그리고 lineage --deep depth 4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n보고서만 내고 4대를 잇지 않으면 깊이가 모자란다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "rep4/g0.capsule.json",
+      "rep4/g1.capsule.json",
+      "rep4/g2.capsule.json",
+      "rep4/g3.capsule.json",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:rep4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:rep4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "감사 보고 실재",
+      "op": "file_exists",
+      "file": "report.json",
+      "minBytes": 64
+    },
+    {
+      "name": "보고 계보 머리 1건 이상",
+      "op": "value_ge",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:rep4}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "rep4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC25.json
+++ b/gym/packs/expert-challenges/tasks/XC25.json
@@ -1,0 +1,67 @@
+{
+  "id": "XC25",
+  "tier": 4,
+  "title": "감사보고와 4세대 리콜",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC25 — 감사보고와 4세대 리콜.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n내부표 4세대에 감사 보고서를 발급하고 뿌리 리콜 영향 4건 이상을 받아라. L3 적합성과 unaffected 는 보지 않는다.\n\n제출 폴더에 reprec/g0.capsule.json · reprec/g1.capsule.json · reprec/g2.capsule.json · reprec/g3.capsule.json · report.json 를 두어라.\n\n수행 힌트: audit-report + recall-scope affected>=4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nXC05 처럼 conformance L3 --deep 을 붙이지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "reprec/g0.capsule.json",
+      "reprec/g1.capsule.json",
+      "reprec/g2.capsule.json",
+      "reprec/g3.capsule.json",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:reprec/g0.capsule.json}",
+        "--among",
+        "{file:reprec}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "감사 보고 실재",
+      "op": "file_exists",
+      "file": "report.json",
+      "minBytes": 64
+    },
+    {
+      "name": "보고 계보 머리 1건 이상",
+      "op": "value_ge",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:reprec}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "reprec/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC26.json
+++ b/gym/packs/expert-challenges/tasks/XC26.json
@@ -1,0 +1,82 @@
+{
+  "id": "XC26",
+  "tier": 5,
+  "title": "정산 판정과 4세대 계보",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC26 — 정산 판정과 4세대 계보.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 막내 캡슐로 청구를 만들고 settle verify 의 **verdict==ok** 와 계보 깊이 4 를 동시에 받아라. 원장 4관문(XC03)은 묻지 않는다.\n\n제출 폴더에 pay4/g0.capsule.json · pay4/g1.capsule.json · pay4/g2.capsule.json · pay4/g3.capsule.json · wo.json · gate.json · claim.json 를 두어라.\n\n수행 힌트: settle propose 후 settle verify (ledger 없음) + lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\ncapsuleOk/gateOk/ledgerOk/workorderOk 네 칸을 동시에 보지 않는다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "pay4/g0.capsule.json",
+      "pay4/g1.capsule.json",
+      "pay4/g2.capsule.json",
+      "pay4/g3.capsule.json",
+      "wo.json",
+      "gate.json",
+      "claim.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:pay4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:pay4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:pay4/g3.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "pay4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC27.json
+++ b/gym/packs/expert-challenges/tasks/XC27.json
@@ -1,0 +1,67 @@
+{
+  "id": "XC27",
+  "tier": 4,
+  "title": "원장 실재와 4세대 계보",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC27 — 원장 실재와 4세대 계보.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 4세대 막내를 정산 원장에 기록하고, **ledger.ndjson 실재** 와 계보 깊이 4 만 본다. 4관문 경로는 채점하지 않는다.\n\n제출 폴더에 led4/g0.capsule.json · led4/g1.capsule.json · led4/g2.capsule.json · led4/g3.capsule.json · wo.json · gate.json · claim.json · ledger.ndjson 를 두어라.\n\n수행 힌트: settle record --ledger + file_exists ledger + lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nverify 의 네 관문 path 를 맞추려 하지 마라. 파일 실재와 계보다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "led4/g0.capsule.json",
+      "led4/g1.capsule.json",
+      "led4/g2.capsule.json",
+      "led4/g3.capsule.json",
+      "wo.json",
+      "gate.json",
+      "claim.json",
+      "ledger.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:led4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:led4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "원장 기록 실재",
+      "op": "file_exists",
+      "file": "ledger.ndjson",
+      "minBytes": 80
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "led4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC28.json
+++ b/gym/packs/expert-challenges/tasks/XC28.json
@@ -1,0 +1,68 @@
+{
+  "id": "XC28",
+  "tier": 5,
+  "title": "정산 판정과 4세대 리콜",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC28 — 정산 판정과 4세대 리콜.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n다중표 4세대의 뿌리 리콜(4건+)과 막내 청구 verdict==ok 를 한 제출에서 닫아라. 원장 4관문은 범위 밖이다.\n\n제출 폴더에 payrec/g0.capsule.json · payrec/g1.capsule.json · payrec/g2.capsule.json · payrec/g3.capsule.json · wo.json · gate.json · claim.json 를 두어라.\n\n수행 힌트: settle verify verdict + recall-scope affected>=4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n리콜만 맞추고 청구를 빠뜨리면 한 축이 빈다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "payrec/g0.capsule.json",
+      "payrec/g1.capsule.json",
+      "payrec/g2.capsule.json",
+      "payrec/g3.capsule.json",
+      "wo.json",
+      "gate.json",
+      "claim.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:payrec/g0.capsule.json}",
+        "--among",
+        "{file:payrec}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:payrec/g3.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "payrec/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC29.json
+++ b/gym/packs/expert-challenges/tasks/XC29.json
@@ -1,0 +1,101 @@
+{
+  "id": "XC29",
+  "tier": 5,
+  "title": "정산 판정과 L4 게이트",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC29 — 정산 판정과 L4 게이트.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n서명·앵커 4세대로 **L4 --deep** 과 막내 settle verify verdict==ok 를 동시에 통과하라. L5 원장과 4관문은 넣지 마라.\n\n제출 폴더에 payl4/g0.capsule.json · payl4/g1.capsule.json · payl4/g2.capsule.json · payl4/g3.capsule.json · keyring.json · anchor.ndjson · policy.json · wo.json · gate.json · claim.json 를 두어라.\n\n수행 힌트: conformance L4 --deep + settle verify (no --ledger).\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nL5 로 올리면 --ledger 가 필수다. 이 보스는 L4+청구다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "payl4/g0.capsule.json",
+      "payl4/g1.capsule.json",
+      "payl4/g2.capsule.json",
+      "payl4/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json",
+      "wo.json",
+      "gate.json",
+      "claim.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:payl4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:payl4/g3.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:payl4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "payl4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC30.json
+++ b/gym/packs/expert-challenges/tasks/XC30.json
@@ -1,0 +1,65 @@
+{
+  "id": "XC30",
+  "tier": 4,
+  "title": "청구 검증과 4세대 유효",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "axis": "자동화",
+  "instructions": "XC30 — 청구 검증과 4세대 유효.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\nHWPX 표 4세대 막내로 청구를 만들고, settle verify verdict==ok 와 lineage valid==true (얕음) 을 받아라. 깊이 3 --deep 을 고정하지 마라.\n\n제출 폴더에 claim4/g0.capsule.json · claim4/g1.capsule.json · claim4/g2.capsule.json · claim4/g3.capsule.json · wo.json · gate.json · claim.json 를 두어라.\n\n수행 힌트: settle propose/verify + lineage (no --deep) valid.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nXC04 의 depth==3 --deep 을 흉내 내지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "claim4/g0.capsule.json",
+      "claim4/g1.capsule.json",
+      "claim4/g2.capsule.json",
+      "claim4/g3.capsule.json",
+      "wo.json",
+      "gate.json",
+      "claim.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "사슬 온전(깊이 숫자 고정 없음)",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:claim4/g3.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:claim4/g3.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "claim4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC31.json
+++ b/gym/packs/expert-challenges/tasks/XC31.json
@@ -1,0 +1,57 @@
+{
+  "id": "XC31",
+  "tier": 5,
+  "title": "표사 4세대 깊은 계보",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC31 — 표사 4세대 깊은 계보.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 만으로 4세대 깊은 계보를 세워라. table-001 사슬(XC04/XC06)을 복사해 오면 산출 해시가 다르다.\n\n제출 폴더에 t004s/g0.capsule.json · t004s/g1.capsule.json · t004s/g2.capsule.json · t004s/g3.capsule.json 를 두어라.\n\n수행 힌트: lineage --deep depth 4 on table-004.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n표본이 바뀌면 계획서 input 도 바뀌어야 한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "t004s/g0.capsule.json",
+      "t004s/g1.capsule.json",
+      "t004s/g2.capsule.json",
+      "t004s/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:t004s/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:t004s/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "t004s/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC32.json
+++ b/gym/packs/expert-challenges/tasks/XC32.json
@@ -1,0 +1,43 @@
+{
+  "id": "XC32",
+  "tier": 5,
+  "title": "다중표 4세대 리콜",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC32 — 다중표 4세대 리콜.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n다중표-001 4세대에서 뿌리 리콜 영향 4건 이상. unaffected 콤보는 금지.\n\n제출 폴더에 mt1r/g0.capsule.json · mt1r/g1.capsule.json · mt1r/g2.capsule.json · mt1r/g3.capsule.json 를 두어라.\n\n수행 힌트: recall-scope affected>=4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\ntable-001 사슬을 재사용하면 표본 계약이 틀린다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "mt1r/g0.capsule.json",
+      "mt1r/g1.capsule.json",
+      "mt1r/g2.capsule.json",
+      "mt1r/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:mt1r/g0.capsule.json}",
+        "--among",
+        "{file:mt1r}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "mt1r/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC33.json
+++ b/gym/packs/expert-challenges/tasks/XC33.json
@@ -1,0 +1,76 @@
+{
+  "id": "XC33",
+  "tier": 5,
+  "title": "내부표 L4 깊은 게이트",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC33 — 내부표 L4 깊은 게이트.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n내부표 4세대를 서명·앵커하고 L4 --deep 만 통과하라. L5 원장·L3 보고는 없다.\n\n제출 폴더에 inl4/g0.capsule.json · inl4/g1.capsule.json · inl4/g2.capsule.json · inl4/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: conformance L4 --deep --keyring --anchor-log --policy.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n내부표가 아닌 표본을 쓰면 이 과제의 입력이 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "inl4/g0.capsule.json",
+      "inl4/g1.capsule.json",
+      "inl4/g2.capsule.json",
+      "inl4/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:inl4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:inl4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "inl4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC34.json
+++ b/gym/packs/expert-challenges/tasks/XC34.json
@@ -1,0 +1,58 @@
+{
+  "id": "XC34",
+  "tier": 5,
+  "title": "표시험 5세대 깊은 계보",
+  "input": "samples/hwp_table_test.hwp",
+  "axis": "자동화",
+  "instructions": "XC34 — 표시험 5세대 깊은 계보.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\nhwp_table_test 로 5세대 깊은 계보. 깊이 5 --deep.\n\n제출 폴더에 tt5/g0.capsule.json · tt5/g1.capsule.json · tt5/g2.capsule.json · tt5/g3.capsule.json · tt5/g4.capsule.json 를 두어라.\n\n수행 힌트: lineage --deep depth 5.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n표시험이 아닌 표를 잇지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "tt5/g0.capsule.json",
+      "tt5/g1.capsule.json",
+      "tt5/g2.capsule.json",
+      "tt5/g3.capsule.json",
+      "tt5/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 5세대",
+      "op": "value_eq",
+      "value": 5,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:tt5/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:tt5/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "tt5/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC35.json
+++ b/gym/packs/expert-challenges/tasks/XC35.json
@@ -1,0 +1,44 @@
+{
+  "id": "XC35",
+  "tier": 5,
+  "title": "복합표 중간 오염 폐쇄",
+  "input": "samples/table-complex.hwp",
+  "axis": "자동화",
+  "instructions": "XC35 — 복합표 중간 오염 폐쇄.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n복합표 5세대에서 **셋째 세대 g2** 를 오염으로 지목해 영향 3건 이상(g2+후손). 뿌리 리콜이 아니다.\n\n제출 폴더에 cxmid/g0.capsule.json · cxmid/g1.capsule.json · cxmid/g2.capsule.json · cxmid/g3.capsule.json · cxmid/g4.capsule.json 를 두어라.\n\n수행 힌트: recall-scope --contaminated g2 --among cxmid.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n뿌리를 오염으로 내면 5건이 잡힌다. 중간을 겨냥하라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "cxmid/g0.capsule.json",
+      "cxmid/g1.capsule.json",
+      "cxmid/g2.capsule.json",
+      "cxmid/g3.capsule.json",
+      "cxmid/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 3건 이상",
+      "op": "len_ge",
+      "value": 3,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:cxmid/g2.capsule.json}",
+        "--among",
+        "{file:cxmid}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "cxmid/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC36.json
+++ b/gym/packs/expert-challenges/tasks/XC36.json
@@ -1,0 +1,57 @@
+{
+  "id": "XC36",
+  "tier": 5,
+  "title": "HWPX 4세대 깊은 계보",
+  "input": "samples/hwpx/basic-table-01.hwpx",
+  "axis": "자동화",
+  "instructions": "XC36 — HWPX 4세대 깊은 계보.\n\n입력 표본은 `samples/hwpx/basic-table-01.hwpx` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\nhwpx/basic-table-01 로 4세대 깊은 계보. HWP 사슬을 그대로 가져오지 마라.\n\n제출 폴더에 hx4/g0.capsule.json · hx4/g1.capsule.json · hx4/g2.capsule.json · hx4/g3.capsule.json 를 두어라.\n\n수행 힌트: lineage --deep depth 4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n확장자가 hwpx 인 입력을 계획서에 적어야 한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "hx4/g0.capsule.json",
+      "hx4/g1.capsule.json",
+      "hx4/g2.capsule.json",
+      "hx4/g3.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:hx4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:hx4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "hx4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC37.json
+++ b/gym/packs/expert-challenges/tasks/XC37.json
@@ -1,0 +1,76 @@
+{
+  "id": "XC37",
+  "tier": 5,
+  "title": "표사 L4 깊은 4세대",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC37 — 표사 L4 깊은 4세대.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 4세대 서명·앵커 L4 --deep. XC16 과 표본이 다르다.\n\n제출 폴더에 t4l4/g0.capsule.json · t4l4/g1.capsule.json · t4l4/g2.capsule.json · t4l4/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: conformance L4 --deep on table-004 chain.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\ntable-001 키링을 재사용하지 마라. 이 사슬을 직접 서명하라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "t4l4/g0.capsule.json",
+      "t4l4/g1.capsule.json",
+      "t4l4/g2.capsule.json",
+      "t4l4/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:t4l4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:t4l4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "t4l4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC38.json
+++ b/gym/packs/expert-challenges/tasks/XC38.json
@@ -1,0 +1,44 @@
+{
+  "id": "XC38",
+  "tier": 5,
+  "title": "다중표2 5세대 리콜",
+  "input": "samples/multi-table-002.hwp",
+  "axis": "자동화",
+  "instructions": "XC38 — 다중표2 5세대 리콜.\n\n입력 표본은 `samples/multi-table-002.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\nmulti-table-002 5세대 뿌리 리콜 영향 5건+. multi-table-001 사슬을 복사하지 마라.\n\n제출 폴더에 mt2r/g0.capsule.json · mt2r/g1.capsule.json · mt2r/g2.capsule.json · mt2r/g3.capsule.json · mt2r/g4.capsule.json 를 두어라.\n\n수행 힌트: recall-scope affected>=5.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n표본 002 가 입력이다. 001 계획을 가져오면 해시가 틀린다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "mt2r/g0.capsule.json",
+      "mt2r/g1.capsule.json",
+      "mt2r/g2.capsule.json",
+      "mt2r/g3.capsule.json",
+      "mt2r/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 5건 이상",
+      "op": "len_ge",
+      "value": 5,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:mt2r/g0.capsule.json}",
+        "--among",
+        "{file:mt2r}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "mt2r/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC39.json
+++ b/gym/packs/expert-challenges/tasks/XC39.json
@@ -1,0 +1,82 @@
+{
+  "id": "XC39",
+  "tier": 5,
+  "title": "내부표 정산과 4세대",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC39 — 내부표 정산과 4세대.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n내부표 4세대 막내 청구 verdict==ok + 계보 깊이 4. 4관문 없음.\n\n제출 폴더에 inpay/g0.capsule.json · inpay/g1.capsule.json · inpay/g2.capsule.json · inpay/g3.capsule.json · wo.json · gate.json · claim.json 를 두어라.\n\n수행 힌트: settle verify + lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n내부표가 아닌 정산 과제를 베끼지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "inpay/g0.capsule.json",
+      "inpay/g1.capsule.json",
+      "inpay/g2.capsule.json",
+      "inpay/g3.capsule.json",
+      "wo.json",
+      "gate.json",
+      "claim.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:inpay/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:inpay/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:inpay/g3.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "inpay/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC40.json
+++ b/gym/packs/expert-challenges/tasks/XC40.json
@@ -1,0 +1,81 @@
+{
+  "id": "XC40",
+  "tier": 4,
+  "title": "표사 감사보고와 4세대",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC40 — 표사 감사보고와 4세대.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 4세대 감사 보고 + 계보 깊이 4. L3 --deep 적합성을 붙이지 마라.\n\n제출 폴더에 t4rep/g0.capsule.json · t4rep/g1.capsule.json · t4rep/g2.capsule.json · t4rep/g3.capsule.json · report.json 를 두어라.\n\n수행 힌트: audit-report + lineage --deep depth 4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nXC05 의 L3 콤보를 열지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "t4rep/g0.capsule.json",
+      "t4rep/g1.capsule.json",
+      "t4rep/g2.capsule.json",
+      "t4rep/g3.capsule.json",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:t4rep/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:t4rep/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "감사 보고 실재",
+      "op": "file_exists",
+      "file": "report.json",
+      "minBytes": 64
+    },
+    {
+      "name": "보고 계보 머리 1건 이상",
+      "op": "value_ge",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:t4rep}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "t4rep/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC41.json
+++ b/gym/packs/expert-challenges/tasks/XC41.json
@@ -1,0 +1,76 @@
+{
+  "id": "XC41",
+  "tier": 5,
+  "title": "4세대 끝칸과 깊은 계보",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC41 — 4세대 끝칸과 깊은 계보.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대 마지막 칸 문구를 남기고, 그 산출 leaf.hwp 의 (0,0) 과 막내 계보 깊이 4 를 동시에 대조하라.\n\n제출 폴더에 cell4/g0.capsule.json · cell4/g1.capsule.json · cell4/g2.capsule.json · cell4/g3.capsule.json · leaf.hwp 를 두어라.\n\n수행 힌트: export-tables leaf.hwp + lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n계보만 잇고 칸 문구를 바꾸지 않으면 cell_text_eq 가 실패한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "cell4/g0.capsule.json",
+      "cell4/g1.capsule.json",
+      "cell4/g2.capsule.json",
+      "cell4/g3.capsule.json",
+      "leaf.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:cell4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:cell4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "(0,0) == 칸4-XC41",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "칸4-XC41",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:leaf.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "cell4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC42.json
+++ b/gym/packs/expert-challenges/tasks/XC42.json
@@ -1,0 +1,63 @@
+{
+  "id": "XC42",
+  "tier": 5,
+  "title": "5세대 끝칸과 리콜",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC42 — 5세대 끝칸과 리콜.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 5세대 끝칸 (0,0) 과 뿌리 리콜 5건+ 를 동시에 닫아라.\n\n제출 폴더에 cell5/g0.capsule.json · cell5/g1.capsule.json · cell5/g2.capsule.json · cell5/g3.capsule.json · cell5/g4.capsule.json · leaf.hwp 를 두어라.\n\n수행 힌트: export-tables + recall-scope.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n칸만 맞추고 사슬을 끊으면 리콜이 1건이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "cell5/g0.capsule.json",
+      "cell5/g1.capsule.json",
+      "cell5/g2.capsule.json",
+      "cell5/g3.capsule.json",
+      "cell5/g4.capsule.json",
+      "leaf.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 5건 이상",
+      "op": "len_ge",
+      "value": 5,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:cell5/g0.capsule.json}",
+        "--among",
+        "{file:cell5}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "(0,0) == 칸5-XC42",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "칸5-XC42",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:leaf.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "cell5/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC43.json
+++ b/gym/packs/expert-challenges/tasks/XC43.json
@@ -1,0 +1,76 @@
+{
+  "id": "XC43",
+  "tier": 5,
+  "title": "표사 끝칸 서명 4세대",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC43 — 표사 끝칸 서명 4세대.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 를 서명한 4세대의 끝칸과 깊은 계보를 동시에 본다. 적합성은 돌리지 마라.\n\n제출 폴더에 csig4/g0.capsule.json · csig4/g1.capsule.json · csig4/g2.capsule.json · csig4/g3.capsule.json · leaf.hwp 를 두어라.\n\n수행 힌트: export-tables + lineage --deep + 서명 캡슐.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n서명 없이 칸만 바꾸면 이 보스의 제출 키링이 없다. 키는 기준풀이가 쓰지만 채점은 계보·칸이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "csig4/g0.capsule.json",
+      "csig4/g1.capsule.json",
+      "csig4/g2.capsule.json",
+      "csig4/g3.capsule.json",
+      "leaf.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:csig4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:csig4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "(0,0) == 칸4-XC43",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "칸4-XC43",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:leaf.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "csig4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC44.json
+++ b/gym/packs/expert-challenges/tasks/XC44.json
@@ -1,0 +1,70 @@
+{
+  "id": "XC44",
+  "tier": 4,
+  "title": "분기 두 잎 산출 상이",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC44 — 분기 두 잎 산출 상이.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n뿌리에서 갈라진 두 잎 left.hwp·right.hwp 가 **서로 다른 바이트**이고, 각 (0,0) 문구가 다르게 남아야 한다. 직선 사슬이 아니다.\n\n제출 폴더에 split/root.capsule.json · split/left.capsule.json · split/right.capsule.json · left.hwp · right.hwp 를 두어라.\n\n수행 힌트: files_differ + export-tables 두 번.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n같은 계획으로 두 잎을 만들면 해시가 같다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "split/root.capsule.json",
+      "split/left.capsule.json",
+      "split/right.capsule.json",
+      "left.hwp",
+      "right.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "왼쪽 잎 칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "좌잎-XC44",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:left.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "오른쪽 잎 칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "우잎-XC44",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:right.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "두 잎 산출이 서로 다름",
+      "op": "files_differ",
+      "files": [
+        "left.hwp",
+        "right.hwp"
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "split/left.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC45.json
+++ b/gym/packs/expert-challenges/tasks/XC45.json
@@ -1,0 +1,63 @@
+{
+  "id": "XC45",
+  "tier": 4,
+  "title": "4세대 원본 차이와 계보",
+  "input": "samples/multi-table-002.hwp",
+  "axis": "자동화",
+  "instructions": "XC45 — 4세대 원본 차이와 계보.\n\n입력 표본은 `samples/multi-table-002.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n다중표-002 4세대 최종 산출이 입력과 바이트가 다르고, 계보 깊이가 4 여야 한다. 무편집 복사를 거절한다.\n\n제출 폴더에 diff4/g0.capsule.json · diff4/g1.capsule.json · diff4/g2.capsule.json · diff4/g3.capsule.json · leaf.hwp 를 두어라.\n\n수행 힌트: differs_from_input leaf.hwp + lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n입력을 그대로 내면 차이 검사가 실패한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "diff4/g0.capsule.json",
+      "diff4/g1.capsule.json",
+      "diff4/g2.capsule.json",
+      "diff4/g3.capsule.json",
+      "leaf.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:diff4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:diff4/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "최종 산출이 입력과 다름",
+      "op": "differs_from_input",
+      "file": "leaf.hwp"
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "diff4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC46.json
+++ b/gym/packs/expert-challenges/tasks/XC46.json
@@ -1,0 +1,55 @@
+{
+  "id": "XC46",
+  "tier": 4,
+  "title": "독립 두 사슬 각각 유효",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC46 — 독립 두 사슬 각각 유효.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n서로 부모를 공유하지 않는 **두 개의 2링크 사슬**(a1→a2, b1→b2)을 dual/ 에 제출하라. 각 막내 lineage valid==true (얕음). 한 사슬 3세대(XC04)가 아니다.\n\n제출 폴더에 dual/a1.capsule.json · dual/a2.capsule.json · dual/b1.capsule.json · dual/b2.capsule.json 를 두어라.\n\n수행 힌트: 두 번 lineage (a2, b2) valid. --deep 과 depth 3 금지.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n한 사슬만 내면 두 번째 검사가 빈다. 두 뿌리는 서로 --parent 로 잇지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "dual/a1.capsule.json",
+      "dual/a2.capsule.json",
+      "dual/b1.capsule.json",
+      "dual/b2.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "첫째 사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:dual/a2.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "둘째 사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:dual/b2.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "dual/a2.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC47.json
+++ b/gym/packs/expert-challenges/tasks/XC47.json
@@ -1,0 +1,74 @@
+{
+  "id": "XC47",
+  "tier": 5,
+  "title": "쌍 사슬 L4 깊은 게이트",
+  "input": "samples/inner-table-01.hwp",
+  "axis": "자동화",
+  "instructions": "XC47 — 쌍 사슬 L4 깊은 게이트.\n\n입력 표본은 `samples/inner-table-01.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n같은 키로 서명한 독립 캡슐 두 장(p,q)을 한 폴더에 두고 둘 다 앵커한 뒤 **L4 --deep** 을 통과하라. 한 장만 내면 보스가 아니다.\n\n제출 폴더에 duall4/p.capsule.json · duall4/q.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: replay --sign-key 두 번, anchor add 두 번, conformance L4 --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n두 장을 부모로 잇지 마라. 독립 두 장이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "duall4/p.capsule.json",
+      "duall4/q.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:duall4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:duall4/q.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "duall4/q.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC48.json
+++ b/gym/packs/expert-challenges/tasks/XC48.json
@@ -1,0 +1,91 @@
+{
+  "id": "XC48",
+  "tier": 5,
+  "title": "원장·보고·4세대 동시",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC48 — 원장·보고·4세대 동시.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n4세대에 원장 기록·감사 보고·계보 깊이 4 를 한 제출에 묶어라. L5 적합성과 4관문 path 는 열지 마라.\n\n제출 폴더에 mix3/g0.capsule.json · mix3/g1.capsule.json · mix3/g2.capsule.json · mix3/g3.capsule.json · wo.json · gate.json · claim.json · ledger.ndjson · report.json 를 두어라.\n\n수행 힌트: settle record + audit-report + lineage --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n세 축 중 하나라도 빠지면 보스가 아니다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "mix3/g0.capsule.json",
+      "mix3/g1.capsule.json",
+      "mix3/g2.capsule.json",
+      "mix3/g3.capsule.json",
+      "wo.json",
+      "gate.json",
+      "claim.json",
+      "ledger.ndjson",
+      "report.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 4세대",
+      "op": "value_eq",
+      "value": 4,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:mix3/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:mix3/g3.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "원장 기록 실재",
+      "op": "file_exists",
+      "file": "ledger.ndjson",
+      "minBytes": 80
+    },
+    {
+      "name": "감사 보고 실재",
+      "op": "file_exists",
+      "file": "report.json",
+      "minBytes": 64
+    },
+    {
+      "name": "보고 계보 머리 1건 이상",
+      "op": "value_ge",
+      "value": 1,
+      "path": "lineage.valid",
+      "cmd": [
+        "audit-report",
+        "{file:mix3}",
+        "-o",
+        "{file:report.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "mix3/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC49.json
+++ b/gym/packs/expert-challenges/tasks/XC49.json
@@ -1,0 +1,76 @@
+{
+  "id": "XC49",
+  "tier": 5,
+  "title": "5세대 중간 오염과 계보",
+  "input": "samples/hwp_table_test.hwp",
+  "axis": "자동화",
+  "instructions": "XC49 — 5세대 중간 오염과 계보.\n\n입력 표본은 `samples/hwp_table_test.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n표시험 5세대에서 셋째 세대 오염 폐쇄(3건+)와 막내 계보 깊이 5 를 동시에 본다.\n\n제출 폴더에 m5/g0.capsule.json · m5/g1.capsule.json · m5/g2.capsule.json · m5/g3.capsule.json · m5/g4.capsule.json 를 두어라.\n\n수행 힌트: recall-scope g2 + lineage --deep depth 5.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n중간 오염과 전체 깊이 5 가 둘 다 맞아야 한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "m5/g0.capsule.json",
+      "m5/g1.capsule.json",
+      "m5/g2.capsule.json",
+      "m5/g3.capsule.json",
+      "m5/g4.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 5세대",
+      "op": "value_eq",
+      "value": 5,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:m5/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:m5/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "영향권 3건 이상",
+      "op": "len_ge",
+      "value": 3,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:m5/g2.capsule.json}",
+        "--among",
+        "{file:m5}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "m5/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC50.json
+++ b/gym/packs/expert-challenges/tasks/XC50.json
@@ -1,0 +1,94 @@
+{
+  "id": "XC50",
+  "tier": 5,
+  "title": "L4 리콜 4세대 서명 완주",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC50 — L4 리콜 4세대 서명 완주.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n서명·앵커 4세대로 L4 --deep 과 뿌리 리콜 4건+ 를 동시에 완주하라. **L5 가 아니다.** 원장·unaffected·3세대 --deep·L3 보고를 붙이지 마라.\n\n제출 폴더에 boss4/g0.capsule.json · boss4/g1.capsule.json · boss4/g2.capsule.json · boss4/g3.capsule.json · keyring.json · anchor.ndjson · policy.json 를 두어라.\n\n수행 힌트: keygen + sign×4 + anchor×4 + conformance L4 --deep + recall-scope.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nL5 로 승격하거나 4관문을 열면 다른 보스(XC01/XC03)를 훔친 것이다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "boss4/g0.capsule.json",
+      "boss4/g1.capsule.json",
+      "boss4/g2.capsule.json",
+      "boss4/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:boss4/g0.capsule.json}",
+        "--among",
+        "{file:boss4}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:boss4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:boss4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "boss4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC51.json
+++ b/gym/packs/expert-challenges/tasks/XC51.json
@@ -1,0 +1,95 @@
+{
+  "id": "XC51",
+  "tier": 5,
+  "title": "끝칸과 L4 4세대 동시",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC51 — 끝칸과 L4 4세대 동시.\n\n입력 표본은 `samples/multi-table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n다중표 4세대를 서명·앵커하고 끝칸 (0,0) 과 L4 --deep 을 동시에 대조하라.\n\n제출 폴더에 cl4/g0.capsule.json · cl4/g1.capsule.json · cl4/g2.capsule.json · cl4/g3.capsule.json · keyring.json · anchor.ndjson · policy.json · leaf.hwp 를 두어라.\n\n수행 힌트: export-tables + conformance L4 --deep.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n칸만 맞추고 서명을 빠뜨리면 L4 가 거부한다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "cl4/g0.capsule.json",
+      "cl4/g1.capsule.json",
+      "cl4/g2.capsule.json",
+      "cl4/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json",
+      "leaf.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:cl4}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:cl4/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "(0,0) == 칸4-XC51",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "칸4-XC51",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:leaf.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "cl4/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC52.json
+++ b/gym/packs/expert-challenges/tasks/XC52.json
@@ -1,0 +1,43 @@
+{
+  "id": "XC52",
+  "tier": 5,
+  "title": "세 갈래 뿌리 리콜",
+  "input": "samples/table-001.hwp",
+  "axis": "자동화",
+  "instructions": "XC52 — 세 갈래 뿌리 리콜.\n\n입력 표본은 `samples/table-001.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n뿌리에서 **세 자식** left·mid·right 가 갈라지게 하고 뿌리 리콜 영향 **4건 이상**. 직선 4세대와 다르다.\n\n제출 폴더에 tri/root.capsule.json · tri/left.capsule.json · tri/mid.capsule.json · tri/right.capsule.json 를 두어라.\n\n수행 힌트: replay --parent root 세 번. recall-scope affected>=4.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n두 자식만 내면 영향이 3이다. 세 갈래가 필요하다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "tri/root.capsule.json",
+      "tri/left.capsule.json",
+      "tri/mid.capsule.json",
+      "tri/right.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "영향권 4건 이상",
+      "op": "len_ge",
+      "value": 4,
+      "path": "affected",
+      "cmd": [
+        "recall-scope",
+        "--contaminated",
+        "{file:tri/root.capsule.json}",
+        "--among",
+        "{file:tri}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "tri/left.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC53.json
+++ b/gym/packs/expert-challenges/tasks/XC53.json
@@ -1,0 +1,63 @@
+{
+  "id": "XC53",
+  "tier": 4,
+  "title": "L2 재현 5세대 끝칸",
+  "input": "samples/table-complex.hwp",
+  "axis": "자동화",
+  "instructions": "XC53 — L2 재현 5세대 끝칸.\n\n입력 표본은 `samples/table-complex.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\n복합표 5세대에 L2 --deep 재현과 끝칸 (0,0) 을 동시에 걸어라. 서명 사다리는 아니다.\n\n제출 폴더에 l2c5/g0.capsule.json · l2c5/g1.capsule.json · l2c5/g2.capsule.json · l2c5/g3.capsule.json · l2c5/g4.capsule.json · leaf.hwp 를 두어라.\n\n수행 힌트: conformance L2 --deep + export-tables.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\nL3 이상을 열지 마라. 키링이 없다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "l2c5/g0.capsule.json",
+      "l2c5/g1.capsule.json",
+      "l2c5/g2.capsule.json",
+      "l2c5/g3.capsule.json",
+      "l2c5/g4.capsule.json",
+      "leaf.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L2 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:l2c5}",
+        "--level",
+        "L2",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "(0,0) == 칸5-XC53",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "칸5-XC53",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:leaf.hwp}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "l2c5/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC54.json
+++ b/gym/packs/expert-challenges/tasks/XC54.json
@@ -1,0 +1,83 @@
+{
+  "id": "XC54",
+  "tier": 5,
+  "title": "5연속 앵커와 5세대 계보",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC54 — 5연속 앵커와 5세대 계보.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 5세대 전부를 앵커 로그에 올리고 막내 계보 깊이 5 와 막내 logged 를 본다.\n\n제출 폴더에 log5/g0.capsule.json · log5/g1.capsule.json · log5/g2.capsule.json · log5/g3.capsule.json · log5/g4.capsule.json · anchor.ndjson 를 두어라.\n\n수행 힌트: anchor add ×5 + lineage --deep + anchor verify.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n한 번만 add 하면 앞 세대가 로그에 없다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "log5/g0.capsule.json",
+      "log5/g1.capsule.json",
+      "log5/g2.capsule.json",
+      "log5/g3.capsule.json",
+      "log5/g4.capsule.json",
+      "anchor.ndjson"
+    ]
+  },
+  "checks": [
+    {
+      "name": "깊이 5세대",
+      "op": "value_eq",
+      "value": 5,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:log5/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "사슬 온전",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:log5/g4.capsule.json}",
+        "--deep",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:log5/g4.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "log5/g4.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/gym/packs/expert-challenges/tasks/XC55.json
+++ b/gym/packs/expert-challenges/tasks/XC55.json
@@ -1,0 +1,101 @@
+{
+  "id": "XC55",
+  "tier": 5,
+  "title": "표사 정산 L4 4세대",
+  "input": "samples/table-004.hwp",
+  "axis": "자동화",
+  "instructions": "XC55 — 표사 정산 L4 4세대.\n\n입력 표본은 `samples/table-004.hwp` 이다. 보스 존 과제다. 한 단만 빠지면 최종 판정이 막힌다. 저장소 samples/ 에 이미 있는 실문서만 쓰고 새 픽스처를 만들지 않는다. expert-challenges pack 은 기존 CLI 표면(keygen · replay · run · anchor · settle · conformance · recall-scope · lineage · audit-report · export-tables) 만으로 여러 축을 한 제출에 묶는다. 새 명령·새 연산자·새 pack 은 없다. 원본을 덮어쓰지 마라. 산출은 제출 폴더의 -o / --capsule 뿐이다. 정답 해시·건수를 과제 파일에 박제하지 마라. 채점은 같은 판정 명령을 다시 돌린다.\n\ntable-004 서명 4세대로 L4 --deep 과 막내 청구 verdict==ok 를 동시에 닫아라. L5·4관문·3세대 --deep 이 아니다.\n\n제출 폴더에 t4mix/g0.capsule.json · t4mix/g1.capsule.json · t4mix/g2.capsule.json · t4mix/g3.capsule.json · keyring.json · anchor.ndjson · policy.json · wo.json · gate.json · claim.json 를 두어라.\n\n수행 힌트: conformance L4 --deep + settle verify.\n\n이 과제는 XC01(L5 --deep 사다리 완주) · XC02(unaffected==0 과 affected>=2 동시) · XC03(정산 4관문 capsuleOk/gateOk/ledgerOk/workorderOk) · XC04(3세대 lineage --deep) · XC05(L3 --deep + audit-report) 를 복제하지 않는다. AU14+ 한 축 저티어 여정, WR 일일 3해시 answer.json, T07 서식 채움(fill-fields · 첫 필드 홍길동) 도 베끼지 마라.\n\n원장을 넣고 L5 로 올리지 마라. 이 보스는 L4+청구다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "t4mix/g0.capsule.json",
+      "t4mix/g1.capsule.json",
+      "t4mix/g2.capsule.json",
+      "t4mix/g3.capsule.json",
+      "keyring.json",
+      "anchor.ndjson",
+      "policy.json",
+      "wo.json",
+      "gate.json",
+      "claim.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "L4 깊은 적합",
+      "op": "value_eq",
+      "value": "conformant",
+      "path": "verdict",
+      "cmd": [
+        "conformance",
+        "{file:t4mix}",
+        "--level",
+        "L4",
+        "--deep",
+        "--keyring",
+        "{file:keyring.json}",
+        "--anchor-log",
+        "{file:anchor.ndjson}",
+        "--policy",
+        "{file:policy.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "청구 검증 ok",
+      "op": "value_eq",
+      "value": "ok",
+      "path": "verdict",
+      "cmd": [
+        "settle",
+        "verify",
+        "{file:claim.json}",
+        "--workorder",
+        "{file:wo.json}",
+        "--capsule",
+        "{file:t4mix/g3.capsule.json}",
+        "--gate-envelope",
+        "{file:gate.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "막내 앵커 등재",
+      "op": "value_eq",
+      "value": true,
+      "path": "logged",
+      "cmd": [
+        "anchor",
+        "verify",
+        "{file:t4mix/g3.capsule.json}",
+        "--log",
+        "{file:anchor.ndjson}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "앵커 로그 실재",
+      "op": "file_exists",
+      "file": "anchor.ndjson",
+      "minBytes": 40
+    },
+    {
+      "name": "막내 캡슐 실재",
+      "op": "file_exists",
+      "file": "t4mix/g3.capsule.json",
+      "minBytes": 80
+    }
+  ]
+}

--- a/mydocs/working/gym_expert_challenges.md
+++ b/mydocs/working/gym_expert_challenges.md
@@ -1,0 +1,106 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_expert_challenges.md
+last_verified: 2026-08-18
+issue: 5261
+---
+
+# gym expert-challenges pack 확장 작업 노트 (이슈 #5261)
+
+## 한 줄
+
+`feat/gym-expert-challenges-expand` 가 XC01–XC05 에서 멈춰 있던 보스
+어트랙션을, 기존 명령·기존 표본만으로 XC06–XC55 과 README·가드 시험까지
+늘린다. 새 CLI 는 없다.
+
+## 배경
+
+보스 pack 은 사다리 여러 단을 한 제출에 묶는다. 개장 다섯 대(XC01–XC05)는
+L5 완주 · 오염 무영향 0 · 정산 4관문 · 3세대 --deep · L3 서명+앵커 완주라는
+지문이 강해, 에이전트가 그 힌트만 외우면 보스 존을 통과한다. 이슈 #5261 은
+그 지문을 복제하지 말고 여정을 늘리라고 한다.
+
+건드리지 않은 것:
+
+- 새 연산자 (`checks.py` 미변경)
+- 새 CLI · 새 표본 · 새 pack
+- T07 서식 채움 복제 (`fill-fields`, 첫 필드 홍길동)
+- XC01–XC05 복제 (L5, 오염 무영향 0, 정산 4관문, 3세대 --deep, L3 완주)
+- AU14+ 복제 (한 축 저티어, tier≤3)
+- WR01+ 복제 (일일 영수증 3해시 answer.json)
+- `gym/README.md` · `gym/PARK.md` · `profiles/*.json` 집계 갱신
+- 다른 pack 의 과제 파일
+- `cargo fmt --all` (JSON·문서·테스트만)
+- `pack.json` 의 `runner` 신원 (`rhwpVersion` / `rhwpCommit` /
+  `capabilitiesSha256`). 요구 명령 목록도 기존 값을 유지했다.
+
+## 설계 원칙
+
+1. **묶음을 바꾼다.** XC04 가 3세대 --deep 이면 XC06 은 4세대, XC07 은
+   5세대다. XC02 가 unaffected+affected 면 XC11+ 는 affected 만 본다.
+   XC03 이 4관문이면 XC26+ 는 verdict 또는 원장 실재만 본다. XC01 이 L5
+   면 XC16+ 는 L4 (원장 없음) 다. XC05 가 L3+보고면 XC24+ 는 보고만.
+2. **표본을 흩는다.** table-001 한 장에 질문을 몰지 않는다. table-004,
+   multi-table-001/002, inner-table-01, hwp_table_test, table-complex,
+   hwpx/basic-table-01. 전부 `samples/` 에 이미 있다.
+3. **티어는 4~5.** AU14+ 가 비운 보스 칸만 채운다.
+4. **보스를 훔치지 않는다.** L5 · 3세대 --deep · 원장 4관문 · 무영향 0
+   콤보는 개장 다섯 대의 것이다.
+5. **T07 금지.** 누름틀을 채우지 않는다.
+
+## 과제 묶음
+
+| 구간 | 축 | 건수 | 핵심 필드 |
+|------|----|------|-----------|
+| XC06–XC10 | 계보 깊이 4·5 | 5 | `lineage.valid` · `depth`≠3 |
+| XC11–XC15 | 리콜 | 5 | `affected` (unaffected 없음) |
+| XC16–XC20 | L4 / L2 | 5 | `conformance.verdict` |
+| XC21–XC25 | 서명·앵커·보고 | 5 | `logged` · `lineage.valid` |
+| XC26–XC30 | 정산 | 5 | `settle.verify.verdict` · ledger 실재 |
+| XC31–XC40 | 표본 이동 | 10 | 위 축을 다른 실문서에 |
+| XC41–XC45 | 끝칸·분기 | 5 | `cell_text_eq` · `files_differ` |
+| XC46–XC55 | 혼합 보스 | 10 | 두 축 이상 동시 |
+
+XC01–XC05 는 그대로 둔다. 번호 구멍 없음 (1…55).
+
+과제 ID 전체: XC06 XC07 XC08 XC09 XC10 XC11 XC12 XC13 XC14 XC15 XC16
+XC17 XC18 XC19 XC20 XC21 XC22 XC23 XC24 XC25 XC26 XC27 XC28 XC29 XC30
+XC31 XC32 XC33 XC34 XC35 XC36 XC37 XC38 XC39 XC40 XC41 XC42 XC43 XC44
+XC45 XC46 XC47 XC48 XC49 XC50 XC51 XC52 XC53 XC54 XC55.
+
+## 사용한 기존 표본
+
+- `samples/table-001.hwp`
+- `samples/table-004.hwp`
+- `samples/multi-table-001.hwp`
+- `samples/multi-table-002.hwp`
+- `samples/inner-table-01.hwp`
+- `samples/hwp_table_test.hwp`
+- `samples/table-complex.hwp`
+- `samples/hwpx/basic-table-01.hwpx`
+
+## 검증
+
+파일만으로 도는 가드:
+
+```text
+python gym/tools/audit.py
+python scripts/tests/test_gym_packs.py
+python scripts/tests/test_gym_expert_challenges_pack.py
+```
+
+`audit.py` 는 전 pack 정합(짝 기준풀이·ID 고유·스키마)을 본다.
+`test_gym_packs.py` 는 전 pack 계약이다. pack 전용 가드는 XC06+ 50건,
+runner 복사, T07/AU14+/WR/XC01-05 복제 금지, 기존 표본·기존 연산자,
+문서에 모든 새 ID 가 있는지를 고정한다.
+
+기준풀이 왕복(`build_baseline.py --pack expert-challenges`)은 로컬
+바이너리가 있을 때 추가로 돈다. 이 확장은 바이너리를 바꾸지 않으므로
+`cargo fmt --all` 을 돌리지 않았다.
+
+## 크기
+
+이슈 DoD 는 `upstream/devel` 대비 insertions ≥ 3000 이다. XC06–XC55
+과제+기준풀이 50쌍, pack README, pack 가드, 이 작업 노트가 그 문을
+채운다. `git add -A` 는 쓰지 않았고 다른 pack 은 편집하지 않았다.

--- a/scripts/tests/test_gym_expert_challenges_pack.py
+++ b/scripts/tests/test_gym_expert_challenges_pack.py
@@ -1,0 +1,463 @@
+"""expert-challenges pack 확장 계약 — XC06+ · README · 기존 명령/연산자/표본만.
+
+이 가드는 이슈 #5261 의 확장 규칙을 파일만으로 고정한다. 바이너리·네트워크가
+없어도 돈다. 새 연산자·새 표본·T07/AU14+/WR/XC01-05 복제·다른 pack 편집이
+들어오면 red.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+PACK = GYM / "packs" / "expert-challenges"
+TASKS = PACK / "tasks"
+REFS = PACK / "reference"
+README = PACK / "README.md"
+WORKING = REPO_ROOT / "mydocs" / "working" / "gym_expert_challenges.md"
+
+EXISTING_OPS = {
+    "same_hash",
+    "differs_from_input",
+    "file_exists",
+    "files_differ",
+    "xml_root_eq",
+    "json_value_eq",
+    "csv_cell_eq",
+    "utf8_bom",
+    "answer_eq",
+    "len_answer_eq",
+    "len_ge",
+    "value_eq",
+    "value_ge",
+    "value_in",
+    "deep_contains",
+    "not_contains",
+    "cell_text_eq",
+}
+
+PACK_COMMANDS = {
+    "keygen",
+    "replay",
+    "run",
+    "anchor",
+    "settle",
+    "conformance",
+    "recall-scope",
+    "lineage",
+    "audit-report",
+    "export-tables",
+}
+
+# devel 에 이미 있던 runner 신원. 이 확장은 복사만 한다.
+RUNNER_PIN = {
+    "rhwpVersion": "0.8.4",
+    "rhwpCommit": "34ba36fa3c48f37867fbedd16614fdb7e8f44709",
+    "capabilitiesSha256": "6e2b231fad617b618fda19663752fc1a57d56086ade31abade84d8e8e000de4c",
+}
+
+SCORE_FORBIDDEN = {"fill-fields", "fields", "inspect", "scan", "bundle", "disclose", "gate", "verify-signature"}
+ALLOWED_SAMPLES = {
+    "samples/table-001.hwp",
+    "samples/table-004.hwp",
+    "samples/multi-table-001.hwp",
+    "samples/multi-table-002.hwp",
+    "samples/inner-table-01.hwp",
+    "samples/hwp_table_test.hwp",
+    "samples/table-complex.hwp",
+    "samples/hwpx/basic-table-01.hwpx",
+}
+MIN_TASKS = 55
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def task_paths():
+    return sorted(TASKS.glob("XC*.json"))
+
+
+def ref_paths():
+    return sorted(REFS.glob("XC*.json"))
+
+
+def xc_num(path: Path) -> int:
+    return int(path.stem[2:])
+
+
+def load_tasks():
+    return [read_json(p) for p in task_paths()]
+
+
+class ExpertChallengesPackLayoutTests(unittest.TestCase):
+    def test_pack_manifest_identity_and_runner_copied(self):
+        manifest = read_json(PACK / "pack.json")
+        self.assertEqual(manifest["id"], "expert-challenges")
+        self.assertEqual(manifest["kind"], "gymPack")
+        self.assertEqual(manifest["schemaVersion"], "1.0")
+        self.assertIn("자동화", manifest["axis"])
+        cmds = set(manifest["requires"]["commands"])
+        self.assertEqual(cmds, PACK_COMMANDS)
+        self.assertEqual(manifest["runner"], RUNNER_PIN)
+
+    def test_readme_exists_and_is_korean(self):
+        self.assertTrue(README.is_file(), "gym/packs/expert-challenges/README.md 가 없다")
+        text = README.read_text(encoding="utf-8")
+        self.assertGreater(len(text), 2000)
+        for needle in (
+            "보스",
+            "사다리",
+            "XC06",
+            "XC55",
+            "기존 연산자",
+            "기존 명령",
+            "T07",
+            "복제하지",
+            "fields[0]",
+            "홍길동",
+            "AU14",
+            "WR",
+            "라이브 오라클",
+        ):
+            self.assertIn(needle, text, f"README 에 '{needle}' 가 없다")
+        self.assertNotIn("fill-fields", text)
+
+    def test_working_notes_exist_and_are_korean(self):
+        self.assertTrue(WORKING.is_file(), "mydocs/working/gym_expert_challenges.md 가 없다")
+        text = WORKING.read_text(encoding="utf-8")
+        self.assertGreater(len(text), 2000)
+        for needle in ("XC06", "XC55", "기존 표본", "T07", "audit", "test_gym_packs"):
+            self.assertIn(needle, text, f"작업 노트에 '{needle}' 가 없다")
+
+    def test_readme_and_working_name_every_new_task(self):
+        readme = README.read_text(encoding="utf-8")
+        working = WORKING.read_text(encoding="utf-8")
+        missing = []
+        for n in range(6, MIN_TASKS + 1):
+            tid = f"XC{n:02d}"
+            if tid not in readme:
+                missing.append(f"README:{tid}")
+            if tid not in working:
+                missing.append(f"working:{tid}")
+        self.assertEqual(missing, [], f"문서에 빠진 과제: {missing}")
+
+
+class ExpertChallengesTaskContractTests(unittest.TestCase):
+    def test_xc06_plus_ship_with_paired_reference(self):
+        plus = [p for p in task_paths() if xc_num(p) >= 6]
+        self.assertGreaterEqual(len(plus), 50, "XC06+ 과제가 50건 미만이다")
+        missing = []
+        for path in plus:
+            tid = path.stem
+            ref = REFS / f"{tid}.json"
+            if not ref.is_file():
+                missing.append(tid)
+                continue
+            task = read_json(path)
+            ref_obj = read_json(ref)
+            self.assertEqual(task["id"], tid)
+            self.assertEqual(ref_obj["id"], tid)
+            self.assertTrue(ref_obj.get("steps"), tid)
+        self.assertEqual(missing, [], f"기준풀이 없음: {missing}")
+
+    def test_task_ids_are_contiguous_xc_prefix(self):
+        nums = sorted(xc_num(p) for p in task_paths())
+        self.assertEqual(nums[0], 1)
+        self.assertGreaterEqual(nums[-1], MIN_TASKS)
+        self.assertEqual(nums, list(range(1, nums[-1] + 1)), "XC 번호에 구멍이 있다")
+
+    def test_every_task_has_required_keys_and_named_checks(self):
+        for task in load_tasks():
+            tid = task["id"]
+            for key in ("id", "tier", "title", "input", "instructions", "submit", "checks"):
+                self.assertIn(key, task, f"{tid}: 필수 키 {key}")
+            self.assertIsInstance(task["tier"], int)
+            self.assertGreaterEqual(task["tier"], 1, tid)
+            self.assertLessEqual(task["tier"], 5, tid)
+            self.assertTrue(task["title"].strip(), tid)
+            self.assertTrue(task["instructions"].strip(), tid)
+            self.assertTrue(task["checks"], tid)
+            for check in task["checks"]:
+                self.assertTrue(check.get("name"), f"{tid}: 이름 없는 검사")
+                self.assertIn(check["op"], EXISTING_OPS, f"{tid}: 허용 밖 연산자 {check['op']}")
+
+    def test_titles_and_instructions_are_unique_korean(self):
+        seen_title = {}
+        seen_inst = {}
+        for path in task_paths():
+            task = read_json(path)
+            tid = task["id"]
+            title = task["title"]
+            inst = task["instructions"]
+            self.assertRegex(inst, r"[가-힣]", tid)
+            self.assertRegex(title, r"[가-힣]", tid)
+            if xc_num(path) >= 6:
+                self.assertGreater(len(inst), 200, tid)
+                self.assertGreaterEqual(task["tier"], 4, f"{tid} 보스 티어가 아니다")
+            self.assertNotIn(title, seen_title, f"{tid} 제목이 {seen_title.get(title)} 와 중복")
+            self.assertNotIn(inst, seen_inst, f"{tid} 지시문이 {seen_inst.get(inst)} 와 같다")
+            seen_title[title] = tid
+            seen_inst[inst] = tid
+
+    def test_operators_are_existing_only(self):
+        unknown = []
+        for task in load_tasks():
+            for check in task["checks"]:
+                if check["op"] not in EXISTING_OPS:
+                    unknown.append(f"{task['id']}:{check['op']}")
+        self.assertEqual(unknown, [], f"새 연산자: {unknown}")
+
+    def test_score_commands_stay_inside_pack_requires(self):
+        bad = []
+        used = set()
+        for task in load_tasks():
+            for check in task.get("checks", []):
+                cmd = check.get("cmd")
+                if not cmd:
+                    continue
+                used.add(cmd[0])
+                if cmd[0] not in PACK_COMMANDS:
+                    bad.append(f"{task['id']}:{cmd[0]}")
+                if cmd[0] in SCORE_FORBIDDEN:
+                    bad.append(f"{task['id']}:금지 {cmd[0]}")
+        self.assertEqual(bad, [], f"pack requires 밖 채점 명령: {bad}")
+        for needed in ("lineage", "recall-scope", "conformance", "settle", "audit-report", "export-tables", "anchor"):
+            self.assertIn(needed, used, f"XC06+ 가 {needed} 를 채점에 쓰지 않았다")
+
+    def test_inputs_are_existing_samples(self):
+        missing = []
+        extra = []
+        for task in load_tasks():
+            rel = task["input"]
+            self.assertTrue(rel.startswith("samples/"), task["id"])
+            if not (REPO_ROOT / rel).exists():
+                missing.append(f"{task['id']}:{rel}")
+            if xc_num(Path(f"{task['id']}.json")) >= 6 and rel not in ALLOWED_SAMPLES:
+                extra.append(f"{task['id']}:{rel}")
+        self.assertEqual(missing, [], f"없는 표본: {missing}")
+        self.assertEqual(extra, [], f"허용 밖 표본: {extra}")
+
+    def test_no_t07_clone(self):
+        hits = []
+        for task in load_tasks():
+            if task["id"].startswith("T0"):
+                hits.append(f"{task['id']}:core-cli id")
+            if task.get("title") == "서식 채움":
+                hits.append(f"{task['id']}:title")
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] in ("fields", "fill-fields"):
+                    hits.append(f"{task['id']}:{cmd[0]}")
+                if "fill-fields" in cmd:
+                    hits.append(f"{task['id']}:fill-fields")
+                if check.get("value") == "홍길동":
+                    hits.append(f"{task['id']}:홍길동")
+                if check.get("path") == "fields[0].value":
+                    hits.append(f"{task['id']}:fields[0].value")
+        self.assertEqual(hits, [], f"T07 복제 흔적: {hits}")
+
+    def test_no_wr_clone(self):
+        hits = []
+        for path in task_paths():
+            if xc_num(path) < 6:
+                continue
+            task = read_json(path)
+            if task["id"].startswith("WR"):
+                hits.append(f"{task['id']}:wr-id")
+            if task.get("title") == "일일 영수증 3해시 발급":
+                hits.append(f"{task['id']}:wr-title")
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] == "replay":
+                    hits.append(f"{task['id']}:replay-score")
+                if check.get("op") == "answer_eq" and check.get("answer") in {
+                    "inputSha256",
+                    "planSha256",
+                    "outputSha256",
+                }:
+                    hits.append(f"{task['id']}:wr-3hash")
+        self.assertEqual(hits, [], f"WR 복제 흔적: {hits}")
+
+    def test_no_au14_clone(self):
+        hits = []
+        au_titles = {
+            "계획서 옆칸 원자 실행",
+            "둘째 행 계획 실행",
+            "table-004 첫 칸 계획",
+            "table-004 적합성 L1",
+            "table-004 청구 검증",
+            "내부표 2링크 리콜",
+        }
+        for path in task_paths():
+            task = read_json(path)
+            if task["id"].startswith("AU"):
+                hits.append(f"{task['id']}:au-id")
+            if task.get("title") in au_titles:
+                hits.append(f"{task['id']}:au-title")
+            if xc_num(path) >= 6 and task["tier"] <= 3:
+                hits.append(f"{task['id']}:au-tier")
+        self.assertEqual(hits, [], f"AU14+ 복제 흔적: {hits}")
+
+    def test_no_xc01_05_clone(self):
+        """XC01 L5 · XC02 unaffected+affected · XC03 4관문 · XC04 depth 3 --deep · XC05 L3+audit."""
+        hits = []
+        for path in task_paths():
+            if xc_num(path) < 6:
+                continue
+            task = read_json(path)
+            blob = json.dumps(task, ensure_ascii=False)
+            if task.get("title", "").startswith("사다리 완주"):
+                hits.append(f"{task['id']}:xc01-title")
+            paths = {c.get("path") for c in task["checks"]}
+            cmds = [c.get("cmd") or [] for c in task["checks"]]
+            for cmd in cmds:
+                if "conformance" in cmd and "--level" in cmd:
+                    idx = cmd.index("--level")
+                    level = cmd[idx + 1] if idx + 1 < len(cmd) else ""
+                    if level == "L5":
+                        hits.append(f"{task['id']}:xc01-l5")
+                    if level == "L3" and "--deep" in cmd:
+                        if any("audit-report" in (c.get("cmd") or []) for c in task["checks"]):
+                            hits.append(f"{task['id']}:xc05-l3-audit")
+                if "recall-scope" in cmd:
+                    if "unaffected" in paths and "affected" in paths:
+                        hits.append(f"{task['id']}:xc02-combo")
+                if "lineage" in cmd and "--deep" in cmd:
+                    for check in task["checks"]:
+                        if check.get("path") == "depth" and check.get("value") == 3:
+                            hits.append(f"{task['id']}:xc04-depth3")
+                if "settle" in cmd and "--ledger" in cmd:
+                    gate_paths = {"capsuleOk", "gateOk", "ledgerOk", "workorderOk"}
+                    if gate_paths <= paths:
+                        hits.append(f"{task['id']}:xc03-4gate")
+            if "unaffected" in blob and "affected" in blob:
+                if "unaffected" in paths and "affected" in paths:
+                    hits.append(f"{task['id']}:xc02-paths")
+        self.assertEqual(hits, [], f"XC01-05 복제 흔적: {hits}")
+
+    def test_xc01_05_files_unchanged(self):
+        for n in range(1, 6):
+            tid = f"XC{n:02d}"
+            task = read_json(TASKS / f"{tid}.json")
+            self.assertEqual(task["id"], tid)
+            self.assertIn(task["title"], {
+                "사다리 완주 — 적합성 L5",
+                "오염 리콜 드릴 — 계보 전파",
+                "정산 완주 — 원장 4관문",
+                "계보 완주 — 3세대 사슬",
+                "감사 표준 발급 — 서명 귀속 L3",
+            })
+
+    def test_no_hardcoded_golden_hashes(self):
+        bad = []
+        for path in task_paths():
+            if xc_num(path) < 6:
+                continue
+            blob = path.read_text(encoding="utf-8").lower()
+            tokens = blob.replace('"', " ").replace(":", " ").split()
+            if any(len(tok) == 64 and all(c in "0123456789abcdef" for c in tok) for tok in tokens):
+                bad.append(path.stem)
+        self.assertEqual(bad, [], f"박제 해시: {bad}")
+
+    def test_schema_module_accepts_every_task(self):
+        sys.path.insert(0, str(REPO_ROOT))
+        from gym.core import schema as gym_schema  # noqa: WPS433
+
+        manifest = read_json(PACK / "pack.json")
+        errors = []
+        gym_schema.validate_pack(manifest, str(PACK), errors)
+        for task in load_tasks():
+            gym_schema.validate_task(task, manifest, None, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+
+class ExpertChallengesReferenceTests(unittest.TestCase):
+    def test_every_task_has_matching_reference(self):
+        refs = {p.stem: read_json(p) for p in ref_paths()}
+        for task in load_tasks():
+            tid = task["id"]
+            self.assertIn(tid, refs, f"{tid} 기준풀이 없음")
+            self.assertEqual(refs[tid]["id"], tid)
+
+    def test_no_orphan_references(self):
+        task_ids = {t["id"] for t in load_tasks()}
+        for path in ref_paths():
+            self.assertIn(path.stem, task_ids, f"고아 기준풀이 {path.stem}")
+
+    def test_reference_steps_use_input_or_sub_placeholders(self):
+        for path in ref_paths():
+            if xc_num(path) < 6:
+                continue
+            ref = read_json(path)
+            self.assertTrue(ref.get("steps"), path.name)
+            blob = json.dumps(ref, ensure_ascii=False)
+            self.assertTrue(
+                "{input}" in blob or "{sub:" in blob or "samples/" in blob,
+                f"{path.name} 자리표/표본 경로가 없다",
+            )
+
+    def test_artifact_reference_writes_submit_files(self):
+        refs = {p.stem: read_json(p) for p in ref_paths()}
+        for task in load_tasks():
+            if xc_num(Path(f"{task['id']}.json")) < 6:
+                continue
+            if task["submit"]["kind"] != "artifact":
+                continue
+            blob = json.dumps(refs[task["id"]], ensure_ascii=False)
+            for fname in task["submit"]["files"]:
+                self.assertIn(fname, blob, f"{task['id']}: 기준풀이가 {fname} 을 쓰지 않는다")
+
+
+class ExpertChallengesExpansionScopeTests(unittest.TestCase):
+    def test_xc06_plus_cover_command_families(self):
+        families = {
+            "lineage": 0,
+            "recall-scope": 0,
+            "conformance": 0,
+            "settle": 0,
+            "audit-report": 0,
+            "export-tables": 0,
+            "anchor": 0,
+        }
+        for path in task_paths():
+            if xc_num(path) < 6:
+                continue
+            task = read_json(path)
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] in families:
+                    families[cmd[0]] += 1
+        for key, count in families.items():
+            self.assertGreaterEqual(count, 2, f"XC06+ 에 {key} 축이 부족하다: {count}")
+
+    def test_other_packs_untouched_by_new_ids(self):
+        leaked = []
+        packs = GYM / "packs"
+        for pack_dir in sorted(p for p in packs.iterdir() if p.is_dir()):
+            if pack_dir.name == "expert-challenges":
+                continue
+            for path in (pack_dir / "tasks").glob("XC*.json"):
+                leaked.append(f"{pack_dir.name}/{path.name}")
+        self.assertEqual(leaked, [], f"다른 pack 에 XC 과제: {leaked}")
+
+    def test_audit_still_passes_for_expert_challenges_pack(self):
+        spec_name = "gym_audit_expert_challenges_pack"
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(spec_name, GYM / "tools" / "audit.py")
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        report = module.audit(str(GYM))
+        self.assertTrue(report["ok"], f"audit 실패: {report}")
+        xc = [p for p in report.get("packs", []) if p["id"] == "expert-challenges" and p.get("issues")]
+        self.assertEqual(xc, [], f"expert-challenges pack 위반: {xc}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

`gym/packs/expert-challenges` 보스 어트랙션을 XC01–XC05 에서 XC06–XC55 로 늘린다. 기존 CLI 명령·기존 연산자·기존 `samples/` 실문서만 쓰고, `pack.json` runner 신원은 복사만 한다. 새 CLI·새 연산자·새 표본·다른 pack 편집은 없다.

개장 보스 지문(L5 `--deep` 완주, `unaffected==0`+`affected>=2`, 정산 4관문, 3세대 `lineage --deep`, L3 `--deep`+감사보고)을 복제하지 않는다. AU14+ 한 축 저티어, WR 일일 3해시, T07 서식 채움(`fields[0]==홍길동`)도 베끼지 않는다.

추가물:
- 과제+기준풀이 XC06–XC55 (50쌍)
- `gym/packs/expert-challenges/README.md`
- `scripts/tests/test_gym_expert_challenges_pack.py`
- `mydocs/working/gym_expert_challenges.md`

## 관련 이슈

closes #5261

## 테스트

- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [x] `python scripts/tests/test_gym_packs.py` 통과
- [x] `python scripts/tests/test_gym_expert_challenges_pack.py` 통과
- [ ] **`cargo fmt --all -- --check`** — JSON·문서·테스트만 변경. `cargo fmt --all` 을 돌리지 않았다
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — Rust 변경 없음
- [ ] `cargo test` — Rust 변경 없음
- [ ] `cargo clippy -- -D warnings` — Rust 변경 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (gym pack JSON·문서·가드 시험만)
- 재현·측정: 미측정