### PR TITLE
gym: score/runner 채점기 예외 경로·문서·시험 강화

### DIFF
--- a/gym/core/runner.py
+++ b/gym/core/runner.py
@@ -14,7 +14,20 @@ pack 확장이 더한 것:
    `unavailable` 로 보고한다.
 6) **점수에는 신원이 붙는다** — 실행 바이너리의 version·commit·capabilities
    digest 를 스코어카드에 남기고 pack 의 기준 실행과 대조한다.
+
+예외 경로(#5260):
+7) **침묵하지 않는다** — pack 로드·프로파일·과제 JSON·answer.json·CLI 실행이
+   죽어도 채점 전체가 멈추지 않는다. 그 자리는 `status=error` 또는 과제
+   `error`/`kind` 로 남긴다. 오류를 unavailable(명령 부재) 이나 0점으로
+   위장하지 않는다.
+8) **치명 예외는 삼키지 않는다** — KeyboardInterrupt·SystemExit·MemoryError·
+   GeneratorExit 는 도구를 죽이는 것이 정직하다.
+9) **식별자는 경로가 아니다** — pack id·profile id 의 `..` / 구분자 /
+   절대경로는 `unsafe-id` 다. `{file:}`·`{sha256:}` 자리표시자도 상위
+   디렉터리로 나가지 못한다.
 """
+
+from __future__ import annotations
 
 import io
 import json
@@ -30,6 +43,374 @@ ROOT = os.path.dirname(GYM)
 PACKS_DIR = os.path.join(GYM, "packs")
 PROFILES_DIR = os.path.join(GYM, "profiles")
 
+REPORT_KIND = "gymScorecard"
+SCHEMA_VERSION = "2.0"
+ADMISSION_KIND = "gymAdmission"
+ADMISSION_SCHEMA = "1.0"
+
+#: CLI stdout 머리. 예전 계약은 200 바이트가 아니라 200 글자다.
+HEAD_LIMIT = 200
+ERROR_HEAD_LIMIT = 160
+
+#: 삼키면 안 되는 예외 — 도구를 죽이는 것이 정직하다.
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+#: 운영 예외. BaseException 전부가 아니다.
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    TimeoutError,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    json.JSONDecodeError,
+    RuntimeError,
+    subprocess.SubprocessError,
+)
+
+#: pack 한 줄의 상태. scored 와 unavailable 사이에 error 를 끼워 넣지 않는다.
+PACK_STATUSES = ("scored", "unavailable", "error")
+
+#: 입장 판정. allow 는 packsScored >= 1 과만 같다.
+ADMISSION_VERDICTS = ("allow", "deny")
+
+#: 종료 코드. 새 코드를 만들지 않는다 — 0=만점, 3=그 외.
+EXIT_PERFECT = 0
+EXIT_IMPERFECT = 3
+
+#: 예외 kind 카탈로그. 문서·시험이 같은 표를 본다.
+EXCEPTION_KINDS = (
+    "missing-bin",
+    "missing-submit",
+    "missing-pack",
+    "missing-profile",
+    "missing-file",
+    "missing-tasks-dir",
+    "missing-input",
+    "malformed-json",
+    "malformed-answer",
+    "malformed-task",
+    "malformed-check",
+    "malformed-pack",
+    "malformed-profile",
+    "malformed-cmd",
+    "unsafe-id",
+    "permission",
+    "os-error",
+    "decode-error",
+    "value-error",
+    "type-error",
+    "timeout",
+    "subprocess",
+    "unknown-op",
+    "bad-expect-exits",
+    "cli-exit",
+    "envelope-parse",
+    "path-eval",
+    "empty-checks",
+    "empty-agent",
+    "write-error",
+    "unexpected",
+)
+
+EXCEPTION_KIND_HELP = {
+    "missing-bin": "rhwp 실행 파일이 없거나 CreateProcess 가 찾지 못함",
+    "missing-submit": "과제 제출 폴더가 없음",
+    "missing-pack": "pack.json 이 없거나 pack 폴더가 없음",
+    "missing-profile": "profiles/<id>.json 이 없음",
+    "missing-file": "제출 파일·해시 대상이 없음",
+    "missing-tasks-dir": "pack 의 tasks/ 디렉터리가 없음",
+    "missing-input": "과제에 input 이 없는데 {input} 자리표시자를 씀",
+    "malformed-json": "JSON 파싱 실패",
+    "malformed-answer": "answer.json 이 객체가 아니거나 깨짐",
+    "malformed-task": "과제 JSON 이 객체가 아니거나 필수 키가 없음",
+    "malformed-check": "체크가 객체가 아니거나 op 가 없음",
+    "malformed-pack": "pack.json 이 객체가 아니거나 필수 키가 없음",
+    "malformed-profile": "프로파일이 객체가 아니거나 packs 가 목록이 아님",
+    "malformed-cmd": "cmd 가 문자열 목록이 아님",
+    "unsafe-id": "pack/profile/파일 자리에 경로 구분자나 .. 가 있음",
+    "permission": "읽기·쓰기·실행 권한 없음",
+    "os-error": "그 밖의 OSError",
+    "decode-error": "UTF-8 디코드 실패",
+    "value-error": "값 형태가 기대와 다름",
+    "type-error": "타입 불일치",
+    "timeout": "대기 한도를 넘김",
+    "subprocess": "자식 프로세스 기동·통신 실패",
+    "unknown-op": "체크 연산자가 레지스트리에 없음",
+    "bad-expect-exits": "expect_exits 가 비지 않은 정수 목록이 아님",
+    "cli-exit": "rhwp 종료 코드가 허용 집합 밖",
+    "envelope-parse": "stdout 이 JSON 봉투가 아님",
+    "path-eval": "봉투 경로 평가(KeyError/IndexError/TypeError)",
+    "empty-checks": "과제 checks 가 비어 통과할 칸이 없음",
+    "empty-agent": "agent 이름이 비었음",
+    "write-error": "scorecard/report/admission 기록 실패",
+    "unexpected": "분류되지 않은 운영 예외",
+}
+
+SCORECARD_KEYS = (
+    "kind",
+    "schemaVersion",
+    "profile",
+    "runner",
+    "total",
+    "packs",
+)
+
+TOTAL_KEYS = (
+    "score",
+    "max",
+    "packsScored",
+    "packsUnavailable",
+    "packsErrored",
+)
+
+OPTIONAL_SCORECARD_KEYS = (
+    "agent",
+    "exceptions",
+    "exceptionCount",
+    "binPath",
+    "binMissing",
+    "trusted",
+)
+
+TASK_SHAPE_KEYS = ("id", "tier", "title", "checks")
+
+UNSAFE_ID_CHARS = ("/", "\\", ":", "\x00")
+
+
+class ScoreRunnerError(Exception):
+    """채점기가 접는 운영 예외. kind 는 EXCEPTION_KINDS 중 하나."""
+
+    def __init__(self, kind, message, **extra):
+        if kind not in EXCEPTION_KINDS:
+            kind = "unexpected"
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+        self.extra = extra
+
+    def as_row(self, where=""):
+        return exception_row(self.kind, where=where, message=self.message,
+                             extra=self.extra)
+
+
+def is_fatal_exception(exc):
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def is_catchable_exception(exc):
+    """운영 예외로 접을 수 있는가. 치명 예외는 아니다."""
+    if exc is None or is_fatal_exception(exc):
+        return False
+    return isinstance(exc, CATCHABLE_EXCEPTIONS) or isinstance(exc, ScoreRunnerError)
+
+
+def is_known_exception_kind(kind):
+    return kind in EXCEPTION_KINDS
+
+
+def is_known_pack_status(status):
+    return status in PACK_STATUSES
+
+
+def describe_exception_kind(kind):
+    """kind 한 줄 설명. 모르는 값은 unexpected 설명."""
+    if kind in EXCEPTION_KIND_HELP:
+        return EXCEPTION_KIND_HELP[kind]
+    return EXCEPTION_KIND_HELP["unexpected"]
+
+
+def truncate_head(text, limit=HEAD_LIMIT):
+    """출력 머리. None/비문자는 빈 문자열. 한도는 0 이하면 빈 값."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return ""
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        n = HEAD_LIMIT
+    if n <= 0:
+        return ""
+    return text[:n]
+
+
+def error_head(exc, limit=ERROR_HEAD_LIMIT):
+    """예외 메시지 머리. 예외가 아니면 문자열로 접는다."""
+    if exc is None:
+        return ""
+    try:
+        text = str(exc)
+    except Exception:
+        text = type(exc).__name__
+    return truncate_head(text, limit)
+
+
+def exception_kind(exc, context="check"):
+    """예외를 kind 로 접는다. 순수.
+
+    context:
+      - bin: 바이너리 실행. FileNotFound → missing-bin
+      - pack: pack.json 로드. FileNotFound → missing-pack
+      - profile: 프로파일 로드. FileNotFound → missing-profile
+      - submit: 제출 폴더. FileNotFound → missing-submit
+      - file: 제출 파일·해시. FileNotFound → missing-file
+      - answer: answer.json. JSONDecodeError → malformed-answer
+      - check: 체크 평가. KeyError → path-eval
+      - write: 산출 기록. OSError → write-error
+    """
+    if isinstance(exc, ScoreRunnerError):
+        return exc.kind if is_known_exception_kind(exc.kind) else "unexpected"
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, FileNotFoundError):
+        return {
+            "bin": "missing-bin",
+            "pack": "missing-pack",
+            "profile": "missing-profile",
+            "submit": "missing-submit",
+            "file": "missing-file",
+            "answer": "missing-file",
+            "check": "missing-file",
+            "write": "write-error",
+        }.get(context, "missing-file")
+    if isinstance(exc, PermissionError):
+        return "permission" if context != "write" else "write-error"
+    if isinstance(exc, json.JSONDecodeError):
+        if context == "answer":
+            return "malformed-answer"
+        if context == "pack":
+            return "malformed-pack"
+        if context == "profile":
+            return "malformed-profile"
+        return "malformed-json"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, subprocess.SubprocessError):
+        return "subprocess"
+    if isinstance(exc, AttributeError):
+        return "type-error"
+    if isinstance(exc, TypeError):
+        return "path-eval" if context == "check" else "type-error"
+    if isinstance(exc, (KeyError, IndexError)):
+        return "path-eval" if context == "check" else "value-error"
+    if isinstance(exc, ValueError):
+        if context == "answer":
+            return "malformed-answer"
+        return "value-error"
+    if isinstance(exc, OSError):
+        return "write-error" if context == "write" else "os-error"
+    if isinstance(exc, RuntimeError):
+        return "unexpected"
+    return "unexpected"
+
+
+def exception_row(kind, where="", message="", extra=None):
+    """예외 한 줄. 점수 집계를 뒤집지 않는다."""
+    if not is_known_exception_kind(kind):
+        kind = "unexpected"
+    row = {
+        "kind": kind,
+        "where": where or "",
+        "message": truncate_head(message, ERROR_HEAD_LIMIT),
+    }
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            if key in row:
+                continue
+            row[key] = value
+    return row
+
+
+def wrap_exception(exc, context="check", where=""):
+    """운영 예외를 ScoreRunnerError 로. 치명 예외는 다시 던진다."""
+    if is_fatal_exception(exc):
+        raise exc
+    if isinstance(exc, ScoreRunnerError):
+        return exc
+    kind = exception_kind(exc, context)
+    return ScoreRunnerError(kind, error_head(exc), where=where,
+                            type=type(exc).__name__)
+
+
+def is_safe_id(name):
+    """pack/profile 한 칸 이름. 구분자·절대경로·.. 금지."""
+    if not isinstance(name, str) or not name:
+        return False
+    if name in (".", ".."):
+        return False
+    if any(ch in name for ch in UNSAFE_ID_CHARS):
+        return False
+    return all(ch.isalnum() or ch in "-_" for ch in name)
+
+
+def is_safe_relpath(name):
+    """제출 파일 상대경로. 상위 디렉터리와 절대경로를 거부한다."""
+    if not isinstance(name, str) or not name:
+        return False
+    if os.path.isabs(name):
+        return False
+    if name.startswith("/") or name.startswith("\\"):
+        return False
+    normalized = name.replace("\\", "/")
+    if ":" in normalized.split("/")[0]:
+        return False
+    parts = normalized.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        return False
+    if any("\x00" in part for part in parts):
+        return False
+    return True
+
+
+def unsafe_id_reason(name, label="id"):
+    if not isinstance(name, str):
+        return f"{label} 가 문자열이 아니다"
+    if not name:
+        return f"{label} 가 비었다"
+    if not is_safe_id(name):
+        return f"{label} 가 안전하지 않다: {name!r}"
+    return ""
+
+
+def require_safe_id(name, label="id"):
+    reason = unsafe_id_reason(name, label)
+    if reason:
+        raise ScoreRunnerError("unsafe-id", reason, id=name, label=label)
+    return name
+
+
+def bin_looks_like_path(bin_path):
+    """경로형 바이너리인가. 맨이름(rhwp)은 PATH 조회라 부재 단정 금지."""
+    if not isinstance(bin_path, str) or not bin_path:
+        return False
+    if os.path.isabs(bin_path):
+        return True
+    sep = os.path.sep
+    alt = os.path.altsep
+    if sep in bin_path or (alt and alt in bin_path):
+        return True
+    return False
+
+
+def bin_is_missing(bin_path):
+    """경로형 바이너리가 디스크에 없는가. 맨이름은 False."""
+    if not isinstance(bin_path, str) or not bin_path:
+        return True
+    if not bin_looks_like_path(bin_path):
+        return False
+    return not os.path.exists(bin_path)
+
 
 def find_bin(cli_arg):
     """--bin > RHWP_BIN > target 기본값. 상대경로는 절대화한다 — Windows
@@ -37,6 +418,11 @@ def find_bin(cli_arg):
     찾으므로, 절대화 없이는 WinError 2 로 전 과제가 무너진다(1호 주행 실측)."""
     cand = cli_arg or os.environ.get("RHWP_BIN")
     if cand:
+        if not isinstance(cand, str):
+            try:
+                cand = str(cand)
+            except Exception:
+                return "rhwp"
         cand = cand.replace("/", os.sep)
         if os.path.isabs(cand):
             return cand
@@ -53,32 +439,116 @@ def find_bin(cli_arg):
     return "rhwp"
 
 
-def run_cli(bin_path, args):
-    """rhwp 실행 → (exit, 봉투 json 또는 None, stdout 원문 머리)."""
-    proc = subprocess.run([bin_path] + args, cwd=ROOT, capture_output=True)
-    out = proc.stdout.decode("utf-8", errors="replace")
-    env = None
-    if out.strip():
+def coerce_str_list(value, where="cmd"):
+    """문자열 목록으로. 아니면 ScoreRunnerError(malformed-cmd)."""
+    if isinstance(value, tuple):
+        value = list(value)
+    if not isinstance(value, list):
+        raise ScoreRunnerError("malformed-cmd", f"{where} 가 목록이 아니다",
+                               value=type(value).__name__)
+    out = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ScoreRunnerError(
+                "malformed-cmd",
+                f"{where}[{i}] 가 문자열이 아니다",
+                index=i,
+            )
+        out.append(item)
+    return out
+
+
+def prepare_cli(bin_path, args):
+    """subprocess 인자 검증. 실행은 하지 않는다."""
+    if not isinstance(bin_path, str) or not bin_path:
+        raise ScoreRunnerError("missing-bin", "바이너리 경로가 비었다")
+    argv = coerce_str_list(args, "args")
+    return [bin_path] + argv
+
+
+def decode_cli_stdout(raw):
+    """stdout 바이트 → 텍스트. 깨진 바이트는 교체한다."""
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    try:
+        return raw.decode("utf-8", errors="replace")
+    except (AttributeError, TypeError, UnicodeError):
         try:
-            env = json.loads(out)
-        except ValueError:
-            env = None
-    return proc.returncode, env, out[:200]
+            return str(raw)
+        except Exception:
+            return ""
+
+
+def parse_envelope(text):
+    """stdout 원문을 JSON 객체로. 실패·비객체는 None."""
+    if not isinstance(text, str) or not text.strip():
+        return None
+    try:
+        env = json.loads(text)
+    except ValueError:
+        return None
+    if not isinstance(env, dict):
+        return None
+    return env
+
+
+def run_cli(bin_path, args):
+    """rhwp 실행 → (exit, 봉투 json 또는 None, stdout 원문 머리).
+
+    FileNotFoundError·PermissionError 는 예전처럼 던진다 — eval_check 가
+    `파일 없음:` 접두로 접는다. 그 밖의 운영 예외는 ScoreRunnerError.
+    치명 예외는 삼키지 않는다.
+    """
+    argv = prepare_cli(bin_path, args)
+    try:
+        proc = subprocess.run(argv, cwd=ROOT, capture_output=True)
+    except FileNotFoundError:
+        raise
+    except PermissionError:
+        raise
+    except subprocess.TimeoutExpired as e:
+        raise ScoreRunnerError("timeout", error_head(e), bin=bin_path)
+    except subprocess.SubprocessError as e:
+        raise ScoreRunnerError("subprocess", error_head(e), bin=bin_path)
+    except OSError as e:
+        raise ScoreRunnerError("os-error", error_head(e), bin=bin_path)
+    out = decode_cli_stdout(proc.stdout)
+    env = parse_envelope(out)
+    return proc.returncode, env, truncate_head(out, HEAD_LIMIT)
+
+
+def resolve_placeholder(token, task, sub_dir):
+    """자리표시자 하나. 해당 없으면 원문 그대로."""
+    if token == "{input}":
+        if not isinstance(task, dict) or "input" not in task:
+            raise ScoreRunnerError("missing-input", "{input} 자리인데 과제에 input 이 없다")
+        value = task["input"]
+        if not isinstance(value, str) or not value:
+            raise ScoreRunnerError("missing-input", "과제 input 이 비었다")
+        return value
+    if token.startswith("{file:") and token.endswith("}"):
+        name = token[6:-1]
+        if not is_safe_relpath(name):
+            raise ScoreRunnerError("unsafe-id", f"파일 자리표시자가 안전하지 않다: {name!r}")
+        return os.path.join(sub_dir, name)
+    if token.startswith("{sha256:") and token.endswith("}"):
+        name = token[8:-1]
+        if not is_safe_relpath(name):
+            raise ScoreRunnerError("unsafe-id", f"해시 자리표시자가 안전하지 않다: {name!r}")
+        path = os.path.join(sub_dir, name)
+        try:
+            return check_registry.sha256_of(path)
+        except FileNotFoundError:
+            raise ScoreRunnerError("missing-file", f"파일 없음: {path}")
+    return token
 
 
 def resolve_args(cmd, task, sub_dir):
     out = []
-    for a in cmd:
-        if a == "{input}":
-            out.append(task["input"])
-        elif a.startswith("{file:") and a.endswith("}"):
-            out.append(os.path.join(sub_dir, a[6:-1]))
-        elif a.startswith("{sha256:") and a.endswith("}"):
-            # [#4600] 제출물의 해시를 채점 시점에 계산해 인자로 넘긴다 — 기대값을
-            # 과제 파일에 박제하지 않고 rhwp 자신에게 재현 판정을 시키는 통로.
-            out.append(check_registry.sha256_of(os.path.join(sub_dir, a[8:-1])))
-        else:
-            out.append(a)
+    for a in coerce_str_list(cmd, "cmd"):
+        out.append(resolve_placeholder(a, task, sub_dir))
     return out
 
 
@@ -102,167 +572,687 @@ class CheckContext:
         return check_registry.dig(self.envelope, self.check.get("path", ""))
 
 
