### PR TITLE
gym: tutorial + PARK 입문 문서·링크·프로파일 계약

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,6 +953,7 @@ jobs:
           python3 -m unittest scripts/tests/test_gym_fuzz_corpus.py
           python3 -m unittest scripts/tests/test_gym_release_diff.py
           python3 -m unittest scripts/tests/test_gym_discriminate.py
+          python3 -m unittest scripts/tests/test_gym_tutorial.py
 
       # [#4855] 경쟁 벤치 하네스 순수 로직 가드 — 집계·능력 매트릭스·리포트 렌더·정직한
       # 저하(못 돌린 도구는 'n/a: 이유', 숫자 날조 금지)를 바이너리·외부도구 없이 검증한다.

--- a/gym/INVITE.md
+++ b/gym/INVITE.md
@@ -83,3 +83,91 @@ python gym/tools/leaderboard.py verify
 
 친구를 부르는 이유는 순위 경쟁을 키우기 위해서가 아니라, 더 많은 눈이 같은
 사다리를 밟을수록 그 사다리가 더 단단해지기 때문이다.
+
+---
+
+## 누구에게 어떤 첫 줄을 주나
+
+초대는 안내다. 손님 종류마다 첫 줄만 다르게 적는다. 채점 규칙은 같다.
+
+### 사람 (부모님·친구)
+
+키 제한 없는 입문존만 권한다.
+
+```bash
+python gym/score.py --agent 부모님 --profile family
+```
+
+5분 안내는 [tutorial/README.md](tutorial/README.md), 표는
+[tutorial/01-admission.md](tutorial/01-admission.md), Windows 는
+[tutorial/19-windows.md](tutorial/19-windows.md). 보스존 링크를 같이
+보내지 마라. 담력은 손님이 고른다.
+
+### 다른 LLM 에이전트
+
+자기 바이너리, 자기 키. 합류 3줄은 초대 봉투의 `join` 과 같다. 휴게실
+지도 [tutorial/README.md](tutorial/README.md) 와 테마파크
+[PARK.md](PARK.md) 를 같이 보낸다. 프로파일 일곱 이름은
+[tutorial/06-profiles.md](tutorial/06-profiles.md).
+
+에이전트에게 "기준 풀이를 베끼라"고 하지 마라. 채점은 통과해도 측정이
+바뀐다. [tutorial/15-scoring-honesty.md](tutorial/15-scoring-honesty.md).
+
+### CI · 봇
+
+같은 세 줄이다. 비밀키(`gym/leaderboard/keys/`)를 로그·아티팩트에
+올리지 않는다. `verify` 가 실패하면 원장을 고치지 말고 그 자리를
+읽는다. 폭로가 점이다.
+
+## 판 지문을 손으로 맞춰 보기
+
+`verify` 한 줄이 정석이다. 손님이 "무엇이 같아야 하는가"를 알고
+싶을 때만 아래를 본다. 새 검증 명령을 만들지 않는다.
+
+1. `gym/leaderboard/invite.json` 의 `fingerprint` 를 연다.
+2. `python gym/tools/leaderboard.py verify` 가 통과하는지 본다.
+3. 원장 줄 수·멤버 수가 초대장이 말한 `ledgerEntries` · `members` 와
+   같은지 눈으로 본다.
+4. 다르면 초대장이 오래된 것이다. 보내는 쪽이 `invite` 를 다시 돌린다.
+
+지문 칸의 뜻은 위 표와 같다. 휴게실 번역은
+[tutorial/13-invite.md](tutorial/13-invite.md).
+
+## 흔한 초대 실수
+
+1. **보내는 쪽이 손님 이름으로 `attest` 한다.** 대리 등재다.
+   keyring 이 막거나, 막지 못해도 손님의 키가 아니다. 손님 스스로
+   등재한다.
+2. **초대장이 있어야 문이 열린다고 적는다.** 거짓이다. 문은 이미
+   열려 있다.
+3. **판 지문을 비밀처럼 보낸다.** 지문은 커밋된 파일의 요약이다.
+   검증하라고 주는 것이다.
+4. **손님에게 `maintainer` 를 첫 프로파일로 준다.** 전 pack 이라
+   unavailable 줄이 섞이기 쉽다. 사람은 `family`, 에이전트는
+   `family` 또는 `starter`.
+5. **비밀키를 초대장에 붙인다.** `invite.json` 에는 비밀이 없다.
+   붙여서도 안 된다.
+
+## 가족과 같이 탈 때
+
+`--profile family` 는 `casual-rides` 만 고른다. 한 집에 이름만 다르게
+쓰면 제출 폴더가 갈린다.
+
+```bash
+python gym/score.py --agent 부모님 --profile family
+python gym/score.py --agent 나 --profile family
+python gym/tools/leaderboard.py attest --agent 부모님
+python gym/tools/leaderboard.py attest --agent 나
+```
+
+점수를 합치지 마라. 프로파일은 묶음을 고를 뿐 점수를 뭉치지 않는다.
+두 사람의 4/4 는 두 줄의 순위이지 8점이 아니다.
+
+## 초대장이 바꾸지 않는 것
+
+- `gym/core/checks.py` 채점 연산자
+- pack 과제 JSON
+- `admission` 의 allow/deny 규칙
+- 원장에 이미 봉인된 줄 (invite 는 `invite.json` 만 새로 쓴다)
+
+초대는 문을 가리킨다. 문을 새로 달지 않는다.

--- a/gym/PARK.md
+++ b/gym/PARK.md
@@ -67,6 +67,49 @@ python gym/score.py --agent 내이름        # 표 발권(admission.json)
 지도만 보면 막막하다. 휴게실에서 첫 놀이기구를 함께 타 본다.
 
 > **→ [gym/tutorial/README.md](tutorial/README.md)** — 5분 첫 방문 안내.
+>
+> 휴게실이 한 장이 되었다. 표를 끊는 법, 입문존 네 놀이기구, 일곱
+> 프로파일, casual 바깥 `starter` 길, 전당과 초대, Windows 번역까지
+> 같은 폴더에 있다. 규약 정본은 [docs/tutorial.md](docs/tutorial.md).
+
+### 첫 방문 동선 (이 지도에서)
+
+1. 표를 끊는다 — `--profile family` ([tutorial/01-admission.md](tutorial/01-admission.md))
+2. 회전목마 CR01 — `rhwp info samples/table-001.hwp --json` 의 `pageCount`
+   ([tutorial/02-cr01-carousel.md](tutorial/02-cr01-carousel.md))
+3. 관람차·서커스·링던지기 — 같은 문서, 다른 창문
+   ([tutorial/03-cr02-ferris.md](tutorial/03-cr02-ferris.md) ·
+   [tutorial/04-cr03-circus.md](tutorial/04-cr03-circus.md) ·
+   [tutorial/05-cr04-ringtoss.md](tutorial/05-cr04-ringtoss.md))
+4. 이름이 필요하면 전당 — `leaderboard.py attest` /
+   `verify` ([tutorial/12-leaderboard.md](tutorial/12-leaderboard.md))
+5. 담력이 붙으면 `starter` 로 casual 바깥
+   ([tutorial/07-starter-path.md](tutorial/07-starter-path.md))
+
+이 동선은 안내다. 입장 조건이 아니다. `boss` 부터 타도 표는 끊긴다.
+
+### 일곱 프로파일 (기계가 읽는 이름)
+
+존 이름은 은유다. 채점기가 읽는 묶음은 `gym/profiles/<id>.json` 의
+`id` 다. 철자가 다르면 파일이 없다.
+
+| id | 묶는 pack | 가까운 존 |
+|---|---|---|
+| `family` | `casual-rides` | 🎠 입문존 |
+| `starter` | `core-cli`, `self-description` | 휴게실 다음 |
+| `editor` | `core-cli`, `text-editing`, `table-editing`, `objects-media` | ✏️ 편집존 |
+| `publisher` | `serialization`, `layout-rendering`, `security` | 📖+🔐 |
+| `operator` | `corpus-diagnostics`, `automation` | ⚙️ 사다리 |
+| `boss` | `expert-challenges` | 🐉 보스존 |
+| `maintainer` | 전 pack | 공원 전체 |
+
+자세히 → [tutorial/06-profiles.md](tutorial/06-profiles.md).
+
+### 제출 자리 (한 줄)
+
+`gym/submissions/<이름>/<pack>/<과제id>/`. pack 폴더가 없으면 평면
+배치는 하위 호환으로만 찾는다. 새로 탈 때는 pack 아래다.
+[tutorial/14-submissions.md](tutorial/14-submissions.md).
 
 ---
 
@@ -203,3 +246,50 @@ python gym/tools/leaderboard.py invite --agent 친구이름   # 초대장 발급
 
 놀이공원이라 부르는 이유는 사람을 부르기 위해서지, 판정을 무르게 하기 위해서가
 아니다.
+
+휴게실 문서와 `gym/docs/tutorial.md` 도 이 조항을 반복한다. 장식이
+늘어난다고 연산자 등록부(`gym/core/checks.py` 의 `REGISTRY`)가
+늘어나지 않는다. 입문 안내가 pack 과제 JSON 을 고쳐서 점수를 쉽게
+만들지도 않는다.
+
+---
+
+## 존별 첫 놀이기구 (기존 과제만)
+
+새 과제를 이 지도가 등재하지 않는다. 이미 있는 1번 과제만 가리킨다.
+지시서 정본은 각 `packs/<id>/tasks/*.json` 이다.
+
+| 존 | 첫 과제 | 한 줄 | 휴게실 |
+|---|---|---|---|
+| 🎠 입문 | CR01 | `info` → `pages` | [tutorial/02-cr01-carousel.md](tutorial/02-cr01-carousel.md) |
+| 입문 다음 | T01 / SD01 | 다른 문서의 쪽수 / 명령 수 | [tutorial/07-starter-path.md](tutorial/07-starter-path.md) |
+| ✏️ 편집 | TE01 · TB01 · OM01 | 치환 · 표 모양 · 누름틀 수 | [tutorial/08-editor-path.md](tutorial/08-editor-path.md) |
+| 📖+🔐 배포 | SR01 · LR01 · SE01 | HWPX · 쪽수 · PII 건수 | [tutorial/09-publisher-path.md](tutorial/09-publisher-path.md) |
+| ⚙️ 사다리 | CD01 · AU01 | 폴더 스윕 · 계획 실행 | [tutorial/10-operator-path.md](tutorial/10-operator-path.md) |
+| 🐉 보스 | XC01 | L5 완주 | [tutorial/11-boss-path.md](tutorial/11-boss-path.md) |
+
+`batch-ops` · `extraction` · `render-tree` · `studio-e2e` ·
+`table-csv` 는 저장소에 있다. `maintainer` 가 전부 고른다. 위 표의
+프로파일에 없는 pack 은 `--pack` 으로 따로 탄다. 이 지도가 프로파일
+JSON 에 몰래 넣지 않는다.
+
+## 막혔을 때 (지도에서)
+
+| 증상 | 먼저 볼 곳 |
+|---|---|
+| `rhwp` 없음 | [tutorial/18-troubleshooting.md](tutorial/18-troubleshooting.md) §1 |
+| 프로파일 파일 없음 | [tutorial/06-profiles.md](tutorial/06-profiles.md) |
+| `unavailable` | [tutorial/16-unavailable.md](tutorial/16-unavailable.md) |
+| 제출 없음 | [tutorial/14-submissions.md](tutorial/14-submissions.md) |
+| bash 가 안 됨 | [tutorial/19-windows.md](tutorial/19-windows.md) |
+| 첫날 한 장 | [tutorial/20-checklist.md](tutorial/20-checklist.md) |
+
+## 이 지도가 바꾸지 않는 것
+
+- `gym/core/checks.py` 의 연산자 정의와 `REGISTRY`
+- `gym/core/runner.py` 의 점수 합산 · unavailable 규칙
+- `gym/score.py` 의 `verdict: allow` 조건 (`packsScored >= 1`)
+- 다른 열린 PR 이 만지는 pack 과제 JSON
+- 리더보드 원장·앵커 바이트 (초대·등재 명령이 그 일을 한다)
+
+장식은 사람을 부른다. 판정은 그대로다.