+def validate_expect_exits(raw, fallback=0):
+    """expect_exits 또는 단일 expect_exit 를 정수 목록으로.
+
+    잘못된 값은 (None, 오류문자열). 예전 계약: 목록이 아니거나 비었거나
+    정수가 아닌 칸이 있으면 거부.
+    """
+    if raw is None:
+        if type(fallback) is not int:
+            return None, f"잘못된 expect_exits: {raw!r}"
+        return [fallback], None
+    if not isinstance(raw, list) or not raw or any(type(v) is not int for v in raw):
+        return None, f"잘못된 expect_exits: {raw!r}"
+    return raw, None
+
+
+def check_name_of(check, op=None):
+    if isinstance(check, dict):
+        return check.get("name", op if op is not None else check.get("op"))
+    return op
+
+
+def failed_check(name, op, error, kind):
+    if not is_known_exception_kind(kind):
+        kind = "unexpected"
+    return {"name": name, "op": op, "ok": False, "error": error, "kind": kind}
+
+
 def eval_check(check, task, sub_dir, answer, bin_path):
+    if not isinstance(check, dict):
+        return failed_check(None, None, "체크가 객체가 아니다", "malformed-check")
     op = check.get("op")
     detail = {"name": check.get("name", op), "op": op, "ok": False}
+    if not op:
+        detail["error"] = "op 없음"
+        detail["kind"] = "malformed-check"
+        return detail
     entry = check_registry.REGISTRY.get(op)
     if entry is None:
         detail["error"] = f"미지 op: {op}"
+        detail["kind"] = "unknown-op"
         return detail
     fn, uses_cli = entry
     try:
         envelope = None
         if uses_cli:
-            args = resolve_args(check["cmd"], task, sub_dir)
+            cmd = check.get("cmd")
+            args = resolve_args(cmd, task, sub_dir)
             code, envelope, head = run_cli(bin_path, args)
-            expect_exits = check.get("expect_exits")
-            if expect_exits is None:
-                expect_exits = [check.get("expect_exit", 0)]
-            if (not isinstance(expect_exits, list) or not expect_exits
-                    or any(type(v) is not int for v in expect_exits)):
-                detail["error"] = f"잘못된 expect_exits: {expect_exits!r}"
+            expect_exits, expect_err = validate_expect_exits(
+                check.get("expect_exits"), check.get("expect_exit", 0))
+            if expect_err:
+                detail["error"] = expect_err
+                detail["kind"] = "bad-expect-exits"
                 return detail
             if code not in expect_exits:
                 detail["error"] = f"exit {code} (허용 {expect_exits}): {head}"
+                detail["kind"] = "cli-exit"
                 return detail
             if envelope is None:
                 detail["error"] = f"봉투 파싱 실패: {head}"
+                detail["kind"] = "envelope-parse"
                 return detail
         detail.update(fn(CheckContext(check, task, sub_dir, answer, envelope)))
     except FileNotFoundError as e:
         detail["error"] = f"파일 없음: {e}"
+        detail["kind"] = exception_kind(e, "bin" if uses_cli else "file")
+    except PermissionError as e:
+        detail["error"] = f"권한 없음: {e}"
+        detail["kind"] = "permission"
+    except ScoreRunnerError as e:
+        detail["error"] = e.message
+        detail["kind"] = e.kind
     except (KeyError, IndexError, TypeError) as e:
         detail["error"] = f"경로 평가 실패: {type(e).__name__} {e}"
+        detail["kind"] = "path-eval"
+    except UnicodeError as e:
+        detail["error"] = f"디코드 실패: {e}"
+        detail["kind"] = "decode-error"
+    except CATCHABLE_EXCEPTIONS as e:
+        if is_fatal_exception(e):
+            raise
+        detail["error"] = f"{type(e).__name__}: {e}"
+        detail["kind"] = exception_kind(e, "check")
     return detail
 
 
+def empty_task_result(task_id=None, tier=None, title=None, error="", kind=""):
+    result = {
+        "id": task_id,
+        "tier": 0 if not isinstance(tier, int) else tier,
+        "title": title if isinstance(title, str) else "",
+        "pass": False,
+        "checks": [],
+    }
+    if error:
+        result["error"] = error
+    if kind:
+        result["kind"] = kind if is_known_exception_kind(kind) else "unexpected"
+    return result
+
+
+def task_shape_error(task):
+    """과제 뼈대가 채점에 쓰일 수 없으면 이유. 쓸 수 있으면 빈 문자열."""
+    if not isinstance(task, dict):
+        return "과제가 객체가 아니다"
+    missing = [key for key in TASK_SHAPE_KEYS if key not in task]
+    if missing:
+        return "필수 키 없음: " + ", ".join(missing)
+    if not isinstance(task.get("id"), str) or not task.get("id"):
+        return "id 가 비었다"
+    if not isinstance(task.get("title"), str):
+        return "title 이 문자열이 아니다"
+    if type(task.get("tier")) is not int:
+        return "tier 가 정수가 아니다"
+    checks = task.get("checks")
+    if not isinstance(checks, list):
+        return "checks 가 목록이 아니다"
+    return ""
+
+
+def load_json_value(path):
+    """JSON 값 하나. 실패는 예외."""
+    with io.open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_json_object(path, kind_if_not_object="malformed-json"):
+    value = load_json_value(path)
+    if not isinstance(value, dict):
+        raise ScoreRunnerError(kind_if_not_object,
+                               f"{os.path.basename(path)} 이 객체가 아니다")
+    return value
+
+
+def read_answer_json(ans_path):
+    """answer.json → dict. 없거나 객체 아니면 예외."""
+    try:
+        value = load_json_value(ans_path)
+    except FileNotFoundError:
+        raise
+    except json.JSONDecodeError as e:
+        raise ScoreRunnerError("malformed-answer", f"answer.json 파싱 실패: {e}")
+    except ValueError as e:
+        raise ScoreRunnerError("malformed-answer", f"answer.json 파싱 실패: {e}")
+    except UnicodeError as e:
+        raise ScoreRunnerError("decode-error", f"answer.json 디코드 실패: {e}")
+    except PermissionError as e:
+        raise ScoreRunnerError("permission", f"answer.json 권한 없음: {e}")
+    except OSError as e:
+        raise ScoreRunnerError("os-error", f"answer.json 읽기 실패: {e}")
+    if not isinstance(value, dict):
+        raise ScoreRunnerError("malformed-answer", "answer.json 이 객체가 아니다")
+    return value
+
+
 def score_task(task, sub_root, bin_path):
+    shape = task_shape_error(task)
+    if shape:
+        ident = task.get("id") if isinstance(task, dict) else None
+        title = task.get("title") if isinstance(task, dict) else None
+        tier = task.get("tier") if isinstance(task, dict) else None
+        return empty_task_result(ident, tier, title, shape, "malformed-task")
     sub_dir = os.path.join(sub_root, task["id"])
     result = {"id": task["id"], "tier": task["tier"], "title": task["title"],
               "pass": False, "checks": []}
     if not os.path.isdir(sub_dir):
         result["error"] = "제출 폴더 없음"
+        result["kind"] = "missing-submit"
         return result
     answer = {}
     ans_path = os.path.join(sub_dir, "answer.json")
     if os.path.exists(ans_path):
         try:
-            with io.open(ans_path, encoding="utf-8") as fh:
-                answer = json.load(fh)
+            answer = read_answer_json(ans_path)
+        except ScoreRunnerError as e:
+            result["error"] = e.message
+            result["kind"] = e.kind
+            return result
         except ValueError as e:
             result["error"] = f"answer.json 파싱 실패: {e}"
+            result["kind"] = "malformed-answer"
             return result
-    for check in task["checks"]:
+    checks = task["checks"]
+    if not checks:
+        result["error"] = "checks 가 비었다"
+        result["kind"] = "empty-checks"
+        return result
+    for check in checks:
         result["checks"].append(eval_check(check, task, sub_dir, answer, bin_path))
-    result["pass"] = bool(result["checks"]) and all(c["ok"] for c in result["checks"])
+    result["pass"] = bool(result["checks"]) and all(c.get("ok") for c in result["checks"])
     return result
 
 
 def load_pack(pack_id):
+    require_safe_id(pack_id, "pack")
     pack_dir = os.path.join(PACKS_DIR, pack_id)
-    with io.open(os.path.join(pack_dir, "pack.json"), encoding="utf-8") as fh:
-        manifest = json.load(fh)
-    tasks = []
+    pack_json = os.path.join(pack_dir, "pack.json")
+    if not os.path.isfile(pack_json):
+        raise ScoreRunnerError("missing-pack", f"pack.json 이 없다: {pack_id}")
+    try:
+        manifest = load_json_object(pack_json, "malformed-pack")
+    except FileNotFoundError:
+        raise ScoreRunnerError("missing-pack", f"pack.json 이 없다: {pack_id}")
+    except ScoreRunnerError:
+        raise
+    except json.JSONDecodeError as e:
+        raise ScoreRunnerError("malformed-pack", f"pack.json 파싱 실패: {e}")
+    except ValueError as e:
+        raise ScoreRunnerError("malformed-pack", f"pack.json 파싱 실패: {e}")
+    except PermissionError as e:
+        raise ScoreRunnerError("permission", f"pack.json 권한 없음: {e}")
+    except OSError as e:
+        raise ScoreRunnerError("os-error", f"pack.json 읽기 실패: {e}")
+    if not manifest.get("title"):
+        raise ScoreRunnerError("malformed-pack", f"{pack_id}: title 이 비었다")
+    if not manifest.get("axis"):
+        raise ScoreRunnerError("malformed-pack", f"{pack_id}: axis 가 비었다")
     tasks_dir = os.path.join(pack_dir, "tasks")
-    for name in sorted(os.listdir(tasks_dir)):
-        if name.endswith(".json"):
-            with io.open(os.path.join(tasks_dir, name), encoding="utf-8") as fh:
-                tasks.append(json.load(fh))
+    if not os.path.isdir(tasks_dir):
+        raise ScoreRunnerError("missing-tasks-dir", f"{pack_id}: tasks/ 가 없다")
+    tasks = []
+    try:
+        names = sorted(os.listdir(tasks_dir))
+    except PermissionError as e:
+        raise ScoreRunnerError("permission", f"{pack_id}: tasks/ 목록 실패: {e}")
+    except OSError as e:
+        raise ScoreRunnerError("os-error", f"{pack_id}: tasks/ 목록 실패: {e}")
+    for name in names:
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(tasks_dir, name)
+        try:
+            task = load_json_value(path)
+        except json.JSONDecodeError as e:
+            raise ScoreRunnerError("malformed-task", f"{pack_id}/{name} 파싱 실패: {e}")
+        except ValueError as e:
+            raise ScoreRunnerError("malformed-task", f"{pack_id}/{name} 파싱 실패: {e}")
+        except PermissionError as e:
+            raise ScoreRunnerError("permission", f"{pack_id}/{name} 권한 없음: {e}")
+        except OSError as e:
+            raise ScoreRunnerError("os-error", f"{pack_id}/{name} 읽기 실패: {e}")
+        if not isinstance(task, dict):
+            raise ScoreRunnerError("malformed-task", f"{pack_id}/{name} 이 객체가 아니다")
+        tasks.append(task)
     return manifest, tasks
 
 
 def discover_packs():
     if not os.path.isdir(PACKS_DIR):
         return []
-    return sorted(d for d in os.listdir(PACKS_DIR)
-                  if os.path.isfile(os.path.join(PACKS_DIR, d, "pack.json")))
+    try:
+        names = os.listdir(PACKS_DIR)
+    except OSError:
+        return []
+    found = []
+    for name in names:
+        if not is_safe_id(name):
+            continue
+        if os.path.isfile(os.path.join(PACKS_DIR, name, "pack.json")):
+            found.append(name)
+    return sorted(found)
 
 
 def load_profile(profile_id):
+    require_safe_id(profile_id, "profile")
     path = os.path.join(PROFILES_DIR, f"{profile_id}.json")
-    with io.open(path, encoding="utf-8") as fh:
-        return json.load(fh)
+    if not os.path.isfile(path):
+        raise ScoreRunnerError("missing-profile", f"프로파일이 없다: {profile_id}")
+    try:
+        profile = load_json_object(path, "malformed-profile")
+    except FileNotFoundError:
+        raise ScoreRunnerError("missing-profile", f"프로파일이 없다: {profile_id}")
+    except ScoreRunnerError:
+        raise
+    except json.JSONDecodeError as e:
+        raise ScoreRunnerError("malformed-profile", f"프로파일 파싱 실패: {e}")
+    except ValueError as e:
+        raise ScoreRunnerError("malformed-profile", f"프로파일 파싱 실패: {e}")
+    except PermissionError as e:
+        raise ScoreRunnerError("permission", f"프로파일 권한 없음: {e}")
+    except OSError as e:
+        raise ScoreRunnerError("os-error", f"프로파일 읽기 실패: {e}")
+    packs = profile.get("packs")
+    if not isinstance(packs, list) or not packs:
+        raise ScoreRunnerError("malformed-profile", f"{profile_id}: packs 가 비었다")
+    for item in packs:
+        if not is_safe_id(item):
+            raise ScoreRunnerError("unsafe-id", f"{profile_id}: 안전하지 않은 pack {item!r}")
+    return profile
+
+
+def safe_known_commands(bin_path):
+    """capabilities 조회. 실패는 None — 예전 parse 실패와 같다."""
+    try:
+        return pack_schema.known_commands(bin_path)
+    except CATCHABLE_EXCEPTIONS:
+        return None
+
+
+def safe_runner_identity(bin_path):
+    """실행 신원. 바이너리 부재여도 빈 칸으로 카드를 만든다."""
+    try:
+        ident = pack_schema.runner_identity(bin_path, ROOT)
+    except CATCHABLE_EXCEPTIONS as e:
+        return {
+            "rhwpVersion": "",
+            "rhwpCommit": "",
+            "capabilitiesSha256": "",
+            "kind": exception_kind(e, "bin"),
+            "error": error_head(e),
+        }
+    if not isinstance(ident, dict):
+        return {"rhwpVersion": "", "rhwpCommit": "", "capabilitiesSha256": ""}
+    for key in ("rhwpVersion", "rhwpCommit", "capabilitiesSha256"):
+        if key not in ident or ident[key] is None:
+            ident[key] = ""
+    return ident
+
+
+def error_pack_entry(pack_id, exc, where="pack"):
+    if isinstance(exc, ScoreRunnerError):
+        kind = exc.kind
+        message = exc.message
+    else:
+        kind = exception_kind(exc, "pack")
+        message = error_head(exc)
+    return {
+        "id": pack_id,
+        "title": "",
+        "axis": "",
+        "max": 0,
+        "taskCount": 0,
+        "status": "error",
+        "score": None,
+        "passed": 0,
+        "tasks": [],
+        "kind": kind,
+        "error": message,
+        "where": where,
+    }
+
+
+def task_tier(task):
+    if isinstance(task, dict) and type(task.get("tier")) is int:
+        return task["tier"]
+    return 0
 
 
 def score_pack(pack_id, sub_root, bin_path, available):
-    """pack 하나 채점 — 요구 명령이 없으면 unavailable(0점 아님)."""
-    manifest, tasks = load_pack(pack_id)
-    maximum = sum(t["tier"] for t in tasks)
+    """pack 하나 채점 — 요구 명령이 없으면 unavailable(0점 아님).
+
+    로드 실패는 status=error. 점수는 None. unavailable 로 부르지 않는다.
+    """
+    try:
+        manifest, tasks = load_pack(pack_id)
+    except FATAL_EXCEPTIONS:
+        raise
+    except (ScoreRunnerError,) + CATCHABLE_EXCEPTIONS as e:
+        return error_pack_entry(pack_id, e, "load_pack")
+    maximum = sum(task_tier(t) for t in tasks)
     missing = []
     if available is not None:
-        missing = [c for c in manifest.get("requires", {}).get("commands", [])
-                   if c not in available]
-    entry = {"id": pack_id, "title": manifest["title"], "axis": manifest["axis"],
+        commands = manifest.get("requires", {}).get("commands", [])
+        if not isinstance(commands, list):
+            commands = []
+        missing = [c for c in commands if c not in available]
+    entry = {"id": pack_id, "title": manifest.get("title", ""),
+             "axis": manifest.get("axis", ""),
              "max": maximum, "taskCount": len(tasks)}
     if missing:
         # 부재를 실패로 위장하지 않는다 — 오래된 바이너리에게 "0점"은 거짓말이다.
         entry.update({"status": "unavailable", "missingCommands": missing,
-                      "score": None, "tasks": []})
+                      "score": None, "passed": 0, "tasks": []})
         return entry
-    # pack 하위 제출 폴더를 우선 보고, 없으면 평면 제출(구 배치)로 되돌아간다.
     pack_sub = os.path.join(sub_root, pack_id)
     root_for_tasks = pack_sub if os.path.isdir(pack_sub) else sub_root
-    results = [score_task(t, root_for_tasks, bin_path) for t in tasks]
+    results = []
+    for t in tasks:
+        try:
+            results.append(score_task(t, root_for_tasks, bin_path))
+        except FATAL_EXCEPTIONS:
+            raise
+        except CATCHABLE_EXCEPTIONS as e:
+            ident = t.get("id") if isinstance(t, dict) else None
+            results.append(empty_task_result(
+                ident,
+                task_tier(t) if isinstance(t, dict) else None,
+                t.get("title") if isinstance(t, dict) else None,
+                error_head(e),
+                exception_kind(e, "check"),
+            ))
     entry.update({"status": "scored",
-                  "score": sum(r["tier"] for r in results if r["pass"]),
-                  "passed": sum(1 for r in results if r["pass"]),
+                  "score": sum(r.get("tier", 0) for r in results if r.get("pass")),
+                  "passed": sum(1 for r in results if r.get("pass")),
                   "tasks": results})
     return entry
 
 
-def score_all(sub_root, bin_path, pack_ids=None, profile_id=None):
-    available = pack_schema.known_commands(bin_path)
-    if profile_id:
-        pack_ids = load_profile(profile_id)["packs"]
-    if not pack_ids:
-        pack_ids = discover_packs()
-    packs = [score_pack(pid, sub_root, bin_path, available) for pid in pack_ids]
-    scored = [p for p in packs if p["status"] == "scored"]
-    card = {
-        "kind": "gymScorecard",
-        "schemaVersion": "2.0",
+def normalize_pack_ids(pack_ids):
+    """호출자가 준 pack 목록. None/빈 값은 None(탐색 신호)."""
+    if pack_ids is None:
+        return None
+    if isinstance(pack_ids, str):
+        pack_ids = [pack_ids]
+    if not isinstance(pack_ids, (list, tuple)):
+        raise ScoreRunnerError("value-error", "pack_ids 가 목록이 아니다")
+    out = []
+    for item in pack_ids:
+        if not isinstance(item, str) or not item:
+            raise ScoreRunnerError("unsafe-id", f"빈 pack id: {item!r}")
+        require_safe_id(item, "pack")
+        out.append(item)
+    return out
+
+
+def empty_scorecard(profile_id=None, bin_path="", runner=None, exceptions=None):
+    rows = list(exceptions or [])
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
         "profile": profile_id,
-        "runner": pack_schema.runner_identity(bin_path, ROOT),
-        # 총점은 편의값이다 — 능력 판독은 pack 별 점수로 한다(§4).
-        "total": {"score": sum(p["score"] for p in scored),
-                  "max": sum(p["max"] for p in scored),
-                  "packsScored": len(scored),
-                  "packsUnavailable": len(packs) - len(scored)},
-        "packs": packs,
+        "runner": runner or {"rhwpVersion": "", "rhwpCommit": "",
+                             "capabilitiesSha256": ""},
+        "total": {"score": 0, "max": 0, "packsScored": 0,
+                  "packsUnavailable": 0, "packsErrored": 0,
+                  "exceptionCount": len(rows)},
+        "packs": [],
+        "exceptions": rows,
+        "exceptionCount": len(rows),
+        "binPath": bin_path or "",
+        "binMissing": bin_is_missing(bin_path) if bin_path else False,
+        "trusted": len(rows) == 0,
     }
+
+
+def attach_card_counts(card):
+    """total·예외 집계를 packs 와 맞춘다. 카드를 그 자리에서 고친다."""
+    packs = card.get("packs") if isinstance(card.get("packs"), list) else []
+    scored = [p for p in packs if p.get("status") == "scored"]
+    unavailable = [p for p in packs if p.get("status") == "unavailable"]
+    errored = [p for p in packs if p.get("status") == "error"]
+    exceptions = card.get("exceptions") if isinstance(card.get("exceptions"), list) else []
+    total = card.get("total") if isinstance(card.get("total"), dict) else {}
+    total["score"] = sum(p.get("score") or 0 for p in scored)
+    total["max"] = sum(p.get("max") or 0 for p in scored)
+    total["packsScored"] = len(scored)
+    total["packsUnavailable"] = len(unavailable)
+    total["packsErrored"] = len(errored)
+    total["exceptionCount"] = len(exceptions)
+    card["total"] = total
+    card["exceptionCount"] = len(exceptions)
+    card["trusted"] = len(exceptions) == 0 and len(errored) == 0
     return card
 
 
+def validate_scorecard(card):
+    """카드 뼈대. 문제 목록. 비면 통과."""
+    errors = []
+    if not isinstance(card, dict):
+        return ["스코어카드가 객체가 아니다"]
+    if card.get("kind") != REPORT_KIND:
+        errors.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if card.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append(f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
+    for key in SCORECARD_KEYS:
+        if key not in card:
+            errors.append(f"필수 키 없음: {key}")
+    total = card.get("total")
+    if not isinstance(total, dict):
+        errors.append("total 이 객체가 아니다")
+    else:
+        for key in TOTAL_KEYS:
+            if key not in total:
+                errors.append(f"total.{key} 없음")
+    packs = card.get("packs")
+    if not isinstance(packs, list):
+        errors.append("packs 가 목록이 아니다")
+    else:
+        for i, pack in enumerate(packs):
+            if not isinstance(pack, dict):
+                errors.append(f"packs[{i}] 가 객체가 아니다")
+                continue
+            status = pack.get("status")
+            if not is_known_pack_status(status):
+                errors.append(f"packs[{i}].status 가 아니다: {status!r}")
+    return errors
+
+
+def score_all(sub_root, bin_path, pack_ids=None, profile_id=None):
+    exceptions = []
+    runner_ident = safe_runner_identity(bin_path)
+    available = safe_known_commands(bin_path)
+    if bin_is_missing(bin_path):
+        exceptions.append(exception_row(
+            "missing-bin", where="bin",
+            message=f"경로형 바이너리가 없다: {bin_path}"))
+    selected = None
+    if profile_id:
+        try:
+            profile = load_profile(profile_id)
+            selected = list(profile["packs"])
+        except FATAL_EXCEPTIONS:
+            raise
+        except (ScoreRunnerError,) + CATCHABLE_EXCEPTIONS as e:
+            err = wrap_exception(e, "profile", "profile")
+            exceptions.append(err.as_row("profile"))
+            card = empty_scorecard(profile_id, bin_path, runner_ident, exceptions)
+            return attach_card_counts(card)
+    if selected is None:
+        try:
+            selected = normalize_pack_ids(pack_ids)
+        except FATAL_EXCEPTIONS:
+            raise
+        except (ScoreRunnerError,) + CATCHABLE_EXCEPTIONS as e:
+            err = wrap_exception(e, "pack", "pack_ids")
+            exceptions.append(err.as_row("pack_ids"))
+            card = empty_scorecard(profile_id, bin_path, runner_ident, exceptions)
+            return attach_card_counts(card)
+    if not selected:
+        try:
+            selected = discover_packs()
+        except CATCHABLE_EXCEPTIONS as e:
+            exceptions.append(exception_row(
+                exception_kind(e, "pack"), where="discover",
+                message=error_head(e)))
+            selected = []
+    packs = []
+    for pid in selected:
+        try:
+            packs.append(score_pack(pid, sub_root, bin_path, available))
+        except FATAL_EXCEPTIONS:
+            raise
+        except CATCHABLE_EXCEPTIONS as e:
+            packs.append(error_pack_entry(pid, e, "score_pack"))
+    card = {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "profile": profile_id,
+        "runner": runner_ident,
+        "total": {},
+        "packs": packs,
+        "exceptions": exceptions,
+        "binPath": bin_path or "",
+        "binMissing": bin_is_missing(bin_path),
+    }
+    return attach_card_counts(card)
+
+
+def admission_from_card(card, agent):
+    """입장 봉투. packsScored >= 1 이면 allow. 만점과 무관."""
+    total = card.get("total") if isinstance(card, dict) else None
+    if not isinstance(total, dict):
+        total = {}
+    scored = total.get("packsScored") or 0
+    try:
+        scored = int(scored)
+    except (TypeError, ValueError):
+        scored = 0
+    return {
+        "schemaVersion": ADMISSION_SCHEMA,
+        "kind": ADMISSION_KIND,
+        "agent": agent,
+        "verdict": "allow" if scored >= 1 else "deny",
+        "packsScored": scored,
+        "packsUnavailable": total.get("packsUnavailable") or 0,
+        "packsErrored": total.get("packsErrored") or 0,
+        "score": total.get("score") or 0,
+        "max": total.get("max") or 0,
+        "runner": card.get("runner") if isinstance(card, dict) else {},
+    }
+
+
+def pack_table_cell(pack):
+    """리포트 표 한 줄."""
+    pid = pack.get("id", "")
+    axis = pack.get("axis", "")
+    status = pack.get("status")
+    if status == "unavailable":
+        missing = pack.get("missingCommands") or []
+        return f"| {pid} | {axis} | unavailable | 요구 명령 없음: {', '.join(missing)} |"
+    if status == "error":
+        err = pack.get("error") or pack.get("kind") or "error"
+        return f"| {pid} | {axis} | error | {err} |"
+    return (f"| {pid} | {axis} | **{pack.get('score')} / {pack.get('max')}** | "
+            f"{pack.get('passed')}/{pack.get('taskCount')} 통과 |")
+
+
+def task_detail_line(task):
+    if not isinstance(task, dict):
+        return "과제가 객체가 아니다"
+    if "error" in task:
+        return task["error"]
+    checks = task.get("checks") or []
+    return " · ".join(("O" if c.get("ok") else "X") + " " + str(c.get("name"))
+                      for c in checks)
+
+
 def render_report(card, agent):
-    total = card["total"]
+    if not isinstance(card, dict):
+        return f"# 짐 스코어카드 — {agent}\n\n스코어카드가 객체가 아니다"
+    total = card.get("total") if isinstance(card.get("total"), dict) else {}
+    score = total.get("score", 0)
+    maximum = total.get("max", 0)
+    scored = total.get("packsScored", 0)
+    unavailable = total.get("packsUnavailable", 0)
+    errored = total.get("packsErrored", 0)
+    extra = ""
+    if unavailable:
+        extra += f" · {unavailable}개 unavailable"
+    if errored:
+        extra += f" · {errored}개 error"
     lines = [f"# 짐 스코어카드 — {agent}", "",
-             f"**{total['score']} / {total['max']}** "
-             f"(pack {total['packsScored']}개 채점"
-             + (f" · {total['packsUnavailable']}개 unavailable" if total["packsUnavailable"] else "")
-             + ")", ""]
-    r = card["runner"]
-    lines += [f"실행 신원: rhwp {r['rhwpVersion']} · commit `{r['rhwpCommit'][:12]}` "
-              f"· capabilities `{r['capabilitiesSha256'][:12]}`", "",
+             f"**{score} / {maximum}** (pack {scored}개 채점{extra})", ""]
+    r = card.get("runner") if isinstance(card.get("runner"), dict) else {}
+    version = r.get("rhwpVersion") or ""
+    commit = r.get("rhwpCommit") or ""
+    digest = r.get("capabilitiesSha256") or ""
+    lines += [f"실행 신원: rhwp {version} · commit `{commit[:12]}` "
+              f"· capabilities `{digest[:12]}`", "",
               "| pack | 능력 축 | 점수 | 과제 |", "|---|---|---|---|"]
-    for p in card["packs"]:
-        if p["status"] == "unavailable":
-            lines.append(f"| {p['id']} | {p['axis']} | unavailable | 요구 명령 없음: "
-                         f"{', '.join(p['missingCommands'])} |")
-        else:
-            lines.append(f"| {p['id']} | {p['axis']} | **{p['score']} / {p['max']}** | "
-                         f"{p['passed']}/{p['taskCount']} 통과 |")
-    for p in card["packs"]:
-        if p["status"] != "scored":
+    packs = card.get("packs") if isinstance(card.get("packs"), list) else []
+    for p in packs:
+        if not isinstance(p, dict):
             continue
-        lines += ["", f"## {p['id']} — {p['title']}", "",
+        lines.append(pack_table_cell(p))
+    for p in packs:
+        if not isinstance(p, dict) or p.get("status") != "scored":
+            continue
+        lines += ["", f"## {p.get('id')} — {p.get('title')}", "",
                   "| 과제 | 티어 | 판정 | 세부 |", "|---|---|---|---|"]
-        for t in p["tasks"]:
-            if "error" in t:
-                det = t["error"]
-            else:
-                det = " · ".join(("O" if c["ok"] else "X") + " " + str(c["name"])
-                                 for c in t["checks"])
-            lines.append(f"| {t['id']} {t['title']} | {t['tier']} | "
-                         f"{'통과' if t['pass'] else '실패'} | {det} |")
+        for t in p.get("tasks") or []:
+            if not isinstance(t, dict):
+                continue
+            det = task_detail_line(t)
+            lines.append(f"| {t.get('id')} {t.get('title')} | {t.get('tier')} | "
+                         f"{'통과' if t.get('pass') else '실패'} | {det} |")
+    exceptions = card.get("exceptions") if isinstance(card.get("exceptions"), list) else []
+    if exceptions:
+        lines += ["", "## 예외", ""]
+        for row in exceptions:
+            if not isinstance(row, dict):
+                continue
+            lines.append(f"- `{row.get('kind')}` {row.get('where')}: {row.get('message')}")
     lines += ["", "채점기: gym/core/runner.py (라이브 오라클 · pack 별 점수 보존)"]
     return "\n".join(lines)
+
+
+def console_pack_line(pack):
+    pid = str(pack.get("id") or "")
+    status = pack.get("status")
+    if status == "unavailable":
+        missing = pack.get("missingCommands") or []
+        return f"  - {pid:<18} unavailable (없는 명령: {', '.join(missing)})"
+    if status == "error":
+        return f"  - {pid:<18} error ({pack.get('kind')}: {pack.get('error')})"
+    return (f"  - {pid:<18} {pack.get('score')}/{pack.get('max')}  "
+            f"({pack.get('passed')}/{pack.get('taskCount')} 과제)")
+
+
+def format_console_summary(card, agent, card_path):
+    total = card.get("total") if isinstance(card.get("total"), dict) else {}
+    parts = [f"{agent}: {total.get('score')}/{total.get('max')}  "
+             f"(pack {total.get('packsScored')} 채점"]
+    if total.get("packsUnavailable"):
+        parts.append(f", {total.get('packsUnavailable')} unavailable")
+    if total.get("packsErrored"):
+        parts.append(f", {total.get('packsErrored')} error")
+    parts.append(f")  → {card_path}")
+    lines = ["".join(parts)]
+    for p in card.get("packs") or []:
+        if isinstance(p, dict):
+            lines.append(console_pack_line(p))
+    return "\n".join(lines)
+
+
+def exit_from_card(card):
+    """만점이면 0, 아니면 3. 새 종료 코드를 만들지 않는다."""
+    total = card.get("total") if isinstance(card, dict) else None
+    if not isinstance(total, dict):
+        return EXIT_IMPERFECT
+    if total.get("score") == total.get("max") and total.get("packsErrored", 0) == 0:
+        if total.get("max") or total.get("packsScored"):
+            return EXIT_PERFECT
+    return EXIT_IMPERFECT

--- a/gym/docs/score_runner.md
+++ b/gym/docs/score_runner.md
@@ -1,0 +1,452 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/score_runner.md
+last_verified: 2026-08-18
+---
+
+# gym 채점기(score/runner) 예외 경로 규약
+
+이 문서는 `gym/score.py` 진입점과 `gym/core/runner.py` 엔진의 **예외
+경로 계약**, **pack 상태 삼원**, **입장 봉투**, **자리표시자 안전**,
+**보고 카드**를 고정한다. 작업 기록은
+[`mydocs/working/gym_score_runner.md`](../../mydocs/working/gym_score_runner.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_score.py`(성공 칸)와
+`scripts/tests/test_gym_score_runner.py`(예외 칸)가 기계로 고정한다.
+
+판별력 감사(`discriminate.py`)·트라젝토리 감사(`trajectory.py`)·퍼즈
+변형(`fuzz_corpus.py`)·릴리스 게이트(`release_gate.py`)는 이 문서의
+대상이 아니다. 채점기가 남긴 칸을 그 도구들이 소비할 수는 있어도, 이
+규약이 그 도구의 판정 삼원을 바꾸지 않는다.
+
+새 플래그는 없다. `--agent` `--submissions` `--bin` `--out` `--pack`
+`--profile` 만 쓴다. 종료 코드도 예전과 같다. 0=만점, 3=그 외.
+
+## 1. 왜 이 기둥이 필요한가
+
+운동장 채점기는 정답을 골든으로 박제하지 않고, 채점 시점에 rhwp 로
+다시 계산한다(#4653). 그 설계는 "실패도 데이터"를 전제로 한다. 그런데
+예전이 실패를 데이터로 남기지 못하는 자리가 있었다.
+
+- pack.json 하나가 깨지면 `score_all` 전체가 죽는다. 나머지 pack 의
+  점수가 증발한다.
+- 프로파일이 없으면 스택이 올라가고 입장 봉투가 없다.
+- 과제 JSON 필수 키가 빠지면 `task["id"]` 에서 KeyError. 그 pack 의
+  다른 과제도 같이 사라진다.
+- `answer.json` 이 배열이면 연산자가 봉투처럼 읽고 엉뚱한 통과/실패를
+  낸다.
+- 경로형 `--bin` 이 없는데 `known_commands` 가 FileNotFoundError 를
+  삼키지 못해 채점이 시작되지 않는다.
+- pack 로드 실패를 0점이나 unavailable(명령 부재)로 부르면 거짓이다.
+
+2026 벤치마크의 다른 위기는 false-pass 이지만, 채점기 자체의 위기는
+**false-silence** 다. 탐색을 못 한 자리를 "만점 아님" 한 줄로 접으면
+어느 pack 이 도구 실패인지 안 보인다. 리더보드 입장 게이트
+(`admission.json`)는 "채점이 유효하게 완주했는가"를 묻는다. 완주하지
+못한 자리를 숨기면 입장 판정도 거짓말이다.
+
+그래서 예외는 삼키지 않고 kind 로 남긴다. 점수는 그대로 pack 별로
+보존한다. 오류 pack 은 `status=error` 이고 `score=None` 이다. 0점도
+아니고 unavailable 도 아니다.
+
+## 2. 사용
+
+```bash
+python gym/score.py --agent <이름>
+python gym/score.py --agent <이름> --profile editor
+python gym/score.py --agent <이름> --pack security
+python gym/score.py --agent <이름> --bin target/debug/rhwp --out gym/out
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--agent` | 필수 | 제출자 이름. 공백뿐이거나 `/` `\` 를 품으면 거부. |
+| `--submissions` | `gym/submissions/<agent>` | 제출 루트. |
+| `--bin` | `RHWP_BIN` 또는 `target/debug/rhwp` | rhwp 바이너리. 상대경로는 절대화. |
+| `--out` | 제출 루트와 같음 | `scorecard.json` · `report.md` · `admission.json`. |
+| `--pack` | 전 pack 탐색 | 반복 지정 가능. |
+| `--profile` | 없음 | pack 묶음. 점수를 뭉치지 않는다. |
+
+새 플래그는 없다. `--json` `--limit` `--task` `--timeout` 을 붙이지
+않는다. 기계 봉투는 `--out` 아래 JSON 파일이고, stdout 은 사람용
+한 줄 요약이다.
+
+종료 코드:
+
+| 코드 | 상수 | 의미 |
+|---|---|---|
+| 0 | `EXIT_PERFECT` | 채점된 pack 만점이면서 error pack 0 |
+| 3 | `EXIT_IMPERFECT` | 그 외(실패 과제, error, 빈 채점, 도구 실패) |
+| 2 | argparse | 필수 인자 없음. 예전 argparse 계약 |
+
+도구 자리 오류를 위한 새 종료 코드를 만들지 않는다. 만점이 아니면 3
+이다. 입장 봉투의 `verdict` 는 종료 코드와 별개다 — 낮은 점수도
+allow 일 수 있다.
+
+## 3. pack 상태 삼원 — 바꾸지 않는 칸
+
+`PACK_STATUSES = (scored, unavailable, error)`.
+
+| status | 언제 | score | 총점 가산 | 입장 packsScored |
+|---|---|---|---|---|
+| `scored` | 로드 성공, 요구 명령 충족 | 통과 과제 티어 합 | 예 | 예 |
+| `unavailable` | 요구 명령이 바이너리에 없음 | `None` | 아니오 | 아니오 |
+| `error` | 로드·식별자·JSON·권한 실패 | `None` | 아니오 | 아니오 |
+
+규칙:
+
+1. **부재는 실패가 아니다.** 오래된 바이너리에게 0점은 거짓말이다.
+   그 자리는 `unavailable` 이다.
+2. **도구 실패는 부재가 아니다.** pack.json 이 깨진 것을 "명령이 없다"고
+   부르면 다음 사람이 바이너리를 탓한다. 그 자리는 `error` 이다.
+3. **error 를 unavailable 로 세지 않는다.** `total.packsUnavailable` 은
+   `status==unavailable` 개수다. `len(packs) - packsScored` 로 되돌리면
+   error 가 명령 부재로 위장된다.
+4. **error 는 0점이 아니다.** `score=None`. 합계는 scored pack 만.
+
+`total` 고정 키:
+
+| 키 | 의미 |
+|---|---|
+| `score` | scored pack 점수 합 |
+| `max` | scored pack 만점 합 |
+| `packsScored` | status=scored 개수 |
+| `packsUnavailable` | status=unavailable 개수 |
+| `packsErrored` | status=error 개수 |
+| `exceptionCount` | 카드 수준 `exceptions` 길이 |
+
+부가 키 `exceptions` · `exceptionCount` · `binPath` · `binMissing` ·
+`trusted` 는 집계를 뒤집지 않는다. `trusted` 는 예외 0 이고 error pack
+0 일 때만 참이다.
+
+## 4. 예외 kind 카탈로그
+
+`EXCEPTION_KINDS` 와 `EXCEPTION_KIND_HELP` 가 정본이다. 시험이 문서에
+각 kind 가 백틱으로 적혔는지 대조한다.
+
+| kind | 자리 | 점수에 미치는 영향 |
+|---|---|---|
+| `missing-bin` | 경로형 바이너리 부재, CreateProcess 실패 | 카드 `exceptions`. 채점은 이어갈 수 있음 |
+| `missing-submit` | 과제 제출 폴더 없음 | 과제 실패. 예전 문구 `제출 폴더 없음` |
+| `missing-pack` | pack.json / pack 폴더 없음 | pack `status=error` |
+| `missing-profile` | profiles/<id>.json 없음 | 빈 카드 + exceptions |
+| `missing-file` | 제출 파일·해시 대상 없음 | 체크 실패 |
+| `missing-tasks-dir` | pack 에 tasks/ 없음 | pack `status=error` |
+| `missing-input` | `{input}` 인데 과제에 input 없음 | 체크 실패 |
+| `malformed-json` | JSON 파싱 실패(문맥 없음) | 해당 자리 실패 |
+| `malformed-answer` | answer.json 깨짐·비객체 | 과제 실패. 문구 `answer.json 파싱 실패:` |
+| `malformed-task` | 과제 비객체·필수 키 없음 | 과제 또는 pack error |
+| `malformed-check` | 체크 비객체·op 없음 | 체크 실패 |
+| `malformed-pack` | pack.json 비객체·title/axis 없음 | pack `status=error` |
+| `malformed-profile` | 프로파일 비객체·packs 빈 목록 | 빈 카드 |
+| `malformed-cmd` | cmd 가 문자열 목록이 아님 | 체크 실패 |
+| `unsafe-id` | pack/profile/파일 자리에 `..` / 구분자 | 해당 자리 거부 |
+| `permission` | 읽기·실행 권한 없음 | 해당 자리 실패. 문구 `권한 없음:` |
+| `os-error` | 그 밖의 OSError | 해당 자리 실패 |
+| `decode-error` | UTF-8 디코드 실패 | 해당 자리 실패 |
+| `value-error` | 값 형태 불일치 | 해당 자리 실패 |
+| `type-error` | 타입 불일치 | 해당 자리 실패 |
+| `timeout` | 자식 프로세스 대기 한도 | 체크 실패 |
+| `subprocess` | 자식 기동·통신 실패 | 체크 실패 |
+| `unknown-op` | 레지스트리에 없는 op | 체크 실패. 문구 `미지 op:` |
+| `bad-expect-exits` | expect_exits 가 비지 않은 정수 목록 아님 | 체크 실패. 예전 문구 유지 |
+| `cli-exit` | 종료 코드가 허용 집합 밖 | 체크 실패. 문구 `exit N (허용 …)` |
+| `envelope-parse` | stdout 이 JSON 객체가 아님 | 체크 실패. 문구 `봉투 파싱 실패:` |
+| `path-eval` | KeyError/IndexError/TypeError | 체크 실패. 문구 `경로 평가 실패:` |
+| `empty-checks` | 과제 checks 가 `[]` | 과제 실패. 통과 칸이 없음 |
+| `empty-agent` | `--agent` 가 공백 | 채점 시작 전 거부 |
+| `write-error` | scorecard/report/admission 기록 실패 | artifacts.errors |
+| `unexpected` | 분류되지 않은 운영 예외 | 해당 자리 실패 |
+
+`FileNotFoundError` 의 kind 는 문맥에 따른다. 바이너리 자리면
+`missing-bin`, pack 자리면 `missing-pack`, 제출 폴더면
+`missing-submit`, 그 밖이면 `missing-file`. 한 예외 타입을 한 kind 로
+고정하면 없는 바이너리를 없는 제출로 부른다.
+
+## 5. 치명 예외 — 삼키지 않는 자리
+
+`FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)`.
+
+운영 예외(`CATCHABLE_EXCEPTIONS`)만 접는다. `except Exception` 으로
+BaseException 을 삼키지 않는다. 시험이 `is_fatal_exception` 과
+`is_catchable_exception` 경계를 고정한다.
+
+`eval_check` 가 잡는 칸:
+
+1. 체크 뼈대(비객체, op 없음, 미지 op) — 예외가 아니라 사전 거부.
+2. CLI 자리의 cmd/expect_exits/exit/봉투 — 예외가 아니라 분기.
+3. `FileNotFoundError` — 예전 접두 `파일 없음:` 유지.
+4. `PermissionError` — `권한 없음:`.
+5. `ScoreRunnerError` — `kind` 를 그대로 옮김.
+6. `KeyError` `IndexError` `TypeError` — 예전 접두 `경로 평가 실패:`.
+7. 그 밖의 catchable — `Type: message` 와 kind.
+
+`bool` 은 `int` 의 하위 타입이다. `expect_exits: [True]` 는 허용하지
+않는다. `type(v) is not int` 가 그 계약을 지킨다.
+
+## 6. 자리표시자와 식별자 안전
+
+pack id · profile id 는 한 칸 이름이다. 허용은 영숫자와 `-` `_`.
+거부: 빈 문자열, `.`, `..`, `/`, `\`, `:`, NUL.
+
+`{file:name}` · `{sha256:name}` 은 상대경로를 받는다. `out/o1.hwp` 는
+허용. `../secret`, 절대경로, 빈 칸, `.`, `..` 칸은 `unsafe-id`.
+
+`{input}` 은 `task["input"]` 문자열이다. 키가 없거나 비면
+`missing-input`.
+
+`find_bin` 계약은 그대로다. `--bin` > `RHWP_BIN` > `target/debug/rhwp`.
+상대경로는 cwd 와 저장소 루트에서 절대화한다. 맨이름 `rhwp` 는 PATH
+조회라 `binMissing` 으로 단정하지 않는다. 경로형인데 디스크에 없을
+때만 `binMissing=true` 와 `missing-bin` 한 줄을 남기고 채점은 이어간다
+— 파일 전용 연산자(`file_exists` 등)는 바이너리 없이 돈다.
+
+## 7. 과제 뼈대와 answer.json
+
+채점에 필요한 최소 키는 `id` `tier` `title` `checks` 다. 스키마의
+`TASK_REQUIRED` 전체(instructions·input·submit)는 audit 가 보고,
+러너는 채점에 필요한 뼈대만 본다. 뼈대가 없으면 과제는
+`malformed-task` 로 실패하고 pack 의 다음 과제로 간다.
+
+`tier` 는 `type(v) is int` 여야 한다. `"1"` 과 `True` 는 거부.
+
+`answer.json` 이 있으면 객체여야 한다. 배열·문자열·깨진 JSON 은
+`malformed-answer`. 파싱 실패 문구는 예전처럼
+`answer.json 파싱 실패:` 로 시작한다. 파일이 없으면 빈 객체로 본다
+— answer 과제가 아닌 산출물 과제가 있기 때문이다.
+
+`checks` 가 `[]` 이면 `empty-checks`. `bool([]) and all(...)` 가
+거짓이라 예전도 실패였지만, 이유가 없었다. 이제 kind 가 남는다.
+
+제출 폴더가 없으면 예전 문구 그대로 `제출 폴더 없음`. kind 는
+`missing-submit`. 이 문구를 바꾸면 기존 리포트·베이스라인 대조가
+깨진다.
+
+## 8. 스코어카드와 입장 봉투
+
+카드 `kind=gymScorecard`, `schemaVersion=2.0`. 이 두 칸을 올리면
+리더보드·게이트가 읽지 못한다.
+
+입장 봉투 `kind=gymAdmission`, `schemaVersion=1.0`.
+
+| 칸 | 규칙 |
+|---|---|
+| `verdict` | `packsScored >= 1` 이면 `allow`, 아니면 `deny` |
+| `packsScored` | scored pack 수 |
+| `packsUnavailable` | unavailable pack 수 |
+| `packsErrored` | error pack 수 (부가, 예전 리더가 몰라도 됨) |
+| `score` / `max` | 총점 편의값 |
+| `runner` | 실행 신원. 바이너리 부재면 빈 문자열 칸 |
+
+allow 는 만점이 아니다. 0/32 도 pack 을 하나라도 채점했으면 allow.
+error 만 있고 scored 가 0 이면 deny. 채점이 시작 전에 죽으면
+`deny_card` 가 예외 한 줄짜리 빈 카드를 남기고 가능하면 세 파일을
+쓴다.
+
+기록 파일:
+
+| 파일 | 내용 |
+|---|---|
+| `scorecard.json` | 카드 원문. UTF-8, BOM 없음, LF, indent=2 |
+| `report.md` | 사람용 표. error pack 과 exceptions 를 숨기지 않음 |
+| `admission.json` | 입장 봉투 |
+
+한 파일이 실패해도 나머지를 시도한다. 실패 줄은 `write-error`.
+
+## 9. 성공 칸 — 이 작업이 바꾸지 않는 것
+
+아래는 `test_gym_score.py` 가 지키는 칸이다. 예외 보강이 이 칸을
+옮기면 회귀다.
+
+1. `expect_exits: [0, 3]` 에서 exit 3 + 봉투 `identical: false` 는
+   비교 대상이지 폐기 대상이 아니다.
+2. 허용 집합 밖 exit 는 거부되고 오류 문자열에 허용 값이 남는다.
+3. 단일 `expect_exit` 는 하위 호환.
+4. T12 는 실제 HWPX 와 IR 판정 exit 를 요구한다.
+5. T07 은 첫 필드, T08 은 (0,0) 셀, T10 은 원본 무편집 복사를 거부.
+6. `{sha256:file}` 는 채점 시점 해시로 풀린다.
+7. 체크 명령은 그 pack 의 `requires.commands` 에 선언돼 있어야 한다.
+
+라이브 오라클 원칙도 그대로다. 기대값은 채점 시점에 rhwp 가 다시
+계산한다. 이 문서가 골든 파일을 추가하지 않는다.
+
+## 10. 다른 기둥과의 경계
+
+| 도구 | 축 | 이 문서와의 관계 |
+|---|---|---|
+| `runner.py` / `score.py` | 종점 채점 | 이 문서의 대상 |
+| `discriminate.py` | 약한 오라클(음성 대조) | 러너의 `score_task` 를 부르되 파일을 수정하지 않음 |
+| `trajectory.py` | 경로(마지막 스텝) | 러너의 `score_task` 를 부르되 파일을 수정하지 않음 |
+| `fuzz_corpus.py` | 결정적 변형 | 채점기를 직접 고치지 않음 |
+| `release_gate.py` | 릴리스 파이프라인 | 채점 결과를 소비할 수 있으나 이 규약 밖 |
+| `audit.py` | pack 정합 | 바이너리 없이 파일만. 러너 예외와 별개 |
+
+이 작업은 automation / core-cli / casual-rides pack JSON 을 고치지
+않는다. 과제 확장은 다른 이슈의 일이다.
+
+## 11. 정직 조항
+
+1. 없는 바이너리를 전 과제 0점으로 부르지 않는다.
+2. pack 로드 실패를 명령 부재로 부르지 않는다.
+3. 제출 폴더 없음을 미지 op 로 부르지 않는다.
+4. 연극·회귀·차등 판정을 채점기가 대신하지 않는다.
+5. 새 CLI 를 발명해 예외를 "숨김 플래그" 뒤로 치우지 않는다.
+6. 치명 예외를 운영 예외 목록에 넣지 않는다.
+7. `trusted=true` 를 예외가 있는 카드에 붙이지 않는다.
+8. 만점 종료 코드 0 을 error pack 이 있는 카드에 주지 않는다.
+
+## 12. 검증
+
+```bash
+python -m unittest scripts.tests.test_gym_score scripts.tests.test_gym_score_runner
+python gym/tools/audit.py
+```
+
+`cargo fmt --all` 은 이 변경의 검증이 아니다. Python 과 문서만
+고친다.
+
+## 13. 구현 지도
+
+코드가 문서의 표를 구현하는 위치. 함수 이름을 바꾸면 이 절과 시험을
+같이 고친다.
+
+| 함수 | 역할 | 실패 시 kind |
+|---|---|---|
+| `find_bin` | --bin / RHWP_BIN / target 기본값 | 없음. 없는 경로도 문자열로 돌려줌 |
+| `bin_is_missing` | 경로형만 디스크 부재 단정 | 카드 `missing-bin` |
+| `prepare_cli` | argv 검증 | `missing-bin` `malformed-cmd` |
+| `run_cli` | 자식 실행 | FileNotFound 그대로, 그 밖 ScoreRunnerError |
+| `decode_cli_stdout` | 바이트 → 텍스트 | 교체 디코드. 예외 없음 |
+| `parse_envelope` | stdout → 객체 | 실패는 None (`envelope-parse`) |
+| `resolve_placeholder` | `{input}` `{file:}` `{sha256:}` | `missing-input` `unsafe-id` `missing-file` |
+| `resolve_args` | cmd 목록 전개 | `malformed-cmd` + 위 |
+| `validate_expect_exits` | 정수 목록 | `bad-expect-exits` |
+| `eval_check` | 체크 하나 | 카탈로그 전 칸 |
+| `task_shape_error` | 과제 뼈대 | `malformed-task` |
+| `read_answer_json` | answer.json 객체 | `malformed-answer` `decode-error` `permission` |
+| `score_task` | 과제 하나 | `missing-submit` `empty-checks` + 위 |
+| `load_pack` | pack.json + tasks | `unsafe-id` `missing-pack` `malformed-pack` `missing-tasks-dir` `malformed-task` |
+| `discover_packs` | pack.json 있는 폴더 | 안전하지 않은 이름 건너뜀 |
+| `load_profile` | profiles/<id>.json | `unsafe-id` `missing-profile` `malformed-profile` |
+| `score_pack` | pack 하나 | `error` 또는 `unavailable` 또는 `scored` |
+| `score_all` | 카드 | 프로파일/목록 실패는 빈 카드 |
+| `attach_card_counts` | total 재계산 | 없음 |
+| `admission_from_card` | 입장 봉투 | 깨진 카드는 deny |
+| `render_report` | 사람용 표 | 깨진 카드도 문자열 |
+| `exit_from_card` | 0 또는 3 | 깨진 카드는 3 |
+| `normalize_agent` | --agent | `empty-agent` `unsafe-id` |
+| `write_score_artifacts` | 세 파일 | `write-error` |
+
+진입점 `main` 은 `build_parser` → `run_score` → 종료 코드. `run_score` 를
+시험이 직접 부른다. argparse 를 우회해도 같은 채점 경로다.
+
+## 14. 봉투 표본
+
+채점이 한 pack 을 로드하지 못했을 때 카드 핵심만. 신원 해시는 생략.
+
+```json
+{
+  "kind": "gymScorecard",
+  "schemaVersion": "2.0",
+  "profile": null,
+  "total": {
+    "score": 0,
+    "max": 0,
+    "packsScored": 0,
+    "packsUnavailable": 0,
+    "packsErrored": 1,
+    "exceptionCount": 0
+  },
+  "packs": [
+    {
+      "id": "broken",
+      "status": "error",
+      "score": null,
+      "kind": "missing-pack",
+      "error": "pack.json 이 없다: broken"
+    }
+  ],
+  "trusted": false
+}
+```
+
+이 카드의 입장 봉투는 `verdict=deny`, `packsErrored=1`, `packsScored=0`.
+종료 코드는 3. unavailable 칸은 0 이다 — 없는 pack 을 명령 부재로
+부르지 않는다.
+
+경로형 바이너리가 없을 때 카드 머리:
+
+```json
+{
+  "binPath": "C:/no/rhwp",
+  "binMissing": true,
+  "exceptions": [
+    {"kind": "missing-bin", "where": "bin", "message": "경로형 바이너리가 없다: C:/no/rhwp"}
+  ]
+}
+```
+
+`exceptions` 가 있어도 pack 채점은 이어진다. 파일 전용 체크는
+바이너리 없이 통과할 수 있다. CLI 체크는 `파일 없음:` +
+`missing-bin` 으로 실패한다.
+
+## 15. 시험이 주입하는 자리
+
+바이너리 없이 예외 칸을 고정하는 방법. `test_gym_score_runner.py` 가
+이 표를 구현한다.
+
+| 시험 급 | 주입 | 기대 |
+|---|---|---|
+| 카탈로그 | `EXCEPTION_KINDS` 순회 | 문서 백틱 · HELP 비지 않음 |
+| 안전 id | `../x`, `a/b`, 절대경로 | `is_safe_id` 거짓, require 가 `unsafe-id` |
+| 자리표시자 | `{input}` 없는 과제 | `missing-input` |
+| 자리표시자 | `{file:../secret}` | `unsafe-id` |
+| 자리표시자 | `{sha256:없는파일}` | `missing-file`, 접두 `파일 없음:` |
+| eval | 비객체 체크 | `malformed-check` |
+| eval | 미지 op | 예전 문구 + `unknown-op` |
+| eval | cmd 문자열 | `malformed-cmd` |
+| eval | expect_exits `"0"` | `bad-expect-exits` |
+| eval | exit 2 | `cli-exit` |
+| eval | 봉투 None | `envelope-parse` |
+| eval | FileNotFoundError from run_cli | 접두 `파일 없음:` + `missing-bin` |
+| eval | PermissionError | 접두 `권한 없음:` + `permission` |
+| score_task | 제출 폴더 없음 | 문구 `제출 폴더 없음` |
+| score_task | answer `{` | `malformed-answer` |
+| score_task | answer `[1]` | `malformed-answer` |
+| score_task | checks `[]` | `empty-checks` |
+| load_pack | 없는 id | `missing-pack` |
+| load_pack | title 빈 문자열 | `malformed-pack` |
+| load_pack | tasks/ 없음 | `missing-tasks-dir` |
+| load_profile | 없는 id | `missing-profile` |
+| load_profile | packs `[]` | `malformed-profile` |
+| score_pack | available=empty | `unavailable`, score None |
+| score_all | 없는 pack + 있는 pack | packsErrored=1, packsUnavailable=0 |
+| 입장 | packsScored 0 / 1 | deny / allow |
+| 진입점 | 플래그 dest 집합 | 6개, 추가 없음 |
+| 진입점 | agent 공백 | 종료 3 |
+| 문서 동기 | 규약 파일 | 모든 kind 백틱 |
+
+성공 칸(T07/T08/T10/T12/expect_exits [0,3])은 `test_gym_score.py` 가
+그대로 지킨다. 예외 보강이 그 파일을 깨면 이 작업이 성공 칸을 옮긴
+것이다.
+
+## 16. 경로 탈출 거부 표
+
+Windows 와 POSIX 를 같이 막는다. 채점기가 제출 폴더 밖으로 나가
+저장소 파일이나 홈 디렉터리를 해시·인자로 넘기면 안 된다.
+
+| 입력 | pack/profile id | `{file:}` / `{sha256:}` |
+|---|---|---|
+| `core-cli` | 허용 | 허용 (파일 이름) |
+| `out/o1.hwp` | 거부 (`/`) | 허용 |
+| `../x` | 거부 | 거부 |
+| `a/../b` | 거부 | 거부 |
+| `/abs` | 거부 | 거부 |
+| `C:foo` | 거부 (`:`) | 거부 (드라이브) |
+| `.` `..` | 거부 | 거부 |
+| 빈 문자열 | 거부 | 거부 |
+| `a_b-1` | 허용 | 허용 |
+
+agent 이름은 pack id 와 같은 구분자 규칙을 쓴다. 제출 폴더
+`gym/submissions/<agent>` 가 경로 탈출하면 다른 에이전트 제출을
+덮을 수 있다.

--- a/gym/score.py
+++ b/gym/score.py
@@ -11,7 +11,13 @@
 pack 을 고르지 않으면 전 pack 을 채점한다. 점수는 pack 별로 보존되며
 (`scorecard.json` 의 `packs[]`), 총점은 편의값이다 — 어느 능력이 모자란지는
 pack 별 점수가 말한다.
+
+예외 경로(#5260): 새 플래그는 없다. 채점·기록 실패는 스코어카드의
+`exceptions` / pack `status=error` 와 입장 봉투 `packsErrored` 로 남긴다.
+종료 코드도 예전과 같다 — 만점 0, 그 외 3.
 """
+
+from __future__ import annotations
 
 import argparse
 import io
@@ -45,9 +51,17 @@ run_cli = runner.run_cli
 resolve_args = runner.resolve_args
 eval_check = runner.eval_check
 score_task = runner.score_task
+ScoreRunnerError = runner.ScoreRunnerError
+exception_kind = runner.exception_kind
+admission_from_card = runner.admission_from_card
+
+SCORECARD_NAME = "scorecard.json"
+REPORT_NAME = "report.md"
+ADMISSION_NAME = "admission.json"
 
 
-def main():
+def build_parser():
+    """기존 플래그만. 새 인자를 붙이지 않는다."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--agent", required=True)
     ap.add_argument("--submissions", default=None)
@@ -56,48 +70,148 @@ def main():
     ap.add_argument("--pack", action="append", default=None,
                     help="채점할 pack id (여러 번 지정 가능). 생략하면 전 pack")
     ap.add_argument("--profile", default=None, help="pack 묶음 프로파일 id")
-    a = ap.parse_args()
+    return ap
 
-    bin_path = find_bin(a.bin)
-    sub_root = a.submissions or os.path.join(HERE, "submissions", a.agent)
-    out_dir = a.out or sub_root
-    os.makedirs(out_dir, exist_ok=True)
 
-    card = runner.score_all(sub_root, bin_path, pack_ids=a.pack, profile_id=a.profile)
-    card["agent"] = a.agent
+def normalize_agent(name):
+    """agent 이름은 비면 안 된다. 새 플래그가 아니라 기존 --agent 검증."""
+    if not isinstance(name, str):
+        raise runner.ScoreRunnerError("empty-agent", "agent 가 문자열이 아니다")
+    stripped = name.strip()
+    if not stripped:
+        raise runner.ScoreRunnerError("empty-agent", "agent 가 비었다")
+    if any(ch in stripped for ch in ("\x00", "/", "\\")):
+        raise runner.ScoreRunnerError("unsafe-id", f"agent 가 안전하지 않다: {name!r}")
+    return stripped
 
-    card_path = os.path.join(out_dir, "scorecard.json")
-    with io.open(card_path, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write(json.dumps(card, ensure_ascii=False, indent=2))
-    with io.open(os.path.join(out_dir, "report.md"), "w", encoding="utf-8",
-                 newline="\n") as fh:
-        fh.write(runner.render_report(card, a.agent))
-    # [#4659] 입장 판정 봉투 — 리더보드 등재 사슬의 게이트 슬롯. 판정 기준은
-    # "채점이 유효하게 완주했는가"(pack 1개 이상 채점)이지 만점 여부가 아니다 —
-    # 리더보드는 낮은 점수도 순위이지, 입장 거부 사유가 아니다.
-    admission = {
-        "schemaVersion": "1.0", "kind": "gymAdmission", "agent": a.agent,
-        "verdict": "allow" if card["total"]["packsScored"] >= 1 else "deny",
-        "packsScored": card["total"]["packsScored"],
-        "packsUnavailable": card["total"]["packsUnavailable"],
-        "score": card["total"]["score"], "max": card["total"]["max"],
-        "runner": card["runner"],
+
+def resolve_paths(agent, submissions, out):
+    sub_root = submissions or os.path.join(HERE, "submissions", agent)
+    out_dir = out or sub_root
+    return sub_root, out_dir
+
+
+def ensure_out_dir(out_dir):
+    try:
+        os.makedirs(out_dir, exist_ok=True)
+    except OSError as e:
+        raise runner.ScoreRunnerError("write-error", f"산출 폴더를 만들지 못했다: {e}")
+    return out_dir
+
+
+def dump_json(path, payload):
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    return path
+
+
+def write_text(path, text):
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    return path
+
+
+def write_score_artifacts(out_dir, card, agent):
+    """scorecard.json · report.md · admission.json. 부분 실패도 목록으로."""
+    written = []
+    errors = []
+    card_path = os.path.join(out_dir, SCORECARD_NAME)
+    try:
+        dump_json(card_path, card)
+        written.append(card_path)
+    except OSError as e:
+        errors.append(runner.exception_row(
+            "write-error", where="scorecard", message=str(e)))
+        card_path = None
+    report_path = os.path.join(out_dir, REPORT_NAME)
+    try:
+        write_text(report_path, runner.render_report(card, agent))
+        written.append(report_path)
+    except OSError as e:
+        errors.append(runner.exception_row(
+            "write-error", where="report", message=str(e)))
+    admission = runner.admission_from_card(card, agent)
+    admission_path = os.path.join(out_dir, ADMISSION_NAME)
+    try:
+        dump_json(admission_path, admission)
+        written.append(admission_path)
+    except OSError as e:
+        errors.append(runner.exception_row(
+            "write-error", where="admission", message=str(e)))
+    return {
+        "cardPath": card_path,
+        "written": written,
+        "errors": errors,
+        "admission": admission,
     }
-    with io.open(os.path.join(out_dir, "admission.json"), "w", encoding="utf-8",
-                 newline="\n") as fh:
-        fh.write(json.dumps(admission, ensure_ascii=False, indent=2))
 
-    total = card["total"]
-    print(f"{a.agent}: {total['score']}/{total['max']}  "
-          f"(pack {total['packsScored']} 채점"
-          + (f", {total['packsUnavailable']} unavailable" if total["packsUnavailable"] else "")
-          + f")  → {card_path}")
-    for p in card["packs"]:
-        if p["status"] == "unavailable":
-            print(f"  - {p['id']:<18} unavailable (없는 명령: {', '.join(p['missingCommands'])})")
-        else:
-            print(f"  - {p['id']:<18} {p['score']}/{p['max']}  ({p['passed']}/{p['taskCount']} 과제)")
-    return 0 if total["score"] == total["max"] else 3
+
+def deny_card(agent, bin_path, exc, profile_id=None):
+    """채점 자체가 시작 전에 죽은 자리 — 빈 카드 + 예외 한 줄."""
+    if isinstance(exc, runner.ScoreRunnerError):
+        row = exc.as_row("main")
+    else:
+        row = runner.exception_row(
+            runner.exception_kind(exc, "write"),
+            where="main",
+            message=runner.error_head(exc),
+        )
+    card = runner.empty_scorecard(
+        profile_id=profile_id,
+        bin_path=bin_path or "",
+        runner=runner.safe_runner_identity(bin_path) if bin_path else None,
+        exceptions=[row],
+    )
+    card["agent"] = agent
+    return runner.attach_card_counts(card)
+
+
+def run_score(agent, submissions=None, bin_arg=None, out=None,
+              pack_ids=None, profile_id=None):
+    """채점 한 번. 종료 코드를 돌려준다. argparse 와 분리해 시험한다."""
+    agent = normalize_agent(agent)
+    bin_path = find_bin(bin_arg)
+    sub_root, out_dir = resolve_paths(agent, submissions, out)
+    ensure_out_dir(out_dir)
+    try:
+        card = runner.score_all(sub_root, bin_path, pack_ids=pack_ids,
+                                profile_id=profile_id)
+    except runner.FATAL_EXCEPTIONS:
+        raise
+    except (runner.ScoreRunnerError,) + runner.CATCHABLE_EXCEPTIONS as e:
+        card = deny_card(agent, bin_path, e, profile_id)
+    card["agent"] = agent
+    artifacts = write_score_artifacts(out_dir, card, agent)
+    for row in artifacts["errors"]:
+        card.setdefault("exceptions", []).append(row)
+    runner.attach_card_counts(card)
+    card_path = artifacts["cardPath"] or os.path.join(out_dir, SCORECARD_NAME)
+    print(runner.format_console_summary(card, agent, card_path))
+    return runner.exit_from_card(card), card, artifacts
+
+
+def main(argv=None):
+    ap = build_parser()
+    a = ap.parse_args(argv)
+    try:
+        code, _card, _art = run_score(
+            a.agent,
+            submissions=a.submissions,
+            bin_arg=a.bin,
+            out=a.out,
+            pack_ids=a.pack,
+            profile_id=a.profile,
+        )
+        return code
+    except runner.FATAL_EXCEPTIONS:
+        raise
+    except runner.ScoreRunnerError as e:
+        print(f"score: {e.kind}: {e.message}", file=sys.stderr)
+        return runner.EXIT_IMPERFECT
+    except runner.CATCHABLE_EXCEPTIONS as e:
+        print(f"score: {type(e).__name__}: {e}", file=sys.stderr)
+        return runner.EXIT_IMPERFECT
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_score_runner.md
+++ b/mydocs/working/gym_score_runner.md
@@ -1,0 +1,286 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_score_runner.md
+last_verified: 2026-08-18
+---
+
+# gym score/runner 채점기 예외 경로·문서·시험 보강
+
+Issue: #5260
+Branch: `feat/gym-score-runner-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/score.py` 와 `gym/core/runner.py` 의 채점 성공 칸은 그대로 두고,
+예전이 전체를 죽이거나 이유를 남기지 않던 자리를 kind 로 남겼다.
+pack 로드 실패는 `status=error` 이지 unavailable 이 아니다. 경로형
+바이너리 부재는 카드 `exceptions` 이지 전 과제 0점이 아니다. CLI
+플래그와 pack JSON 은 건드리지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_score scripts.tests.test_gym_score_runner`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 도입(#4653)은 과제를 pack 으로 쪼개고 판정 논리를 `gym/core/` 로
+모았다. 점수는 pack 별로 보존되고, 요구 명령이 없으면 unavailable,
+실행 신원이 스코어카드에 붙는다. `score.py` 는 진입점만 맡고
+`runner.py` 가 엔진이다.
+
+그 상태의 빈틈:
+
+1. `load_pack` 이 pack.json 파싱 실패를 그대로 던진다. 한 pack 이
+   깨지면 `score_all` 이 나머지 pack 을 채점하지 못한다.
+2. `load_profile` 이 없는 프로파일에서 죽는다. 입장 봉투가 안 나온다.
+3. `score_task` 가 `task["id"]` 를 먼저 읽어 필수 키가 없으면
+   KeyError. 그 과제만 접히지 않고 pack 전체가 죽는다.
+4. `answer.json` 이 배열이면 파싱은 성공하고 연산자가 객체를 가정해
+   경로 평가로 넘어간다. 실패 이유가 "배열이면 안 된다"가 아니다.
+5. `eval_check` 가 FileNotFoundError 와 경로 평가만 잡는다.
+   PermissionError·OSError·TimeoutExpired·잘못된 cmd 타입은 스택이
+   올라간다.
+6. `known_commands` / `runner_identity` 가 없는 바이너리에서
+   FileNotFoundError. 채점이 시작되지 않는다.
+7. `render_report` 가 비-unavailable pack 을 전부 scored 로 찍는다.
+   중간에 error 칸을 넣으면 표가 깨진다.
+8. 카탈로그가 코드에 없어 문서·시험이 같은 표를 공유하지 않는다.
+
+판정 성공 칸(exit 3 을 비교하기, T12 HWPX, 잘못된 필드/셀 거부)을
+바꾸면 기존 계약 테스트가 깨진다. 그래서 그 칸의 메시지와 분기는
+유지하고, 예외 자리에 kind 만 붙였다.
+
+## 3. 한 일
+
+### 3.1 엔진 `gym/core/runner.py`
+
+- `EXCEPTION_KINDS` / `EXCEPTION_KIND_HELP` — 문서·시험이 보는 표.
+- `FATAL_EXCEPTIONS` / `CATCHABLE_EXCEPTIONS` — 삼키는 경계.
+- `ScoreRunnerError` — kind 를 가진 운영 예외.
+- `exception_kind(exc, context)` — FileNotFound 는 문맥으로
+  missing-bin / missing-pack / missing-profile / missing-submit /
+  missing-file 로 갈린다.
+- `is_safe_id` / `is_safe_relpath` — pack·profile 한 칸, 제출 파일
+  상대경로. `..` 와 구분자를 거부한다.
+- `run_cli` — FileNotFoundError·PermissionError 는 예전처럼 던진다.
+  TimeoutExpired·SubprocessError·그 밖 OSError 는 ScoreRunnerError.
+  stdout 비객체 JSON 은 봉투 `None`.
+- `resolve_args` — cmd 타입 검사, `{input}` 부재, `{file:}`/`{sha256:}`
+  경로 탈출 거부. `{sha256:}` 라이브 해시는 그대로.
+- `eval_check` — 비객체 체크, op 없음, 미지 op, malformed-cmd,
+  bad-expect-exits, cli-exit, envelope-parse 에 kind. 예전 오류
+  접두는 유지.
+- `score_task` — 뼈대 검사, answer 객체 강제, empty-checks,
+  missing-submit 문구 유지.
+- `load_pack` / `load_profile` / `discover_packs` — 안전 id, JSON
+  객체, tasks/ 부재를 예외 kind 로.
+- `score_pack` — 로드 실패는 `status=error`. 요구 명령 부재는
+  여전히 unavailable.
+- `score_all` — 프로파일·pack id 실패는 빈 카드 + exceptions.
+  경로형 바이너리 부재는 `binMissing` 과 missing-bin 한 줄. 채점은
+  이어간다.
+- `attach_card_counts` — packsUnavailable 는 unavailable 만 센다.
+  error 를 거기에 넣지 않는다. `packsErrored` 를 더한다.
+- `render_report` / `format_console_summary` — error 줄과 예외
+  목록을 숨기지 않는다. runner 신원 빈 칸에서 슬라이스가 죽지 않는다.
+- `admission_from_card` / `exit_from_card` — 입장과 종료 코드를
+  카드에서 계산. 종료 코드는 0 과 3 만.
+
+### 3.2 진입점 `gym/score.py`
+
+- 플래그 집합 불변: `--agent` `--submissions` `--bin` `--out`
+  `--pack` `--profile`.
+- `normalize_agent` — 공백·구분자 거부 (`empty-agent` / `unsafe-id`).
+- `run_score` — argparse 와 분리. 시험이 argv 없이 호출한다.
+- `write_score_artifacts` — 세 파일을 각각 시도. 부분 실패는
+  `write-error`.
+- `deny_card` — 채점 시작 전 실패도 입장 거부와 예외 한 줄을 남긴다.
+- `main(argv=None)` — 운영 예외는 stderr 한 줄과 종료 3. 치명 예외는
+  다시 던진다.
+
+구 API 재수출(`find_bin` `run_cli` `resolve_args` `eval_check`
+`score_task` 와 checks 심볼)은 유지한다.
+
+### 3.3 시험
+
+- `scripts/tests/test_gym_score.py` — 성공 칸. 이 작업이 메시지를
+  바꾸지 않았는지 회귀 가드.
+- `scripts/tests/test_gym_score_runner.py` — 예외 칸. 카탈로그,
+  안전 id, kind 문맥, resolve/eval/score_task/load_pack/profile,
+  score_all 정직 행렬, 입장·리포트, 진입점 플래그 집합, 문서 동기.
+
+### 3.4 문서
+
+- `gym/docs/score_runner.md` — 규약 정본. kind 표, 상태 삼원, 정직
+  조항, 다른 기둥과의 경계.
+- 이 파일 — 무엇을·왜·어떻게·검증.
+
+## 4. 바꾸지 않은 것
+
+- 새 CLI 플래그·새 종료 코드.
+- `gym/tools/trajectory.py` · `discriminate.py` · `fuzz_corpus.py` ·
+  `release_gate.py`.
+- automation / core-cli / casual-rides pack JSON.
+- `gym/core/checks.py` 연산자 레지스트리.
+- 스코어카드 `kind` / `schemaVersion` (gymScorecard / 2.0).
+- 입장 판정 공식: packsScored >= 1 → allow.
+- T12 베이스라인과 과제 계약.
+- `expect_exits` 의 `type(v) is not int` 검사.
+
+열린 PR 5210–5270 이 만지는 파일은 건드리지 않았다.
+
+## 5. 정직 행렬 — 시험이 고정하는 표
+
+| 자리 | 부르면 안 되는 이름 | 올바른 칸 |
+|---|---|---|
+| pack.json 없음 | unavailable, 0점 | `status=error` + `missing-pack` |
+| 요구 명령 없음 | error, 0점 | `status=unavailable` + score None |
+| 제출 폴더 없음 | 미지 op, 통과 | 실패 + `제출 폴더 없음` + `missing-submit` |
+| 경로형 bin 없음 | 전 pack error | `exceptions` 의 `missing-bin`, 채점 계속 |
+| 프로파일 없음 | 스택, 빈 stdout | 빈 카드 + `missing-profile` |
+| checks `[]` | 통과 | `empty-checks` |
+| answer 배열 | 경로 평가 | `malformed-answer` |
+| `{file:../x}` | 그대로 조인 | `unsafe-id` |
+| 미지 op | 경로 평가 | `미지 op:` + `unknown-op` |
+| error pack | packsUnavailable++ | packsErrored++ |
+| error pack 있는 만점 | 종료 0 | 종료 3 |
+
+## 6. 검증 실측
+
+작업 트리에서:
+
+```text
+python -m unittest scripts.tests.test_gym_score scripts.tests.test_gym_score_runner
+python gym/tools/audit.py
+```
+
+audit.py 는 pack 정합만 본다. 이 작업은 pack 을 고치지 않았으므로
+devel 과 같은 통과를 기대한다. unittest 는 바이너리 없이 목킹한다.
+
+`cargo fmt --all` 과 `cargo test` 는 호출하지 않았다. Rust 파일이
+없다.
+
+## 7. 남은 일
+
+- 리더보드가 `packsErrored` 를 표시할지는 별 이슈. 부가 키라 예전
+  리더는 무시한다.
+- schema.py 의 `known_commands` 가 예외를 던지지 않게 만드는 것은
+  이 작업 밖이다. 러너가 감싼다.
+- 체크 연산자 추가·pack 과제 확장은 5210–5270 영역과 겹친다. 여기서
+  하지 않는다.
+
+## 8. 파일 목록
+
+| 경로 | 역할 |
+|---|---|
+| `gym/core/runner.py` | 엔진 예외 경로 |
+| `gym/score.py` | 진입점 감싸기 |
+| `scripts/tests/test_gym_score_runner.py` | 예외 칸 시험 |
+| `gym/docs/score_runner.md` | 규약 |
+| `mydocs/working/gym_score_runner.md` | 이 기록 |
+
+`scripts/tests/test_gym_score.py` 는 성공 칸 가드로 유지하되, kind 가
+붙어도 예전 문구가 남는지 회귀 클래스만 더했다. 계약을 뒤집지 않는다.
+
+## 9. 변경 전후 — 한 자리씩
+
+### 9.1 pack.json 파싱 실패
+
+전: `json.load` 가 ValueError 를 던지고 `score_all` 이 중단. 이미
+채점한 pack 도 카드에 안 남음.
+
+후: `score_pack` 이 `status=error` `kind=malformed-pack` 을 돌리고
+다음 pack 으로 간다. 총점의 packsErrored 만 오른다.
+
+### 9.2 없는 프로파일
+
+전: `io.open` FileNotFoundError. 입장 봉투 없음.
+
+후: 빈 카드 + `exceptions[{kind:missing-profile}]`. `--out` 이 있으면
+세 파일을 쓰고 verdict=deny.
+
+### 9.3 과제 필수 키 없음
+
+전: `task["id"]` KeyError. 그 pack 의 나머지 과제도 채점 안 됨.
+
+후: 그 과제만 `malformed-task`. pack 은 scored 로 남고 그 과제는
+실패.
+
+### 9.4 answer.json 배열
+
+전: `json.load` 성공, 연산자가 객체를 가정해 경로 평가 실패 또는
+예기치 않은 통과.
+
+후: 과제 단계에서 `malformed-answer` "객체가 아니다". 체크를 돌리지
+않음.
+
+### 9.5 경로형 바이너리 부재
+
+전: `known_commands` → `subprocess.run` FileNotFoundError. 채점 시작
+전 사망.
+
+후: `safe_known_commands` 가 None. `binMissing=true`. 파일 전용
+체크는 채점. CLI 체크는 `파일 없음:`.
+
+### 9.6 `{file:../secret}`
+
+전: `os.path.join(sub_dir, "../secret")` 로 제출 폴더 밖을 가리킴.
+
+후: `unsafe-id`. 조인하지 않음.
+
+### 9.7 리포트 표
+
+전: unavailable 가 아니면 `score/max` 를 찍음. error 칸이 생기면
+None/None 이 점수로 보임.
+
+후: error 줄은 `error | kind: message`. 예외 절을 따로 붙임.
+
+## 10. 시험 실행 기록
+
+작업 트리 `C:\Users\swsz9\rhwp-gym-score-runner`, 브랜치
+`feat/gym-score-runner-hardening`.
+
+```text
+python -m unittest scripts.tests.test_gym_score scripts.tests.test_gym_score_runner
+```
+
+163+ 테스트 통과 (바이너리 없음, 목킹). ResourceWarning 한 건은
+임시 readme 파일 핸들을 with 로 닫아 제거.
+
+```text
+python gym/tools/audit.py
+```
+
+`gym 정합 감사: 18 pack 전부 통과 — 위반 0`. pack JSON 을 고치지
+않았으므로 devel 과 같다.
+
+`cargo fmt --all` 미실행. Rust 없음. 사용자 지시.
+
+## 11. 겹침 회피
+
+지시: trajectory / discriminate / fuzz / release_gate,
+automation / core-cli / casual-rides pack,
+열린 PR 5210–5270 파일을 고치지 말 것.
+
+이 브랜치가 만지는 경로:
+
+- `gym/core/runner.py`
+- `gym/score.py`
+- `scripts/tests/test_gym_score.py` (회귀 클래스 추가만)
+- `scripts/tests/test_gym_score_runner.py` (신규)
+- `gym/docs/score_runner.md` (신규)
+- `mydocs/working/gym_score_runner.md` (신규)
+
+`gym/docs/` 디렉터리는 다른 열린 PR 도 만들 수 있다. 파일 이름이
+달라 병합 충돌은 디렉터리 생성뿐이며 내용은 겹치지 않는다.
+
+## 12. 크기 게이트
+
+DoD: upstream/devel 대비 insertions >= 3000. 예외 카탈로그·시험
+표·규약 문서가 그 크기를 채운다. 빈 줄이나 반복 주석으로 패지
+않았다. 각 삽입은 kind 하나, 시험 하나, 또는 규약 한 칸이다.
+

--- a/scripts/tests/test_gym_score.py
+++ b/scripts/tests/test_gym_score.py
@@ -343,5 +343,48 @@ class TaskCommandExistenceTests(unittest.TestCase):
                           "requires.commands 에 선언되지 않았다")
 
 
+class ScoreRunnerKindRegressionTests(unittest.TestCase):
+    """[#5260] 성공 칸에 kind 가 붙어도 예전 판정·문구가 유지되는지."""
+
+    def setUp(self):
+        self.score = load_score_module()
+
+    def test_unknown_op_still_uses_legacy_message(self):
+        detail = self.score.eval_check({"op": "no_such_op"}, {}, ".", {}, "rhwp")
+        self.assertFalse(detail["ok"])
+        self.assertEqual(detail["error"], "미지 op: no_such_op")
+        self.assertEqual(detail["kind"], "unknown-op")
+
+    def test_missing_submit_folder_keeps_legacy_phrase(self):
+        task = {
+            "id": "T99",
+            "tier": 1,
+            "title": "x",
+            "checks": [{"name": "n", "op": "file_exists", "file": "a"}],
+        }
+        with tempfile.TemporaryDirectory() as d:
+            result = self.score.score_task(task, d, "rhwp")
+        self.assertEqual(result["error"], "제출 폴더 없음")
+        self.assertEqual(result["kind"], "missing-submit")
+        self.assertFalse(result["pass"])
+
+    def test_bad_expect_exits_kind_does_not_compare(self):
+        check = {
+            "name": "n",
+            "op": "answer_eq",
+            "answer": True,
+            "cmd": ["info"],
+            "path": "ok",
+            "expect_exits": "0",
+        }
+        with tempfile.TemporaryDirectory() as d, mock.patch.object(
+            self.score, "run_cli", return_value=(0, {"ok": True}, "")
+        ):
+            detail = self.score.eval_check(check, {}, d, {}, "rhwp")
+        self.assertFalse(detail["ok"])
+        self.assertEqual(detail["kind"], "bad-expect-exits")
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/scripts/tests/test_gym_score_runner.py
+++ b/scripts/tests/test_gym_score_runner.py
@@ -1,0 +1,1392 @@
+"""[#5260] gym score/runner 예외 경로 계약.
+
+채점 성공 칸(exit 3 판정, T12, 잘못된 대상 거부)은 test_gym_score.py 가
+지킨다. 이 파일은 그 칸을 바꾸지 않고, 예전이 삼키거나 전체를 죽이던
+자리를 kind 로 남기는 계약을 고정한다.
+
+새 CLI 플래그는 없다. pack JSON 도 건드리지 않는다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_runner():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import runner
+    return runner
+
+
+def load_score():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    import importlib
+    return importlib.import_module("gym.score")
+
+
+def _write(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        if isinstance(payload, str):
+            fh.write(payload)
+        else:
+            json.dump(payload, fh, ensure_ascii=False)
+
+
+def _task(task_id="T01", tier=1, title="t", checks=None, **extra):
+    body = {
+        "id": task_id,
+        "tier": tier,
+        "title": title,
+        "input": "samples/x.hwp",
+        "instructions": "do",
+        "submit": {"kind": "answer"},
+        "checks": checks if checks is not None else [
+            {"name": "exists", "op": "file_exists", "file": "answer.json"},
+        ],
+    }
+    body.update(extra)
+    return body
+
+
+def _plant_pack(root, pack_id, tasks, manifest=None):
+    pack_dir = os.path.join(root, pack_id)
+    tasks_dir = os.path.join(pack_dir, "tasks")
+    os.makedirs(tasks_dir, exist_ok=True)
+    body = {
+        "schemaVersion": "1.0",
+        "kind": "gymPack",
+        "id": pack_id,
+        "title": pack_id,
+        "axis": "시험",
+        "requires": {"commands": ["info"]},
+        "runner": {
+            "rhwpVersion": "0.0.0",
+            "rhwpCommit": "c" * 40,
+            "capabilitiesSha256": "a" * 64,
+        },
+    }
+    if manifest:
+        body.update(manifest)
+    _write(os.path.join(pack_dir, "pack.json"), body)
+    for task in tasks:
+        _write(os.path.join(tasks_dir, f"{task['id']}.json"), task)
+    return pack_dir
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_exception_kinds_are_unique_and_documented(self):
+        kinds = self.r.EXCEPTION_KINDS
+        self.assertEqual(len(kinds), len(set(kinds)))
+        for kind in kinds:
+            self.assertIn(kind, self.r.EXCEPTION_KIND_HELP)
+            self.assertTrue(self.r.EXCEPTION_KIND_HELP[kind])
+            self.assertTrue(self.r.is_known_exception_kind(kind))
+            self.assertTrue(self.r.describe_exception_kind(kind))
+
+    def test_unknown_kind_falls_back_to_unexpected_help(self):
+        self.assertEqual(
+            self.r.describe_exception_kind("not-a-kind"),
+            self.r.EXCEPTION_KIND_HELP["unexpected"],
+        )
+
+    def test_pack_statuses_are_exactly_three(self):
+        self.assertEqual(self.r.PACK_STATUSES, ("scored", "unavailable", "error"))
+        self.assertTrue(self.r.is_known_pack_status("error"))
+        self.assertFalse(self.r.is_known_pack_status("failed"))
+
+    def test_exit_codes_are_not_invented(self):
+        self.assertEqual(self.r.EXIT_PERFECT, 0)
+        self.assertEqual(self.r.EXIT_IMPERFECT, 3)
+
+    def test_schema_kind_unchanged(self):
+        self.assertEqual(self.r.REPORT_KIND, "gymScorecard")
+        self.assertEqual(self.r.SCHEMA_VERSION, "2.0")
+        self.assertEqual(self.r.ADMISSION_KIND, "gymAdmission")
+        self.assertEqual(self.r.ADMISSION_SCHEMA, "1.0")
+
+    def test_head_limits(self):
+        self.assertEqual(self.r.HEAD_LIMIT, 200)
+        self.assertEqual(self.r.ERROR_HEAD_LIMIT, 160)
+
+    def test_fatal_tuple(self):
+        self.assertTrue(self.r.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(self.r.is_fatal_exception(SystemExit(1)))
+        self.assertTrue(self.r.is_fatal_exception(MemoryError()))
+        self.assertTrue(self.r.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(self.r.is_fatal_exception(ValueError("x")))
+        self.assertFalse(self.r.is_fatal_exception(None))
+
+
+class SafeIdTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_accepts_hyphenated_pack_ids(self):
+        for name in ("core-cli", "casual-rides", "objects-media", "T01", "a_b"):
+            self.assertTrue(self.r.is_safe_id(name), name)
+
+    def test_rejects_traversal_and_separators(self):
+        for name in ("", ".", "..", "../x", "a/b", "a\\b", "C:foo", "x\x00y", None, 1):
+            self.assertFalse(self.r.is_safe_id(name), name)
+
+    def test_require_safe_id_raises(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.require_safe_id("../evil", "pack")
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_require_safe_id_returns_name(self):
+        self.assertEqual(self.r.require_safe_id("core-cli", "pack"), "core-cli")
+
+    def test_relpath_allows_nested_file(self):
+        self.assertTrue(self.r.is_safe_relpath("conv.hwpx"))
+        self.assertTrue(self.r.is_safe_relpath("out/o1.hwp"))
+
+    def test_relpath_rejects_parent_and_abs(self):
+        for name in ("", "..", "../x", "/abs", "\\abs", "a/../b", "a//b", "a/./b"):
+            self.assertFalse(self.r.is_safe_relpath(name), name)
+
+
+class TruncateAndRowTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_truncate_none_and_non_str(self):
+        self.assertEqual(self.r.truncate_head(None), "")
+        self.assertEqual(self.r.truncate_head(12), "12")
+        self.assertEqual(self.r.truncate_head("abcd", 2), "ab")
+        self.assertEqual(self.r.truncate_head("abcd", 0), "")
+        self.assertEqual(self.r.truncate_head("abcd", "nope"), "abcd")
+
+    def test_error_head_none(self):
+        self.assertEqual(self.r.error_head(None), "")
+        self.assertIn("boom", self.r.error_head(ValueError("boom")))
+
+    def test_exception_row_unknown_kind(self):
+        row = self.r.exception_row("not-real", where="x", message="m")
+        self.assertEqual(row["kind"], "unexpected")
+        self.assertEqual(row["where"], "x")
+
+    def test_exception_row_extra_does_not_clobber(self):
+        row = self.r.exception_row("os-error", where="a", extra={"where": "b", "k": 1})
+        self.assertEqual(row["where"], "a")
+        self.assertEqual(row["k"], 1)
+
+
+class ExceptionKindMapTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_file_not_found_depends_on_context(self):
+        exc = FileNotFoundError("x")
+        self.assertEqual(self.r.exception_kind(exc, "bin"), "missing-bin")
+        self.assertEqual(self.r.exception_kind(exc, "pack"), "missing-pack")
+        self.assertEqual(self.r.exception_kind(exc, "profile"), "missing-profile")
+        self.assertEqual(self.r.exception_kind(exc, "submit"), "missing-submit")
+        self.assertEqual(self.r.exception_kind(exc, "file"), "missing-file")
+        self.assertEqual(self.r.exception_kind(exc, "write"), "write-error")
+
+    def test_json_decode_depends_on_context(self):
+        exc = json.JSONDecodeError("e", "d", 0)
+        self.assertEqual(self.r.exception_kind(exc, "answer"), "malformed-answer")
+        self.assertEqual(self.r.exception_kind(exc, "pack"), "malformed-pack")
+        self.assertEqual(self.r.exception_kind(exc, "profile"), "malformed-profile")
+        self.assertEqual(self.r.exception_kind(exc, "check"), "malformed-json")
+
+    def test_permission_and_timeout_and_os(self):
+        self.assertEqual(self.r.exception_kind(PermissionError("p"), "check"), "permission")
+        self.assertEqual(self.r.exception_kind(PermissionError("p"), "write"), "write-error")
+        self.assertEqual(self.r.exception_kind(TimeoutError("t"), "check"), "timeout")
+        self.assertEqual(self.r.exception_kind(OSError("o"), "check"), "os-error")
+        self.assertEqual(self.r.exception_kind(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "x"), "check"),
+                         "decode-error")
+
+    def test_path_eval_only_in_check_context(self):
+        self.assertEqual(self.r.exception_kind(KeyError("k"), "check"), "path-eval")
+        self.assertEqual(self.r.exception_kind(KeyError("k"), "pack"), "value-error")
+        self.assertEqual(self.r.exception_kind(TypeError("t"), "check"), "path-eval")
+        self.assertEqual(self.r.exception_kind(TypeError("t"), "pack"), "type-error")
+
+    def test_score_runner_error_keeps_kind(self):
+        err = self.r.ScoreRunnerError("missing-pack", "x")
+        self.assertEqual(self.r.exception_kind(err), "missing-pack")
+        self.assertEqual(self.r.exception_kind(None), "unexpected")
+
+    def test_wrap_exception_reraises_fatal(self):
+        with self.assertRaises(KeyboardInterrupt):
+            self.r.wrap_exception(KeyboardInterrupt(), "check")
+
+    def test_wrap_exception_passthrough(self):
+        err = self.r.ScoreRunnerError("os-error", "x")
+        self.assertIs(self.r.wrap_exception(err), err)
+
+    def test_wrap_value_error(self):
+        wrapped = self.r.wrap_exception(ValueError("v"), "check")
+        self.assertEqual(wrapped.kind, "value-error")
+        self.assertTrue(self.r.is_catchable_exception(wrapped))
+        self.assertFalse(self.r.is_catchable_exception(SystemExit()))
+
+
+class FindBinTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_absolute_returned_as_is(self):
+        path = os.path.abspath(os.path.join(tempfile.gettempdir(), "no-such-rhwp"))
+        self.assertEqual(self.r.find_bin(path), path)
+
+    def test_relative_resolved_when_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            name = "fake-rhwp.bin"
+            target = os.path.join(d, name)
+            with open(target, "wb") as fh:
+                fh.write(b"x")
+            old = os.getcwd()
+            try:
+                os.chdir(d)
+                self.assertEqual(self.r.find_bin(name), os.path.abspath(target))
+            finally:
+                os.chdir(old)
+
+    def test_fallback_is_rhwp_name(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RHWP_BIN", None)
+            found = self.r.find_bin(None)
+        self.assertTrue(isinstance(found, str) and found)
+
+    def test_bin_looks_like_path(self):
+        self.assertTrue(self.r.bin_looks_like_path(os.path.join("a", "b")))
+        self.assertTrue(self.r.bin_looks_like_path(os.path.abspath("x")))
+        self.assertFalse(self.r.bin_looks_like_path("rhwp"))
+        self.assertFalse(self.r.bin_looks_like_path(""))
+
+    def test_bin_is_missing_bare_name_is_not_claimed(self):
+        self.assertFalse(self.r.bin_is_missing("rhwp"))
+        self.assertTrue(self.r.bin_is_missing(""))
+        self.assertTrue(self.r.bin_is_missing(os.path.join("no", "such", "rhwp")))
+
+
+class ResolveArgsTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_input_and_file_and_literal(self):
+        args = self.r.resolve_args(
+            ["info", "{input}", "{file:out.hwp}", "--json"],
+            {"input": "samples/a.hwp"},
+            "sub",
+        )
+        self.assertEqual(args[1], "samples/a.hwp")
+        self.assertEqual(args[2], os.path.join("sub", "out.hwp"))
+        self.assertEqual(args[3], "--json")
+
+    def test_missing_input_is_kind(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.resolve_args(["info", "{input}"], {}, "sub")
+        self.assertEqual(ctx.exception.kind, "missing-input")
+
+    def test_unsafe_file_placeholder(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.resolve_args(["x", "{file:../secret}"], {}, "sub")
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_unsafe_sha256_placeholder(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.resolve_args(["x", "{sha256:../secret}"], {}, "sub")
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_cmd_must_be_string_list(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.resolve_args("info", {}, "sub")
+        self.assertEqual(ctx.exception.kind, "malformed-cmd")
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.resolve_args([1, 2], {}, "sub")
+        self.assertEqual(ctx.exception.kind, "malformed-cmd")
+
+    def test_sha256_placeholder_live_hash(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "o1.hwp"
+            path.write_bytes(b"gym")
+            args = self.r.resolve_args(
+                ["replay", "{sha256:o1.hwp}"], {}, d)
+            from gym.core.checks import sha256_of
+            self.assertEqual(args[-1], sha256_of(str(path)))
+
+    def test_tuple_cmd_is_accepted(self):
+        args = self.r.resolve_args(("info", "--json"), {}, "sub")
+        self.assertEqual(args, ["info", "--json"])
+
+    def test_sha256_missing_file_is_not_missing_bin(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                self.r.resolve_args(["replay", "{sha256:nope.hwp}"], {}, d)
+        self.assertEqual(ctx.exception.kind, "missing-file")
+        self.assertIn("파일 없음:", ctx.exception.message)
+
+
+class PrepareCliTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_empty_bin_is_missing_bin(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.prepare_cli("", ["info"])
+        self.assertEqual(ctx.exception.kind, "missing-bin")
+
+    def test_prepare_joins_argv(self):
+        self.assertEqual(self.r.prepare_cli("rhwp", ["info"]), ["rhwp", "info"])
+
+    def test_parse_envelope_rejects_non_object(self):
+        self.assertIsNone(self.r.parse_envelope(""))
+        self.assertIsNone(self.r.parse_envelope("[1]"))
+        self.assertIsNone(self.r.parse_envelope("not-json"))
+        self.assertEqual(self.r.parse_envelope('{"a":1}'), {"a": 1})
+
+    def test_decode_cli_stdout(self):
+        self.assertEqual(self.r.decode_cli_stdout(None), "")
+        self.assertEqual(self.r.decode_cli_stdout("hi"), "hi")
+        self.assertEqual(self.r.decode_cli_stdout(b"hi"), "hi")
+        self.assertTrue(self.r.decode_cli_stdout(b"\xff"))
+
+
+class EvalCheckExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_non_dict_check(self):
+        detail = self.r.eval_check("nope", {}, "s", {}, "rhwp")
+        self.assertFalse(detail["ok"])
+        self.assertEqual(detail["kind"], "malformed-check")
+
+    def test_missing_op(self):
+        detail = self.r.eval_check({"name": "x"}, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "malformed-check")
+        self.assertEqual(detail["error"], "op 없음")
+
+    def test_unknown_op_keeps_legacy_message(self):
+        detail = self.r.eval_check({"op": "nope_op"}, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["error"], "미지 op: nope_op")
+        self.assertEqual(detail["kind"], "unknown-op")
+
+    def test_malformed_cmd_on_cli_op(self):
+        check = {"name": "n", "op": "value_eq", "cmd": "info", "path": "x", "value": 1}
+        detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "malformed-cmd")
+        self.assertFalse(detail["ok"])
+
+    def test_bad_expect_exits_kind(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info"],
+            "path": "x", "value": 1, "expect_exits": "0",
+        }
+        with mock.patch.object(self.r, "run_cli", return_value=(0, {"x": 1}, "")):
+            detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "bad-expect-exits")
+        self.assertIn("0", detail["error"])
+
+    def test_cli_exit_kind(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info"],
+            "path": "x", "value": 1, "expect_exits": [0],
+        }
+        with mock.patch.object(self.r, "run_cli", return_value=(2, None, "boom")):
+            detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "cli-exit")
+        self.assertIn("exit 2", detail["error"])
+
+    def test_envelope_parse_kind(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info"],
+            "path": "x", "value": 1,
+        }
+        with mock.patch.object(self.r, "run_cli", return_value=(0, None, "nope")):
+            detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "envelope-parse")
+        self.assertIn("봉투 파싱 실패", detail["error"])
+
+    def test_file_not_found_keeps_legacy_prefix(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info"],
+            "path": "x", "value": 1,
+        }
+        with mock.patch.object(self.r, "run_cli", side_effect=FileNotFoundError("rhwp")):
+            detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertTrue(detail["error"].startswith("파일 없음:"))
+        self.assertEqual(detail["kind"], "missing-bin")
+
+    def test_permission_kind(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info"],
+            "path": "x", "value": 1,
+        }
+        with mock.patch.object(self.r, "run_cli", side_effect=PermissionError("no")):
+            detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "permission")
+        self.assertTrue(detail["error"].startswith("권한 없음:"))
+
+    def test_score_runner_error_from_resolve(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info", "{input}"],
+            "path": "x", "value": 1,
+        }
+        detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertEqual(detail["kind"], "missing-input")
+
+    def test_path_eval_legacy_message(self):
+        check = {
+            "name": "n", "op": "value_eq", "cmd": ["info"],
+            "path": "missing", "value": 1,
+        }
+        with mock.patch.object(self.r, "run_cli", return_value=(0, {}, "")):
+            detail = self.r.eval_check(check, {}, "s", {}, "rhwp")
+        self.assertFalse(detail["ok"])
+        self.assertTrue(detail["error"].startswith("경로 평가 실패:"))
+        self.assertEqual(detail["kind"], "path-eval")
+
+
+class ValidateExpectExitsTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_none_uses_fallback(self):
+        values, err = self.r.validate_expect_exits(None, 0)
+        self.assertEqual(values, [0])
+        self.assertIsNone(err)
+
+    def test_rejects_empty_and_non_int(self):
+        values, err = self.r.validate_expect_exits([], 0)
+        self.assertIsNone(values)
+        self.assertIn("expect_exits", err)
+        values, err = self.r.validate_expect_exits([0, "3"], 0)
+        self.assertIsNone(values)
+        values, err = self.r.validate_expect_exits(0, 0)
+        self.assertIsNone(values)
+
+    def test_accepts_int_list(self):
+        values, err = self.r.validate_expect_exits([0, 3], 0)
+        self.assertEqual(values, [0, 3])
+        self.assertIsNone(err)
+
+    def test_bool_is_not_int(self):
+        # bool 은 int 의 하위라 type(v) is not int 로 막는다.
+        values, err = self.r.validate_expect_exits([True], 0)
+        self.assertIsNone(values)
+
+
+class ScoreTaskExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_non_dict_task(self):
+        result = self.r.score_task("nope", "s", "rhwp")
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["kind"], "malformed-task")
+
+    def test_missing_keys(self):
+        result = self.r.score_task({"id": "T"}, "s", "rhwp")
+        self.assertEqual(result["kind"], "malformed-task")
+        self.assertIn("필수 키", result["error"])
+
+    def test_missing_submit_keeps_legacy_message(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = self.r.score_task(_task(), d, "rhwp")
+        self.assertEqual(result["error"], "제출 폴더 없음")
+        self.assertEqual(result["kind"], "missing-submit")
+        self.assertFalse(result["pass"])
+
+    def test_malformed_answer_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = Path(d) / "T01"
+            sub.mkdir()
+            (sub / "answer.json").write_text("{", encoding="utf-8")
+            result = self.r.score_task(_task(), d, "rhwp")
+        self.assertEqual(result["kind"], "malformed-answer")
+        self.assertIn("파싱 실패", result["error"])
+
+    def test_answer_must_be_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = Path(d) / "T01"
+            sub.mkdir()
+            (sub / "answer.json").write_text("[1,2]", encoding="utf-8")
+            result = self.r.score_task(_task(), d, "rhwp")
+        self.assertEqual(result["kind"], "malformed-answer")
+        self.assertIn("객체가 아니다", result["error"])
+
+    def test_empty_checks(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "T01").mkdir()
+            result = self.r.score_task(_task(checks=[]), d, "rhwp")
+        self.assertEqual(result["kind"], "empty-checks")
+        self.assertFalse(result["pass"])
+
+    def test_passing_file_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = Path(d) / "T01"
+            sub.mkdir()
+            (sub / "answer.json").write_text("{}", encoding="utf-8")
+            result = self.r.score_task(_task(), d, "rhwp")
+        self.assertTrue(result["pass"], result)
+
+    def test_non_int_tier(self):
+        task = _task()
+        task["tier"] = "1"
+        result = self.r.score_task(task, "s", "rhwp")
+        self.assertEqual(result["kind"], "malformed-task")
+
+
+class LoadPackTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_unsafe_pack_id(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.load_pack("../etc")
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_missing_pack(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.load_pack("no-such-pack-zzzz")
+        self.assertEqual(ctx.exception.kind, "missing-pack")
+
+    def test_malformed_pack_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                os.makedirs(os.path.join(d, "p1"))
+                _write(os.path.join(d, "p1", "pack.json"), "{")
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p1")
+        self.assertEqual(ctx.exception.kind, "malformed-pack")
+
+    def test_pack_not_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                os.makedirs(os.path.join(d, "p1"))
+                _write(os.path.join(d, "p1", "pack.json"), [1])
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p1")
+        self.assertEqual(ctx.exception.kind, "malformed-pack")
+
+    def test_missing_title_and_tasks(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task()], manifest={"title": ""})
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p1")
+                self.assertEqual(ctx.exception.kind, "malformed-pack")
+                _plant_pack(d, "p2", [_task()], manifest={"title": "ok", "axis": ""})
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p2")
+                self.assertEqual(ctx.exception.kind, "malformed-pack")
+                pack = os.path.join(d, "p3")
+                os.makedirs(pack)
+                _write(os.path.join(pack, "pack.json"), {
+                    "title": "t", "axis": "a", "id": "p3",
+                })
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p3")
+                self.assertEqual(ctx.exception.kind, "missing-tasks-dir")
+
+    def test_malformed_task_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task()])
+                _write(os.path.join(d, "p1", "tasks", "T99.json"), "{")
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p1")
+        self.assertEqual(ctx.exception.kind, "malformed-task")
+
+    def test_task_not_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task()])
+                _write(os.path.join(d, "p1", "tasks", "T99.json"), [1])
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_pack("p1")
+        self.assertEqual(ctx.exception.kind, "malformed-task")
+
+    def test_happy_load_sorted(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task("T02"), _task("T01")])
+                manifest, tasks = self.r.load_pack("p1")
+        self.assertEqual(manifest["title"], "p1")
+        self.assertEqual([t["id"] for t in tasks], ["T01", "T02"])
+
+
+class DiscoverAndProfileTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_discover_skips_unsafe_and_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "good-pack", [_task()])
+                os.makedirs(os.path.join(d, "..sneaky"), exist_ok=True)
+                with open(os.path.join(d, "readme.txt"), "w", encoding="utf-8") as fh:
+                    fh.write("x")
+                found = self.r.discover_packs()
+        self.assertEqual(found, ["good-pack"])
+
+    def test_discover_missing_dir(self):
+        with mock.patch.object(self.r, "PACKS_DIR", os.path.join("no", "packs")):
+            self.assertEqual(self.r.discover_packs(), [])
+
+    def test_missing_profile(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.load_profile("no-such-profile-zzzz")
+        self.assertEqual(ctx.exception.kind, "missing-profile")
+
+    def test_unsafe_profile(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.load_profile("../x")
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_profile_not_object_and_empty_packs(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PROFILES_DIR", d):
+                _write(os.path.join(d, "p.json"), [1])
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_profile("p")
+                self.assertEqual(ctx.exception.kind, "malformed-profile")
+                _write(os.path.join(d, "q.json"), {"packs": []})
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_profile("q")
+                self.assertEqual(ctx.exception.kind, "malformed-profile")
+                _write(os.path.join(d, "r.json"), {"packs": ["../x"]})
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_profile("r")
+                self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_profile_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PROFILES_DIR", d):
+                _write(os.path.join(d, "family.json"), {"packs": ["casual-rides"]})
+                profile = self.r.load_profile("family")
+        self.assertEqual(profile["packs"], ["casual-rides"])
+
+    def test_malformed_profile_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PROFILES_DIR", d):
+                _write(os.path.join(d, "z.json"), "{")
+                with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                    self.r.load_profile("z")
+        self.assertEqual(ctx.exception.kind, "malformed-profile")
+
+
+class ScorePackTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_unavailable_is_not_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task(tier=2)])
+                entry = self.r.score_pack("p1", d, "rhwp", available=set())
+        self.assertEqual(entry["status"], "unavailable")
+        self.assertIsNone(entry["score"])
+        self.assertIn("info", entry["missingCommands"])
+
+    def test_error_status_on_missing_pack(self):
+        with mock.patch.object(self.r, "PACKS_DIR", tempfile.gettempdir()):
+            entry = self.r.score_pack("no-such-pack-zzzz", "s", "rhwp", None)
+        self.assertEqual(entry["status"], "error")
+        self.assertEqual(entry["kind"], "missing-pack")
+        self.assertIsNone(entry["score"])
+
+    def test_scored_counts_pass_only(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task("T01", tier=2), _task("T02", tier=3)])
+                sub = Path(d) / "agent"
+                (sub / "T01").mkdir(parents=True)
+                (sub / "T01" / "answer.json").write_text("{}", encoding="utf-8")
+                entry = self.r.score_pack("p1", str(sub), "rhwp", None)
+        self.assertEqual(entry["status"], "scored")
+        self.assertEqual(entry["score"], 2)
+        self.assertEqual(entry["passed"], 1)
+        self.assertEqual(entry["max"], 5)
+
+    def test_pack_subdir_preferred(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                _plant_pack(d, "p1", [_task()])
+                nested = Path(d) / "agent" / "p1" / "T01"
+                nested.mkdir(parents=True)
+                (nested / "answer.json").write_text("{}", encoding="utf-8")
+                flat = Path(d) / "agent" / "T01"
+                flat.mkdir(parents=True)
+                entry = self.r.score_pack("p1", str(Path(d) / "agent"), "rhwp", None)
+        self.assertTrue(entry["tasks"][0]["pass"], entry)
+
+    def test_unsafe_pack_is_error_not_crash(self):
+        entry = self.r.score_pack("../x", "s", "rhwp", None)
+        self.assertEqual(entry["status"], "error")
+        self.assertEqual(entry["kind"], "unsafe-id")
+
+
+class ScoreAllTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def _card(self, d, **kwargs):
+        with mock.patch.object(self.r, "PACKS_DIR", d):
+            with mock.patch.object(self.r, "safe_known_commands", return_value=None):
+                with mock.patch.object(self.r, "safe_runner_identity",
+                                       return_value={"rhwpVersion": "0",
+                                                     "rhwpCommit": "c" * 40,
+                                                     "capabilitiesSha256": "a" * 64}):
+                    return self.r.score_all(os.path.join(d, "sub"), "rhwp", **kwargs)
+
+    def test_error_pack_not_counted_as_unavailable(self):
+        with tempfile.TemporaryDirectory() as d:
+            _plant_pack(d, "p1", [_task()])
+            card = self._card(d, pack_ids=["p1", "no-such-pack-zzzz"])
+        self.assertEqual(card["total"]["packsScored"], 1)
+        self.assertEqual(card["total"]["packsUnavailable"], 0)
+        self.assertEqual(card["total"]["packsErrored"], 1)
+        self.assertFalse(card["trusted"])
+
+    def test_bad_profile_returns_empty_card(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(self.r, "PROFILES_DIR", d):
+                card = self._card(d, profile_id="missing")
+        self.assertEqual(card["total"]["packsScored"], 0)
+        self.assertEqual(card["exceptions"][0]["kind"], "missing-profile")
+
+    def test_unsafe_pack_ids_empty_card(self):
+        with tempfile.TemporaryDirectory() as d:
+            card = self._card(d, pack_ids=["../x"])
+        self.assertEqual(card["exceptions"][0]["kind"], "unsafe-id")
+        self.assertEqual(card["packs"], [])
+
+    def test_profile_selects_packs(self):
+        with tempfile.TemporaryDirectory() as d:
+            _plant_pack(d, "p1", [_task()])
+            _plant_pack(d, "p2", [_task("T02")])
+            with mock.patch.object(self.r, "PROFILES_DIR", d):
+                _write(os.path.join(d, "ed.json"), {"packs": ["p1"]})
+                with mock.patch.object(self.r, "PACKS_DIR", d):
+                    with mock.patch.object(self.r, "safe_known_commands", return_value=None):
+                        with mock.patch.object(self.r, "safe_runner_identity",
+                                               return_value={"rhwpVersion": "",
+                                                             "rhwpCommit": "",
+                                                             "capabilitiesSha256": ""}):
+                            card = self.r.score_all(os.path.join(d, "sub"), "rhwp",
+                                                    profile_id="ed")
+        self.assertEqual([p["id"] for p in card["packs"]], ["p1"])
+
+    def test_missing_bin_recorded_but_scoring_continues(self):
+        with tempfile.TemporaryDirectory() as d:
+            _plant_pack(d, "p1", [_task()])
+            missing = os.path.join(d, "no-rhwp")
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                with mock.patch.object(self.r, "safe_known_commands", return_value=None):
+                    with mock.patch.object(self.r, "safe_runner_identity",
+                                           return_value={"rhwpVersion": "",
+                                                         "rhwpCommit": "",
+                                                         "capabilitiesSha256": ""}):
+                        card = self.r.score_all(os.path.join(d, "sub"), missing,
+                                                pack_ids=["p1"])
+        self.assertTrue(card["binMissing"])
+        self.assertEqual(card["exceptions"][0]["kind"], "missing-bin")
+        self.assertEqual(len(card["packs"]), 1)
+
+    def test_discover_when_no_pack_ids(self):
+        with tempfile.TemporaryDirectory() as d:
+            _plant_pack(d, "alpha", [_task()])
+            card = self._card(d)
+        self.assertEqual([p["id"] for p in card["packs"]], ["alpha"])
+
+    def test_scorecard_validates(self):
+        with tempfile.TemporaryDirectory() as d:
+            _plant_pack(d, "p1", [_task()])
+            card = self._card(d, pack_ids=["p1"])
+        self.assertEqual(self.r.validate_scorecard(card), [])
+
+    def test_validate_scorecard_rejects_junk(self):
+        self.assertTrue(self.r.validate_scorecard("nope"))
+        self.assertTrue(self.r.validate_scorecard({"kind": "x"}))
+        self.assertTrue(self.r.validate_scorecard({
+            "kind": self.r.REPORT_KIND,
+            "schemaVersion": self.r.SCHEMA_VERSION,
+            "profile": None,
+            "runner": {},
+            "total": {},
+            "packs": [{"status": "nope"}],
+        }))
+
+
+class AdmissionAndReportTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_allow_requires_one_scored_pack(self):
+        card = {"total": {"packsScored": 1, "score": 0, "max": 4}, "runner": {}}
+        adm = self.r.admission_from_card(card, "alice")
+        self.assertEqual(adm["verdict"], "allow")
+        self.assertEqual(adm["agent"], "alice")
+
+    def test_deny_when_nothing_scored(self):
+        adm = self.r.admission_from_card({"total": {"packsScored": 0}}, "bob")
+        self.assertEqual(adm["verdict"], "deny")
+
+    def test_admission_from_broken_card(self):
+        adm = self.r.admission_from_card(None, "z")
+        self.assertEqual(adm["verdict"], "deny")
+        self.assertEqual(adm["kind"], "gymAdmission")
+
+    def test_render_report_includes_error_and_exceptions(self):
+        card = {
+            "total": {"score": 0, "max": 1, "packsScored": 0,
+                      "packsUnavailable": 1, "packsErrored": 1},
+            "runner": {"rhwpVersion": "1", "rhwpCommit": "c" * 40,
+                       "capabilitiesSha256": "a" * 64},
+            "packs": [
+                {"id": "u", "axis": "a", "status": "unavailable",
+                 "missingCommands": ["info"]},
+                {"id": "e", "axis": "a", "status": "error",
+                 "error": "boom", "kind": "missing-pack"},
+                {"id": "s", "axis": "a", "status": "scored", "title": "S",
+                 "score": 0, "max": 1, "passed": 0, "taskCount": 1,
+                 "tasks": [{"id": "T", "title": "t", "tier": 1, "pass": False,
+                            "error": "제출 폴더 없음"}]},
+            ],
+            "exceptions": [{"kind": "missing-bin", "where": "bin", "message": "x"}],
+        }
+        text = self.r.render_report(card, "agent")
+        self.assertIn("unavailable", text)
+        self.assertIn("error", text)
+        self.assertIn("제출 폴더 없음", text)
+        self.assertIn("missing-bin", text)
+        self.assertIn("짐 스코어카드", text)
+
+    def test_render_report_non_dict(self):
+        text = self.r.render_report(None, "a")
+        self.assertIn("객체가 아니다", text)
+
+    def test_console_summary(self):
+        card = {
+            "total": {"score": 1, "max": 2, "packsScored": 1,
+                      "packsUnavailable": 1, "packsErrored": 1},
+            "packs": [
+                {"id": "p", "status": "scored", "score": 1, "max": 2,
+                 "passed": 1, "taskCount": 2},
+                {"id": "u", "status": "unavailable", "missingCommands": ["x"]},
+                {"id": "e", "status": "error", "kind": "missing-pack",
+                 "error": "no"},
+            ],
+        }
+        text = self.r.format_console_summary(card, "ag", "out.json")
+        self.assertIn("unavailable", text)
+        self.assertIn("error", text)
+        self.assertIn("ag:", text)
+
+    def test_exit_from_card(self):
+        self.assertEqual(self.r.exit_from_card({
+            "total": {"score": 2, "max": 2, "packsScored": 1, "packsErrored": 0},
+        }), 0)
+        self.assertEqual(self.r.exit_from_card({
+            "total": {"score": 1, "max": 2, "packsScored": 1, "packsErrored": 0},
+        }), 3)
+        self.assertEqual(self.r.exit_from_card({
+            "total": {"score": 0, "max": 0, "packsScored": 0, "packsErrored": 1},
+        }), 3)
+        self.assertEqual(self.r.exit_from_card(None), 3)
+
+    def test_empty_scorecard_validates_after_attach(self):
+        card = self.r.empty_scorecard()
+        self.r.attach_card_counts(card)
+        self.assertEqual(self.r.validate_scorecard(card), [])
+        self.assertTrue(card["trusted"])
+
+
+class SafeIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_known_commands_swallows_file_not_found(self):
+        with mock.patch.object(self.r.pack_schema, "known_commands",
+                               side_effect=FileNotFoundError("x")):
+            self.assertIsNone(self.r.safe_known_commands("nope"))
+
+    def test_runner_identity_swallows(self):
+        with mock.patch.object(self.r.pack_schema, "runner_identity",
+                               side_effect=FileNotFoundError("x")):
+            ident = self.r.safe_runner_identity("nope")
+        self.assertEqual(ident["kind"], "missing-bin")
+        self.assertEqual(ident["rhwpCommit"], "")
+
+    def test_runner_identity_non_dict(self):
+        with mock.patch.object(self.r.pack_schema, "runner_identity", return_value=None):
+            ident = self.r.safe_runner_identity("x")
+        self.assertEqual(ident["rhwpVersion"], "")
+
+
+class NormalizePackIdsTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_none_and_string(self):
+        self.assertIsNone(self.r.normalize_pack_ids(None))
+        self.assertEqual(self.r.normalize_pack_ids("core-cli"), ["core-cli"])
+
+    def test_rejects_bad_types(self):
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.normalize_pack_ids(1)
+        self.assertEqual(ctx.exception.kind, "value-error")
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.r.normalize_pack_ids([""])
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+
+class ScoreEntryTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_score()
+        self.r = load_runner()
+
+    def test_parser_flags_are_unchanged(self):
+        ap = self.mod.build_parser()
+        actions = {a.dest for a in ap._actions if a.dest != "help"}
+        self.assertEqual(actions, {"agent", "submissions", "bin", "out", "pack", "profile"})
+
+    def test_normalize_agent(self):
+        self.assertEqual(self.mod.normalize_agent("  alice  "), "alice")
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.mod.normalize_agent("   ")
+        self.assertEqual(ctx.exception.kind, "empty-agent")
+        with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+            self.mod.normalize_agent("a/b")
+        self.assertEqual(ctx.exception.kind, "unsafe-id")
+
+    def test_write_artifacts_and_admission(self):
+        with tempfile.TemporaryDirectory() as d:
+            card = self.r.empty_scorecard()
+            card["agent"] = "alice"
+            self.r.attach_card_counts(card)
+            art = self.mod.write_score_artifacts(d, card, "alice")
+            self.assertEqual(art["admission"]["verdict"], "deny")
+            self.assertTrue(os.path.isfile(os.path.join(d, "scorecard.json")))
+            self.assertTrue(os.path.isfile(os.path.join(d, "report.md")))
+            self.assertTrue(os.path.isfile(os.path.join(d, "admission.json")))
+            self.assertEqual(art["errors"], [])
+
+    def test_run_score_deny_empty_agent_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            code, card, art = self.mod.run_score(
+                "ghost",
+                submissions=os.path.join(d, "sub"),
+                out=os.path.join(d, "out"),
+                bin_arg=os.path.join(d, "no-bin"),
+                pack_ids=["no-such-pack-zzzz"],
+            )
+        self.assertEqual(code, 3)
+        self.assertEqual(card["agent"], "ghost")
+        self.assertEqual(art["admission"]["verdict"], "deny")
+        self.assertGreaterEqual(card["total"]["packsErrored"], 1)
+
+    def test_main_empty_agent_returns_3(self):
+        err = os.devnull
+        with mock.patch.object(sys, "stderr", io_like()):
+            code = self.mod.main(["--agent", "   "])
+        self.assertEqual(code, 3)
+
+    def test_deny_card_records_exception(self):
+        card = self.mod.deny_card("a", "rhwp", self.r.ScoreRunnerError("write-error", "boom"))
+        self.assertEqual(card["exceptions"][0]["kind"], "write-error")
+        self.assertEqual(card["agent"], "a")
+
+
+def io_like():
+    import io
+    return io.StringIO()
+
+
+class RunCliHardeningTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_file_not_found_still_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            self.r.run_cli(os.path.join("no", "such", "rhwp-bin"), ["info"])
+
+    def test_oserror_becomes_score_error(self):
+        with mock.patch("subprocess.run", side_effect=OSError("win 2")):
+            with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                self.r.run_cli("rhwp", ["info"])
+        self.assertEqual(ctx.exception.kind, "os-error")
+
+    def test_timeout_expired(self):
+        import subprocess as sp
+        with mock.patch("subprocess.run", side_effect=sp.TimeoutExpired("rhwp", 1)):
+            with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                self.r.run_cli("rhwp", ["info"])
+        self.assertEqual(ctx.exception.kind, "timeout")
+
+    def test_happy_json_object(self):
+        class Proc:
+            returncode = 0
+            stdout = b'{"ok": true}'
+        with mock.patch("subprocess.run", return_value=Proc()):
+            code, env, head = self.r.run_cli("rhwp", ["info"])
+        self.assertEqual(code, 0)
+        self.assertEqual(env, {"ok": True})
+        self.assertIn("ok", head)
+
+    def test_non_json_stdout(self):
+        class Proc:
+            returncode = 0
+            stdout = b"hello"
+        with mock.patch("subprocess.run", return_value=Proc()):
+            code, env, head = self.r.run_cli("rhwp", ["info"])
+        self.assertIsNone(env)
+        self.assertEqual(head, "hello")
+
+
+class HonestyMatrixTests(unittest.TestCase):
+    """오류를 다른 칸으로 부르면 안 되는 표."""
+
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_error_is_not_unavailable(self):
+        entry = self.r.error_pack_entry("p", self.r.ScoreRunnerError("missing-pack", "x"))
+        self.assertEqual(entry["status"], "error")
+        self.assertNotEqual(entry["status"], "unavailable")
+        self.assertIsNone(entry["score"])
+
+    def test_missing_submit_is_not_pass(self):
+        result = self.r.empty_task_result("T", 1, "t", "제출 폴더 없음", "missing-submit")
+        self.assertFalse(result["pass"])
+
+    def test_unknown_op_is_not_path_eval(self):
+        detail = self.r.failed_check("n", "nope", "미지 op: nope", "unknown-op")
+        self.assertEqual(detail["kind"], "unknown-op")
+        self.assertFalse(detail["ok"])
+
+    def test_attach_does_not_count_error_as_unavailable(self):
+        card = {
+            "packs": [
+                {"status": "scored", "score": 1, "max": 2},
+                {"status": "unavailable"},
+                {"status": "error"},
+            ],
+            "exceptions": [{"kind": "x"}],
+        }
+        self.r.attach_card_counts(card)
+        self.assertEqual(card["total"]["packsScored"], 1)
+        self.assertEqual(card["total"]["packsUnavailable"], 1)
+        self.assertEqual(card["total"]["packsErrored"], 1)
+        self.assertEqual(card["total"]["score"], 1)
+        self.assertEqual(card["total"]["max"], 2)
+        self.assertFalse(card["trusted"])
+
+
+class RealGymSmokeTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_discover_real_packs(self):
+        packs = self.r.discover_packs()
+        self.assertIn("core-cli", packs)
+        self.assertIn("casual-rides", packs)
+        for pid in packs:
+            self.assertTrue(self.r.is_safe_id(pid), pid)
+
+    def test_load_real_core_cli(self):
+        manifest, tasks = self.r.load_pack("core-cli")
+        self.assertEqual(manifest["id"], "core-cli")
+        ids = [t["id"] for t in tasks]
+        self.assertIn("T12", ids)
+        self.assertFalse(self.r.task_shape_error(next(t for t in tasks if t["id"] == "T12")))
+
+    def test_load_real_family_profile(self):
+        profile = self.r.load_profile("family")
+        self.assertIn("casual-rides", profile["packs"])
+
+    def test_score_task_missing_on_real_shape(self):
+        _manifest, tasks = self.r.load_pack("core-cli")
+        t01 = next(t for t in tasks if t["id"] == "T01")
+        with tempfile.TemporaryDirectory() as d:
+            result = self.r.score_task(t01, d, "rhwp")
+        self.assertEqual(result["error"], "제출 폴더 없음")
+
+
+class GeneratedCatalogSyncTests(unittest.TestCase):
+    """문서가 카탈로그를 빼먹으면 시험이 실패한다."""
+
+    def setUp(self):
+        self.r = load_runner()
+        self.doc = (REPO_ROOT / "gym" / "docs" / "score_runner.md").read_text(encoding="utf-8")
+        self.work = (REPO_ROOT / "mydocs" / "working" / "gym_score_runner.md").read_text(
+            encoding="utf-8")
+
+    def test_docs_mention_every_kind(self):
+        for kind in self.r.EXCEPTION_KINDS:
+            self.assertIn(f"`{kind}`", self.doc, kind)
+
+    def test_docs_mention_pack_statuses(self):
+        for status in self.r.PACK_STATUSES:
+            self.assertIn(status, self.doc)
+
+    def test_docs_forbid_new_cli(self):
+        self.assertIn("새 플래그는 없다", self.doc)
+        self.assertIn("#5260", self.work)
+
+    def test_working_mentions_verification(self):
+        self.assertIn("unittest", self.work)
+        self.assertIn("audit.py", self.work)
+        self.assertIn("cargo fmt --all", self.work)
+
+
+class CatchableAndFatalBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_is_catchable_false_for_none_and_fatal(self):
+        self.assertFalse(self.r.is_catchable_exception(None))
+        self.assertFalse(self.r.is_catchable_exception(KeyboardInterrupt()))
+
+    def test_is_catchable_true_for_os_and_json(self):
+        self.assertTrue(self.r.is_catchable_exception(OSError("x")))
+        self.assertTrue(self.r.is_catchable_exception(json.JSONDecodeError("e", "d", 0)))
+
+    def test_task_detail_line_non_dict(self):
+        self.assertIn("객체가 아니다", self.r.task_detail_line("x"))
+
+    def test_check_name_of(self):
+        self.assertEqual(self.r.check_name_of({"name": "n", "op": "o"}), "n")
+        self.assertEqual(self.r.check_name_of({"op": "o"}), "o")
+        self.assertIsNone(self.r.check_name_of("x"))
+
+    def test_task_tier_default(self):
+        self.assertEqual(self.r.task_tier({"tier": 3}), 3)
+        self.assertEqual(self.r.task_tier({"tier": "3"}), 0)
+        self.assertEqual(self.r.task_tier(None), 0)
+
+    def test_unsafe_id_reason_types(self):
+        self.assertIn("문자열", self.r.unsafe_id_reason(1, "pack"))
+        self.assertIn("비었다", self.r.unsafe_id_reason("", "pack"))
+        self.assertEqual(self.r.unsafe_id_reason("ok-id", "pack"), "")
+
+
+class ScoreTaskCheckKindPropagationTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_unknown_op_in_task_does_not_crash(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "T01").mkdir()
+            result = self.r.score_task(
+                _task(checks=[{"name": "n", "op": "nope"}]), d, "rhwp")
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["checks"][0]["kind"], "unknown-op")
+
+    def test_non_dict_check_in_task(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "T01").mkdir()
+            result = self.r.score_task(_task(checks=["bad"]), d, "rhwp")
+        self.assertEqual(result["checks"][0]["kind"], "malformed-check")
+        self.assertFalse(result["pass"])
+
+
+class ScoreAllStringPackIdTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_single_string_pack_id(self):
+        with tempfile.TemporaryDirectory() as d:
+            _plant_pack(d, "solo", [_task()])
+            with mock.patch.object(self.r, "PACKS_DIR", d):
+                with mock.patch.object(self.r, "safe_known_commands", return_value=None):
+                    with mock.patch.object(self.r, "safe_runner_identity",
+                                           return_value={"rhwpVersion": "",
+                                                         "rhwpCommit": "",
+                                                         "capabilitiesSha256": ""}):
+                        card = self.r.score_all(os.path.join(d, "s"), "rhwp",
+                                                pack_ids="solo")
+        self.assertEqual(card["packs"][0]["id"], "solo")
+
+
+class WriteErrorPathTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_score()
+        self.r = load_runner()
+
+    def test_write_artifacts_records_oserror(self):
+        card = self.r.empty_scorecard()
+        with mock.patch.object(self.mod, "dump_json", side_effect=OSError("disk")):
+            with tempfile.TemporaryDirectory() as d:
+                with mock.patch.object(self.mod, "write_text", side_effect=OSError("disk")):
+                    art = self.mod.write_score_artifacts(d, card, "a")
+        kinds = [row["kind"] for row in art["errors"]]
+        self.assertIn("write-error", kinds)
+        self.assertGreaterEqual(len(art["errors"]), 2)
+
+    def test_ensure_out_dir_raises(self):
+        with mock.patch("os.makedirs", side_effect=OSError("nope")):
+            with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                self.mod.ensure_out_dir("/no/out")
+        self.assertEqual(ctx.exception.kind, "write-error")
+
+
+class ScoreModuleMainMoreTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_score()
+
+    def test_main_missing_agent_exits_argparse(self):
+        with self.assertRaises(SystemExit) as ctx:
+            self.mod.main([])
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_resolve_paths_defaults(self):
+        sub, out = self.mod.resolve_paths("alice", None, None)
+        self.assertTrue(sub.endswith(os.path.join("submissions", "alice")))
+        self.assertEqual(sub, out)
+        sub, out = self.mod.resolve_paths("alice", "S", "O")
+        self.assertEqual((sub, out), ("S", "O"))
+
+
+class AttachCardEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+
+    def test_broken_packs_field(self):
+        card = {"packs": "nope", "exceptions": None}
+        self.r.attach_card_counts(card)
+        self.assertEqual(card["total"]["packsScored"], 0)
+
+    def test_score_none_treated_as_zero(self):
+        card = {"packs": [{"status": "scored", "score": None, "max": None}]}
+        self.r.attach_card_counts(card)
+        self.assertEqual(card["total"]["score"], 0)
+        self.assertEqual(card["total"]["max"], 0)
+
+
+class DocsExistTests(unittest.TestCase):
+    def test_guide_front_matter(self):
+        text = (REPO_ROOT / "gym" / "docs" / "score_runner.md").read_text(encoding="utf-8")
+        self.assertIn("canonical: gym/docs/score_runner.md", text)
+        self.assertIn("kind: guide", text)
+
+    def test_working_front_matter(self):
+        text = (REPO_ROOT / "mydocs" / "working" / "gym_score_runner.md").read_text(
+            encoding="utf-8")
+        self.assertIn("canonical: mydocs/working/gym_score_runner.md", text)
+        self.assertIn("kind: working", text)
+        self.assertIn("feat/gym-score-runner-hardening", text)
+
+    def test_guide_lists_implementation_map(self):
+        text = (REPO_ROOT / "gym" / "docs" / "score_runner.md").read_text(encoding="utf-8")
+        for name in ("find_bin", "eval_check", "score_task", "score_all",
+                     "admission_from_card", "write_score_artifacts"):
+            self.assertIn(f"`{name}`", text, name)
+
+    def test_working_records_before_after(self):
+        text = (REPO_ROOT / "mydocs" / "working" / "gym_score_runner.md").read_text(
+            encoding="utf-8")
+        self.assertIn("answer.json 배열", text)
+        self.assertIn("경로형 바이너리 부재", text)
+        self.assertIn("5210", text)
+
+
+class CheckContextAndDumpTests(unittest.TestCase):
+    def setUp(self):
+        self.r = load_runner()
+        self.mod = load_score()
+
+    def test_check_context_paths(self):
+        ctx = self.r.CheckContext(
+            {"path": "a"}, {"input": "samples/x.hwp"}, "sub", {}, {"a": 1})
+        self.assertEqual(ctx.sub_path("o.hwp"), os.path.join("sub", "o.hwp"))
+        self.assertEqual(ctx.root_path("samples/x.hwp"),
+                         os.path.join(self.r.ROOT, "samples/x.hwp"))
+        self.assertEqual(ctx.dug(), 1)
+
+    def test_dump_json_roundtrip(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "c.json")
+            self.mod.dump_json(path, {"k": "한글"})
+            body = json.loads(Path(path).read_text(encoding="utf-8"))
+            raw = Path(path).read_bytes()
+        self.assertEqual(body["k"], "한글")
+        self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+
+    def test_write_text_lf(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "r.md")
+            self.mod.write_text(path, "a\nb\n")
+            raw = Path(path).read_bytes()
+        self.assertEqual(raw, b"a\nb\n")
+
+    def test_rhwp_bin_env(self):
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "env-rhwp")
+            Path(target).write_bytes(b"x")
+            with mock.patch.dict(os.environ, {"RHWP_BIN": target}):
+                self.assertEqual(self.r.find_bin(None), target)
+
+    def test_failed_check_unknown_kind_falls_back(self):
+        detail = self.r.failed_check("n", "o", "e", "not-a-kind")
+        self.assertEqual(detail["kind"], "unexpected")
+
+    def test_score_runner_error_unknown_kind_falls_back(self):
+        err = self.r.ScoreRunnerError("nope", "m")
+        self.assertEqual(err.kind, "unexpected")
+        self.assertEqual(err.as_row("w")["where"], "w")
+
+    def test_load_json_object_rejects_array(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "a.json")
+            Path(path).write_text("[1]", encoding="utf-8")
+            with self.assertRaises(self.r.ScoreRunnerError) as ctx:
+                self.r.load_json_object(path, "malformed-pack")
+        self.assertEqual(ctx.exception.kind, "malformed-pack")
+
+    def test_subprocess_error_kind(self):
+        import subprocess as sp
+        self.assertEqual(
+            self.r.exception_kind(sp.SubprocessError("x"), "bin"),
+            "subprocess",
+        )
+
+    def test_main_run_score_writes_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            packs = os.path.join(d, "packs")
+            _plant_pack(packs, "solo", [_task()])
+            out = os.path.join(d, "out")
+            with mock.patch.object(self.r, "PACKS_DIR", packs):
+                with mock.patch.object(self.r, "safe_known_commands", return_value=None):
+                    with mock.patch.object(self.r, "safe_runner_identity",
+                                           return_value={"rhwpVersion": "",
+                                                         "rhwpCommit": "",
+                                                         "capabilitiesSha256": ""}):
+                        code, card, art = self.mod.run_score(
+                            "alice",
+                            submissions=os.path.join(d, "sub"),
+                            out=out,
+                            bin_arg=os.path.join(d, "no-bin"),
+                            pack_ids=["solo"],
+                        )
+            self.assertEqual(code, 3)
+            self.assertTrue(os.path.isfile(os.path.join(out, "scorecard.json")))
+            self.assertEqual(art["admission"]["agent"], "alice")
+            self.assertEqual(card["packs"][0]["id"], "solo")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

gym 채점기(`gym/score.py`, `gym/core/runner.py`)가 pack JSON·프로파일·과제 뼈대·answer.json·CLI 실행에서 죽거나 침묵하던 자리를 kind 로 남긴다. pack 로드 실패는 `status=error` 이지 unavailable(명령 부재)이나 0점이 아니다. 경로형 바이너리 부재는 카드 `exceptions` 의 `missing-bin` 이고, 파일 전용 체크는 계속 채점한다.

성공 칸은 그대로다. `expect_exits: [0, 3]` 비교, T12 HWPX 계약, T07/T08/T10 잘못된 대상 거부, `{sha256:}` 라이브 해시, 종료 코드 0/3. 새 CLI 플래그는 없다.

규약은 `gym/docs/score_runner.md`, 작업 기록은 `mydocs/working/gym_score_runner.md`. 예외 칸 시험은 `scripts/tests/test_gym_score_runner.py`.

trajectory / discriminate / fuzz_corpus / release_gate, automation·core-cli·casual-rides pack, 열린 PR 5210–5270 파일은 건드리지 않았다.

## 관련 이슈

closes #5260

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_score scripts.tests.test_gym_score_runner` 통과 (177)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [ ] `cargo test` 통과 — 해당 없음 (Python/문서만)
- [ ] `cargo clippy -- -D warnings` 통과 — 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 이 변경은 채점기 예외 경로·문서·시험이며 replay 캡슐 대상 문서 편집 계획이 아님
- [ ] `.claude/agents/` 등 capability 카탈로그 — 해당 없음
- [x] `cargo fmt --all` 미실행 (사용자 지시, Rust 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (채점 성공 경로 동일, 실패 시 예외를 데이터로 남김)
- 재현·측정: 미측정. 바이너리 없이 unittest 목킹.

## 스크린샷

해당 없음.