--- a/gym/docs/tutorial.md
+++ b/gym/docs/tutorial.md
@@ -1,0 +1,249 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/tutorial.md
+last_verified: 2026-08-18
+---
+
+# gym 휴게실 · 테마파크 입문 규약
+
+이 문서는 `gym/tutorial/` · `gym/PARK.md` · `gym/INVITE.md` 가
+지켜야 하는 **입문 안내 계약**을 고정한다. 작업 기록은
+[`mydocs/working/gym_tutorial.md`](../../mydocs/working/gym_tutorial.md).
+기계 시험은 `scripts/tests/test_gym_tutorial.py` 다.
+
+채점 논리의 정본은 여기가 아니다. 연산자 등록부는
+`gym/core/checks.py`, 채점 절차는 `gym/core/runner.py`, 진입점은
+`gym/score.py` 다. 이 규약이 그 세 파일을 고치지 않는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+테마파크 장식(#4664)은 입구·휴게실·초대장만 얇게 남겼다. 처음 온
+사람·에이전트는 `PARK.md` 한 장과 `tutorial/README.md` 90줄만 보고
+다음 존을 추측해야 했다.
+
+- 프로파일 일곱 이름이 문서마다 다르게 불리기 쉽다 (`casual`,
+  `Family`, `beginner`).
+- 입문존 네 놀이기구의 답 키(`pages`/`paragraphs`/`tables`/`hits`)가
+  오라클 경로와 섞인다.
+- Windows 방문자가 bash 줄을 붙여 JSON 에 BOM 을 넣는다.
+- 안내를 고치려다 `checks.py` 나 다른 PR 의 pack JSON 을 건드린다.
+
+그래서 휴게실을 동선 문서로 늘리고, 프로파일 이름·상대 링크·채점
+불가침을 시험이 잠근다. 새 pack 과 새 연산자는 이 기둥의 산출이
+아니다.
+
+## 2. 문서 지도
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tutorial/README.md` | 5분 첫 방문 + 휴게실 색인 |
+| `gym/tutorial/01-admission.md` | 입장 봉투 |
+| `gym/tutorial/02-cr01-carousel.md` | CR01 |
+| `gym/tutorial/03-cr02-ferris.md` | CR02 |
+| `gym/tutorial/04-cr03-circus.md` | CR03 |
+| `gym/tutorial/05-cr04-ringtoss.md` | CR04 |
+| `gym/tutorial/06-profiles.md` | 일곱 프로파일 |
+| `gym/tutorial/07-starter-path.md` | casual 바깥 첫 입문 |
+| `gym/tutorial/08-editor-path.md` | editor 첫 과제 |
+| `gym/tutorial/09-publisher-path.md` | publisher 첫 과제 |
+| `gym/tutorial/10-operator-path.md` | operator 첫 과제 |
+| `gym/tutorial/11-boss-path.md` | boss / XC01 |
+| `gym/tutorial/12-leaderboard.md` | attest / verify / render |
+| `gym/tutorial/13-invite.md` | 초대장 방문 안내 |
+| `gym/tutorial/14-submissions.md` | 제출 폴더 |
+| `gym/tutorial/15-scoring-honesty.md` | 채점 불가침 |
+| `gym/tutorial/16-unavailable.md` | 부재 ≠ 0점 |
+| `gym/tutorial/17-faq.md` | FAQ |
+| `gym/tutorial/18-troubleshooting.md` | 막힘 |
+| `gym/tutorial/19-windows.md` | PowerShell 번역 |
+| `gym/tutorial/20-checklist.md` | 첫날 한 장 |
+| `gym/docs/tutorial.md` | 이 규약 |
+| `mydocs/working/gym_tutorial.md` | 작업 기록 |
+| `gym/PARK.md` | 테마파크 한 장 지도 |
+| `gym/INVITE.md` | 초대장 정본 |
+
+상대 링크는 파일이 실재해야 한다. 외부 URL 과 문서 내 앵커는
+`scripts/check_markdown_links.py` 와 같은 범위로, 이 규약의
+필수 검사는 **저장소 내부 상대 경로**다.
+
+## 3. 프로파일 이름 계약
+
+`gym/profiles/*.json` 의 `id` 가 유일 정본이다. 안내 문서는 아래
+일곱 철자를 그대로 쓴다.
+
+| id | packs (정본 파일 그대로) |
+|---|---|
+| `family` | `casual-rides` |
+| `starter` | `core-cli`, `self-description` |
+| `editor` | `core-cli`, `text-editing`, `table-editing`, `objects-media` |
+| `publisher` | `serialization`, `layout-rendering`, `security` |
+| `operator` | `corpus-diagnostics`, `automation` |
+| `boss` | `expert-challenges` |
+| `maintainer` | 저장소의 모든 pack id |
+
+금지 별명: `Family`, `FAMILY`, `casual`, `beginner`, `expert`,
+`guest`, `kiddie`, `admin`. 본문에 이 별명을 **프로파일 id 처럼**
+쓰면 시험이 실패한다. 설명 문장에서 "입문자"처럼 쓰는 것은 이름이
+아니다.
+
+`--profile family` · `--profile starter` · `--profile editor` ·
+`--profile publisher` · `--profile operator` · `--profile boss` ·
+`--profile maintainer` 가 휴게실 허브(`tutorial/README.md`)와
+프로파일 문서에 나타나야 한다.
+
+## 4. 입문존 네 놀이기구 계약
+
+과제 JSON 을 이 규약이 고치지 않는다. 안내가 옮겨 적는 값은 아래와
+같아야 한다. 입력이 네 과제 모두 `samples/table-001.hwp` 다.
+
+| id | 명령 | 오라클 경로 | 답 키 |
+|---|---|---|---|
+| CR01 | `rhwp info samples/table-001.hwp --json` | `pageCount` | `pages` |
+| CR02 | `rhwp explain samples/table-001.hwp --json` | `paragraphCount` | `paragraphs` |
+| CR03 | `rhwp export-tables samples/table-001.hwp --json` | `tableCount` | `tables` |
+| CR04 | `rhwp search samples/table-001.hwp --json -- 표` | `matchCount` | `hits` |
+
+`casual-rides` 의 `requires.commands` 는 `info`, `explain`,
+`export-tables`, `search` 다. 하나라도 없으면 pack 은
+`unavailable` 이다.
+
+## 5. 채점 불가침
+
+이 기둥이 **금지하는** 변경:
+
+1. `gym/core/checks.py` 의 `REGISTRY` 키를 더하거나 빼기
+2. `GLOBAL_SCAN_OPS` 집합 변경
+3. `op_*` 함수의 비교 의미 변경
+4. 다른 열린 PR 이 만지는 `gym/packs/*/tasks/*.json` 편집
+5. `gym/score.py` 의 `verdict` 계산식 변경
+6. `score_pack` 의 unavailable 규칙을 0점으로 접기
+
+`REGISTRY` 스냅샷 (devel, 이 규약이 잠그는 집합):
+
+```
+same_hash
+differs_from_input
+file_exists
+files_differ
+xml_root_eq
+json_value_eq
+csv_cell_eq
+utf8_bom
+answer_eq
+len_answer_eq
+len_ge
+value_eq
+value_ge
+value_in
+deep_contains
+not_contains
+cell_text_eq
+```
+
+`GLOBAL_SCAN_OPS = {deep_contains, not_contains}`.
+
+안내 문서가 연산자를 **이름만** 인용하는 것은 허용한다. 구현을
+복사해 넣거나, 열여덟 번째 연산자를 제안하며 등록부를 고치는 것은
+이 기둥 밖이다.
+
+## 6. 입장 봉투
+
+`admission.json` 의 키와 의미는 `gym/score.py` 가 정본이다.
+
+- `kind` = `gymAdmission`
+- `verdict` = `packsScored >= 1` 이면 `allow`, 아니면 `deny`
+- 만점은 조건이 아니다
+- `runner` 신원이 붙는다
+
+휴게실이 이 계산을 재구현하지 않는다. 읽기만 한다.
+
+## 7. 링크 계약
+
+다음 허브는 서로 가리켜야 한다.
+
+- `gym/PARK.md` → `tutorial/README.md`, `INVITE.md`, `docs/tutorial.md`
+- `gym/INVITE.md` → `tutorial/README.md`, `PARK.md`
+- `gym/tutorial/README.md` → `../PARK.md`, `../INVITE.md`,
+  `../docs/tutorial.md`, 01~20 페이지
+- `gym/docs/tutorial.md` → `mydocs/working/gym_tutorial.md`
+
+상대 링크 대상 파일이 없으면 시험이 실패한다. 깨진 링크를 통과시키는
+허브는 입문 기둥이 아니다.
+
+## 8. 정직 문장
+
+아래 문장이 PARK · 휴게실 정직 문서 · 이 규약에 남아야 한다.
+철자 하나가 달라도 안 된다기보다, **이 네 주장이 모두 나타나야**
+한다.
+
+1. 점수는 pack 별로 보존되고 총점은 편의값이다
+2. 기대값은 채점 시점에 rhwp 로 재계산한다 (라이브 오라클)
+3. 부재는 0점이 아니라 `unavailable`
+4. 테마는 장식이고 판정 논리와 무관하다
+
+## 9. casual 바깥 입문
+
+이슈 #5263 은 "필요하면 casual 외 입문 문서와 시험"을 허용한다.
+허용하는 것은 **문서와 시험**이다. 새 과제 JSON 이 아니다.
+
+`starter` 길이 가리키는 기존 과제:
+
+| pack | id | 답 키 | 오라클 |
+|---|---|---|---|
+| core-cli | T01 | `pages` | `info` / `pageCount` |
+| core-cli | T02 | `matchCount` | `search` / `matches` 길이 |
+| self-description | SD01 | `commands` | `capabilities` / `commands` 길이 |
+
+editor / publisher / operator / boss 는 각 pack 의 **이미 있는
+1번 과제**만 안내한다. 다른 열린 PR 이 CR05+ 나 EX03+ 를 늘리고
+있으면 그 파일은 그 PR 의 것이다.
+
+## 10. Windows 번역
+
+`gym/tutorial/19-windows.md` 는 bash 와 같은 동작을 PowerShell 로
+옮긴다. 필수 요소:
+
+- `New-Item -ItemType Directory -Force` (mkdir -p 대응)
+- UTF-8 **without BOM** 으로 `answer.json` 쓰기
+- `--profile family` 철자 그대로
+- 답 키 네 개 그대로
+
+콘솔 코드 페이지가 한글을 `??` 로 바꾸는 문제는 제출 파일 바이트로
+우회한다고 적어야 한다. 채점기를 CP949 로 바꾸라고 하면 안 된다.
+
+## 11. 시험이 잠그는 것
+
+`scripts/tests/test_gym_tutorial.py`:
+
+- 필수 문서가 존재한다
+- 일곱 프로파일 파일·id·packs 가 문서와 같다
+- 상대 링크가 저장소 안에서 풀린다
+- CR01~CR04 키와 명령이 휴게실에 있다
+- `REGISTRY` 키가 위 스냅샷과 같다
+- 안내 문서가 `gym/core/checks.py` 를 "고친다/추가한다"고 말하지
+  않는다
+- PARK · INVITE · 휴게실이 서로를 가리킨다
+- CI 가 이 시험을 호출한다
+
+음성 회귀: 임시로 링크를 지운 텍스트는 검사 함수가 문제를 내야
+한다. 통과만 보면 가드가 썩는다.
+
+## 12. 하지 않는 것
+
+- 새 CLI 플래그
+- 새 pack, 새 과제 JSON
+- 새 채점 연산자
+- `gym/README.md` 만점 표의 숫자를 이 기둥이 갱신하는 일 (다른
+  pack 확장 PR 과 싸운다)
+- `cargo fmt --all`
+
+## 13. 재현
+
+```bash
+python -m unittest scripts.tests.test_gym_tutorial
+python gym/tools/audit.py
+```
+
+`audit.py` 는 pack 정합이다. 이 기둥이 pack JSON 을 안 만지면
+devel 과 같은 통과여야 한다. 실패하면 작업 트리 오염을 먼저 의심한다.

--- a/gym/tutorial/01-admission.md
+++ b/gym/tutorial/01-admission.md
@@ -1,0 +1,119 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 1. 입장 티켓 — admission.json
+
+놀이공원은 표를 끊고 들어간다. 운동장의 표는 채점기가 쓰는 **입장 봉투**
+(`admission.json`)다. 이 페이지는 그 봉투를 처음 발급받는 절차만 안내한다.
+입장 조건을 바꾸지 않는다. 조건의 정본은 `gym/score.py` 다.
+
+돌아가기: [README.md](README.md) · 지도: [../PARK.md](../PARK.md)
+
+## 왜 표가 따로 있나
+
+채점(`scorecard.json`)과 입장(`admission.json`)은 다른 봉투다.
+
+- 스코어카드는 **몇 점을 받았는가** 다.
+- 입장 봉투는 **이 러너로 pack 을 하나라도 유효하게 채점했는가** 다.
+
+만점이 입장 조건이 아니다. 낮은 점수도 순위이지 입장 거부 사유가 아니다.
+이 구분은 [../PARK.md](../PARK.md) 의 입구 절과 [15-scoring-honesty.md](15-scoring-honesty.md)
+가 같은 말을 한다.
+
+## 표를 끊는 명령
+
+저장소 루트에서:
+
+```bash
+python gym/score.py --agent 나 --profile family
+```
+
+`--profile family` 는 `gym/profiles/family.json` 을 읽어 pack 목록을
+`casual-rides` 하나로 줄인다. 프로파일 이름이 `family` 가 아니면 파일이
+없다. 시험이 이 이름을 잠근다.
+
+같은 표를 프로파일 없이 입문 pack 만 지목해도 끊을 수 있다.
+
+```bash
+python gym/score.py --agent 나 --pack casual-rides
+```
+
+`--agent` 는 제출 폴더 이름이다. 한글이든 영문이든 된다. 나중에 전당에
+오를 이름과 같게 두는 편이 덜 헷갈린다.
+
+## 발급되는 파일
+
+채점이 끝나면 `gym/submissions/나/` 아래에 적어도 세 파일이 생긴다.
+
+| 파일 | 역할 |
+|---|---|
+| `scorecard.json` | pack 별 점수, 러너 신원, 과제 결과 |
+| `report.md` | 사람이 읽는 같은 내용 |
+| `admission.json` | 입장 판정 봉투 |
+
+입장 봉투의 뼈대는 이렇다. 키 이름은 `gym/score.py` 가 쓰는 그대로다.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "kind": "gymAdmission",
+  "agent": "나",
+  "verdict": "allow",
+  "packsScored": 1,
+  "packsUnavailable": 0,
+  "score": 4,
+  "max": 4,
+  "runner": {
+    "rhwpVersion": "…",
+    "rhwpCommit": "…",
+    "capabilitiesSha256": "…"
+  }
+}
+```
+
+- `verdict` 는 `packsScored >= 1` 이면 `allow`, 아니면 `deny` 다.
+- `packsScored` 는 실제로 채점된 pack 수다. `unavailable` 은 여기에 안 든다.
+- `runner` 는 **어느 바이너리로 채점했는가** 다. 점수는 바이너리마다 달라질
+  수 있으므로 신원이 같이 붙는다.
+
+이 안내가 `verdict` 계산식을 바꾸지 않는다. 읽기만 한다.
+
+## 기준 풀이가 먼저 돈다
+
+아직 `gym/submissions/나/casual-rides/` 에 답을 안 넣었는데 4/4 가 나올 수
+있다. 채점기가 기준 풀이(`gym/packs/casual-rides/reference/`)를 써서 스스로
+푼 것이다. 그건 "놀이기구가 고장 나지 않았다"는 뜻이지, "네가 탔다"는 뜻이
+아니다.
+
+직접 타려면 [02-cr01-carousel.md](02-cr01-carousel.md) 처럼 제출 폴더에
+`answer.json` 을 놓고 다시 채점한다. 틀린 숫자를 넣으면 그 과제만 떨어진다.
+
+## 표가 deny 일 때
+
+`verdict: deny` 는 보통 이런 경우다.
+
+1. `--profile` 오타. `familly` 나 `Family` 는 파일이 없다.
+2. 바이너리를 못 찾아 채점이 시작도 못 함.
+3. 고른 pack 이 전부 `unavailable` 이라 `packsScored` 가 0.
+
+0점과 deny 는 다르다. 채점은 됐는데 답을 전부 틀린 사람은 `allow` 다.
+점수가 낮을 뿐, 입장 거부 사유가 아니다. 부재는 [16-unavailable.md](16-unavailable.md).
+
+## Windows
+
+PowerShell 5.1 에서는 `mkdir -p` 가 없다. 표만 끊는 명령은 같다.
+
+```powershell
+python gym/score.py --agent 나 --profile family
+```
+
+폴더를 손으로 만들 때는 [19-windows.md](19-windows.md).
+
+## 다음
+
+표를 끊었으면 회전목마를 탄다 → [02-cr01-carousel.md](02-cr01-carousel.md).
+프로파일 일곱 이름을 먼저 보고 싶으면 → [06-profiles.md](06-profiles.md).

--- a/gym/tutorial/02-cr01-carousel.md
+++ b/gym/tutorial/02-cr01-carousel.md
@@ -1,0 +1,98 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 2. 🎠 CR01 회전목마 — 몇 쪽인가요?
+
+입문존의 첫 놀이기구. 문서를 한 번 열고, 쪽수 하나를 `answer.json` 에
+옮기면 된다. 과제 JSON 은 이 안내가 고치지 않는다. 정본은
+`gym/packs/casual-rides/tasks/CR01.json` 이다.
+
+돌아가기: [README.md](README.md) · 입장: [01-admission.md](01-admission.md)
+
+## 과제가 묻는 것
+
+| 항목 | 값 |
+|---|---|
+| id | `CR01` |
+| tier | 1 (키 제한 없음) |
+| 제목 | 몇 쪽인가요? |
+| 입력 | `samples/table-001.hwp` |
+| 제출 | `answer.json` 의 `pages` |
+| 라이브 오라클 | `rhwp info {input} --json` 의 `pageCount` |
+
+채점기는 골든 숫자를 가지고 있지 않다. 채점 시점에 `rhwp info` 를 다시
+돌려 `pageCount` 와 네 `pages` 를 비교한다. 연산자는 `answer_eq` 다.
+이 연산자의 정의는 `gym/core/checks.py` 에 있고, 휴게실이 그 정의를
+바꾸지 않는다.
+
+## 손으로 타기
+
+저장소 루트에서 문서를 연다.
+
+```bash
+rhwp info samples/table-001.hwp --json
+```
+
+출력 JSON 에서 `pageCount` 를 찾는다. 그 숫자를 그대로 적는다. 예시는
+숫자가 3 일 때다. **네 바이너리가 말한 수를 적어라.** 이 문서의 3 은
+설명용이다. 라이브 오라클이 다른 수를 내면 그 수가 정답이다.
+
+```bash
+mkdir -p gym/submissions/나/casual-rides/CR01
+```
+
+`gym/submissions/나/casual-rides/CR01/answer.json`:
+
+```json
+{"pages": 3}
+```
+
+채점:
+
+```bash
+python gym/score.py --agent 나 --pack casual-rides
+```
+
+`CR01` 줄이 통과면 첫 바퀴를 돈 것이다.
+
+## 제출 자리
+
+채점기는 먼저 `gym/submissions/<이름>/casual-rides/CR01/` 을 본다.
+pack 폴더가 없으면 예전 평면 배치 `gym/submissions/<이름>/CR01/` 로
+되돌아간다. 새로 탈 때는 pack 아래가 맞다. 자리는
+[14-submissions.md](14-submissions.md) 가 한 장으로 모은다.
+
+## 일부러 틀려 보기
+
+라이브 오라클인지 확인하고 싶으면 `{"pages": 0}` 을 넣고 다시 채점한다.
+통과하면 안 된다. 채점기가 골든을 안 보고 `rhwp info` 를 다시 계산하기
+때문이다. 확인이 끝나면 올바른 숫자로 되돌린다.
+
+음성 대조(일 안 한 제출)를 전 pack 에 자동으로 넣는 도구는
+`gym/tools/discriminate.py` 다. 휴게실 범위 밖이고, 채점 논리도 아니다.
+
+## Windows
+
+```powershell
+New-Item -ItemType Directory -Force -Path gym/submissions/나/casual-rides/CR01 | Out-Null
+Set-Content -Encoding utf8 gym/submissions/나/casual-rides/CR01/answer.json '{"pages": 3}'
+python gym/score.py --agent 나 --pack casual-rides
+```
+
+BOM 이 섞이면 JSON 파싱이 깨질 수 있다. [19-windows.md](19-windows.md)
+의 UTF-8 without BOM 절차를 본다.
+
+##  copilot 이 아니라 네가 센다
+
+`reference/CR01.json` 은 기준 풀이다. 채점 재현용이지 치트 시트가
+아니다. 봐도 채점은 정직하게 돈다. 다만 그때 측정되는 것은 "쪽수를
+스스로 읽었는가"가 아니라 "따라 쳤는가"다.
+
+## 다음
+
+관람차 → [03-cr02-ferris.md](03-cr02-ferris.md). 같은 문서
+`samples/table-001.hwp` 를 문단 수로 다시 읽는다.

--- a/gym/tutorial/03-cr02-ferris.md
+++ b/gym/tutorial/03-cr02-ferris.md
@@ -1,0 +1,76 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 3. 🎡 CR02 관람차 — 문단이 몇 개인가요?
+
+회전목마와 같은 문서, 다른 창문. 쪽수 대신 문단 수를 읽는다. 과제 정본은
+`gym/packs/casual-rides/tasks/CR02.json` 이다. 이 안내는 그 JSON 을
+고치지 않는다.
+
+돌아가기: [README.md](README.md) · 이전: [02-cr01-carousel.md](02-cr01-carousel.md)
+
+## 과제가 묻는 것
+
+| 항목 | 값 |
+|---|---|
+| id | `CR02` |
+| tier | 1 |
+| 제목 | 문단이 몇 개인가요? |
+| 입력 | `samples/table-001.hwp` |
+| 제출 | `answer.json` 의 `paragraphs` |
+| 라이브 오라클 | `rhwp explain {input} --json` 의 `paragraphCount` |
+
+명령이 `info` 가 아니라 `explain` 이다. 입문존은 "한 번 실행하고 숫자
+하나를 옮긴다"는 결은 같고, **어느 창문을 여는가** 만 달라진다.
+
+## 손으로 타기
+
+```bash
+rhwp explain samples/table-001.hwp --json
+```
+
+`paragraphCount` 를 찾는다. 그 수를 `paragraphs` 에 넣는다.
+
+```bash
+mkdir -p gym/submissions/나/casual-rides/CR02
+```
+
+`gym/submissions/나/casual-rides/CR02/answer.json`:
+
+```json
+{"paragraphs": 0}
+```
+
+`0` 은 자리 표시다. 네 `explain` 출력을 적어라. 채점기가 그 자리에서
+다시 센다.
+
+```bash
+python gym/score.py --agent 나 --pack casual-rides
+```
+
+## 자주 하는 실수
+
+1. **CR01 의 키를 다시 쓴다.** `pages` 는 CR01 전용이다. CR02 는
+   `paragraphs` 다. 키가 틀리면 `answer_eq` 가 그 칸을 못 읽는다.
+2. **명령을 `info` 로 연다.** `info` 의 `pageCount` 는 쪽수다. 문단
+   수가 아니다. 과제 힌트가 `explain` 인 이유가 있다.
+3. **같은 `answer.json` 을 CR01 폴더에 덮어쓴다.** 과제마다 폴더가
+   갈린다. `CR01/` 과 `CR02/` 는 다른 제출이다.
+
+## 왜 같은 문서인가
+
+입문존 네 놀이기구는 모두 `samples/table-001.hwp` 를 본다. 문서를 바꾸는
+게 목적이 아니다. **같은 입력을 네 명령으로 네 숫자로 읽는 것**이
+목적이다. `info` · `explain` · `export-tables` · `search` 가
+`casual-rides` pack 의 `requires.commands` 다. 하나라도 바이너리에
+없으면 이 pack 전체는 `unavailable` 이다. 0점이 아니다.
+→ [16-unavailable.md](16-unavailable.md)
+
+## 다음
+
+서커스 텐트 → [04-cr03-circus.md](04-cr03-circus.md). 같은 문서의 표
+개수를 센다.

--- a/gym/tutorial/04-cr03-circus.md
+++ b/gym/tutorial/04-cr03-circus.md
@@ -1,0 +1,79 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 4. 🎪 CR03 서커스 텐트 — 표가 몇 개인가요?
+
+같은 문서의 표를 센다. 과제 정본은
+`gym/packs/casual-rides/tasks/CR03.json`. 이 안내는 JSON 을 고치지
+않는다.
+
+돌아가기: [README.md](README.md) · 이전: [03-cr02-ferris.md](03-cr02-ferris.md)
+
+## 과제가 묻는 것
+
+| 항목 | 값 |
+|---|---|
+| id | `CR03` |
+| tier | 1 |
+| 제목 | 표가 몇 개인가요? |
+| 입력 | `samples/table-001.hwp` |
+| 제출 | `answer.json` 의 `tables` |
+| 라이브 오라클 | `rhwp export-tables {input} --json` 의 `tableCount` |
+
+나중에 편집존(`table-editing`)에 가면 같은 `export-tables` 가 좌표
+조사의 입구가 된다. 입문존에서는 개수만 묻는다.
+
+## 손으로 타기
+
+```bash
+rhwp export-tables samples/table-001.hwp --json
+```
+
+`tableCount` 를 찾는다. 표 배열 `tables` 의 길이와 같은 수여야 한다.
+그 수를 답 키 `tables` 에 넣는다. 키 이름과 봉투 필드 이름이 같아서
+헷갈리기 쉽다. **답 파일의 키는 `tables` 이고, 오라클 경로는
+`tableCount` 다.**
+
+```bash
+mkdir -p gym/submissions/나/casual-rides/CR03
+```
+
+`gym/submissions/나/casual-rides/CR03/answer.json`:
+
+```json
+{"tables": 0}
+```
+
+`0` 은 자리 표시다. 네 `export-tables` 출력을 적어라.
+
+```bash
+python gym/score.py --agent 나 --pack casual-rides
+```
+
+## 표를 열어 보지 않아도 되나
+
+된다. 입문존은 숫자를 옮기는 곳이다. 표를 CSV 로 뽑거나 셀을 고치는
+일은 `editor` 프로파일의 `table-editing` · `table-csv` 가 맡는다.
+지금 단계의 성공 조건은 `tableCount` 와 `tables` 가 같은 것이다.
+
+셀 좌표를 벌써 보고 싶다면 [08-editor-path.md](08-editor-path.md) 의
+TB01 안내로 건너뛰어도 된다. 키 제한은 없지만, 입문존 네 개를 먼저
+닫는 편이 제출 폴더 결이 몸에 붙는다.
+
+## 자주 하는 실수
+
+1. **답 키를 `tableCount` 로 적는다.** 오라클 경로를 답 키로 착각한
+   것이다. CR03 의 답 키는 `tables` 다.
+2. **표 배열 전체를 붙여 넣는다.** `answer_eq` 는 숫자(또는 정규화된
+   숫자 문자열)를 기대한다. 배열을 넣으면 비교가 실패한다.
+3. **원본 샘플을 편집한다.** 입문존은 원본을 건드리지 않는다. 제출은
+   `gym/submissions/` 아래 `answer.json` 뿐이다.
+
+## 다음
+
+링 던지기 → [05-cr04-ringtoss.md](05-cr04-ringtoss.md). 같은 문서에서
+글자 '표' 가 몇 번 나오는지 센다.

--- a/gym/tutorial/05-cr04-ringtoss.md
+++ b/gym/tutorial/05-cr04-ringtoss.md
@@ -1,0 +1,83 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 5. 🎯 CR04 링 던지기 — '표' 글자가 몇 번?
+
+입문존의 마지막 놀이기구. 검색 한 번으로 숫자를 옮긴다. 과제 정본은
+`gym/packs/casual-rides/tasks/CR04.json`. 이 안내는 JSON 을 고치지
+않는다.
+
+돌아가기: [README.md](README.md) · 이전: [04-cr03-circus.md](04-cr03-circus.md)
+
+## 과제가 묻는 것
+
+| 항목 | 값 |
+|---|---|
+| id | `CR04` |
+| tier | 1 |
+| 제목 | '표' 글자가 몇 번? |
+| 입력 | `samples/table-001.hwp` |
+| 제출 | `answer.json` 의 `hits` |
+| 라이브 오라클 | `rhwp search {input} --json -- 표` 의 `matchCount` |
+
+`--` 는 검색어와 옵션을 가르는 관례다. 검색어가 옵션처럼 보이면
+파서가 삼킨다. 과제 힌트가 `-- 표` 인 이유를 휴게실이 바꾸지 않는다.
+
+## 손으로 타기
+
+```bash
+rhwp search samples/table-001.hwp --json -- 표
+```
+
+`matchCount` 를 찾는다. 그 수를 `hits` 에 넣는다.
+
+```bash
+mkdir -p gym/submissions/나/casual-rides/CR04
+```
+
+`gym/submissions/나/casual-rides/CR04/answer.json`:
+
+```json
+{"hits": 0}
+```
+
+`0` 은 자리 표시다. 네 `search` 출력을 적어라.
+
+```bash
+python gym/score.py --agent 나 --pack casual-rides
+```
+
+네 과제 모두 통과면 입문존을 한 바퀴 돈 것이다. 전당에 이름을 올리려면
+[12-leaderboard.md](12-leaderboard.md). 다음 존은
+[07-starter-path.md](07-starter-path.md).
+
+## 표 개수와 '표' 글자 수는 다른 것
+
+CR03 은 **표 개체** 수(`tableCount`)다. CR04 는 본문에 글자 **표** 가
+몇 번 나오는지(`matchCount`)다. 표가 3개여도 본문에 '표' 가 더 많거나
+적을 수 있다. 두 숫자를 같게 맞추려 하지 마라. 라이브 오라클이 각각
+다른 명령을 돌린다.
+
+## 검색어를 바꾸면
+
+`표` 가 아닌 다른 글자를 세면 떨어진다. 채점기는 네가 어떤 검색어를
+썼는지가 아니라, **과제에 적힌 명령으로 다시 센 값**과 네 답을
+비교한다. 따라 치는 검색어를 바꿔도 오라클은 바뀌지 않는다.
+
+이 성질이 [15-scoring-honesty.md](15-scoring-honesty.md) 의 "기대값을
+박제하지 마라"다. 골든 `hits: 7` 같은 숫자는 저장소에 없다.
+
+## 입문존을 닫은 뒤
+
+1. 프로파일 이름을 한 번 본다 → [06-profiles.md](06-profiles.md)
+2. casual 바깥 첫 입문 → [07-starter-path.md](07-starter-path.md)
+3. 부모님을 부르려면 → [13-invite.md](13-invite.md) · [../INVITE.md](../INVITE.md)
+4. 첫날 체크리스트 → [20-checklist.md](20-checklist.md)
+
+`family` 프로파일은 `casual-rides` 만 고른다. 입문존을 닫아도
+`--profile family` 는 계속 그 네 과제만 채점한다. 다음 존은
+`--profile starter` 또는 `--pack core-cli` 로 고른다.

--- a/gym/tutorial/06-profiles.md
+++ b/gym/tutorial/06-profiles.md
@@ -1,0 +1,103 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 6. 프로파일 — pack 을 고르는 일곱 이름
+
+프로파일은 점수를 뭉치지 않는다. pack 목록을 고를 뿐이다. 이름과 묶음은
+`gym/profiles/<id>.json` 이 정본이다. 이 페이지는 그 파일을 읽기 쉽게
+옮겨 적는다. 파일을 고치지 않고, 채점 논리도 고치지 않는다.
+
+돌아가기: [README.md](README.md) · 지도: [../PARK.md](../PARK.md)
+
+## 일곱 이름
+
+시험이 아래 `id` 일곱 개가 `gym/profiles/` 에 있고, 문서가 그 철자를
+그대로 쓰는지 잠근다. 대소문자·복수형·별명을 만들지 마라.
+
+| id | 파일 | title | packs |
+|---|---|---|---|
+| `family` | `gym/profiles/family.json` | 가족 코스 | `casual-rides` |
+| `starter` | `gym/profiles/starter.json` | 입문 | `core-cli`, `self-description` |
+| `editor` | `gym/profiles/editor.json` | 편집자 | `core-cli`, `text-editing`, `table-editing`, `objects-media` |
+| `publisher` | `gym/profiles/publisher.json` | 배포자 | `serialization`, `layout-rendering`, `security` |
+| `operator` | `gym/profiles/operator.json` | 운영자 | `corpus-diagnostics`, `automation` |
+| `boss` | `gym/profiles/boss.json` | 보스 코스 | `expert-challenges` |
+| `maintainer` | `gym/profiles/maintainer.json` | 메인테이너 | 전 pack |
+
+`maintainer` 의 packs 배열은 저장소에 있는 모든 pack id 와 같아야
+한다. 그 계약은 이미 `scripts/tests/test_gym_packs.py` 의
+`test_maintainer_profile_covers_every_pack` 이 잠근다. 휴게실은 그
+시험을 복제하지 않고, 이름만 안내한다.
+
+## 어떻게 고르나
+
+```bash
+python gym/score.py --agent 나 --profile family
+python gym/score.py --agent 나 --profile starter
+python gym/score.py --agent 나 --profile editor
+python gym/score.py --agent 나 --profile publisher
+python gym/score.py --agent 나 --profile operator
+python gym/score.py --agent 나 --profile boss
+python gym/score.py --agent 나 --profile maintainer
+```
+
+`--profile` 과 `--pack` 을 같이 주면 프로파일이 pack 목록을 덮어쓴다.
+구현은 `gym/core/runner.py` 의 `score_all` 이다. 이 안내가 그 순서를
+바꾸지 않는다.
+
+없는 이름을 주면 `gym/profiles/<오타>.json` 을 열다가 실패한다.
+`Family`, `casual`, `beginner`, `expert` 는 프로파일 id 가 아니다.
+
+## 테마파크 존과의 대응
+
+[../PARK.md](../PARK.md) 의 존은 은유다. 프로파일은 기계가 읽는 묶음이다.
+
+| 존 (은유) | 가까운 프로파일 | 비고 |
+|---|---|---|
+| 🎠 입문존 | `family` | 키 제한 없는 네 놀이기구 |
+| ☕ 휴게실 다음 | `starter` | casual 바깥 첫 입문 |
+| ✏️ 편집존 | `editor` | 본문·표·개체 |
+| 📖 판독존 + 🔐 보안존 | `publisher` | 변환·조판·보안 |
+| ⚙️ 사다리존 + 판독 일부 | `operator` | 스윕과 10단 |
+| 🐉 보스존 | `boss` | 한 단만 틀려도 막힘 |
+| 공원 전체 | `maintainer` | 전 pack, 총점은 편의값 |
+
+은유가 점수를 바꾸지 않는다. 정직 조항은 PARK 와
+[15-scoring-honesty.md](15-scoring-honesty.md) 가 같이 지킨다.
+
+## 고르는 순서 (추천)
+
+처음 온 사람·에이전트는 이 순서가 덜 다친다.
+
+1. `family` — 숫자 네 개를 옮겨 제출 폴더 결을 익힌다.
+2. `starter` — `info`/`search` 와 `capabilities` 로 도구가 자기를
+   설명하는 법을 본다.
+3. `editor` 또는 `publisher` — 하고 싶은 일에 가까운 쪽.
+4. `operator` — 폴더와 사다리.
+5. `boss` — 담력이 붙은 뒤.
+6. `maintainer` — 구멍 없이 한 바퀴.
+
+순서는 권장이지 입장 조건이 아니다. `boss` 부터 타도 표는 끊긴다.
+떨어질 뿐이다.
+
+## 각 길로 가는 문
+
+- `family` 실습: [02-cr01-carousel.md](02-cr01-carousel.md) ~ [05-cr04-ringtoss.md](05-cr04-ringtoss.md)
+- `starter`: [07-starter-path.md](07-starter-path.md)
+- `editor`: [08-editor-path.md](08-editor-path.md)
+- `publisher`: [09-publisher-path.md](09-publisher-path.md)
+- `operator`: [10-operator-path.md](10-operator-path.md)
+- `boss`: [11-boss-path.md](11-boss-path.md)
+
+## 프로파일이 하지 않는 것
+
+- 점수를 가중하지 않는다. `family` 의 4점과 `boss` 의 23점은 다른
+  pack 의 점수다. 총점은 편의값이다.
+- 새 과제를 만들지 않는다. pack 에 있는 과제만 고른다.
+- 채점 연산자를 바꾸지 않는다. `answer_eq` 는 여전히 `answer_eq` 다.
+- 리더보드 순위를 바꾸지 않는다. 등재는
+  [12-leaderboard.md](12-leaderboard.md) 의 `attest` 가 한다.

--- a/gym/tutorial/07-starter-path.md
+++ b/gym/tutorial/07-starter-path.md
@@ -1,0 +1,138 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 7. starter 길 — casual 바깥 첫 입문
+
+입문존(`family`)을 닫은 다음 자연스러운 걸음이다. `starter` 는
+`core-cli` 와 `self-description` 두 pack 을 고른다. 부모님용 회전목마는
+아니지만, 여전히 "읽고 숫자 하나"에 가까운 과제가 앞에 있다.
+
+이 페이지는 기존 과제 JSON 을 **읽기만** 한다. 새 과제를 추가하지
+않고, 다른 열린 PR 의 pack 과제 파일도 건드리지 않는다.
+
+돌아가기: [README.md](README.md) · 프로파일: [06-profiles.md](06-profiles.md)
+
+## 왜 이 두 pack 인가
+
+`gym/profiles/starter.json` 이 그렇게 묶는다.
+
+- `core-cli` — 조사·추출·편집·검증의 최소 코어. T01 은 쪽수다.
+- `self-description` — 도구가 자기를 설명하는 계약. SD01 은 명령 개수다.
+
+둘 다 "문서를 고치기 전에 도구와 입력을 읽는다"는 결이다. 편집은
+`editor` 로 미룬다.
+
+```bash
+python gym/score.py --agent 나 --profile starter
+```
+
+또는 pack 을 하나씩:
+
+```bash
+python gym/score.py --agent 나 --pack core-cli
+python gym/score.py --agent 나 --pack self-description
+```
+
+## 첫 과제 T01 — 문서 신상
+
+정본: `gym/packs/core-cli/tasks/T01.json`
+
+| 항목 | 값 |
+|---|---|
+| id | `T01` |
+| tier | 1 |
+| 입력 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` |
+| 답 키 | `pages` |
+| 오라클 | `rhwp info {input} --json` 의 `pageCount` |
+
+CR01 과 같은 동작이다. 입력 문서만 다르다. 입문존에서 익힌 결을 다른
+샘플에 적용하는 것이 첫 숙제다.
+
+```bash
+rhwp info samples/basic/issue2007_nested_cell_pagination_42065.hwp --json
+mkdir -p gym/submissions/나/core-cli/T01
+```
+
+`gym/submissions/나/core-cli/T01/answer.json`:
+
+```json
+{"pages": 0}
+```
+
+`0` 은 자리 표시다. 네 `info` 출력을 적어라. 폴더가 `casual-rides` 가
+아니라 `core-cli` 인 것을 놓치지 마라.
+
+## 두 번째 맛보기 T02 — 전수 검색
+
+정본: `gym/packs/core-cli/tasks/T02.json`
+
+| 항목 | 값 |
+|---|---|
+| id | `T02` |
+| 입력 | `samples/2022년 국립국어원 업무계획.hwp` |
+| 답 키 | `matchCount` |
+| 오라클 | `rhwp search {input} 국어 --json` 의 `matches` **길이** |
+
+CR04 와 비슷해 보이지만 연산자가 `answer_eq` 가 아니라
+`len_answer_eq` 다. 답 키 `matchCount` 는 `matches` 배열의 길이와
+같아야 한다. 연산자 정의는 `gym/core/checks.py` 에 있다. 휴게실이 그
+정의를 바꾸지 않는다.
+
+```bash
+rhwp search "samples/2022년 국립국어원 업무계획.hwp" 국어 --json
+mkdir -p gym/submissions/나/core-cli/T02
+```
+
+경로에 공백·한글이 있다. 따옴표를 빼면 셸이 파일을 둘로 나눈다.
+Windows 는 [19-windows.md](19-windows.md).
+
+## 자기서술 SD01 — 명령 표면 계수
+
+정본: `gym/packs/self-description/tasks/SD01.json`
+
+| 항목 | 값 |
+|---|---|
+| id | `SD01` |
+| 입력 | `samples/table-001.hwp` (이 과제는 문서보다 도구가 대상) |
+| 답 키 | `commands` |
+| 오라클 | `rhwp capabilities` 의 `commands` **길이** |
+
+```bash
+rhwp capabilities
+mkdir -p gym/submissions/나/self-description/SD01
+```
+
+`gym/submissions/나/self-description/SD01/answer.json`:
+
+```json
+{"commands": 0}
+```
+
+`0` 은 자리 표시다. `capabilities` 봉투의 `commands` 배열 길이를
+적어라. 바이너리가 새로워지면 수가 늘어날 수 있다. 그래서 골든을
+박제하지 않는다.
+
+`self-description` pack 은 `capabilities`, `export-agent-manifest`,
+`export-ontology`, `export-plan-schema`, `export-provenance-map` 을
+요구한다. 하나라도 없으면 pack 전체가 `unavailable` 이다.
+
+## starter 가 아직 아닌 것
+
+- 본문을 치환하는 일 (`text-editing` TE01) — [08-editor-path.md](08-editor-path.md)
+- HWPX 로 내보내는 일 (`serialization` SR01) — [09-publisher-path.md](09-publisher-path.md)
+- 사다리 10단 (`automation`) — [10-operator-path.md](10-operator-path.md)
+- L5 완주 (`expert-challenges` XC01) — [11-boss-path.md](11-boss-path.md)
+
+`core-cli` 에는 T07 이후 편집·변환·하네스 과제도 있다. 그것들은
+starter 묶음 안에 들어 있지만, 난도가 입문 숫자 옮기기보다 높다.
+처음부터 T13/T14 로 뛰지 않아도 된다. T01·T02·SD01 이 닫히면
+`starter` 길의 입구는 통과한 것이다.
+
+## 다음
+
+문서를 고치고 싶으면 [08-editor-path.md](08-editor-path.md).
+배포 전 확인이면 [09-publisher-path.md](09-publisher-path.md).

--- a/gym/tutorial/08-editor-path.md
+++ b/gym/tutorial/08-editor-path.md
@@ -1,0 +1,104 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 8. editor 길 — 문서를 실제로 고친다
+
+`editor` 프로파일은 `core-cli`, `text-editing`, `table-editing`,
+`objects-media` 를 고른다. 정본은 `gym/profiles/editor.json`. 이
+페이지는 각 pack 의 **첫 과제만** 안내한다. 과제 JSON 을 늘리거나
+고치지 않는다.
+
+돌아가기: [README.md](README.md) · 프로파일: [06-profiles.md](06-profiles.md)
+
+## 한 줄로 고르기
+
+```bash
+python gym/score.py --agent 나 --profile editor
+```
+
+편집 과제는 산출물을 `-o` 로 새로 만든다. **원본 샘플을 덮어쓰지
+마라.** 제출은 `gym/submissions/나/<pack>/<과제id>/` 아래다.
+
+## TE01 — 문구 치환 왕복
+
+정본: `gym/packs/text-editing/tasks/TE01.json`
+
+입력 `samples/basic/issue2007_nested_cell_pagination_42065.hwp` 에서
+'규제' 를 모두 '점검' 으로 바꾼 `edited.hwp` 를 낸다.
+
+채점 세 칸 (연산자는 이미 있는 것들이다):
+
+1. `value_eq` — 산출물에서 '규제' 의 `matchCount` 가 0
+2. `value_ge` — 산출물에서 '점검' 의 `matchCount` 가 1 이상
+3. `differs_from_input` — 산출물 바이트가 입력과 다름
+
+세 번째가 없으면 원본을 이름만 바꿔 내는 제출이 통과한다. 그 연산자를
+휴게실이 추가하는 것이 아니다. 과제에 이미 있다.
+
+힌트 명령은 `rhwp edit replace-text` 다. 정확한 플래그는 과제
+`instructions` 와 `rhwp capabilities` 를 본다. 이 안내가 CLI 표면을
+새로 만들지 않는다.
+
+```bash
+mkdir -p gym/submissions/나/text-editing/TE01
+# 산출물은 이 폴더의 edited.hwp 로 낸다. 원본 경로는 -o 로 피한다.
+```
+
+## TB01 — 표 좌표 조사
+
+정본: `gym/packs/table-editing/tasks/TB01.json`
+
+아직 셀을 고치지 않는다. 첫 표의 행·열 수를 읽는다.
+
+```bash
+rhwp export-tables samples/basic/issue2007_nested_cell_pagination_42065.hwp --json
+mkdir -p gym/submissions/나/table-editing/TB01
+```
+
+`answer.json`:
+
+```json
+{"rows": 0, "cols": 0}
+```
+
+`0` 은 자리 표시다. `tables[0].rows` 와 `tables[0].cols` 를 적어라.
+CR03 이 표 **개수**였다면, TB01 은 첫 표의 **모양**이다.
+
+## OM01 — 누름틀 전수 조사
+
+정본: `gym/packs/objects-media/tasks/OM01.json`
+
+```bash
+rhwp fields samples/field-01.hwp --json
+mkdir -p gym/submissions/나/objects-media/OM01
+```
+
+`answer.json` 의 키는 `fields`, 오라클 경로는 `fieldCount` 다.
+
+이 pack 의 뒤 과제들은 필드 채움·개체 렌더로 올라간다. 첫 과제는
+조사다. 조사 없이 채우면 좌표가 틀린다.
+
+## 원본 무훼손
+
+편집 길의 공통 규칙이다.
+
+- 입력은 `samples/` 아래 픽스처다. 커밋된 바이트를 바꾸지 마라.
+- 산출은 항상 `-o` (또는 동등한 출력 옵션)로 제출 폴더에 만든다.
+- `differs_from_input` 이 있는 과제는 무편집 복사를 거절한다.
+- `.hwp`/`.hwpx` 산출은 보통 커밋하지 않는다(`.gitignore`).
+  재실행하면 다시 만들 수 있어야 한다.
+
+이 규칙은 `gym/README.md` 제출 형식 절과 같다. 휴게실이 새 규칙을
+발명하지 않는다.
+
+## editor 다음에
+
+배포·변환·보안은 [09-publisher-path.md](09-publisher-path.md).
+표만 CSV 로 왕복하고 싶으면 `table-csv` pack 이 따로 있다. 그 pack 은
+`editor` 프로파일에 묶여 있지 않다. `--pack table-csv` 로 고른다.
+프로파일에 없는 pack 을 몰래 넣지 않는 것이
+[06-profiles.md](06-profiles.md) 의 결이다.

--- a/gym/tutorial/09-publisher-path.md
+++ b/gym/tutorial/09-publisher-path.md
@@ -1,0 +1,89 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 9. publisher 길 — 내보내고 배포하기 전에
+
+`publisher` 는 `serialization`, `layout-rendering`, `security` 를
+고른다. 정본은 `gym/profiles/publisher.json`. 변환이 진짜인지, 쪽수가
+맞는지, 배포 전 오염이 있는지를 먼저 묻는다.
+
+돌아가기: [README.md](README.md) · 프로파일: [06-profiles.md](06-profiles.md)
+
+```bash
+python gym/score.py --agent 나 --profile publisher
+```
+
+## SR01 — HWPX 변환 자기검증
+
+정본: `gym/packs/serialization/tasks/SR01.json`
+
+입력을 HWPX 로 보내 `conv.hwpx` 를 내고, IR 이 같은지 `answer.json` 의
+`identical` 에 true/false 로 적는다.
+
+채점 두 칸:
+
+1. `value_eq` — `rhwp info conv.hwpx --json` 의 `format` 이 `"hwpx"`
+2. `answer_eq` — `rhwp ir-diff {input} conv.hwpx --json` 의 `identical`
+
+`ir-diff` 는 다르면 종료 코드 3 을 낼 수 있다. 과제가
+`expect_exits: [0, 3]` 을 허용하는 이유다. 종료 코드 3 을 실패로
+버리면 정직한 "다르다" 판정이 사라진다. 이 계약은
+`scripts/tests/test_gym_score.py` 가 이미 잠근다. 휴게실이 그 시험을
+바꾸지 않는다.
+
+힌트: `rhwp export-hwpx --verify`. 변환 명령을 `convert` 로 추측하지
+마라. 과제가 가리키는 명령을 쓴다.
+
+```bash
+mkdir -p gym/submissions/나/serialization/SR01
+```
+
+## LR01 — 쪽수 판정
+
+정본: `gym/packs/layout-rendering/tasks/LR01.json`
+
+CR01·T01 과 같은 창문이다. 입력만
+`samples/basic/issue2007_nested_cell_pagination_42065.hwp` 다.
+조판 pack 의 첫 과제가 쪽수인 이유는, 렌더 산출을 보기 전에 "몇
+쪽으로 읽히는가"가 맞아야 해서다.
+
+```bash
+rhwp info samples/basic/issue2007_nested_cell_pagination_42065.hwp --json
+mkdir -p gym/submissions/나/layout-rendering/LR01
+```
+
+`answer.json` 키는 `pages`.
+
+## SE01 — PII 탐지 (읽기 전용)
+
+정본: `gym/packs/security/tasks/SE01.json`
+
+입력 `samples/task2097/75544_pii_bunseok.hwpx` 에서 개인정보 후보가
+몇 건인지 **읽기 전용으로** 센다.
+
+```bash
+rhwp edit redact samples/task2097/75544_pii_bunseok.hwpx --dry-run --json
+mkdir -p gym/submissions/나/security/SE01
+```
+
+답 키는 `findings`, 오라클 경로는 `findingCount`. `--dry-run` 이
+빠지면 원본을 고칠 수 있다. 과제가 읽기 전용을 명시한 이유를 지킨다.
+
+보안존의 뒤 과제들은 은닉 텍스트·주입 신호·유니코드·서명으로 올라간다.
+첫 과제는 "배포 전에 숫자를 읽는다"다. 입문존과 같은 결을 오염 축에
+적용한 것이다.
+
+## publisher 가 묶지 않는 것
+
+`render-tree` 와 `studio-e2e` 는 저장소에 있지만 `publisher` 목록에
+없다. 필요하면 `--pack` 으로 고른다. 프로파일 JSON 을 이 안내가
+고쳐 넣지 않는다. 다른 열린 PR 이 pack 을 늘리고 있을 수 있다.
+
+## 다음
+
+폴더 스윕과 사다리 → [10-operator-path.md](10-operator-path.md).
+보스존은 그 다음 → [11-boss-path.md](11-boss-path.md).

--- a/gym/tutorial/10-operator-path.md
+++ b/gym/tutorial/10-operator-path.md
@@ -1,0 +1,71 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 10. operator 길 — 폴더를 훑고 사다리를 오른다
+
+`operator` 는 `corpus-diagnostics` 와 `automation` 을 고른다. 정본은
+`gym/profiles/operator.json`. 한 문서의 숫자에서 폴더와 계획으로
+시야를 넓힌다.
+
+돌아가기: [README.md](README.md) · 프로파일: [06-profiles.md](06-profiles.md)
+
+```bash
+python gym/score.py --agent 나 --profile operator
+```
+
+## CD01 — 폴더 스윕 계수
+
+정본: `gym/packs/corpus-diagnostics/tasks/CD01.json`
+
+입력 필드는 `samples/table-001.hwp` 이지만, 실제로 세는 대상은
+`samples/hml` 폴더다. 과제가 `rhwp scan` 을 그 폴더에 돌리라고 적었다.
+
+```bash
+rhwp scan samples/hml --json
+mkdir -p gym/submissions/나/corpus-diagnostics/CD01
+```
+
+답 키는 `files`. 연산자는 `len_answer_eq` 이고 오라클 경로는
+`files` 배열이다. 폴더에 파일이 늘면 수가 바뀐다. 그래서 골든을
+박제하지 않는다.
+
+## AU01 — 계획서 원자 실행
+
+정본: `gym/packs/automation/tasks/AU01.json`
+
+첫 표 (0, 0) 을 '계획실행' 으로 바꾸는 `run` 계획서를 실행하고
+`out.hwp` 를 낸다.
+
+채점 두 칸:
+
+1. `cell_text_eq` — `export-tables` 로 본 (0, 0) 이 `계획실행`
+2. `differs_from_input` — 원본 복사가 아님
+
+`cell_text_eq` 는 표 좌표를 지목한다. `cells[0]` 순서 가정이 아니다.
+그 이유는 `gym/core/checks.py` 의 `find_cell` 주석(#4600)에 있다.
+휴게실이 그 함수를 고치지 않는다.
+
+힌트: `rhwp run --plan-json`. 계획서 한 장이 검증을 포함하고, 실행은
+원자여야 한다. 에이전트 작업 표준의 영수증 축(AW-L1)을 운동장이
+과제로 소비하는 입구다.
+
+```bash
+mkdir -p gym/submissions/나/automation/AU01
+```
+
+## 사다리 은유와 실제 pack
+
+[../PARK.md](../PARK.md) 는 automation 을 "검증 사다리 10단" 으로
+그린다. 그 은유가 점수를 바꾸지 않는다. 과제는 AU01 부터 AU13 까지
+이미 등재된 것들이다. 이 안내가 14번째 과제를 끼워 넣지 않는다.
+다른 열린 PR 이 automation 과제를 늘리고 있으면 그 파일은 그 PR 의
+것이다.
+
+## operator 다음에
+
+보스존은 사다리를 **한 체인으로** 묶는다. 부분 점수가 없다.
+[11-boss-path.md](11-boss-path.md).

--- a/gym/tutorial/11-boss-path.md
+++ b/gym/tutorial/11-boss-path.md
@@ -1,0 +1,79 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 11. boss 길 — 한 단만 틀려도 막힌다
+
+`boss` 프로파일은 `expert-challenges` 만 고른다. 정본은
+`gym/profiles/boss.json`. 테마파크 지도의 🐉 보스존과 같은 pack 이다.
+
+돌아가기: [README.md](README.md) · 지도: [../PARK.md](../PARK.md)
+
+```bash
+python gym/score.py --agent 나 --profile boss
+```
+
+## 왜 먼저 타지 않나
+
+입문존은 숫자 하나다. 보스존은 서명·앵커·정산·계보·감사 표준을 한
+제출로 묶는다. 키 제한(tier)이 4~5 다. 한 단계가 빠지면 최종 판정이
+막힌다. 자이로드롭에서 안전바 하나만 안 걸려도 출발하지 않는 것과
+같다. 은유는 [../PARK.md](../PARK.md) 보스존 절과 같다.
+
+못 푸는 보스는 열지 않는다는 것이 정직 조항이다. 다섯 과제 모두
+`gym/packs/expert-challenges/reference/` 기준 풀이 왕복을 통과한
+뒤에야 등재됐다. 이 안내가 여섯 번째 보스를 슬쩍 끼워 넣지 않는다.
+
+## XC01 — 사다리 완주 (적합성 L5)
+
+정본: `gym/packs/expert-challenges/tasks/XC01.json`
+
+제출 폴더에 다음을 둔다.
+
+- `caps/work.capsule.json` (서명한 작업 캡슐)
+- `keyring.json`
+- `anchor.ndjson`
+- `policy.json`
+- `ledger.ndjson`
+
+채점은 `rhwp conformance {file:caps} --level L5 --deep …` 의
+`verdict` 가 `conformant` 인지 본다. 종료 코드 0 과 3 을 허용한다.
+한 파일이 빠지면 L5 는 막힌다.
+
+힌트 사슬: `keygen` → `replay --sign-key` → `anchor add` →
+`settle propose/record` → `conformance --level L5 --deep`.
+
+이 사다리가 [에이전트 작업 표준(AWS) 1.0](../../mydocs/tech/standards/agent_work_standard.md)
+의 AW-L1~L5 를 과제로 소비한다. 운동장은 그 표준을 다시 정의하지
+않는다.
+
+## 나머지 보스 (이름만)
+
+정본은 각 `tasks/XC0n.json` 이다. 여기서는 지도만 옮긴다.
+
+| id | tier | 무엇을 완주하나 | 최종 판정 |
+|---|---|---|---|
+| XC01 | 5 | 서명→앵커→정산까지 전 사다리 | 적합성 L5 conformant |
+| XC02 | 5 | 2세대 계보에서 오염 전파 | 오염원의 후손까지 리콜 |
+| XC03 | 4 | 청구→원장→검증 | 캡슐·게이트·원장·워크오더 4관문 |
+| XC04 | 4 | 끊기지 않는 3세대 사슬 | lineage valid · depth 3 |
+| XC05 | 5 | 감사 리포트 + 서명 귀속 | 적합성 L3 conformant |
+
+세부 힌트는 과제 `instructions` 가 유일 지시서다. 휴게실이 힌트를
+늘려 채점을 쉽게 만들지 않는다.
+
+## 보스존과 전당
+
+보스 점수도 다른 pack 과 같이 스코어카드에 남는다. 전당 등재는
+여전히 `attest` 다. 보스만 탔어도 표는 끊긴다(`packsScored >= 1`).
+만점이어야 이름이 오르는 것이 아니다.
+
+```bash
+python gym/tools/leaderboard.py attest --agent 나
+python gym/tools/leaderboard.py verify
+```
+
+→ [12-leaderboard.md](12-leaderboard.md)

--- a/gym/tutorial/12-leaderboard.md
+++ b/gym/tutorial/12-leaderboard.md
@@ -1,0 +1,75 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 12. 명예의 전당 — 위조 불가능한 리더보드
+
+탔으면 전당에 이름을 올린다. 이 점수판은 자기 신고가 아니라 검증
+사다리로 봉인된다. 도구 정본은 `gym/tools/leaderboard.py` 다. 이
+페이지는 방문자가 쓰는 세 명령만 안내한다.
+
+돌아가기: [README.md](README.md) · 초대: [13-invite.md](13-invite.md)
+· 정본: [../INVITE.md](../INVITE.md)
+
+## 세 명령
+
+```bash
+python gym/score.py --agent 나                    # 채점 → scorecard + admission
+python gym/tools/leaderboard.py attest --agent 나  # 등재
+python gym/tools/leaderboard.py verify             # 전 사슬 재검증
+python gym/tools/leaderboard.py render             # 검증본에서 순위표
+```
+
+`attest` 전에 채점이 있어야 한다. 스코어카드와 입장 봉투가
+`gym/submissions/나/` 에 있어야 사슬이 시작된다.
+
+## 사슬이 막는 것
+
+`gym/tools/leaderboard.py` 문서 문자열이 이미 적은 표다.
+
+| 공격 | 막는 축 |
+|---|---|
+| 점수 위조(스코어카드 수정) | 청구의 capsuleSha256 고정 (P1) |
+| 소급 조작(과거 항목 수정) | 원장·앵커의 줄 해시 체인 |
+| 이중 등재(같은 결과 재탕) | 원장 전역 capsuleSha256 유일성 (P3) |
+| 대리 제출 | 청구 Ed25519 서명 + keyring 판정 |
+
+새 암호학은 없다. 전부 기존 rhwp 명령의 조합이다. 휴게실이 네 번째
+해시를 발명하지 않는다.
+
+## 봉인 범위 (정직)
+
+이 사슬이 봉인하는 것은 "이 스코어카드가 이 시점에 이 신원으로
+등재되었고 이후 변조되지 않았다"까지다. **채점 자체의 재현**은
+스코어카드에 박힌 runner 신원과 커밋된 제출물로 제3자가 수행한다.
+초대장이 채점을 대신하지 않는다.
+
+`render` 는 검증을 통과한 항목만 순위에 올린다. 검증 불가 항목은
+숨기지 않고 `unverified` 로 남긴다. 부재를 실패로 위장하지 않는 결
+그대로다.
+
+## 비밀키
+
+등재 때 생기는 비밀키는 `gym/leaderboard/keys/` 에만 있고
+**커밋되지 않는다** (`.gitignore`). 전당에 오르는 것은 공개키·서명·
+스코어카드뿐이다. 남의 키로 대리 등재할 수 없다.
+
+## 같은 스코어카드를 두 번
+
+원장이 거부한다 (`duplicate: true`). 점수를 다시 올리려면 채점을
+다시 하고 다른 스코어카드로 등재한다. 같은 바이트를 재탕하는 길이
+막혀 있다.
+
+## 친구를 부르려면
+
+문은 이미 열려 있다. `attest` 는 아무 이름이든 받는다. 초대장은
+권한이 아니라 안내다.
+
+```bash
+python gym/tools/leaderboard.py invite --agent 친구이름
+```
+
+자세히 → [13-invite.md](13-invite.md) · [../INVITE.md](../INVITE.md)

--- a/gym/tutorial/13-invite.md
+++ b/gym/tutorial/13-invite.md
@@ -1,0 +1,85 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 13. 친구를 휴게실로 — 초대장 방문 안내
+
+초대장의 정본은 [../INVITE.md](../INVITE.md) 다. 이 페이지는 휴게실
+동선에 맞춰 같은 내용을 한 번 더 밟는다. 초대 메커니즘과 채점 논리를
+바꾸지 않는다.
+
+돌아가기: [README.md](README.md) · 전당: [12-leaderboard.md](12-leaderboard.md)
+
+## 초대는 권한이 아니다
+
+`attest` 는 아무 이름이든 받는다. 초대장이 없어도 등재는 막히지
+않는다. 초대장이 하는 일은 두 가지다.
+
+1. 손님이 어느 이름으로 오면 되는지 알려 준다.
+2. 손님이 합류하는 판이 위조본이 아님을 **판 지문**으로 확인하게 한다.
+
+`gym/tools/leaderboard.py` 의 `cmd_invite` 가 `gym/leaderboard/invite.json`
+을 발급한다. 그 봉투의 `kind` 는 `gymLeaderboardInvite` 다.
+
+## 보내는 쪽
+
+```bash
+python gym/tools/leaderboard.py invite --agent 친구이름
+```
+
+지문에 들어 있는 칸은 INVITE 정본과 같다.
+
+| 지문 항목 | 뜻 |
+|---|---|
+| `members` | 지금 전당에 오른 신원 수 |
+| `ledgerEntries` | 원장에 봉인된 등재 항목 수 |
+| `ledgerChain` · `anchorChain` | 두 해시 체인의 무결 상태 |
+| `merkleRoot` | 앵커 체크포인트의 머클 루트 |
+| `workorderSha256` | 상설 발주서의 바이트 해시 |
+| `ledgerSnapshotSha256` | 원장 파일 전체의 바이트 해시 |
+
+새 비밀은 없다. 전부 커밋된 원장·앵커에서 다시 계산할 수 있다.
+
+## 받는 쪽 — 사람
+
+부모님·친구는 입문존부터 탄다.
+
+1. 저장소를 받고 `cargo build --bin rhwp`
+2. [README.md](README.md) 의 5분을 그대로 밟는다 (`--profile family`)
+3. 합류 전에 `python gym/tools/leaderboard.py verify`
+4. `attest --agent <자기이름>`
+
+5분이면 첫 놀이기구를 탄다. 보스존을 권하지 마라.
+
+## 받는 쪽 — 다른 에이전트
+
+Claude·GPT·Gemini·Cursor·Codex·Qwen 무엇이든, 자기 바이너리로
+채점하고 자기 키로 등재한다. 합류 3줄은 초대 봉투의 `join` 과 같다.
+
+```bash
+python gym/score.py --agent 친구이름
+python gym/tools/leaderboard.py attest --agent 친구이름
+python gym/tools/leaderboard.py verify
+```
+
+## 받는 쪽 — CI
+
+자동 채점 파이프라인도 같은 세 줄이다. 비밀키를 로그에 찍지 않는다.
+`gym/leaderboard/keys/` 는 산출물이 아니라 로컬 비밀이다.
+
+## 휴게실에서 초대할 때 같이 보낼 링크
+
+- 지도: [../PARK.md](../PARK.md)
+- 5분 안내: [README.md](README.md)
+- 입장: [01-admission.md](01-admission.md)
+- Windows: [19-windows.md](19-windows.md)
+- 정본 초대장: [../INVITE.md](../INVITE.md)
+
+## 초대장이 하지 않는 것
+
+- 채점 점수를 바꾸지 않는다.
+- 없는 사람을 전당에 올리지 않는다. 등재는 손님이 자기 키로 한다.
+- 판 지문을 비밀로 만들지 않는다. 검증 가능하게 만들 뿐이다.

--- a/gym/tutorial/14-submissions.md
+++ b/gym/tutorial/14-submissions.md
@@ -1,0 +1,82 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 14. 제출 폴더 — 어디에 무엇을 놓나
+
+채점기는 파일을 찾는다. 폴더 이름이 틀리면 그 과제는 "제출 없음"으로
+떨어진다. 이 페이지는 `gym/core/runner.py` 가 이미 하는 탐색 순서를
+방문어로 옮긴다. 탐색 순서를 바꾸지 않는다.
+
+돌아가기: [README.md](README.md)
+
+## 기본 자리
+
+```text
+gym/submissions/<에이전트이름>/
+├── scorecard.json
+├── report.md
+├── admission.json
+├── casual-rides/
+│   ├── CR01/answer.json
+│   ├── CR02/answer.json
+│   ├── CR03/answer.json
+│   └── CR04/answer.json
+├── core-cli/
+│   └── T01/answer.json
+└── text-editing/
+    └── TE01/edited.hwp
+```
+
+`<에이전트이름>` 은 `--agent` 와 같다. 채점 명령과 제출 폴더가
+어긋나면 빈 점수가 나온다.
+
+## pack 우선, 평면은 하위 호환
+
+`score_pack` 은 먼저 `submissions/<이름>/<packid>/` 를 본다. 그
+폴더가 없으면 `submissions/<이름>/` 을 과제 id 로 직접 훑는다.
+옛날 배치를 깨지 않으려는 하위 호환이다. 새로 탈 때는 pack 아래가
+맞다. 입문존과 본식 존 과제 id 가 한 폴더에 섞이지 않는다.
+
+## 제출 종류
+
+`gym/README.md` 제출 형식 절과 같다.
+
+| `submit.kind` | 놓는 것 | 입문 예 |
+|---|---|---|
+| `answer` | `answer.json` (과제가 요구한 키만) | CR01 `pages` |
+| `artifact` | 지정된 파일 이름 | TE01 `edited.hwp` |
+| `pair` | 산출 2개 + 계획서 | core-cli T10 |
+
+`answer` 에 여분 키를 넣어도 보통 채점은 필요한 키만 본다. 그래도
+과제가 요구한 키만 넣는 편이 실수가 적다. `artifact` 는 파일 이름이
+과제 `submit.files` 와 같아야 한다. `edited.hwp` 를 `out.hwp` 로
+내면 그 과제는 파일을 못 찾는다.
+
+## 원본을 제출 자리에 복사하지 마라
+
+`samples/` 는 입력이다. 제출이 아니다. 편집 과제는 `-o` 로 새
+파일을 만든다. `differs_from_input` 이 있는 과제는 입력 바이트와
+같은 산출을 거절한다.
+
+산출 `.hwp`/`.hwpx` 는 보통 커밋하지 않는다. 재실행으로 다시 만들
+수 있어야 한다는 것이 이 저장소의 검증 문화다.
+
+## 채점 산출물은 제출이 아니다
+
+`scorecard.json` · `report.md` · `admission.json` 은 채점기가 쓴다.
+이 세 파일을 손으로 고쳐 점수를 올리는 것은 전당 사슬이 막는다.
+로컬 파일을 고치는 것 자체는 가능하지만, `attest` 이후 `verify` 가
+해시 불일치를 폭로한다.
+
+## Windows 경로
+
+PowerShell 에서 `나` 같은 한글 에이전트 이름은 된다. 콘솔 코드
+페이지가 CP949 면 `echo` 로 쓴 JSON 이 깨질 수 있다.
+[19-windows.md](19-windows.md) 의 UTF-8 without BOM 을 쓴다.
+
+슬래시와 백슬래시는 Python 쪽 `os.path.join` 이 맞춘다. 제출 폴더를
+문서에 쓸 때는 저장소 관례대로 `/` 를 쓴다.

--- a/gym/tutorial/15-scoring-honesty.md
+++ b/gym/tutorial/15-scoring-honesty.md
@@ -1,0 +1,85 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 15. 채점은 라이브다 — 휴게실이 바꾸지 않는 것
+
+이 페이지는 방문자가 오해하기 쉬운 채점 성질을 적는다. **채점 논리를
+바꾸라는 지시가 아니다.** `gym/core/checks.py` 의 연산자 등록부와
+`gym/core/runner.py` 의 채점 절차가 정본이다. 휴게실·PARK·INVITE·
+`gym/docs/tutorial.md` 는 장식과 안내다.
+
+돌아가기: [README.md](README.md) · PARK 정직 조항: [../PARK.md](../PARK.md)
+
+## 정직 조항 (PARK 와 같은 말)
+
+- 점수는 pack 별로 보존되고, 총점은 편의값이다.
+- 기대값은 골든 파일로 박제하지 않고 **채점 시점에 rhwp 로 재계산**한다.
+- 보스 어트랙션도 예외 없이 기준 풀이 왕복을 통과해야 등재된다.
+- 부재는 실패로 위장하지 않는다. 요구 명령이 없는 pack 은 `unavailable`.
+
+놀이공원이라 부르는 이유는 사람을 부르기 위해서지, 판정을 무르게 하기
+위해서가 아니다.
+
+## 연산자 등록부 — 읽기만
+
+`gym/core/checks.py` 의 `REGISTRY` 는 지금 이 열일곱 이름이다. 휴게실
+작업이 열여덟 번째를 추가하지 않는다. 시험이 이 집합을 잠근다.
+
+파일 연산자(CLI 를 부르지 않음):
+
+- `same_hash`
+- `differs_from_input`
+- `file_exists`
+- `files_differ`
+- `xml_root_eq`
+- `json_value_eq`
+- `csv_cell_eq`
+- `utf8_bom`
+
+봉투 연산자(CLI 를 부름):
+
+- `answer_eq`
+- `len_answer_eq`
+- `len_ge`
+- `value_eq`
+- `value_ge`
+- `value_in`
+- `deep_contains`
+- `not_contains`
+- `cell_text_eq`
+
+전역 훑기(`GLOBAL_SCAN_OPS`)는 `deep_contains` 와 `not_contains` 다.
+편집 과제에서 좌표 없이 쓰면 스키마가 막는다(#4600). 그 막음은
+`gym/core/schema.py` 가 이미 한다.
+
+## 라이브 오라클이란
+
+CR01 을 예로 든다. 저장소 어디에도 "정답은 3쪽"이라고 박제된 숫자가
+없다. 채점기가 그때 `rhwp info samples/table-001.hwp --json` 을 돌려
+`pageCount` 를 읽는다. 픽스처가 진화하면 정답도 따라 진화한다.
+
+그래서 이 안내의 예시 숫자(`{"pages": 3}`)는 **설명용**이다. 네
+바이너리가 다른 수를 말하면 그 수가 정답이다.
+
+## 기준 풀이(reference/)의 자리
+
+`reference/<id>.json` 은 "이 과제를 풀 수 있다"는 선언이다. 채점기가
+방문자의 답을 이 파일과 문자열 비교하지 않는다. 기준 풀이는 과제를
+등재할 때 왕복으로 실측하는 데 쓴다. 방문자가 그걸 베끼면 채점은
+통과할 수 있어도, 측정되는 능력은 "따라 치기"다.
+
+## 이 작업이 명시적으로 하지 않는 것
+
+이슈 #5263 의 범위다.
+
+- `gym/core/checks.py` 를 고치지 않는다.
+- 다른 열린 PR 의 pack 과제 JSON 을 고치지 않는다.
+- 새 check 연산자를 추가하지 않는다.
+- 점수 가중·만점 계산·unavailable 규칙을 바꾸지 않는다.
+- `cargo fmt --all` 을 돌리지 않는다 (Rust 변경이 없다).
+
+잠그는 시험은 `scripts/tests/test_gym_tutorial.py` 다.

--- a/gym/tutorial/16-unavailable.md
+++ b/gym/tutorial/16-unavailable.md
@@ -1,0 +1,66 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 16. unavailable — 0점이 아닌 부재
+
+어떤 pack 줄이 `unavailable` 로 나오면, 그것은 실패가 아니다. 요구
+명령이 지금 바이너리에 없다는 정직한 표기다. 이 페이지는
+`gym/core/runner.py` 의 `score_pack` 이 이미 하는 일을 방문어로
+옮긴다. 규칙을 바꾸지 않는다.
+
+돌아가기: [README.md](README.md) · 정직: [15-scoring-honesty.md](15-scoring-honesty.md)
+
+## 한 줄로
+
+오래된 바이너리에게 "너는 0점"이라고 말하는 것은 거짓말이다. 그
+놀이기구의 키가 없을 뿐이다. 최신으로 빌드하면 열린다.
+
+```bash
+cargo build --bin rhwp
+python gym/score.py --agent 나 --profile family
+```
+
+## 어디서 오나
+
+각 pack 의 `pack.json` 에 `requires.commands` 가 있다.
+`casual-rides` 는 `info`, `explain`, `export-tables`, `search` 다.
+하나라도 `rhwp capabilities` 에 없으면 그 pack 은 채점하지 않고
+`status: unavailable` 과 `missingCommands` 를 남긴다. `score` 는
+`null` 이다. 0 이 아니다.
+
+입장 봉투의 `packsScored` 는 unavailable pack 을 세지 않는다. 고른
+pack 이 전부 부재면 `verdict` 는 `deny` 일 수 있다. 그것은 "점수가
+낮다"가 아니라 "유효 채점이 하나도 없다"다.
+
+## 출력에서 읽는 법
+
+```
+나: 4/4  (pack 1 채점, 1 unavailable)
+  - casual-rides       4/4  (4/4 과제)
+  - self-description   unavailable (없는 명령: export-ontology)
+```
+
+위는 설명용이다. 실제 빠진 명령 이름은 네 바이너리에 따라 다르다.
+
+## 자주 있는 원인
+
+1. **빌드하지 않았다.** `cargo build --bin rhwp` 가 없다.
+2. **PATH 의 다른 rhwp.** 예전 설치본이 먼저 잡힌다. `gym/score.py --bin target/debug/rhwp` 로 지목한다.
+3. **부분 빌드.** 일부 명령만 있는 오래된 커밋을 돌린다.
+4. **프로파일을 넓게 골랐다.** `maintainer` 는 전 pack 이다. 새 pack
+   이 요구하는 명령이 없으면 그 줄만 unavailable 이다. 다른 줄 점수와
+   섞지 마라.
+
+## 0점과 어떻게 다른가
+
+| 상태 | 의미 | 입장 |
+|---|---|---|
+| `scored` 0/N | 명령은 있고 답이 틀렸다 | allow (채점은 됨) |
+| `unavailable` | 명령이 없어 채점하지 않았다 | 그 pack 은 packsScored 에 안 듦 |
+
+둘을 같은 색으로 그리면 정직 조항이 깨진다. 리포트와 리더보드도
+이 구분을 지킨다. 휴게실이 색을 섞지 않는다.

--- a/gym/tutorial/17-faq.md
+++ b/gym/tutorial/17-faq.md
@@ -1,0 +1,78 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 17. 자주 묻는 것
+
+돌아가기: [README.md](README.md) · 막힘: [18-troubleshooting.md](18-troubleshooting.md)
+
+## 입장과 프로파일
+
+**Q. 프로파일 이름에 대문자를 써도 되나?**
+안 된다. 파일 이름이 `family.json` 이다. `Family` 나 `FAMILY` 는
+다른 경로다.
+
+**Q. `casual` 프로파일이 있나?**
+없다. 입문존을 고르는 이름은 `family` 다. pack 을 직접 고르려면
+`--pack casual-rides`.
+
+**Q. `beginner` / `expert` / `guest` 는?**
+프로파일 id 가 아니다. 일곱 이름은
+`family` · `starter` · `editor` · `publisher` · `operator` ·
+`boss` · `maintainer` 뿐이다. [06-profiles.md](06-profiles.md).
+
+**Q. 만점이어야 들어가나?**
+아니다. pack 을 하나라도 유효하게 채점하면 `verdict: allow` 다.
+[01-admission.md](01-admission.md).
+
+## 제출과 채점
+
+**Q. 기준 풀이를 봐도 되나?**
+봐도 채점은 정직하게 돈다. 측정되는 능력만 달라진다.
+[15-scoring-honesty.md](15-scoring-honesty.md).
+
+**Q. 예시의 `{"pages": 3}` 을 그대로 내면?**
+네 `rhwp info` 가 3 을 줄 때만 통과한다. 예시 숫자는 설명용이다.
+라이브 오라클이 정답이다.
+
+**Q. CR01 과 T01 이 둘 다 쪽수면 답을 재사용하나?**
+입력 문서가 다르다. 숫자도 다를 수 있다. 폴더도 `casual-rides/CR01`
+과 `core-cli/T01` 로 갈린다.
+
+**Q. 원본 샘플을 고치면?**
+하지 마라. 제출은 `gym/submissions/` 아래 새 파일이다. 커밋된
+픽스처를 바꾸면 다른 과제와 시각 검증까지 깨진다.
+
+**Q. 이 안내가 채점 점수를 바꾸나?**
+바꾸지 않는다. `gym/core/checks.py` 는 이 작업의 범위 밖이다.
+
+## 리더보드와 초대
+
+**Q. 초대장이 있어야 등재되나?**
+아니다. 문은 열려 있다. 초대장은 안내와 판 지문이다.
+[13-invite.md](13-invite.md) · [../INVITE.md](../INVITE.md).
+
+**Q. 비밀키를 PR 에 올려야 하나?**
+안 된다. `gym/leaderboard/keys/` 는 `.gitignore` 다. 공개키·서명·
+스코어카드만 오른다.
+
+**Q. 같은 점수를 두 번 등재하면?**
+원장이 거부한다. 전역 유일성(P3).
+
+## 환경
+
+**Q. 오프라인에서도 되나?**
+된다. 채점과 봉인은 로컬이다.
+
+**Q. Windows 인데 문서의 bash 가 안 된다.**
+[19-windows.md](19-windows.md).
+
+**Q. 파이썬 버전이?**
+3.8+ 이면 채점기·감사기가 돈다. 표준 라이브러리만 쓴다.
+
+**Q. `audit.py` 는 방문자가 돌리나?**
+기여자가 pack 을 손댈 때 필수다. 입문 방문자는 안 돌려도 탄다.
+이 작업(#5263)은 pack JSON 을 안 만지므로, 감사기는 회귀 확인용이다.

--- a/gym/tutorial/18-troubleshooting.md
+++ b/gym/tutorial/18-troubleshooting.md
@@ -1,0 +1,100 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 18. 막혔을 때
+
+돌아가기: [README.md](README.md) · FAQ: [17-faq.md](17-faq.md)
+· Windows: [19-windows.md](19-windows.md)
+
+이 페이지는 입문 방문자가 실제로 걸리는 자리만 적는다. 새 진단 명령을
+만들지 않는다. 있는 CLI 와 채점기 출력으로 좁힌다.
+
+## 1. `rhwp` 를 못 찾는다
+
+증상: `rhwp: command not found` 또는 PowerShell 의
+`용어 'rhwp'이(가) cmdlet … 인식되지 않습니다`.
+
+1. 저장소 루트인지 확인한다.
+2. `cargo build --bin rhwp` 를 돌린다.
+3. 채점기에 바이너리를 직접 넘긴다.
+
+```bash
+python gym/score.py --agent 나 --profile family --bin target/debug/rhwp
+```
+
+Windows 는 `target\debug\rhwp.exe`.
+
+## 2. 프로파일 파일을 못 연다
+
+증상: `FileNotFoundError` 가 `gym/profiles/…json` 을 가리킨다.
+
+철자를 [06-profiles.md](06-profiles.md) 의 일곱 이름과 대조한다.
+`--profile casual` 은 없다. `--pack casual-rides` 또는
+`--profile family`.
+
+## 3. 4/4 가 나왔는데 내가 탄 것 같지 않다
+
+기준 풀이가 먼저 돈 것이다. 제출 폴더에 `answer.json` 을 놓고 틀린
+숫자를 넣으면 그 과제만 떨어진다. 그게 라이브 오라클이다.
+[02-cr01-carousel.md](02-cr01-carousel.md) 의 "일부러 틀려 보기".
+
+## 4. 과제가 제출 없음으로 떨어진다
+
+1. 폴더가 `gym/submissions/<같은이름>/<pack>/<과제id>/` 인가.
+2. `--agent 나` 인데 폴더는 `gym/submissions/me/` 인가.
+3. 파일 이름이 `answer.json` / `edited.hwp` 처럼 과제가 적은 그대로인가.
+4. JSON 이 BOM 이나 작은따옴표로 깨졌는가.
+
+자리 결은 [14-submissions.md](14-submissions.md).
+
+## 5. `unavailable`
+
+[16-unavailable.md](16-unavailable.md). 먼저
+`rhwp capabilities` 가 JSON 을 내는지 본다. 안 나오면 바이너리가
+너무 오래됐다.
+
+## 6. 한글 경로에서 search 가 실패한다
+
+T02 입력 `samples/2022년 국립국어원 업무계획.hwp` 는 따옴표가
+필요하다. PowerShell 은 작은따옴표가 리터럴이다.
+
+```powershell
+rhwp search 'samples/2022년 국립국어원 업무계획.hwp' 국어 --json
+```
+
+콘솔이 한글을 `??` 로 바꾸면 코드 페이지 문제다.
+[19-windows.md](19-windows.md).
+
+## 7. `attest` 가 스코어카드를 못 찾는다
+
+채점을 먼저 한다. `gym/submissions/<이름>/scorecard.json` 과
+`admission.json` 이 있어야 한다. 입장 거절(`deny`) 상태면 등재
+사슬의 게이트가 막힐 수 있다. 표를 다시 끊는다.
+[01-admission.md](01-admission.md).
+
+## 8. `verify` 가 한 줄을 폭로한다
+
+원장이나 스코어카드를 손으로 고친 흔적이다. 로컬 실험을 되돌려
+커밋된 리더보드 파일과 맞춘 뒤, 자기 제출만 다시 등재한다.
+커밋된 `gym/leaderboard/ledger.ndjson` 을 고쳐서 점수를 올리는
+길은 없다. `verify` 가 그 자리를 가리킨다.
+
+## 9. 이 안내와 과제 JSON 이 다르다
+
+과제 파일이 유일 지시서다 (`gym/README.md` 규칙 1). 휴게실은
+요약이다. 충돌하면 `packs/<id>/tasks/<과제>.json` 의
+`instructions` 를 따른다. 이 문서를 고쳐서 채점을 쉽게 만들지
+말고, 과제가 바뀐 것이면 그 pack 의 PR 을 본다. 다른 열린 PR 의
+과제 JSON 을 이 가지에서 고치지 않는다.
+
+## 10. 그래도 막히면
+
+- 지도: [../PARK.md](../PARK.md)
+- 정직 조항: [15-scoring-honesty.md](15-scoring-honesty.md)
+- 첫날 한 장: [20-checklist.md](20-checklist.md)
+- 저장소 기여 절차는 휴게실 밖이다. `rhwp-contributor` 스킬과
+  `CONTRIBUTING.md`.

--- a/gym/tutorial/19-windows.md
+++ b/gym/tutorial/19-windows.md
@@ -1,0 +1,119 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 19. Windows PowerShell — 같은 놀이기구, 다른 셸
+
+휴게실의 본문은 bash 관례(`mkdir -p`, `echo '{…}' >`)로 적혀 있다.
+Windows 방문자가 그 줄을 그대로 붙이면 폴더가 안 생기거나 JSON 에
+BOM·CP949 가 섞인다. 이 페이지는 **같은 동작의 PowerShell 번역**이다.
+채점 논리와 과제 JSON 을 바꾸지 않는다.
+
+돌아가기: [README.md](README.md) · 막힘: [18-troubleshooting.md](18-troubleshooting.md)
+
+저장소 루트(`rhwp` 가 있는 곳)에서 실행한다. 작업 폴더가
+`C:\Users\…\rhwp-gym-tutorial-park-docs` 같은 worktree 여도 된다.
+
+## 표 끊기
+
+```powershell
+python gym/score.py --agent 나 --profile family
+```
+
+바이너리를 지목할 때:
+
+```powershell
+python gym/score.py --agent 나 --profile family --bin target\debug\rhwp.exe
+```
+
+## 폴더 만들기
+
+```powershell
+New-Item -ItemType Directory -Force -Path gym\submissions\나\casual-rides\CR01 | Out-Null
+New-Item -ItemType Directory -Force -Path gym\submissions\나\casual-rides\CR02 | Out-Null
+New-Item -ItemType Directory -Force -Path gym\submissions\나\casual-rides\CR03 | Out-Null
+New-Item -ItemType Directory -Force -Path gym\submissions\나\casual-rides\CR04 | Out-Null
+```
+
+`mkdir -p` 의 `-p` 는 PowerShell 기본 `mkdir` 에 없다. `-Force` 가
+이미 있는 폴더를 허용한다.
+
+## JSON 을 UTF-8 without BOM 으로 쓰기
+
+PowerShell 5.1 의 `Set-Content -Encoding utf8` 은 BOM 을 붙인다.
+채점기의 `json.load` 는 BOM 을 거절할 수 있다. PR 본문과 같은
+이유로 **BOM 없는 UTF-8** 을 쓴다.
+
+```powershell
+$utf8 = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText(
+    (Join-Path (Get-Location) 'gym\submissions\나\casual-rides\CR01\answer.json'),
+    '{"pages": 3}',
+    $utf8)
+```
+
+`3` 은 설명용이다. `rhwp info samples/table-001.hwp --json` 이 준
+`pageCount` 로 바꾼다.
+
+CR02·CR03·CR04 도 같은 방식으로 키만 바꾼다.
+
+```powershell
+# CR02 paragraphs / CR03 tables / CR04 hits — 숫자는 네 오라클
+[System.IO.File]::WriteAllText((Join-Path (Get-Location) 'gym\submissions\나\casual-rides\CR02\answer.json'), '{"paragraphs": 0}', $utf8)
+[System.IO.File]::WriteAllText((Join-Path (Get-Location) 'gym\submissions\나\casual-rides\CR03\answer.json'), '{"tables": 0}', $utf8)
+[System.IO.File]::WriteAllText((Join-Path (Get-Location) 'gym\submissions\나\casual-rides\CR04\answer.json'), '{"hits": 0}', $utf8)
+```
+
+## 문서 읽기
+
+```powershell
+rhwp info samples\table-001.hwp --json
+rhwp explain samples\table-001.hwp --json
+rhwp export-tables samples\table-001.hwp --json
+rhwp search samples\table-001.hwp --json -- 표
+```
+
+경로 구분자는 `\` 나 `/` 둘 다 되는 경우가 많다. 샘플 이름에 한글·
+공백이 있으면 작은따옴표로 감싼다.
+
+```powershell
+rhwp search 'samples/2022년 국립국어원 업무계획.hwp' 국어 --json
+```
+
+## 콘솔이 한글을 `??` 로 바꿀 때
+
+현재 콘솔 코드 페이지가 CP949 면 `rhwp` 의 UTF-8 출력이 깨져 보일
+수 있다. 채점기는 파일을 UTF-8 로 읽으므로, **보이는 글자보다
+answer.json 바이트**가 중요하다. 출력을 파일로 받아 키를 읽는다.
+
+```powershell
+rhwp info samples\table-001.hwp --json | Out-File -Encoding utf8 tmp-info.json
+```
+
+이 `Out-File` 에도 BOM 이 붙을 수 있다. 숫자를 눈으로 확인하는 용도로만
+쓰고, 제출 파일은 위의 `UTF8Encoding($false)` 로 쓴다.
+
+채점기 자체는 `sys.stdout.reconfigure(encoding="utf-8")` 를 시도한다.
+그래도 콘솔이 깨지면 파일(`scorecard.json`, `report.md`)을 편집기로
+연다.
+
+## 전당과 초대
+
+```powershell
+python gym/tools/leaderboard.py attest --agent 나
+python gym/tools/leaderboard.py verify
+python gym/tools/leaderboard.py invite --agent 친구이름
+```
+
+명령은 bash 와 같다. 경로만 백슬래시로 바꿔도 된다.
+
+## 이 페이지가 바꾸지 않는 것
+
+- 답 키 (`pages`, `paragraphs`, `tables`, `hits`)
+- 라이브 오라클 명령
+- 프로파일 이름
+- `admission.json` 의 `verdict` 계산
+- `gym/core/checks.py`

--- a/gym/tutorial/20-checklist.md
+++ b/gym/tutorial/20-checklist.md
@@ -1,0 +1,81 @@
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# 20. 첫날 체크리스트
+
+휴게실을 한 바퀴 닫는 한 장이다. 항목은 기존 명령과 기존 과제다.
+새 과제를 만들지 않는다.
+
+돌아가기: [README.md](README.md) · 지도: [../PARK.md](../PARK.md)
+
+## 빌드
+
+- [ ] 저장소 루트에 있다
+- [ ] `cargo build --bin rhwp` 가 성공했다 (Windows 는 `rhwp.exe`)
+- [ ] `rhwp info samples/table-001.hwp --json` 이 JSON 을 냈다
+
+## 입장 (`family`)
+
+- [ ] `python gym/score.py --agent 나 --profile family`
+- [ ] `gym/submissions/나/admission.json` 의 `verdict` 가 `allow`
+- [ ] 프로파일 철자가 `family` 다 (`Family` 아님)
+
+자세히: [01-admission.md](01-admission.md)
+
+## 입문존 네 바퀴
+
+- [ ] CR01 `pages` ← `info` 의 `pageCount` — [02-cr01-carousel.md](02-cr01-carousel.md)
+- [ ] CR02 `paragraphs` ← `explain` 의 `paragraphCount` — [03-cr02-ferris.md](03-cr02-ferris.md)
+- [ ] CR03 `tables` ← `export-tables` 의 `tableCount` — [04-cr03-circus.md](04-cr03-circus.md)
+- [ ] CR04 `hits` ← `search -- 표` 의 `matchCount` — [05-cr04-ringtoss.md](05-cr04-ringtoss.md)
+- [ ] 제출이 `gym/submissions/나/casual-rides/CR0n/answer.json` 이다
+- [ ] 틀린 숫자를 한 번 넣어 떨어지는지 보고, 올바른 숫자로 되돌렸다
+
+## 전당 (선택)
+
+- [ ] `python gym/tools/leaderboard.py attest --agent 나`
+- [ ] `python gym/tools/leaderboard.py verify`
+- [ ] 비밀키를 커밋하지 않았다
+
+[12-leaderboard.md](12-leaderboard.md)
+
+## casual 바깥 한 걸음 (선택)
+
+- [ ] 일곱 이름을 읽었다 — [06-profiles.md](06-profiles.md)
+- [ ] `starter`: T01 쪽수 또는 SD01 명령 수 — [07-starter-path.md](07-starter-path.md)
+- [ ] 다음 길이 숙제면 해당 페이지만 연다
+      (`editor` / `publisher` / `operator` / `boss`)
+
+## 친구 (선택)
+
+- [ ] [../INVITE.md](../INVITE.md) 를 읽었다
+- [ ] `invite --agent 친구이름` 으로 판 지문을 붙였다
+- [ ] 부모님에게는 `--profile family` 만 권했다
+
+[13-invite.md](13-invite.md)
+
+## 하지 않은 일로 체크하지 말 것
+
+- `gym/core/checks.py` 를 고쳤다 — 하면 안 된다
+- 다른 PR 의 pack 과제 JSON 을 고쳤다 — 하면 안 된다
+- 기준 풀이를 베껴 만점을 만들었다 — 타지 않은 것이다
+- 원본 `samples/` 를 편집했다 — 되돌린다
+
+정직 조항: [15-scoring-honesty.md](15-scoring-honesty.md)
+
+## 기여자라면 (방문 다음)
+
+이슈 #5263 같은 문서 작업의 로컬 확인은 이렇다.
+
+```bash
+python -m unittest scripts.tests.test_gym_tutorial
+python gym/tools/audit.py
+```
+
+`audit.py` 는 pack 정합이다. 휴게실 문서가 pack JSON 을 안 만지면
+devel 과 같은 결과가 나와야 한다. `cargo fmt --all` 은 Rust 가 없을
+때 돌리지 않는다.

--- a/gym/tutorial/README.md
+++ b/gym/tutorial/README.md
@@ -1,10 +1,56 @@
-# ☕ 휴게실 — 처음 오신 분을 위한 5분 안내
+---
+kind: guide
+status: active
+canonical: gym/tutorial/README.md
+last_verified: 2026-08-18
+---
+
+# ☕ 휴게실 — 처음 오신 분을 위한 안내
 
 운동장 지도([PARK.md](../PARK.md))만 보면 막막하다. 여기서 첫 놀이기구를 함께
-타 본다. 커피 한 잔 마시는 시간이면 충분하다.
+타 본다. 5분이면 표를 끊고 회전목마를 한 바퀴 돌 수 있다. 담력이 붙으면 같은
+휴게실에서 다음 존 입구까지 걸어간다.
 
-전제: 저장소를 빌드해 `rhwp` 바이너리가 있고(`cargo build`), 저장소 루트에서
-파이썬 3.8+ 이 돈다.
+전제: 저장소를 빌드해 `rhwp` 바이너리가 있고(`cargo build --bin rhwp`), 저장소
+루트에서 파이썬 3.8+ 이 돈다. Windows 는 [19-windows.md](19-windows.md) 를
+먼저 본다.
+
+채점 논리·검사 연산자·pack 과제 JSON 은 이 휴게실이 **바꾸지 않는다**. 여기는
+입구 안내다. 판정 정본은 `gym/core/checks.py` 와 각 `packs/*/tasks/*.json` 이다.
+
+규약 정본(기계가 잠그는 계약)은 [../docs/tutorial.md](../docs/tutorial.md) 다.
+작업 기록은 [../../mydocs/working/gym_tutorial.md](../../mydocs/working/gym_tutorial.md).
+
+---
+
+## 휴게실 지도
+
+| 순서 | 문서 | 누구에게 |
+|---|---|---|
+| 0 | 이 파일 (5분 첫 방문) | 누구나 |
+| 1 | [01-admission.md](01-admission.md) | 표를 어디서 끊는지 |
+| 2 | [02-cr01-carousel.md](02-cr01-carousel.md) | 🎠 CR01 회전목마 |
+| 3 | [03-cr02-ferris.md](03-cr02-ferris.md) | 🎡 CR02 관람차 |
+| 4 | [04-cr03-circus.md](04-cr03-circus.md) | 🎪 CR03 서커스 텐트 |
+| 5 | [05-cr04-ringtoss.md](05-cr04-ringtoss.md) | 🎯 CR04 링 던지기 |
+| 6 | [06-profiles.md](06-profiles.md) | 일곱 프로파일 이름 |
+| 7 | [07-starter-path.md](07-starter-path.md) | casual 다음, `starter` |
+| 8 | [08-editor-path.md](08-editor-path.md) | `editor` 첫 편집 |
+| 9 | [09-publisher-path.md](09-publisher-path.md) | `publisher` 변환·보안 |
+| 10 | [10-operator-path.md](10-operator-path.md) | `operator` 사다리 |
+| 11 | [11-boss-path.md](11-boss-path.md) | `boss` 자이로드롭 |
+| 12 | [12-leaderboard.md](12-leaderboard.md) | 명예의 전당 |
+| 13 | [13-invite.md](13-invite.md) | 친구 초대 |
+| 14 | [14-submissions.md](14-submissions.md) | 제출 폴더 결 |
+| 15 | [15-scoring-honesty.md](15-scoring-honesty.md) | 채점은 라이브다 |
+| 16 | [16-unavailable.md](16-unavailable.md) | 0점이 아닌 부재 |
+| 17 | [17-faq.md](17-faq.md) | 자주 묻는 것 |
+| 18 | [18-troubleshooting.md](18-troubleshooting.md) | 막혔을 때 |
+| 19 | [19-windows.md](19-windows.md) | PowerShell 명령 |
+| 20 | [20-checklist.md](20-checklist.md) | 첫날 체크리스트 |
+
+테마파크 한 장 지도는 [../PARK.md](../PARK.md), 초대장 정본은
+[../INVITE.md](../INVITE.md).
 
 ---
 
@@ -17,8 +63,9 @@
 python gym/score.py --agent 나 --profile family
 ```
 
-`--profile family` 는 부모님·친구와 함께 도는 **입문존만** 고른다. 출력 끝에
-이렇게 나오면 표가 발권된 것이다:
+`--profile family` 는 부모님·친구와 함께 도는 **입문존만** 고른다. 프로파일
+이름은 `gym/profiles/family.json` 의 `id` 와 같다. 출력 끝에 이렇게 나오면
+표가 발권된 것이다:
 
 ```
 나: 4/4  (pack 1 채점)
@@ -27,6 +74,10 @@ python gym/score.py --agent 나 --profile family
 
 > 방금 무슨 일이? 채점기가 입문존 놀이기구 4개를 스스로 풀어(기준 풀이) 채점하고,
 > `gym/submissions/나/admission.json` 에 `verdict: allow` 티켓을 남겼다.
+> 만점이 입장 조건이 아니다. pack 을 하나라도 유효하게 채점하면 들어온다.
+
+입장 봉투의 판정 기준은 `gym/score.py` 가 이미 하는 일이다. 이 안내가 그
+조건을 바꾸지 않는다. 자세히 → [01-admission.md](01-admission.md).
 
 ## 2. 회전목마를 직접 탄다 (2분)
 
@@ -54,6 +105,17 @@ python gym/score.py --agent 나 --pack casual-rides
 않는다(채점기가 `rhwp info` 로 정답을 **그 자리에서 다시 계산**하기 때문 —
 골든 파일이 아니다).
 
+나머지도 같은 결이다.
+
+| 놀이기구 | 명령 | 읽는 칸 | 답 키 |
+|---|---|---|---|
+| 🎠 CR01 | `rhwp info samples/table-001.hwp --json` | `pageCount` | `pages` |
+| 🎡 CR02 | `rhwp explain samples/table-001.hwp --json` | `paragraphCount` | `paragraphs` |
+| 🎪 CR03 | `rhwp export-tables samples/table-001.hwp --json` | `tableCount` | `tables` |
+| 🎯 CR04 | `rhwp search samples/table-001.hwp --json -- 표` | `matchCount` | `hits` |
+
+한 대씩 타려면 [02-cr01-carousel.md](02-cr01-carousel.md) 부터 순서대로.
+
 ## 3. 명예의 전당에 이름을 올린다 (1분)
 
 탔으면 전당에 올린다. 이 점수판은 자기 신고가 아니라 검증 사다리로 봉인된다.
@@ -64,9 +126,38 @@ python gym/tools/leaderboard.py verify
 ```
 
 `verify` 가 전 사슬을 재검증하고 통과를 보고한다. 네 점수는 이제 위조 불가능한
-방식으로 봉인됐다.
+방식으로 봉인됐다. 자세히 → [12-leaderboard.md](12-leaderboard.md).
 
 ---
+
+## 일곱 프로파일 — 이름을 외우지 말고 파일을 본다
+
+프로파일은 pack 을 **고르는** 도구이지 점수를 뭉치는 도구가 아니다. 이름은
+`gym/profiles/<id>.json` 의 `id` 필드와 같아야 한다. 시험이 이 일곱 이름을
+잠근다.
+
+| id | 묶는 pack | 언제 |
+|---|---|---|
+| `family` | `casual-rides` | 부모님·친구, 키 제한 없음 |
+| `starter` | `core-cli`, `self-description` | 도구의 결을 익힐 때 |
+| `editor` | `core-cli`, `text-editing`, `table-editing`, `objects-media` | 문서를 고칠 때 |
+| `publisher` | `serialization`, `layout-rendering`, `security` | 내보내고 배포하기 전 |
+| `operator` | `corpus-diagnostics`, `automation` | 폴더와 사다리 |
+| `boss` | `expert-challenges` | 한 단만 틀려도 막히는 곳 |
+| `maintainer` | 전 pack | 운동장 전체를 돌 때 |
+
+```bash
+python gym/score.py --agent 나 --profile family
+python gym/score.py --agent 나 --profile starter
+python gym/score.py --agent 나 --profile editor
+python gym/score.py --agent 나 --profile publisher
+python gym/score.py --agent 나 --profile operator
+python gym/score.py --agent 나 --profile boss
+python gym/score.py --agent 나 --profile maintainer
+```
+
+표의 정본은 [06-profiles.md](06-profiles.md). casual 바깥 입문은
+[07-starter-path.md](07-starter-path.md) 부터다.
 
 ## 다음 어디로?
 
@@ -75,7 +166,8 @@ python gym/tools/leaderboard.py verify
 | 본식 놀이기구 (편집·판독·보안) | `python gym/score.py --agent 나` (전 존) |
 | 검증 사다리 10단 | `--profile operator` |
 | 🐉 **보스존** (고난도) | `--profile boss` — 한 단만 틀려도 막힌다 |
-| 부모님·친구 초대 | [../INVITE.md](../INVITE.md) |
+| 부모님·친구 초대 | [../INVITE.md](../INVITE.md) · [13-invite.md](13-invite.md) |
+| 첫날 한 장 | [20-checklist.md](20-checklist.md) |
 
 ## 자주 묻는 것
 
@@ -86,7 +178,17 @@ python gym/tools/leaderboard.py verify
 **Q. 왜 내 점수가 어떤 pack 은 `unavailable` 인가?**
 그 pack 이 요구하는 rhwp 명령이 네 바이너리에 없다는 뜻이다. 0점이 아니라
 "이 놀이기구는 지금 네 키(바이너리)로는 못 탄다"는 정직한 표기다. 최신으로
-빌드하면 열린다.
+빌드하면 열린다. → [16-unavailable.md](16-unavailable.md)
 
 **Q. 오프라인에서도 되나?**
 전부 로컬이다. 네트워크 없이 돈다 — 채점도, 리더보드 봉인도.
+
+**Q. 이 안내가 채점 점수를 바꾸나?**
+바꾸지 않는다. `gym/core/checks.py` 의 연산자 등록부와 pack 과제 JSON 은
+휴게실 문서의 범위 밖이다. 점수는 여전히 pack 별로 보존되고, 기대값은 채점
+시점에 rhwp 로 재계산된다. → [15-scoring-honesty.md](15-scoring-honesty.md)
+
+**Q. Windows 인데 `mkdir -p` 가 안 된다.**
+PowerShell 명령은 [19-windows.md](19-windows.md) 에 모아 두었다.
+
+더 많은 질문 → [17-faq.md](17-faq.md). 막히면 → [18-troubleshooting.md](18-troubleshooting.md).

--- a/mydocs/working/gym_tutorial.md
+++ b/mydocs/working/gym_tutorial.md
@@ -1,0 +1,235 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_tutorial.md
+last_verified: 2026-08-18
+---
+
+# gym 휴게실 · PARK 입문 문서 보강
+
+Issue: #5263
+Branch: `feat/gym-tutorial-park-docs`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tutorial/` 을 5분 안내 한 장에서 입문 동선 세트로 늘렸다.
+`gym/docs/tutorial.md` 가 프로파일 이름·상대 링크·채점 불가침을
+규약으로 고정하고, `scripts/tests/test_gym_tutorial.py` 가 그 규약을
+기계로 잠근다. `gym/PARK.md` 와 `gym/INVITE.md` 에는 첫 방문 동선·
+일곱 프로파일·초대 손님별 첫 줄처럼 **실제로 온보딩에 쓰는 절**만
+보탰다.
+
+하지 않은 것 (이 기둥이 고치지 않는다):
+
+- `gym/core/checks.py` 채점 논리
+- 다른 열린 PR 의 pack 과제 JSON
+- 새 pack · 새 과제 · 새 연산자
+- `cargo fmt --all`
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_tutorial`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+이슈 #5263:
+
+> gym/tutorial 보강, 필요하면 casual 외 입문 문서와 시험. 채점 논리
+> 변경 금지. 열린 pack PR 과 파일 충돌 금지.
+> DoD: additions >= 3000. audit.py.
+
+devel 의 휴게실은 `gym/tutorial/README.md` 93줄이었다. PARK 와
+INVITE 는 테마파크 은유와 초대 3줄이 있었지만, casual 바깥으로
+가는 동선·Windows 번역·프로파일 철자 계약·링크 가드가 없었다.
+
+같은 날 열린 가지들이 pack 과제 JSON 을 크게 늘리고 있다
+(casual-rides CR05+, extraction, batch-ops, text-editing 등).
+그 파일에 손대면 충돌하고, 이슈가 명시한 금지를 깬다. 그래서
+문서·시험만 만진다.
+
+## 3. 한 일
+
+### 3.1 휴게실 (`gym/tutorial/`)
+
+| 파일 | 내용 |
+|---|---|
+| `README.md` | 5분 안내 유지, 01~20 색인, 일곱 프로파일 표 |
+| `01-admission.md` | 입장 봉투, allow ≠ 만점 |
+| `02`~`05` | CR01~CR04 손타기, 답 키와 오라클 경로 |
+| `06-profiles.md` | family/starter/editor/publisher/operator/boss/maintainer |
+| `07-starter-path.md` | T01 · T02 · SD01 (기존 과제만) |
+| `08-editor-path.md` | TE01 · TB01 · OM01 |
+| `09-publisher-path.md` | SR01 · LR01 · SE01 |
+| `10-operator-path.md` | CD01 · AU01 |
+| `11-boss-path.md` | XC01 과 보스 표 |
+| `12-leaderboard.md` | attest / verify / render, 봉인 범위 |
+| `13-invite.md` | 사람·에이전트·CI |
+| `14-submissions.md` | pack 우선 제출 자리 |
+| `15-scoring-honesty.md` | REGISTRY 열일곱, 불가침 |
+| `16-unavailable.md` | 부재 ≠ 0점 |
+| `17-faq.md` | 이름·제출·전당·환경 |
+| `18-troubleshooting.md` | 막힘 10칸 |
+| `19-windows.md` | PowerShell, UTF-8 without BOM |
+| `20-checklist.md` | 첫날 한 장 |
+
+모든 페이지가 `gym/tutorial/README.md` 를 canonical 로 가리킨다.
+규약 정본은 `gym/docs/tutorial.md`.
+
+### 3.2 PARK · INVITE
+
+PARK 에 보탠 것:
+
+- 휴게실이 한 장이 되었다는 포인터와 `docs/tutorial.md`
+- 첫 방문 동선 다섯 걸음
+- 일곱 프로파일 표
+- 제출 자리 한 줄
+- 존별 첫 놀이기구 (기존 1번 과제만)
+- 막혔을 때 표
+- 이 지도가 바꾸지 않는 것 (checks.py · pack JSON · verdict)
+
+INVITE 에 보탠 것:
+
+- 사람 / 에이전트 / CI 첫 줄
+- 판 지문을 손으로 맞추는 순서
+- 흔한 초대 실수 다섯
+- 가족과 같이 탈 때 이름이 갈린다는 것
+- 초대장이 바꾸지 않는 것
+
+은유와 정직 조항의 원래 문장은 유지했다. 채점 의미를 뒤집는 문장은
+넣지 않았다.
+
+### 3.3 규약과 기록
+
+- `gym/docs/tutorial.md` — 링크·프로파일·CR 키·REGISTRY 스냅샷·
+  금지 변경
+- `mydocs/working/gym_tutorial.md` — 이 기록
+
+### 3.4 시험
+
+`scripts/tests/test_gym_tutorial.py`
+
+- 필수 파일이 있다
+- 일곱 프로파일 JSON 의 id·packs 가 안내와 같다
+- 상대 링크가 저장소 안에서 풀린다
+- CR01~CR04 키와 명령이 휴게실에 있다
+- `REGISTRY` 가 열일곱 이름 그대로다
+- 안내가 checks.py 를 고친다고 말하지 않는다
+- PARK/INVITE/휴게실이 서로를 가리킨다
+- CI 워크플로가 이 시험을 호출한다
+- 링크를 지운 텍스트는 검사 함수가 문제를 낸다 (음성 회귀)
+
+### 3.5 CI
+
+`.github/workflows/ci.yml` 의 "Validate gym scorer contracts" 에
+`python3 -m unittest scripts/tests/test_gym_tutorial.py` 한 줄을
+더했다. 다른 gym 도구 시험 파일을 고치지 않았다.
+
+## 4. 의도적으로 하지 않은 일
+
+- casual-rides 에 CR05 를 만들지 않았다. 그 자리의 열린 PR 과
+  싸운다.
+- `gym/README.md` 의 만점 표(12 pack · 221점)를 고치지 않았다.
+  실제 pack 수는 그보다 많다. 숫자 갱신은 pack 확장 PR 의 일이다.
+- `maintainer.json` 을 고치지 않았다. 이미 전 pack 을 가리킨다.
+- `audit.py` 는 실행만 했고 수정하지 않았다.
+- 시각 검증·Rust 테스트는 해당 파일이 없다.
+
+## 5. 위험과 남은 구멍
+
+1. **예시 숫자.** CR01 문서의 `{"pages": 3}` 은 설명용이라고
+   여러 번 적었다. 그래도 붙여 넣는 방문자가 있을 수 있다. 라이브
+   오라클이 거절한다. 안내가 골든을 만들지는 않는다.
+2. **열린 pack PR.** 병합 후 입문존 과제 수가 4 가 아닐 수 있다.
+   휴게실은 CR01~CR04 만 잠근다. CR05+ 는 그 PR 의 README 가
+   맡는다.
+3. **프로파일에 없는 pack.** `table-csv` 등은 `--pack` 으로만
+   고른다. 이 기둥이 프로파일에 끼워 넣지 않았다.
+4. **링크 검사 범위.** 시험은 상대 경로 파일 존재만 본다. 헤딩
+   앵커와 외부 URL 은 보지 않는다. `check_markdown_links.py` 와
+   같은 범위다.
+5. **CI 한 줄.** 다른 가지가 같은 블록을 고치면 충돌할 수 있다.
+   충돌 시 우리 줄(`test_gym_tutorial.py`)만 남기면 된다.
+
+## 6. 재현
+
+격리 worktree: `C:\Users\swsz9\rhwp-gym-tutorial-park-docs`
+기준: `upstream/devel`
+브랜치: `feat/gym-tutorial-park-docs`
+
+```bash
+python -m unittest scripts.tests.test_gym_tutorial
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+## 7. 시험 목록 (클래스)
+
+| 클래스 | 고정하는 것 |
+|---|---|
+| `RequiredFilesTests` | 규약이 적은 문서가 디스크에 있다 |
+| `ProfileNameTests` | 일곱 id, 별명 금지, packs 매핑 |
+| `TutorialLinkTests` | 상대 링크가 풀린다, 허브가 서로를 가리킨다 |
+| `CasualRideContractTests` | CR01~CR04 명령·키·입력 |
+| `ScoringUntouchedTests` | REGISTRY · GLOBAL_SCAN_OPS · checks.py 불가침 문장 |
+| `HonestyClauseTests` | pack 별 점수, 라이브 오라클, unavailable |
+| `AdmissionContractTests` | allow ≠ 만점, packsScored |
+| `CiWiringTests` | ci.yml 이 이 시험을 호출한다 |
+| `NegativeGuardTests` | 깨진 링크·빠진 프로파일은 반드시 걸린다 |
+
+## 8. 크기 게이트
+
+이슈 DoD: `additions >= 3000` vs `upstream/devel`.
+
+허용에 가까운 경로:
+
+- `gym/tutorial/**`
+- `gym/docs/tutorial.md`
+- `mydocs/working/gym_tutorial.md`
+- `gym/PARK.md`
+- `gym/INVITE.md`
+- `scripts/tests/test_gym_tutorial.py`
+- `.github/workflows/ci.yml` (한 줄)
+
+`git add -A` 금지. 위 경로만 스테이징한다. 워킹트리에 다른 열린
+PR 의 pack JSON 이 나타나도 커밋에 넣지 않는다.
+
+## 9. 설계에서 버린 대안
+
+1. **casual-rides 에 읽기 과제 추가.** 이슈가 문서·시험을 말하고
+   열린 pack PR 과의 충돌을 금지한다. 과제는 그 PR 에 맡긴다.
+2. **프로파일 JSON 에 table-csv 등을 추가.** maintainer 가 이미
+   전 pack 을 가리킨다. family/starter 를 넓히면 입문 의미가
+   흐려진다.
+3. **checks.py 에 주석만 추가.** 이슈가 채점 논리 변경 금지를
+   걸었다. 주석도 그 파일의 책임 범위라 안 만진다.
+4. **gym/README.md 만점 표 갱신.** pack 확장 PR 과 숫자가 싸운다.
+5. **영문 휴게실.** 저장소 입문 표면은 한글이다. 번역은 후속.
+
+## 10. 로컬 명령 기록
+
+격리 worktree 에서 실행한 것:
+
+```
+python -m unittest scripts.tests.test_gym_tutorial
+python gym/tools/audit.py
+```
+
+`cargo fmt --all` 과 `cargo fmt --all -- --check` 는 돌리지 않았다.
+Rust 파일이 없다. 사용자 지시가 명시적으로 금지했다.
+
+`audit.py` 는 devel 의 pack 정합을 그대로 통과해야 한다. pack JSON
+을 이 가지가 만지지 않으므로 audit 실패는 회귀가 아니라 작업 트리
+오염이다.
+
+PR 본문은 한글, base 는 `devel`, `closes #5263`, `--body-file` 로
+보낸다.
+
+닫는 문장: 휴게실이 두꺼워져도 채점은 얇다. 안내가 연산자를 늘리지
+않는다.
+
+이상.
+
+(이 기록은 작업 메모다. 규약 정본은 `gym/docs/tutorial.md`.)

--- a/scripts/tests/test_gym_tutorial.py
+++ b/scripts/tests/test_gym_tutorial.py
@@ -1,0 +1,728 @@
+"""[#5263] gym 휴게실·PARK 입문 계약 — 링크·프로파일·채점 불가침.
+
+이 시험이 지키는 것:
+
+- `gym/tutorial/` · `gym/docs/tutorial.md` · `mydocs/working/gym_tutorial.md`
+  · `gym/PARK.md` · `gym/INVITE.md` 가 실재하고 서로를 가리킨다.
+- 프로파일 일곱 이름과 packs 묶음이 `gym/profiles/*.json` 과 같다.
+- 입문존 CR01~CR04 의 명령·답 키·입력이 안내에 그대로 있다.
+- `gym/core/checks.py` 의 `REGISTRY` 가 열일곱 이름 그대로다.
+  휴게실 작업이 채점 논리를 바꾸면 이 시험이 실패한다.
+
+바이너리 없이 순수 파일 검사다. 새 pack · 새 과제 JSON 을 만들지 않는다.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+TUTORIAL = GYM / "tutorial"
+PROFILES = GYM / "profiles"
+PACKS = GYM / "packs"
+CHECKS_PY = GYM / "core" / "checks.py"
+CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+INLINE_LINK_RE = re.compile(
+    r"!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^)\s]+))(?:\s+[^)]*)?\s*\)"
+)
+
+PROFILE_IDS = (
+    "family",
+    "starter",
+    "editor",
+    "publisher",
+    "operator",
+    "boss",
+    "maintainer",
+)
+
+PROFILE_PACKS = {
+    "family": ("casual-rides",),
+    "starter": ("core-cli", "self-description"),
+    "editor": ("core-cli", "text-editing", "table-editing", "objects-media"),
+    "publisher": ("serialization", "layout-rendering", "security"),
+    "operator": ("corpus-diagnostics", "automation"),
+    "boss": ("expert-challenges",),
+}
+
+CASUAL_RIDES = (
+    {
+        "id": "CR01",
+        "cmd": "info",
+        "input": "samples/table-001.hwp",
+        "oracle": "pageCount",
+        "answer": "pages",
+    },
+    {
+        "id": "CR02",
+        "cmd": "explain",
+        "input": "samples/table-001.hwp",
+        "oracle": "paragraphCount",
+        "answer": "paragraphs",
+    },
+    {
+        "id": "CR03",
+        "cmd": "export-tables",
+        "input": "samples/table-001.hwp",
+        "oracle": "tableCount",
+        "answer": "tables",
+    },
+    {
+        "id": "CR04",
+        "cmd": "search",
+        "input": "samples/table-001.hwp",
+        "oracle": "matchCount",
+        "answer": "hits",
+    },
+)
+
+TUTORIAL_PAGES = (
+    "README.md",
+    "01-admission.md",
+    "02-cr01-carousel.md",
+    "03-cr02-ferris.md",
+    "04-cr03-circus.md",
+    "05-cr04-ringtoss.md",
+    "06-profiles.md",
+    "07-starter-path.md",
+    "08-editor-path.md",
+    "09-publisher-path.md",
+    "10-operator-path.md",
+    "11-boss-path.md",
+    "12-leaderboard.md",
+    "13-invite.md",
+    "14-submissions.md",
+    "15-scoring-honesty.md",
+    "16-unavailable.md",
+    "17-faq.md",
+    "18-troubleshooting.md",
+    "19-windows.md",
+    "20-checklist.md",
+)
+
+REQUIRED_DOCS = (
+    GYM / "PARK.md",
+    GYM / "INVITE.md",
+    GYM / "docs" / "tutorial.md",
+    REPO_ROOT / "mydocs" / "working" / "gym_tutorial.md",
+)
+
+REGISTRY_SNAPSHOT = {
+    "same_hash",
+    "differs_from_input",
+    "file_exists",
+    "files_differ",
+    "xml_root_eq",
+    "json_value_eq",
+    "csv_cell_eq",
+    "utf8_bom",
+    "answer_eq",
+    "len_answer_eq",
+    "len_ge",
+    "value_eq",
+    "value_ge",
+    "value_in",
+    "deep_contains",
+    "not_contains",
+    "cell_text_eq",
+}
+
+FORBIDDEN_PROFILE_FLAGS = (
+    "--profile Family",
+    "--profile FAMILY",
+    "--profile casual",
+    "--profile beginner",
+    "--profile expert",
+    "--profile guest",
+    "--profile kiddie",
+    "--profile admin",
+)
+
+SCORING_MUTATION_PHRASES = (
+    "checks.py 를 고친다",
+    "checks.py를 고친다",
+    "REGISTRY 에 연산자를 추가",
+    "새 채점 연산자를 추가한다",
+    "unavailable 을 0점",
+    "unavailable을 0점",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _tutorial_text() -> str:
+    parts = [_read(TUTORIAL / name) for name in TUTORIAL_PAGES]
+    parts.append(_read(GYM / "docs" / "tutorial.md"))
+    parts.append(_read(GYM / "PARK.md"))
+    parts.append(_read(GYM / "INVITE.md"))
+    return "\n".join(parts)
+
+
+def iter_md_links(text: str):
+    """마크다운 인라인 링크의 (줄번호, 대상)을 낸다. 1-based."""
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for match in INLINE_LINK_RE.finditer(line):
+            dest = match.group(1) or match.group(2) or ""
+            dest = dest.strip()
+            if dest:
+                yield lineno, dest
+
+
+def is_internal_file_link(dest: str) -> bool:
+    if dest.startswith(("http://", "https://", "mailto:", "irc:")):
+        return False
+    if dest.startswith("#"):
+        return False
+    if dest.startswith("//"):
+        return False
+    return True
+
+
+def dest_path(dest: str) -> str:
+    return dest.split("#", 1)[0].split("?", 1)[0]
+
+
+def broken_relative_links(source: Path, text: str | None = None) -> list[str]:
+    """source 기준 상대 링크 중 디스크에 없는 대상을 모은다."""
+    text = _read(source) if text is None else text
+    problems = []
+    for lineno, dest in iter_md_links(text):
+        if not is_internal_file_link(dest):
+            continue
+        rel = dest_path(dest)
+        if not rel:
+            continue
+        resolved = (source.parent / rel).resolve()
+        try:
+            resolved.relative_to(REPO_ROOT.resolve())
+        except ValueError:
+            problems.append(f"{source.relative_to(REPO_ROOT)}:{lineno} 저장소 밖 {dest}")
+            continue
+        if not resolved.exists():
+            problems.append(
+                f"{source.relative_to(REPO_ROOT)}:{lineno} 없는 파일 {dest} → {resolved}"
+            )
+    return problems
+
+
+def load_checks():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import checks  # noqa: WPS433
+
+    return checks
+
+
+def pack_ids() -> list[str]:
+    return sorted(p.name for p in PACKS.iterdir() if (p / "pack.json").is_file())
+
+
+class RequiredFilesTests(unittest.TestCase):
+    def test_tutorial_pages_exist(self):
+        missing = [name for name in TUTORIAL_PAGES if not (TUTORIAL / name).is_file()]
+        self.assertEqual(missing, [], f"휴게실 페이지 없음: {missing}")
+
+    def test_required_docs_exist(self):
+        missing = [str(p.relative_to(REPO_ROOT)) for p in REQUIRED_DOCS if not p.is_file()]
+        self.assertEqual(missing, [], f"필수 문서 없음: {missing}")
+
+    def test_tutorial_readme_is_not_the_only_page(self):
+        pages = [p for p in TUTORIAL.glob("*.md") if p.is_file()]
+        self.assertGreaterEqual(len(pages), 20, "휴게실이 다시 한 장으로 줄었다")
+
+    def test_docs_tutorial_declares_canonical(self):
+        text = _read(GYM / "docs" / "tutorial.md")
+        self.assertIn("canonical: gym/docs/tutorial.md", text)
+        self.assertIn("scripts/tests/test_gym_tutorial.py", text)
+
+    def test_working_note_points_at_issue(self):
+        text = _read(REPO_ROOT / "mydocs" / "working" / "gym_tutorial.md")
+        self.assertIn("#5263", text)
+        self.assertIn("feat/gym-tutorial-park-docs", text)
+        self.assertIn("audit.py", text)
+
+
+class ProfileNameTests(unittest.TestCase):
+    def test_seven_profile_files_exist(self):
+        for pid in PROFILE_IDS:
+            path = PROFILES / f"{pid}.json"
+            self.assertTrue(path.is_file(), f"프로파일 파일 없음: {path}")
+
+    def test_profile_ids_match_filenames(self):
+        for pid in PROFILE_IDS:
+            data = _load_json(PROFILES / f"{pid}.json")
+            self.assertEqual(data["id"], pid)
+            self.assertEqual(data["kind"], "gymProfile")
+            self.assertTrue(data["packs"], pid)
+
+    def test_named_profile_pack_lists_match_json(self):
+        for pid, expected in PROFILE_PACKS.items():
+            data = _load_json(PROFILES / f"{pid}.json")
+            self.assertEqual(tuple(data["packs"]), expected, pid)
+
+    def test_maintainer_covers_every_pack(self):
+        data = _load_json(PROFILES / "maintainer.json")
+        self.assertEqual(sorted(data["packs"]), pack_ids())
+
+    def test_no_extra_profile_files(self):
+        on_disk = sorted(p.stem for p in PROFILES.glob("*.json"))
+        self.assertEqual(on_disk, sorted(PROFILE_IDS))
+
+    def test_hub_documents_list_all_profile_ids(self):
+        hubs = (
+            _read(TUTORIAL / "README.md"),
+            _read(TUTORIAL / "06-profiles.md"),
+            _read(GYM / "docs" / "tutorial.md"),
+            _read(GYM / "PARK.md"),
+        )
+        for text in hubs:
+            for pid in PROFILE_IDS:
+                self.assertIn(pid, text, f"{pid} 가 허브에서 빠졌다")
+
+    def test_readme_has_profile_cli_flags(self):
+        text = _read(TUTORIAL / "README.md")
+        for pid in PROFILE_IDS:
+            self.assertIn(f"--profile {pid}", text, pid)
+
+    def test_forbidden_profile_flags_are_not_commands(self):
+        """오타 프로파일을 실행 예로 주면 입구에서 넘어진다.
+
+        '쓰지 마라'는 설명에 철자가 등장할 수는 있다. `--profile Family`
+        처럼 플래그 형태로 권하면 안 된다.
+        """
+        command_blobs = []
+        for name in TUTORIAL_PAGES:
+            text = _read(TUTORIAL / name)
+            command_blobs.extend(re.findall(r"```(?:bash|powershell)?\n(.*?)```", text, re.S))
+        joined = "\n".join(command_blobs)
+        for flag in FORBIDDEN_PROFILE_FLAGS:
+            self.assertNotIn(flag, joined, f"실행 예에 금지 플래그: {flag}")
+
+    def test_family_selects_only_casual_rides(self):
+        data = _load_json(PROFILES / "family.json")
+        self.assertEqual(data["packs"], ["casual-rides"])
+
+    def test_boss_selects_only_expert_challenges(self):
+        data = _load_json(PROFILES / "boss.json")
+        self.assertEqual(data["packs"], ["expert-challenges"])
+
+
+class TutorialLinkTests(unittest.TestCase):
+    def test_all_tutorial_relative_links_resolve(self):
+        problems = []
+        for name in TUTORIAL_PAGES:
+            problems.extend(broken_relative_links(TUTORIAL / name))
+        self.assertEqual(problems, [], "\n".join(problems))
+
+    def test_park_invite_docs_links_resolve(self):
+        problems = []
+        for path in (
+            GYM / "PARK.md",
+            GYM / "INVITE.md",
+            GYM / "docs" / "tutorial.md",
+            REPO_ROOT / "mydocs" / "working" / "gym_tutorial.md",
+        ):
+            problems.extend(broken_relative_links(path))
+        self.assertEqual(problems, [], "\n".join(problems))
+
+    def test_readme_indexes_every_tutorial_page(self):
+        text = _read(TUTORIAL / "README.md")
+        for name in TUTORIAL_PAGES:
+            if name == "README.md":
+                continue
+            self.assertIn(f"]({name})", text, f"색인에 {name} 링크 없음")
+
+    def test_park_points_at_tutorial_and_invite_and_docs(self):
+        text = _read(GYM / "PARK.md")
+        self.assertIn("tutorial/README.md", text)
+        self.assertIn("INVITE.md", text)
+        self.assertIn("docs/tutorial.md", text)
+
+    def test_invite_points_at_tutorial_and_park(self):
+        text = _read(GYM / "INVITE.md")
+        self.assertIn("tutorial/README.md", text)
+        self.assertIn("PARK.md", text)
+
+    def test_tutorial_readme_points_at_park_invite_docs(self):
+        text = _read(TUTORIAL / "README.md")
+        self.assertIn("../PARK.md", text)
+        self.assertIn("../INVITE.md", text)
+        self.assertIn("../docs/tutorial.md", text)
+
+    def test_docs_point_at_working_note(self):
+        text = _read(GYM / "docs" / "tutorial.md")
+        self.assertIn("mydocs/working/gym_tutorial.md", text)
+
+    def test_broken_link_helper_flags_missing_target(self):
+        fake = "# x\n\n[없음](does-not-exist-5263.md)\n"
+        problems = broken_relative_links(TUTORIAL / "README.md", fake)
+        self.assertTrue(any("does-not-exist-5263.md" in p for p in problems), problems)
+
+    def test_broken_link_helper_accepts_existing_relative(self):
+        ok = "# x\n\n[지도](../PARK.md)\n"
+        self.assertEqual(broken_relative_links(TUTORIAL / "README.md", ok), [])
+
+    def test_external_links_are_ignored_by_file_checker(self):
+        text = "# x\n\n[웹](https://example.com/nope)\n"
+        self.assertEqual(broken_relative_links(TUTORIAL / "README.md", text), [])
+
+
+class CasualRideContractTests(unittest.TestCase):
+    def test_task_json_still_matches_tutorial_table(self):
+        """안내가 과제 JSON 과 어긋나면 방문자가 틀린 키를 낸다.
+
+        이 시험은 과제 JSON 을 고치지 않는다. 읽어서 안내와 같은지만 본다.
+        """
+        for ride in CASUAL_RIDES:
+            task = _load_json(PACKS / "casual-rides" / "tasks" / f"{ride['id']}.json")
+            self.assertEqual(task["id"], ride["id"])
+            self.assertEqual(task["tier"], 1)
+            self.assertEqual(task["input"], ride["input"])
+            self.assertEqual(task["submit"]["kind"], "answer")
+            check = task["checks"][0]
+            self.assertEqual(check["op"], "answer_eq")
+            self.assertEqual(check["answer"], ride["answer"])
+            self.assertEqual(check["path"], ride["oracle"])
+            self.assertEqual(check["cmd"][0], ride["cmd"])
+
+    def test_tutorial_repeats_command_oracle_and_key(self):
+        text = _tutorial_text()
+        for ride in CASUAL_RIDES:
+            self.assertIn(ride["id"], text)
+            self.assertIn(ride["cmd"], text)
+            self.assertIn(ride["oracle"], text)
+            self.assertIn(f"`{ride['answer']}`", text)
+            self.assertIn(ride["input"], text)
+
+    def test_casual_requires_the_four_read_commands(self):
+        manifest = _load_json(PACKS / "casual-rides" / "pack.json")
+        self.assertEqual(
+            set(manifest["requires"]["commands"]),
+            {"info", "explain", "export-tables", "search"},
+        )
+
+    def test_cr_pages_exist_for_each_ride(self):
+        mapping = {
+            "CR01": "02-cr01-carousel.md",
+            "CR02": "03-cr02-ferris.md",
+            "CR03": "04-cr03-circus.md",
+            "CR04": "05-cr04-ringtoss.md",
+        }
+        for tid, name in mapping.items():
+            text = _read(TUTORIAL / name)
+            self.assertIn(tid, text)
+            self.assertIn(f"gym/packs/casual-rides/tasks/{tid}.json", text)
+
+    def test_tutorial_does_not_invent_cr05(self):
+        """다른 열린 PR 의 CR05+ 와 싸우지 않는다. 안내는 네 개만 잠근다."""
+        readme = _read(TUTORIAL / "README.md")
+        self.assertNotIn("CR05", readme)
+        self.assertIn("CR01", readme)
+        self.assertIn("CR04", readme)
+
+
+class ScoringUntouchedTests(unittest.TestCase):
+    def test_registry_matches_devel_snapshot(self):
+        checks = load_checks()
+        self.assertEqual(set(checks.REGISTRY), REGISTRY_SNAPSHOT)
+
+    def test_registry_has_seventeen_operators(self):
+        checks = load_checks()
+        self.assertEqual(len(checks.REGISTRY), 17)
+        self.assertEqual(len(set(checks.REGISTRY)), 17)
+
+    def test_global_scan_ops_unchanged(self):
+        checks = load_checks()
+        self.assertEqual(checks.GLOBAL_SCAN_OPS, {"deep_contains", "not_contains"})
+
+    def test_needs_cli_partition_unchanged(self):
+        checks = load_checks()
+        file_ops = {name for name, (_fn, cli) in checks.REGISTRY.items() if not cli}
+        cli_ops = {name for name, (_fn, cli) in checks.REGISTRY.items() if cli}
+        self.assertEqual(
+            file_ops,
+            {
+                "same_hash",
+                "differs_from_input",
+                "file_exists",
+                "files_differ",
+                "xml_root_eq",
+                "json_value_eq",
+                "csv_cell_eq",
+                "utf8_bom",
+            },
+        )
+        self.assertEqual(
+            cli_ops,
+            {
+                "answer_eq",
+                "len_answer_eq",
+                "len_ge",
+                "value_eq",
+                "value_ge",
+                "value_in",
+                "deep_contains",
+                "not_contains",
+                "cell_text_eq",
+            },
+        )
+
+    def test_honesty_page_lists_every_registry_name(self):
+        text = _read(TUTORIAL / "15-scoring-honesty.md")
+        for name in sorted(REGISTRY_SNAPSHOT):
+            self.assertIn(f"`{name}`", text, name)
+
+    def test_docs_snapshot_lists_every_registry_name(self):
+        text = _read(GYM / "docs" / "tutorial.md")
+        for name in sorted(REGISTRY_SNAPSHOT):
+            self.assertIn(name, text, name)
+
+    def test_tutorial_markdown_does_not_define_op_functions(self):
+        for name in TUTORIAL_PAGES:
+            text = _read(TUTORIAL / name)
+            self.assertNotRegex(text, r"^def op_", f"{name} 이 연산자를 구현한다")
+
+    def test_guides_do_not_claim_to_edit_checks(self):
+        text = _tutorial_text()
+        for phrase in SCORING_MUTATION_PHRASES:
+            self.assertNotIn(phrase, text, phrase)
+
+    def test_guides_say_checks_are_out_of_scope(self):
+        text = _tutorial_text()
+        self.assertIn("gym/core/checks.py", text)
+        self.assertRegex(text, r"바꾸지 않는다|고치지 않는다|불가침")
+
+    def test_checks_py_still_lives_at_canonical_path(self):
+        self.assertTrue(CHECKS_PY.is_file())
+        source = _read(CHECKS_PY)
+        self.assertIn("REGISTRY = {", source)
+        self.assertIn('GLOBAL_SCAN_OPS = {"deep_contains", "not_contains"}', source)
+        for name in REGISTRY_SNAPSHOT:
+            self.assertIn(f'"{name}"', source, name)
+
+
+class HonestyClauseTests(unittest.TestCase):
+    def test_park_keeps_four_honesty_claims(self):
+        text = _read(GYM / "PARK.md")
+        self.assertIn("장식", text)
+        self.assertIn("라이브 오라클", text)
+        self.assertIn("unavailable", text)
+        self.assertIn("총점은 편의값", text)
+
+    def test_honesty_page_repeats_live_oracle(self):
+        text = _read(TUTORIAL / "15-scoring-honesty.md")
+        self.assertIn("라이브", text)
+        self.assertIn("골든", text)
+        self.assertIn("unavailable", text)
+        self.assertIn("총점은 편의값", text)
+
+    def test_unavailable_page_rejects_zero_disguise(self):
+        text = _read(TUTORIAL / "16-unavailable.md")
+        self.assertIn("0점이 아닌 부재", text)
+        self.assertIn("missingCommands", text)
+        self.assertIn("packsScored", text)
+
+    def test_park_still_has_mermaid_map(self):
+        text = _read(GYM / "PARK.md")
+        self.assertIn("```mermaid", text)
+        self.assertIn("casual-rides", text)
+        self.assertIn("expert-challenges", text)
+
+
+class AdmissionContractTests(unittest.TestCase):
+    def test_admission_kind_and_allow_rule_are_documented(self):
+        blobs = (
+            _read(TUTORIAL / "01-admission.md"),
+            _read(GYM / "docs" / "tutorial.md"),
+        )
+        joined = "\n".join(blobs)
+        self.assertIn("gymAdmission", joined)
+        self.assertIn("packsScored", joined)
+        self.assertIn("allow", joined)
+        self.assertIn("deny", joined)
+
+    def test_admission_is_not_perfect_score(self):
+        text = _read(TUTORIAL / "01-admission.md")
+        self.assertIn("만점", text)
+        self.assertIn("입장 거부", text)
+
+    def test_score_py_allow_rule_unchanged(self):
+        source = _read(GYM / "score.py")
+        self.assertIn('verdict": "allow" if card["total"]["packsScored"] >= 1 else "deny"', source)
+
+
+class StarterPathContractTests(unittest.TestCase):
+    def test_starter_first_tasks_still_exist(self):
+        self.assertTrue((PACKS / "core-cli" / "tasks" / "T01.json").is_file())
+        self.assertTrue((PACKS / "core-cli" / "tasks" / "T02.json").is_file())
+        self.assertTrue((PACKS / "self-description" / "tasks" / "SD01.json").is_file())
+
+    def test_starter_guide_names_those_tasks(self):
+        text = _read(TUTORIAL / "07-starter-path.md")
+        self.assertIn("T01", text)
+        self.assertIn("T02", text)
+        self.assertIn("SD01", text)
+        self.assertIn("pages", text)
+        self.assertIn("matchCount", text)
+        self.assertIn("commands", text)
+
+    def test_t01_is_still_pagecount_on_a_different_sample(self):
+        task = _load_json(PACKS / "core-cli" / "tasks" / "T01.json")
+        self.assertEqual(task["checks"][0]["path"], "pageCount")
+        self.assertNotEqual(task["input"], "samples/table-001.hwp")
+
+    def test_editor_guide_names_existing_first_tasks(self):
+        text = _read(TUTORIAL / "08-editor-path.md")
+        for tid in ("TE01", "TB01", "OM01"):
+            self.assertIn(tid, text)
+            self.assertTrue((PACKS / {
+                "TE01": "text-editing",
+                "TB01": "table-editing",
+                "OM01": "objects-media",
+            }[tid] / "tasks" / f"{tid}.json").is_file())
+
+    def test_publisher_guide_names_existing_first_tasks(self):
+        text = _read(TUTORIAL / "09-publisher-path.md")
+        for tid, pack in (("SR01", "serialization"), ("LR01", "layout-rendering"),
+                          ("SE01", "security")):
+            self.assertIn(tid, text)
+            self.assertTrue((PACKS / pack / "tasks" / f"{tid}.json").is_file())
+
+    def test_operator_and_boss_guides_name_existing_first_tasks(self):
+        op = _read(TUTORIAL / "10-operator-path.md")
+        boss = _read(TUTORIAL / "11-boss-path.md")
+        self.assertIn("CD01", op)
+        self.assertIn("AU01", op)
+        self.assertIn("XC01", boss)
+        self.assertTrue((PACKS / "corpus-diagnostics" / "tasks" / "CD01.json").is_file())
+        self.assertTrue((PACKS / "automation" / "tasks" / "AU01.json").is_file())
+        self.assertTrue((PACKS / "expert-challenges" / "tasks" / "XC01.json").is_file())
+
+
+class WindowsAndInviteTests(unittest.TestCase):
+    def test_windows_page_has_bom_free_utf8(self):
+        text = _read(TUTORIAL / "19-windows.md")
+        self.assertIn("UTF8Encoding", text)
+        self.assertIn("without BOM", text)
+        self.assertIn("New-Item", text)
+        self.assertIn("--profile family", text)
+
+    def test_windows_page_keeps_answer_keys(self):
+        text = _read(TUTORIAL / "19-windows.md")
+        for key in ("pages", "paragraphs", "tables", "hits"):
+            self.assertIn(key, text)
+
+    def test_invite_guide_and_canonical_share_fingerprint_keys(self):
+        invite = _read(GYM / "INVITE.md")
+        lounge = _read(TUTORIAL / "13-invite.md")
+        for key in (
+            "members",
+            "ledgerEntries",
+            "merkleRoot",
+            "workorderSha256",
+            "ledgerSnapshotSha256",
+        ):
+            self.assertIn(key, invite, key)
+            self.assertIn(key, lounge, key)
+
+    def test_invite_is_guidance_not_permission(self):
+        text = _read(GYM / "INVITE.md") + _read(TUTORIAL / "13-invite.md")
+        self.assertIn("권한이 아니라 안내", text)
+        self.assertIn("attest", text)
+
+
+class CiWiringTests(unittest.TestCase):
+    def test_ci_invokes_tutorial_contract(self):
+        text = _read(CI_YML)
+        self.assertIn("scripts/tests/test_gym_tutorial.py", text)
+
+    def test_ci_still_invokes_audit_and_packs(self):
+        text = _read(CI_YML)
+        self.assertIn("scripts/tests/test_gym_audit.py", text)
+        self.assertIn("scripts/tests/test_gym_packs.py", text)
+
+
+class NegativeGuardTests(unittest.TestCase):
+    def test_missing_profile_id_is_caught_by_hub_assertion_shape(self):
+        """허브에서 이름 하나가 빠지면 프로파일 시험이 실패해야 한다."""
+        text = _read(TUTORIAL / "06-profiles.md")
+        for pid in PROFILE_IDS:
+            self.assertIn(f"`{pid}`", text)
+
+    def test_link_checker_reports_line_number(self):
+        fake = "한 줄\n두 줄\n[깨짐](missing-page.md)\n"
+        problems = broken_relative_links(TUTORIAL / "README.md", fake)
+        self.assertTrue(any(":3 " in p or ":3" in p for p in problems), problems)
+
+    def test_registry_snapshot_rejects_added_operator(self):
+        checks = load_checks()
+        mutated = set(checks.REGISTRY) | {"brand_new_op_5263"}
+        self.assertNotEqual(mutated, REGISTRY_SNAPSHOT)
+
+    def test_registry_snapshot_rejects_removed_operator(self):
+        checks = load_checks()
+        mutated = set(checks.REGISTRY) - {"answer_eq"}
+        self.assertNotEqual(mutated, REGISTRY_SNAPSHOT)
+
+
+class FrontMatterTests(unittest.TestCase):
+    def test_tutorial_pages_declare_readme_canonical(self):
+        for name in TUTORIAL_PAGES:
+            text = _read(TUTORIAL / name)
+            self.assertTrue(text.startswith("---\n"), name)
+            self.assertIn("kind: guide", text)
+            self.assertIn("status: active", text)
+            self.assertIn("canonical: gym/tutorial/README.md", text)
+
+    def test_docs_and_working_have_front_matter(self):
+        docs = _read(GYM / "docs" / "tutorial.md")
+        working = _read(REPO_ROOT / "mydocs" / "working" / "gym_tutorial.md")
+        self.assertIn("kind: guide", docs)
+        self.assertIn("kind: working", working)
+        self.assertIn("last_verified: 2026-08-18", docs)
+        self.assertIn("last_verified: 2026-08-18", working)
+
+
+class ScopeGuardTests(unittest.TestCase):
+    """이 기둥이 pack 과제 JSON 을 늘리지 않았는지 느슨히 확인한다.
+
+    다른 PR 이 devel 에 합쳐지면 과제 수는 늘어날 수 있다. 여기서
+    잠그는 것은 '이 시험 파일이 새 과제를 전제로 쓰지 않는다'와
+    '입문 안내가 CR01~CR04 만 가리킨다'다.
+    """
+
+    def test_casual_rides_on_this_tree_still_has_four_committed_tasks(self):
+        tasks = sorted((PACKS / "casual-rides" / "tasks").glob("CR*.json"))
+        # devel 기준 4개. 다른 PR 이 합쳐지면 늘어날 수 있어 하한만 둔다.
+        self.assertGreaterEqual(len(tasks), 4)
+        ids = {p.stem for p in tasks}
+        self.assertTrue({"CR01", "CR02", "CR03", "CR04"}.issubset(ids))
+
+    def test_working_note_forbids_pack_json_edits(self):
+        text = _read(REPO_ROOT / "mydocs" / "working" / "gym_tutorial.md")
+        self.assertIn("pack 과제 JSON", text)
+        self.assertIn("고치지 않는다", text)
+        self.assertIn("git add -A", text)
+
+    def test_docs_forbid_new_operator_and_new_pack(self):
+        text = _read(GYM / "docs" / "tutorial.md")
+        self.assertIn("새 pack", text)
+        self.assertIn("새 채점 연산자", text)
+        self.assertIn("cargo fmt --all", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

gym 휴게실(`tutorial/`)을 5분 안내 한 장에서 입문 동선 세트로 늘리고, 테마파크 지도와 초대장에 실제 온보딩 절을 보탠다. 프로파일 일곱 이름·상대 링크·채점 불가침을 시험이 잠근다. 채점 논리와 다른 열린 PR 의 pack 과제 JSON 은 만지지 않았다.

- 휴게실 01~20: 입장 봉투, CR01~CR04 손타기, 일곱 프로파일, casual 바깥 `starter`/`editor`/`publisher`/`operator`/`boss` 첫 과제(기존 JSON 만 읽음), 전당·초대, 제출 자리, 정직 조항, Windows PowerShell
- `gym/docs/tutorial.md` — 링크·프로파일·REGISTRY 스냅샷 규약
- `mydocs/working/gym_tutorial.md` — 작업 기록
- `gym/PARK.md` · `gym/INVITE.md` — 첫 방문 동선, 프로파일 표, 손님별 첫 줄. 은유와 정직 조항은 유지
- `scripts/tests/test_gym_tutorial.py` — 파일 존재, 프로파일 이름, 상대 링크, CR 키, `REGISTRY` 열일곱, CI 배선
- `gym/core/checks.py` 와 pack 과제 JSON 은 변경 없음. `cargo fmt --all` 은 돌리지 않음

## 관련 이슈

closes #5263

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_tutorial` — 68 ran, 0 failed
- [x] `python gym/tools/audit.py` — 18 pack 통과
- [ ] **`cargo fmt --all -- --check` 통과** (이번 변경은 Python/문서만. 사용자 지시에 따라 생략)
- [ ] `cargo test` 통과 (해당 없음)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 단위 시험과 `audit.py` 는 바이너리 없이 돈다. 채점 연산자와 pack 과제는 그대로다.
