### PR TITLE
gym: build_baseline 자리표·부재 산출·실패 보고 고도화

### DIFF
--- a/gym/docs/build_baseline.md
+++ b/gym/docs/build_baseline.md
@@ -1,0 +1,556 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/build_baseline.md
+last_verified: 2026-08-18
+---
+
+# gym 기준 풀이 조립기 규약
+
+이 문서는 `gym/tools/build_baseline.py` 의 **자리표 치환**, **경로 안전**,
+**부재 산출**, **실패 보고**, **기준 풀이 스텝**, **왕복 요약**을 고정한다.
+작업 기록은
+[`mydocs/working/gym_build_baseline.md`](../../mydocs/working/gym_build_baseline.md)
+를 본다. 시험 계약은
+`scripts/tests/test_gym_build_baseline.py` 와
+`scripts/tests/test_gym_packs.py` 의 `BaselineResolveTests` 가 기계로
+고정한다.
+
+트라젝토리 감사(`trajectory.py`)는 이 조립기를 재사용한다. 부분
+트라젝토리도 같은 `build_task` · 같은 `resolve` 를 탄다. 조립기의
+공개 서명(`resolve` · `build_task` · `verify_built_task`)을 바꾸면
+감사 계약이 깨진다. 이 문서는 그 서명을 유지한 채 예외 자리를
+연다.
+
+CLI 플래그는 `--agent` · `--pack` · `--bin` 뿐이다. 새 플래그·새
+pack 을 이 도구에 붙이지 않는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+과제를 손으로 늘리면 "돌아가지 않는 과제" 가 섞인다. pack 이 늘어나는
+순간 그 위험은 pack 수만큼 커진다. 그래서 각 pack 은
+`reference/<과제ID>.json` 에 **기준 풀이**를 두고, 이 스크립트가 그것을
+실행해 제출물을 만든 뒤 곧바로 채점한다.
+
+신규 과제는 이 왕복을 통과해야만 등재된다. 저장소에 들어간 모든 과제는
+**풀 수 있음이 실측된 과제**다.
+
+기준 풀이는 정답 노출이므로 `reference/` 로 분리한다. 과제를 푸는
+에이전트는 이 폴더를 보지 않는 것이 규칙이다. 보더라도 측정되는 것은
+"스스로 경로를 찾는 능력"이 아니게 될 뿐, 채점은 정직하게 돌아간다.
+
+왕복이 없으면 세 가지가 동시에 생긴다.
+
+1. 선언만 있고 돌지 않는 과제.
+2. 자리표를 한 개만 바꿔 다세대 계획서가 다음 입력을 잃는 과제.
+3. 생성은 됐는데 산출 파일이 없거나 채점이 실패한 과제를 성공으로
+   집계하는 보고.
+
+이 도구는 그 세 자리를 닫는다.
+
+## 2. 사용
+
+```bash
+python gym/tools/build_baseline.py --agent claude-fable-5
+python gym/tools/build_baseline.py --agent claude-fable-5 --pack core-cli
+python gym/tools/build_baseline.py --agent claude-fable-5 --pack text-editing --bin target/debug/rhwp
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--agent` | `claude-fable-5` | 제출 폴더 이름. `gym/submissions/<agent>/` |
+| `--pack` | 전 pack | 반복 가능. 지정한 pack 만 조립한다. |
+| `--bin` | 러너 탐색 | rhwp 바이너리. `runner.find_bin` 이 상대경로를 절대화한다. |
+
+새 플래그는 없다. `--json` / `--task` / `--limit` / `--out` /
+`--dry-run` 은 없다. 이 도구의 점는 **왕복을 실제로 돌리는 것**이다.
+한 과제만 골라 성공했다고 말하면 나머지 pack 의 구멍이 남는다. 한
+과제만 보고 싶을 때는 `--pack` 으로 pack 을 줄인다. 과제 ID 필터는
+넣지 않는다.
+
+종료 코드:
+
+| 코드 | 의미 |
+|---|---|
+| 0 | `failed == 0` |
+| 1 | 조립 오류·부재 산출·채점 실패가 한 건이라도 있다 |
+
+기준 풀이 파일이 없는 과제는 `skipped` 다. 실패가 아니다. 왕복
+요약의 "기준 풀이 없음" 칸이 그 수다.
+
+작업 디렉터리는 `gym/submissions/<agent>/<pack>/<task>/` 이다. 한
+과제를 다시 조립하면 그 폴더를 지우고 시작한다.
+
+## 3. 자리표 — 바꾸지 않는 칸
+
+`resolve(token, task, sub_dir)` 의 공개 서명은 그대로다. 토큰 분류는
+`classify_token` 이 여덟 칸으로 접는다.
+
+| 자리 | 토큰 예 | 하는 일 |
+|---|---|---|
+| `exact-input` | `{input}` | 과제 `input` 을 그대로 돌려준다. 경로 구분자는 원본. |
+| `exact-sub` | `{sub:edited.hwp}` | 제출 폴더 아래 경로. 부모 폴더를 만든다. 백슬래시는 이스케이프하지 않는다. |
+| `embedded-sub` | `{"o":"{sub:a}","p":"{sub:b}"}` | 문자열 안의 `{sub:}` 를 **전부** 바꾼다. 계획서 JSON 을 위해 백슬래시를 두 번 쓴다. |
+| `embedded-input` | `src={input}` | 문자열 안의 `{input}` 을 `/` 구분 경로로 바꾼다. |
+| `mixed` | `{"in":"{input}","out":"{sub:o}"}` | `{sub:}` 를 모두 바꾼 뒤 `{input}` 도 바꾼다. |
+| `literal` | `--json` | 그대로 둔다. |
+| `unclosed-sub` | `{sub:o.hwp` | `RuntimeError`. 전 왕복을 죽이지 않고 그 과제만 실패. |
+| `not-str` | `None` | 그대로 돌려준다. |
+
+다세대 계획서는 input·output 을 모두 `{sub:}` 로 가리킨다. 첫 하나만
+바꾸면 나머지가 리터럴로 남아 엉뚱한 이름의 파일이 생기고 다음 세대가
+입력을 잃는다. 이것이 #4664 의 계약이다. #5273 은 그 계약을 **세 개
+이상**과 **`{input}` 혼합**까지 연다.
+
+`extract_sub_names` 는 등장 순서를 유지하고 중복도 남긴다.
+`unique_sub_names` 는 등장 순서를 유지하되 한 번만 센다.
+`count_sub_placeholders` 는 중복을 포함해 센다.
+
+`has_unresolved_placeholder` 는 치환 뒤에 `{sub:` 또는 `{input}` 이
+남아 있으면 참이다. 시험이 치환 결과를 이 함수로 검사한다.
+
+## 4. 경로 안전
+
+`{sub:이름}` 의 이름은 제출 폴더 안의 상대경로만 허용한다.
+`normalize_rel` / `unsafe_rel_reason` 이 거절 이유를 카탈로그 단어로
+남긴다.
+
+| 이유 | 예 | 허용? |
+|---|---|---|
+| (없음) | `edited.hwp` · `capsules/work.json` | 예 |
+| `empty` | `""` · `"   "` · `"."` | 아니오 |
+| `not-str` | `None` · `3` | 아니오 |
+| `absolute` | `/tmp/x` | 아니오 |
+| `drive` | `C:/tmp/x` | 아니오 |
+| `unc` | `//server/share` | 아니오 |
+| `home` | `~/secret` | 아니오 |
+| `parent` | `../escape.hwp` | 아니오 |
+
+`.` 구간과 빈 구간은 접는다. `./edited.hwp` 는 `edited.hwp` 다.
+`a//b` 는 `a/b` 다.
+
+불안전 이름은 `RuntimeError("불안전 제출 경로 (parent): ...")` 다.
+`ValueError` 로 전 왕복을 죽이지 않는다. `main` 의 잡기 목록은
+`CATCHABLE_EXCEPTIONS` 이고 `ValueError` 도 포함한다. 닫히지 않은
+자리표는 구현이 `RuntimeError` 로 올린다.
+
+중첩 제출 경로(`capsules/…`)는 미리 만든다. 기준 풀이가 폴더 생성까지
+신경 쓰게 하면 풀이가 절차 잡음으로 지저분해진다. `join_sub_path(...,
+mkdir=True)` 가 부모를 만든다.
+
+`escape_json_path` 는 계획서 JSON 문자열 안에 넣을 때 백슬래시를 두 번
+쓴다. 토큰 전체가 `{sub:이름}` 인 자리(`exact-sub`)는 이스케이프하지
+않는다. 이 차이는 기존 기준 풀이·Windows 경로와 호환하기 위한 것이다.
+
+## 5. 기준 풀이 스텝
+
+`STEP_KINDS` 는 다섯 값이다. 시험이 이 튜플을 고정한다.
+
+| 키 | 하는 일 | 자리표 |
+|---|---|---|
+| `run` | rhwp 를 실행한다. `allowExits` 로 판정성 종료 코드를 허용한다. | 인자 각 칸 |
+| `copy` | `from` 을 `to` 로 복사한다. 상대 `from` 은 저장소 루트. 절대 `from` 은 그대로. | `from` · `to` |
+| `write_json` | 부속 JSON 을 쓴다. 본문의 `{input}` · `{sub:}` 를 치환한다. | `to` · `body` |
+| `keyring_from` | 발급한 키의 공개키로 키링을 조립한다. | `key` · `out` |
+| `answer` | 봉투에서 값을 길어 `answer.json` 에 합친다. `const` 는 라이브 호출 없이 쓴다. `len` 은 배열 길이가 답. | `cmd` |
+
+`allowExits` 는 스텝 키로 세지 않는다. `step_keys` 는 이 키를 빼고
+정렬한다. `step_kind` 는 `STEP_KINDS` 순서로 첫 알려진 키를 고른다.
+
+`classify_reference` 의 네 라벨:
+
+| 라벨 | 언제 |
+|---|---|
+| `ok` | `steps` 가 비지 않은 목록이고 모든 스텝이 알려진 키를 가진다 |
+| `empty-steps` | `steps` 가 `[]` |
+| `malformed-reference` | 기준 풀이가 객체가 아니거나 `steps` 가 목록이 아니다 |
+| `unknown-step` | 목록 안에 알려진 키가 없는 칸이 있다 |
+
+`validate_reference` 는 사람용 오류 문자열 목록을 돌려준다. 조립
+루프는 이 목록을 강제하지 않는다. 알 수 없는 스텝은 `build_task` 가
+`RuntimeError` 로 올린다. 검증 함수는 시험·문서가 같은 표를 보게
+하려고 있다.
+
+`collect_sub_names(reference)` 는 전 스텝을 걸어 `{sub:}` 이름을 등장
+순·중복 제거로 모은다. 이 목록을 `submit.files` 대신 요구 산출로
+승격하지 않는다. 중간 산출(키, 임시 hwp)까지 제출 계약으로 오인하기
+때문이다.
+
+## 6. 부재 산출
+
+생성 성공만으로 통과 처리하지 않는다. 과제가 `submit.files` 를
+선언했으면 그 파일이 제출 폴더에 있어야 한다.
+
+`expected_artifacts(task)` 는 `submit.files` 만 본다. 상대경로로 쓸 수
+있는 것만, 선언 순, 중복 제거. 불안전 칸은 버린다.
+
+`missing_artifacts(sub_dir, expected)` 는 expected 순서로, 파일이 아닌
+이름을 남긴다. 폴더만 있고 파일이 없으면 부재다.
+
+`missing_artifact_message(pack_id, task, sub_dir)` 는 한 줄이다.
+
+```
+pack-b/T02: 부재 산출: edited.hwp
+```
+
+여러 파일이면 쉼표로 잇는다.
+
+```
+pack-b/T02: 부재 산출: edited.hwp, plan.json
+```
+
+`inspect_built_task` 는 부재를 **채점 전에** 본다. 파일이 없으면
+`runner.score_task` 를 부르지 않는다. 없는 산출을 채점해 "제출 폴더
+없음" 이나 `file_exists` 실패로 덮지 않는다. 자리는
+`kind=missing-artifact` 다.
+
+`submit.files` 가 비었거나 answer 과제면 산출 검사를 건너뛴다.
+`answer.json` 은 이 목록에 넣지 않는다. `answer` 스텝이 답을 모으면
+조립기가 그 파일을 스스로 쓴다.
+
+## 7. 실패 보고
+
+`verify_built_task(bin_path, pack_id, task, sub_root)` 의 공개 서명은
+그대로다. 채점은 같은 pack 경로에서 한다.
+
+```
+runner.score_task(task, os.path.join(sub_root, pack_id), bin_path)
+```
+
+리터럴 `"/"` 로 붙이지 않는다. Windows 에서 백슬래시 결합과 어긋나
+크로스플랫폼으로 깨진다(#4689).
+
+`fold_score_result` 가 채점 봉투를 네 칸으로 접는다.
+
+| 자리 | 결과 | 한 줄 |
+|---|---|---|
+| `pass` 가 참 | 통과. 반환 `None` | (없음) |
+| `error` 필드 | 실패 | `pack/task: {error}` |
+| `checks` 중 `ok` 가 아닌 칸 | 실패 | `pack/task: 이름: 이유; ...` |
+| 비-dict · `pass` 키 없음 · 검사 목록 없음 | 실패 | `pack/task: 채점 결과가 dict 가 아니다` 또는 `채점 실패` |
+
+기존 계약 한 줄은 유지한다.
+
+```
+pack-b/T02: 제출 폴더 없음
+```
+
+검사 실패는 이름을 남긴다. 이름 없으면 `op`, 그것도 없으면 `검사`.
+이유 없으면 `판정 불일치`.
+
+```
+core-cli/T09: 1단계 반영: 없음; 2단계 반영: 없음
+```
+
+비-dict 채점 결과를 `result.get("pass")` 로 읽지 않는다. 그 자리는
+`AttributeError` 로 전 왕복을 죽일 수 있다. `score_is_pass` 가 비-dict
+를 실패로 접는다.
+
+`kind=failed-score` 는 채점이 거부한 자리이지, 조립이 죽은 자리가
+아니다. 조립 예외는 `kind=build-error` 다.
+
+## 8. 왕복 루프
+
+`process_one_task` 가 한 과제를 조립·검증하고 집계를 갱신한다.
+
+| 자리 | `kind` | 집계 |
+|---|---|---|
+| 조립 예외 | `build-error` | `failed` + `buildError` |
+| 부재 산출 | `missing-artifact` | `failed` + `missingArtifact` |
+| 채점 실패 | `failed-score` | `failed` + `failedScore` |
+| 통과 | `ok` | `built` |
+| 기준 풀이 파일 없음 | (루프에서 continue) | `skipped` |
+
+사람용 한 줄은 예전 형식이다.
+
+```
+기준 풀이 왕복: 성공 12 · 실패 3 · 기준 풀이 없음 1
+```
+
+실패가 있으면 부가 줄을 붙인다.
+
+```
+  내역: 부재 산출 2 · 채점 실패 1 · 조립 오류 0
+```
+
+`failed` 가 0 이면 종료 코드 0, 아니면 1. `skipped` 는 종료 코드를
+뒤집지 않는다.
+
+`process_pack` 은 기준 풀이 폴더가 없으면 pack 전체를 건너뛰고
+`[pack] 기준 풀이 없음 — 건너뜀` 을 찍는다. 이 자리는 `skipped` 에
+넣지 않는다. 과제 단위 건너뜀과 pack 단위 부재를 섞지 않는다.
+
+기준 풀이 JSON 파싱이 죽으면 그 과제만 `build-error` 다. 다음 과제로
+간다. 한 파일이 전 왕복을 멈추지 않는다.
+
+## 9. 예외 — 삼키지 않는 자리, 죽이는 자리
+
+`CATCHABLE_EXCEPTIONS`:
+
+- `RuntimeError`
+- `OSError`
+- `KeyError`
+- `IndexError`
+- `TypeError`
+- `ValueError`
+- `json.JSONDecodeError`
+
+`FATAL_EXCEPTIONS` 는 다시 올린다.
+
+- `KeyboardInterrupt`
+- `SystemExit`
+- `MemoryError`
+- `GeneratorExit`
+
+닫히지 않은 `{sub:` 는 예전에는 `str.split("}", 1)` 이 `ValueError` 를
+올렸다. `main` 이 `ValueError` 를 잡지 않아 전 왕복이 죽었다. 지금은
+`RuntimeError` 로 올리고, 잡기 목록에도 `ValueError` 를 넣는다. 한
+과제의 자리표 오류가 나머지 pack 을 가리지 않는다.
+
+`FileNotFoundError` 는 `OSError` 의 하위라 조립 오류로 접힌다. 없는
+바이너리를 "채점 실패" 로 부르지 않는다. 그 자리는 조립이 시작되지
+못한 자리다.
+
+## 10. 공개 함수 — 시험이 고정하는 이름
+
+아래 이름은 문서·시험·도구가 같이 본다. 바꾸려면 시험을 먼저 바꾼다.
+
+자리표:
+
+- `classify_token`
+- `extract_sub_names` · `unique_sub_names` · `extract_placeholders`
+- `count_sub_placeholders` · `count_input_placeholders`
+- `has_unclosed_sub` · `has_unresolved_placeholder`
+- `resolve` · `resolve_args` · `resolve_write_json_body`
+
+경로:
+
+- `normalize_rel` · `unsafe_rel_reason` · `is_safe_sub_name`
+- `join_sub_path` · `escape_json_path`
+
+스텝:
+
+- `step_kind` · `classify_step` · `classify_reference`
+- `validate_step` · `validate_reference`
+- `collect_sub_names`
+
+산출:
+
+- `submit_files` · `expected_artifacts`
+- `missing_artifacts` · `artifact_status`
+- `missing_artifact_message` · `inspect_built_task`
+
+채점:
+
+- `score_is_pass` · `fold_score_result` · `failed_check_lines`
+- `score_failure_message` · `verify_built_task`
+
+집계:
+
+- `empty_counts` · `bump_count`
+- `format_summary` · `format_summary_detail` · `summary_exit`
+
+조립:
+
+- `build_task` · `process_one_task` · `process_pack` · `main`
+
+CLI:
+
+- `parse_args` · `cli_flag_names`
+- `CLI_FLAGS == ("--agent", "--pack", "--bin")`
+
+## 11. 하지 않는 것
+
+- 새 CLI 플래그를 붙이지 않는다.
+- 새 pack · 새 과제를 만들지 않는다.
+- `score.py` · `runner.py` 를 고치지 않는다. 채점 계약은 러너의
+  몫이다. 이 도구는 봉투를 접을 뿐이다.
+- `expert-challenges` · `studio-e2e` · `render-tree` · `tutorial` ·
+  `PARK.md` · `release_gate.py` 를 열지 않는다.
+- `trajectory.py` 가 의존하는 `build_task` · `resolve` 서명을 바꾸지
+  않는다.
+- `{sub:}` 이름을 `submit.files` 없이 요구 산출로 승격하지 않는다.
+- 기준 풀이 없는 과제를 실패로 부르지 않는다. 그 자리는 `skipped` 다.
+
+## 12. 기존 세 계약 (#4664 · #4689)
+
+`BaselineResolveTests` 가 이미 고정한 세 줄은 그대로다.
+
+1. 한 문자열의 여러 `{sub:}` 를 모두 바꾼다. 치환 뒤에 `{sub:` 가
+   남으면 실패.
+2. `verify_built_task` 는 `score_task(task, join(sub_root, pack), bin)`
+   을 한 번 부른다.
+3. `{"pass": false, "error": "제출 폴더 없음"}` 은
+   `pack-b/T02: 제출 폴더 없음` 이다.
+
+#5273 이 더하는 세 줄:
+
+4. `{sub:}` 가 세 개여도 전부 바꾼다.
+5. `submit.files` 가 선언한 파일이 없으면 채점 전에
+   `pack/task: 부재 산출: 이름` 을 남긴다. `score_task` 는 부르지
+   않는다.
+6. 채점 실패는 검사 이름을 남긴다.
+   `core-cli/T09: 1단계 반영: 없음`.
+
+## 13. write_json 본문
+
+`write_json.body` 는 JSON 객체다. 조립기는 `json.dumps` 한 뒤
+`{input}` 을 `/` 구분 입력 경로로 바꾸고, `{sub:}` 가 있으면 제출
+경로로 바꾼 다음 `json.loads` 로 되돌린다.
+
+자리표가 없는 본문은 라운드트립이다. 키 순서는 `json.dumps` 기본이다.
+본문 의미가 바뀌지 않으면 된다.
+
+`to` 는 `resolve` 를 탄다. `{sub:plan.json}` 이면 제출 폴더에
+`plan.json` 을 쓴다.
+
+## 14. copy · keyring_from
+
+`copy.from` 이 상대 경로이거나 `{input}` 이면 저장소 루트 아래에
+붙인다. 이미 절대 경로면 그대로 쓴다. 시험이 임시 파일을 절대 경로로
+심을 수 있게 하려는 자리다.
+
+`copy.to` 는 `{sub:이름}` 이다. 부모 폴더를 만든다.
+
+`keyring_from` 은 `key` JSON 의 `publicKey` 를 읽어 키링을 쓴다.
+`schemaVersion` 은 `"1.0"`, `kind` 는 `"keyring"`, `revoked` 는
+`null` 이다. `keyId` 는 기준 풀이가 준 문자열이다.
+
+## 15. answer.json
+
+`answer` 스텝이 하나라도 값을 모으면 `answer.json` 을 제출 폴더에
+쓴다. 값이 없으면 파일을 만들지 않는다.
+
+`const` 키는 라이브 호출 없이 그 값을 쓴다. `cmd` 키는 `run_step` 으로
+봉투를 받고 `dig(env, path)` 로 값을 긴다. `len` 이 참이면 배열
+길이가 답이다.
+
+답안 봉투 파싱이 실패하면
+`{task}: 답안 봉투 파싱 실패` 다. 빈 객체를 답으로 넣지 않는다.
+
+## 16. 보고 문구 카탈로그
+
+시험이 아래 문구의 머리를 고정한다. 번역하거나 꾸미지 않는다.
+
+| 자리 | 문구 |
+|---|---|
+| 왕복 요약 | `기준 풀이 왕복: 성공 N · 실패 M · 기준 풀이 없음 K` |
+| 실패 내역 | `  내역: 부재 산출 A · 채점 실패 B · 조립 오류 C` |
+| 부재 산출 | `{pack}/{task}: 부재 산출: {names}` |
+| 채점 error | `{pack}/{task}: {error}` |
+| 채점 검사 | `{pack}/{task}: {name}: {error}; ...` |
+| 채점 비-dict | `{pack}/{task}: 채점 결과가 dict 가 아니다` |
+| 채점 공란 | `{pack}/{task}: 채점 실패` |
+| 닫히지 않은 자리표 | `닫히지 않은 {sub:} 자리표: ...` |
+| 불안전 경로 | `불안전 제출 경로 ({reason}): ...` |
+| 알 수 없는 스텝 | `{task}: 알 수 없는 기준 풀이 단계 [...]` |
+| 답안 파싱 | `{task}: 답안 봉투 파싱 실패` |
+| pack 부재 | `[{pack}] 기준 풀이 없음 — 건너뜀` |
+| 과제 실패 줄 | `  X {message}` |
+
+## 17. 다른 기둥과의 경계
+
+| 도구 | 축 | 이 조립기와의 관계 |
+|---|---|---|
+| `score.py` | 종점 채점 | 부르지 않는다. `runner.score_task` 만 쓴다. |
+| `runner.py` | pack 로드·채점 | import 만. 수정하지 않는다. |
+| `trajectory.py` | 경로(마지막 스텝) | `build_task` 를 재사용한다. |
+| `discriminate.py` | 약한 오라클 | 음성 대조는 그쪽. 이 도구는 기준 풀이 양 대조. |
+| `audit.py` | pack 정합 | 기준 풀이 짝이 있는지만 본다. 왕복은 이쪽. |
+| `release_gate.py` | 릴리스 차단 | 열지 않는다. |
+
+판별력 감사는 "일 안 한 제출을 거부하는가" 를 묻는다. 이 조립기는
+"기준 풀이가 실제로 제출을 만들고 그 제출이 채점을 통과하는가" 를
+묻는다. 두 질문을 한 도구에 넣지 않는다.
+
+## 18. 검증
+
+```bash
+python -m unittest scripts.tests.test_gym_build_baseline scripts.tests.test_gym_packs.BaselineResolveTests
+python gym/tools/audit.py
+```
+
+바이너리 없이 자리표·부재 산출·실패 보고가 고정된다. 라이브 왕복
+(`--bin target/debug/rhwp`)은 기존처럼 rhwp 가 필요하다. 가드는 순수
+경로만 탄다.
+
+## 19. 실제 기준 풀이가 이 규약을 쓰는 자리
+
+아래는 devel 에 있는 기준 풀이다. 조립기가 자리표를 어떻게 읽는지
+고정하려고 인용한다. pack JSON 을 이 PR 이 바꾸지 않는다.
+
+### 19.1 TE01 — exact-input + exact-sub
+
+```
+edit replace-text {input} --find 규제 --replace 점검 -o {sub:edited.hwp} --json
+```
+
+`{input}` 은 과제 입력 경로 그대로다. `{sub:edited.hwp}` 는 제출
+폴더의 `edited.hwp` 다. 토큰이 각각 자리표 전체이므로 이스케이프하지
+않는다.
+
+### 19.2 T09 — 한 문자열의 `{sub:}` 하나
+
+`--plan-json` 인자 하나가 JSON 문자열이다. 그 안에
+`{sub:plan_out.hwp}` 가 박혀 있다. `classify_token` 은
+`embedded-sub` 다. 백슬래시 경로는 두 번 써서 JSON 이 깨지지 않는다.
+
+### 19.3 T10 — 같은 계획서가 두 세대를 가리킨다
+
+두 `run` 스텝이 각각 `{sub:o1.hwp}` · `{sub:o2.hwp}` 를 쓴다. 한
+토큰 안의 여러 `{sub:}` 는 T10 본문에는 없지만, 같은 패턴을 한
+문자열에 넣으면 `{"input":"{sub:o1.hwp}","output":"{sub:o2.hwp}"}`
+가 된다. #4664 가 그 자리를 열었고 #5273 이 세 개 이상을 시험으로
+고정한다.
+
+### 19.4 T14 — 중첩 제출 + 중간 산출
+
+`{sub:key.json}` · `{sub:work.capsule.json}` · `{sub:_o.hwp}` ·
+`{sub:anchor.ndjson}` · `{sub:keyring.json}` 이 한 기준 풀이에
+같이 있다. `submit.files` 는 `work.capsule.json` · `keyring.json` ·
+`anchor.ndjson` 뿐이다. `_o.hwp` 와 `key.json` 은 중간 산출이다.
+부재 산출 검사는 제출 계약만 본다.
+
+`{sub:capsules/work.json}` 처럼 폴더가 있으면 `join_sub_path` 가
+`capsules/` 를 만든다.
+
+## 20. 실패를 접는 순서
+
+한 과제에 대해 `process_one_task` 가 보는 순서다.
+
+1. `build_task` — 스텝을 앞에서 뒤로 적용. 여기서 죽으면
+   `build-error`. 산출 검사는 하지 않는다.
+2. `inspect_built_task`
+   1. `expected_artifacts` 가 비지 않고 `missing_artifacts` 가
+      있으면 `missing-artifact`. 채점하지 않는다.
+   2. `verify_built_task` → `score_task`.
+   3. `fold_score_result`. 통과가 아니면 `failed-score`.
+3. 집계를 갱신하고 `  X {message}` 를 찍는다.
+
+이 순서를 바꾸면 부재와 채점 실패가 다시 섞인다. 시험
+`test_missing_artifact_short_circuits_score` 가 2.1 을 고정한다.
+
+## 21. Windows 경로
+
+- `exact-sub` 의 반환은 `os.path.join` 이라 구분자가 `\` 일 수 있다.
+- `embedded-sub` 는 `escape_json_path` 로 `\` 를 `\\` 로 쓴다.
+  계획서 JSON 문자열이 `\` 한 번이면 파서가 이스케이프로 먹는다.
+- `embedded-input` 은 `task.input` 의 `\` 를 `/` 로 바꾼다. rhwp 가
+  입력을 `/` 로도 받기 때문이다.
+- 채점 경로는 `os.path.join(sub_root, pack_id)` 다. 리터럴 `"/"` 로
+  잇지 않는다(#4689).
+- `list_submission_files` 의 상대경로는 `/` 로 정규화한다. 시험이
+  `"n/a.txt"` 를 기대한.
+
+## 22. 용어
+
+| 말 | 뜻 |
+|---|---|
+| 자리표 | `{input}` 또는 `{sub:이름}` |
+| 기준 풀이 | `reference/<과제ID>.json` |
+| 왕복 | 조립 → 산출 확인 → 채점 |
+| 부재 산출 | 선언된 제출 파일이 없음 |
+| 실패 보고 | 채점이 거부한 한 줄 |
+| 중간 산출 | `{sub:}` 이지만 `submit.files` 가 아닌 파일 |
+| 제출 계약 | `task.submit.files` |
+| 공개 서명 | `resolve` · `build_task` · `verify_built_task` · `run_step` · `main` |

--- a/gym/tools/build_baseline.py
+++ b/gym/tools/build_baseline.py
@@ -31,10 +31,40 @@
   자리표를 쓴다. `allowExits` 로 판정성 종료 코드를 허용한다.
 - `answer` — 봉투에서 값을 길어 `answer.json` 에 합친다(라이브 재계산).
 - `copy` — 과제 입력이나 자산을 제출 폴더로 복사한다.
+- `write_json` — 부속 JSON(계획·정책)을 제출 폴더에 쓴다. 본문의 `{input}`
+  · `{sub:}` 도 치환한다.
+- `keyring_from` — 발급한 키의 공개키로 키링을 조립한다.
+
+자리표 규약(#4664, #5273):
+
+- 한 문자열의 `{sub:}` 는 **전부** 바꾼다. 첫 하나만 바꾸면 다세대
+  계획서의 나머지 자리표가 리터럴로 남아 엉뚱한 파일이 생긴다.
+- `{input}` 이 문자열 안에 박혀 있어도 바꾼다. 토큰 전체가 `{input}` 일
+  때만 바꾸던 자리는 계획서 JSON 에서 입력을 놓친다.
+- `{sub:}` 이름은 제출 폴더 안의 상대경로만 허용한다. 부모(`..`)·절대·
+  드라이브·UNC·홈은 거부한다.
+- 닫히지 않은 `{sub:` 는 그 과제만 실패로 접는다. `ValueError` 로
+  전 왕복을 죽이지 않는다.
+
+조립 뒤 두 자리(#5273):
+
+- **부재 산출** — `submit.files` 가 선언한 파일이 제출 폴더에 없으면
+  채점 전에 `missing-artifact` 로 보고한다. 생성 성공만으로 통과시키지
+  않는다.
+- **실패 보고** — 채점 봉투의 `pass` 가 참이 아니면 과제 ID 와 이유
+  (`error` 또는 실패한 검사 이름)를 남긴다. 비-dict·키 없음은 통과로
+  접지 않는다.
 
 사용:
   python gym/tools/build_baseline.py --agent claude-fable-5 [--pack <id>] [--bin <경로>]
+
+새 CLI 플래그·새 pack 은 없다. 시험은
+`scripts/tests/test_gym_build_baseline.py` 와
+`scripts/tests/test_gym_packs.py` 의 `BaselineResolveTests` 가 바이너리
+없이 고정한다. 규약 문서는 `gym/docs/build_baseline.md`.
 """
+
+from __future__ import annotations
 
 import argparse
 import io
@@ -58,149 +88,1062 @@ from gym.core.checks import dig  # noqa: E402
 ROOT = runner.ROOT
 PACKS_DIR = runner.PACKS_DIR
 
+PLACEHOLDER_INPUT = "{input}"
+PLACEHOLDER_SUB_PREFIX = "{sub:"
+PLACEHOLDER_SUB_CLOSE = "}"
+
+STEP_KINDS = ("run", "copy", "write_json", "keyring_from", "answer")
+KNOWN_STEP_KINDS = frozenset(STEP_KINDS)
+
+TOKEN_KINDS = (
+    "literal",
+    "exact-input",
+    "exact-sub",
+    "embedded-sub",
+    "embedded-input",
+    "mixed",
+    "unclosed-sub",
+    "not-str",
+)
+
+FAILURE_KINDS = (
+    "ok",
+    "missing-artifact",
+    "failed-score",
+    "build-error",
+    "missing-reference",
+    "malformed-reference",
+    "unknown-step",
+    "unsafe-sub",
+    "unclosed-placeholder",
+    "empty-steps",
+)
+
+UNSAFE_REL_REASONS = (
+    "empty",
+    "not-str",
+    "absolute",
+    "drive",
+    "parent",
+    "unc",
+    "home",
+)
+
+REFERENCE_LABELS = (
+    "ok",
+    "empty-steps",
+    "malformed-reference",
+    "unknown-step",
+)
+
+COUNT_KEYS = (
+    "built",
+    "failed",
+    "skipped",
+    "missingArtifact",
+    "failedScore",
+    "buildError",
+)
+
+DEFAULT_ALLOW_EXITS = (0,)
+ERROR_HEAD_LIMIT = 300
+ANSWER_FILENAME = "answer.json"
+
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+CATCHABLE_EXCEPTIONS = (
+    RuntimeError,
+    OSError,
+    KeyError,
+    IndexError,
+    TypeError,
+    ValueError,
+    json.JSONDecodeError,
+)
+
+CLI_FLAGS = ("--agent", "--pack", "--bin")
+
+
+def is_fatal_exception(exc) -> bool:
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def is_str(value) -> bool:
+    return isinstance(value, str)
+
+
+def as_text(value) -> str | None:
+    if not is_str(value):
+        return None
+    return value
+
+
+def placeholder_input() -> str:
+    return PLACEHOLDER_INPUT
+
+
+def placeholder_sub(name: str) -> str:
+    return f"{PLACEHOLDER_SUB_PREFIX}{name}{PLACEHOLDER_SUB_CLOSE}"
+
+
+def is_exact_input(token) -> bool:
+    return token == PLACEHOLDER_INPUT
+
+
+def is_exact_sub(token) -> bool:
+    if not is_str(token):
+        return False
+    return token.startswith(PLACEHOLDER_SUB_PREFIX) and token.endswith(
+        PLACEHOLDER_SUB_CLOSE) and token.count(PLACEHOLDER_SUB_PREFIX) == 1
+
+
+def has_sub_placeholder(token) -> bool:
+    return is_str(token) and PLACEHOLDER_SUB_PREFIX in token
+
+
+def has_input_placeholder(token) -> bool:
+    return is_str(token) and PLACEHOLDER_INPUT in token
+
+
+def has_unclosed_sub(token) -> bool:
+    """닫히지 않은 `{sub:` 가 남아 있는가. 순수."""
+    if not is_str(token):
+        return False
+    rest = token
+    while PLACEHOLDER_SUB_PREFIX in rest:
+        _head, rest = rest.split(PLACEHOLDER_SUB_PREFIX, 1)
+        if PLACEHOLDER_SUB_CLOSE not in rest:
+            return True
+        _name, rest = rest.split(PLACEHOLDER_SUB_CLOSE, 1)
+    return False
+
+
+def classify_token(token) -> str:
+    """한 토큰의 자리표 종류. 문서·시험이 같은 표를 본다."""
+    if not is_str(token):
+        return "not-str"
+    if has_unclosed_sub(token):
+        return "unclosed-sub"
+    if is_exact_input(token):
+        return "exact-input"
+    if is_exact_sub(token):
+        return "exact-sub"
+    has_sub = has_sub_placeholder(token)
+    has_input = has_input_placeholder(token) and not is_exact_input(token)
+    if has_sub and has_input:
+        return "mixed"
+    if has_sub:
+        return "embedded-sub"
+    if has_input:
+        return "embedded-input"
+    return "literal"
+
+
+def iter_sub_placeholders(token):
+    """문자열 안의 `{sub:이름}` 을 (이름, 시작, 끝) 으로 낸다. 닫히지 않으면 중단."""
+    if not is_str(token):
+        return
+    index = 0
+    while True:
+        start = token.find(PLACEHOLDER_SUB_PREFIX, index)
+        if start < 0:
+            return
+        close = token.find(PLACEHOLDER_SUB_CLOSE, start + len(PLACEHOLDER_SUB_PREFIX))
+        if close < 0:
+            return
+        name = token[start + len(PLACEHOLDER_SUB_PREFIX):close]
+        yield name, start, close + 1
+        index = close + 1
+
+
+def extract_sub_names(token) -> list[str]:
+    """등장 순서를 유지한 `{sub:}` 이름. 중복도 남긴다."""
+    return [name for name, _start, _end in iter_sub_placeholders(token)]
+
+
+def unique_sub_names(token) -> list[str]:
+    """등장 순서를 유지하되 중복은 한 번만."""
+    out = []
+    seen = set()
+    for name in extract_sub_names(token):
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def extract_placeholders(token) -> list[dict]:
+    """토큰 안의 자리표를 종류·이름과 함께 나열한다. 순수."""
+    if not is_str(token):
+        return []
+    found = []
+    index = 0
+    while index < len(token):
+        sub_at = token.find(PLACEHOLDER_SUB_PREFIX, index)
+        input_at = token.find(PLACEHOLDER_INPUT, index)
+        if sub_at < 0 and input_at < 0:
+            break
+        if input_at >= 0 and (sub_at < 0 or input_at < sub_at):
+            found.append({"kind": "input", "name": "", "start": input_at,
+                          "end": input_at + len(PLACEHOLDER_INPUT)})
+            index = input_at + len(PLACEHOLDER_INPUT)
+            continue
+        close = token.find(PLACEHOLDER_SUB_CLOSE, sub_at + len(PLACEHOLDER_SUB_PREFIX))
+        if close < 0:
+            found.append({"kind": "unclosed-sub", "name": token[sub_at + len(PLACEHOLDER_SUB_PREFIX):],
+                          "start": sub_at, "end": len(token)})
+            break
+        found.append({"kind": "sub",
+                      "name": token[sub_at + len(PLACEHOLDER_SUB_PREFIX):close],
+                      "start": sub_at, "end": close + 1})
+        index = close + 1
+    return found
+
+
+def count_sub_placeholders(token) -> int:
+    return len(extract_sub_names(token))
+
+
+def count_input_placeholders(token) -> int:
+    if not is_str(token):
+        return 0
+    return token.count(PLACEHOLDER_INPUT)
+
+
+def remaining_placeholders(text) -> list[str]:
+    """치환 뒤에 남은 자리표 조각. 비어 있어야 정상."""
+    if not is_str(text):
+        return []
+    leftover = []
+    if PLACEHOLDER_SUB_PREFIX in text:
+        leftover.append(PLACEHOLDER_SUB_PREFIX)
+    if PLACEHOLDER_INPUT in text:
+        leftover.append(PLACEHOLDER_INPUT)
+    return leftover
+
+
+def has_unresolved_placeholder(text) -> bool:
+    return bool(remaining_placeholders(text))
+
+
+def _as_rel_text(rel) -> str | None:
+    if not is_str(rel):
+        return None
+    text = rel.strip()
+    return text if text else None
+
+
+def normalize_rel(rel) -> str | None:
+    """제출 상대경로를 `/` 로 정규화한다. 불안전하면 None.
+
+    절대경로·드라이브·UNC·홈·부모(`..`)는 제출 폴더 밖으로 쓸 수 있으므로
+    버린다. `.` 구간과 빈 구간만 접는다.
+    """
+    text = _as_rel_text(rel)
+    if text is None:
+        return None
+    unified = text.replace("\\", "/")
+    if unified.startswith("/") or unified.startswith("//"):
+        return None
+    if unified.startswith("~"):
+        return None
+    head = unified.split("/", 1)[0]
+    if ":" in head:
+        return None
+    parts = []
+    for part in unified.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            return None
+        parts.append(part)
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
+def unsafe_rel_reason(rel) -> str | None:
+    """정규화가 거절한 이유를 카탈로그 단어로. 안전하면 None."""
+    if not is_str(rel):
+        return "not-str"
+    text = rel.strip()
+    if not text:
+        return "empty"
+    unified = text.replace("\\", "/")
+    if unified.startswith("//") or unified.startswith("\\\\"):
+        return "unc"
+    if unified.startswith("/"):
+        return "absolute"
+    if unified.startswith("~"):
+        return "home"
+    head = unified.split("/", 1)[0]
+    if ":" in head:
+        return "drive"
+    for part in unified.split("/"):
+        if part == "..":
+            return "parent"
+    if normalize_rel(rel) is None:
+        return "empty"
+    return None
+
+
+def is_safe_rel(rel) -> bool:
+    return normalize_rel(rel) is not None
+
+
+def is_safe_sub_name(name) -> bool:
+    return is_safe_rel(name)
+
+
+def require_safe_sub_name(name) -> str:
+    """안전하면 정규화된 이름, 아니면 RuntimeError."""
+    reason = unsafe_rel_reason(name)
+    if reason is not None:
+        raise RuntimeError(f"불안전 제출 경로 ({reason}): {name!r}")
+    safe = normalize_rel(name)
+    if safe is None:
+        raise RuntimeError(f"불안전 제출 경로 (empty): {name!r}")
+    return safe
+
+
+def join_sub_path(sub_dir, name, *, mkdir=False) -> str:
+    """정규화된 상대경로를 제출 폴더 아래에 붙인다."""
+    safe = require_safe_sub_name(name)
+    path = os.path.join(sub_dir, *safe.split("/"))
+    if mkdir:
+        ensure_parent_dir(path, sub_dir)
+    return path
+
+
+def escape_json_path(path: str) -> str:
+    """계획서 JSON 문자열 안에 넣을 때 백슬래시를 두 번 쓴다."""
+    return path.replace("\\", "\\\\")
+
+
+def ensure_parent_dir(path, fallback=None) -> str:
+    """산출 파일의 부모 폴더를 만든다. 부모가 없으면 fallback(보통 제출 폴더)."""
+    parent = os.path.dirname(path)
+    if not parent:
+        parent = fallback or "."
+    os.makedirs(parent, exist_ok=True)
+    return parent
+
+
+def task_input(task) -> str:
+    if not isinstance(task, dict):
+        raise RuntimeError("과제가 객체가 아니다")
+    value = task.get("input")
+    if not is_str(value) or not value:
+        raise RuntimeError("과제 input 이 없다")
+    return value
+
+
+def task_id_of(task) -> str:
+    if not isinstance(task, dict):
+        return "?"
+    value = task.get("id")
+    return value if is_str(value) and value else "?"
+
+
+def resolve_exact_input(task) -> str:
+    return task_input(task)
+
+
+def resolve_exact_sub(name, sub_dir, *, mkdir=True) -> str:
+    return join_sub_path(sub_dir, name, mkdir=mkdir)
+
+
+def replace_embedded_subs(token, sub_dir, *, mkdir=True, escape=True) -> str:
+    """한 문자열의 `{sub:}` 를 전부 경로로 바꾼다. 닫히지 않으면 실패."""
+    if not is_str(token):
+        raise RuntimeError("자리표 토큰이 문자열이 아니다")
+    if has_unclosed_sub(token):
+        raise RuntimeError(f"닫히지 않은 {{sub:}} 자리표: {token[:80]}")
+    out = []
+    rest = token
+    while PLACEHOLDER_SUB_PREFIX in rest:
+        head, rest = rest.split(PLACEHOLDER_SUB_PREFIX, 1)
+        if PLACEHOLDER_SUB_CLOSE not in rest:
+            raise RuntimeError(f"닫히지 않은 {{sub:}} 자리표: {token[:80]}")
+        name, rest = rest.split(PLACEHOLDER_SUB_CLOSE, 1)
+        path = join_sub_path(sub_dir, name, mkdir=mkdir)
+        out.append(head + (escape_json_path(path) if escape else path))
+    out.append(rest)
+    return "".join(out)
+
+
+def replace_embedded_inputs(token, task) -> str:
+    """한 문자열의 `{input}` 을 전부 바꾼다. 경로 구분자는 `/`."""
+    if not is_str(token):
+        raise RuntimeError("자리표 토큰이 문자열이 아니다")
+    return token.replace(PLACEHOLDER_INPUT, task_input(task).replace("\\", "/"))
+
 
 def resolve(token, task, sub_dir):
-    if token == "{input}":
-        return task["input"]
-    if token.startswith("{sub:") and token.endswith("}"):
-        path = os.path.join(sub_dir, token[5:-1])
-        # 중첩 제출 경로(capsules/… 등)를 미리 만든다 — 기준 풀이가 폴더 생성까지
-        # 신경 쓰게 하면 풀이가 절차 잡음으로 지저분해진다.
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        return path
-    if "{sub:" in token:
-        # 계획서 JSON 처럼 자리표가 문자열 안에 박힌 경우 — 한 문자열에 여러 개가
-        # 있을 수 있다(다세대 계획서는 input·output 을 모두 {sub:} 로 가리킨다).
-        # 첫 하나만 바꾸면 나머지가 리터럴로 남아 엉뚱한 이름의 파일이 생긴다(#4664).
-        out = []
-        rest = token
-        while "{sub:" in rest:
-            head, rest = rest.split("{sub:", 1)
-            name, rest = rest.split("}", 1)
-            path = os.path.join(sub_dir, name)
-            os.makedirs(os.path.dirname(path) or sub_dir, exist_ok=True)
-            out.append(head + path.replace("\\", "\\\\"))
-        out.append(rest)
-        return "".join(out)
+    """자리표를 제출 경로·입력 경로로 바꾼다.
+
+    기존 계약:
+    - 토큰 전체가 `{input}` 이면 과제 입력을 그대로 돌려준다(구분자는 원본).
+    - 토큰 전체가 `{sub:이름}` 이면 제출 폴더 아래 경로를 만들고 부모를 만든다.
+      이 자리의 백슬래시는 이스케이프하지 않는다.
+    - 문자열 안의 `{sub:}` 는 전부 바꾸고, 계획서 JSON 을 위해 백슬래시를
+      두 번 쓴다(#4664).
+
+    보강(#5273):
+    - 문자열 안의 `{input}` 도 바꾼다(혼합 토큰).
+    - 닫히지 않은 `{sub:` · 불안전 이름은 RuntimeError.
+    """
+    if not is_str(token):
+        return token
+    kind = classify_token(token)
+    if kind == "unclosed-sub":
+        raise RuntimeError(f"닫히지 않은 {{sub:}} 자리표: {token[:80]}")
+    if kind == "exact-input":
+        return resolve_exact_input(task)
+    if kind == "exact-sub":
+        return resolve_exact_sub(token[len(PLACEHOLDER_SUB_PREFIX):-1], sub_dir, mkdir=True)
+    if kind in ("embedded-sub", "mixed"):
+        replaced = replace_embedded_subs(token, sub_dir, mkdir=True, escape=True)
+        if PLACEHOLDER_INPUT in replaced:
+            replaced = replace_embedded_inputs(replaced, task)
+        return replaced
+    if kind == "embedded-input":
+        return replace_embedded_inputs(token, task)
     return token
 
 
+def resolve_args(args, task, sub_dir) -> list:
+    if not isinstance(args, (list, tuple)):
+        raise RuntimeError("run 인자가 목록이 아니다")
+    return [resolve(arg, task, sub_dir) for arg in args]
+
+
+def resolve_text(text, task, sub_dir) -> str:
+    """JSON 덤프처럼 자리표가 박힌 본문을 치환한다."""
+    return resolve(text, task, sub_dir) if is_str(text) else text
+
+
+def resolve_write_json_body(body, task, sub_dir):
+    """write_json 본문의 `{input}` · `{sub:}` 를 바꾸고 객체로 되돌린다."""
+    dumped = json.dumps(body)
+    dumped = replace_embedded_inputs(dumped, task)
+    if has_sub_placeholder(dumped):
+        dumped = replace_embedded_subs(dumped, sub_dir, mkdir=True, escape=True)
+    return json.loads(dumped)
+
+
+def resolve_copy_source(spec_from, task, sub_dir) -> str:
+    """copy.from 이 상대면 저장소 루트, 이미 절대면 그대로."""
+    resolved = resolve(spec_from, task, sub_dir)
+    if is_str(resolved) and os.path.isabs(resolved):
+        return resolved
+    return os.path.join(ROOT, resolved)
+
+
+def is_step_mapping(step) -> bool:
+    return isinstance(step, dict)
+
+
+def step_keys(step) -> list[str]:
+    if not is_step_mapping(step):
+        return []
+    return sorted(str(key) for key in step.keys() if key != "allowExits")
+
+
+def step_kind(step) -> str | None:
+    """한 스텝의 주 키. 알려진 키가 없으면 None."""
+    if not is_step_mapping(step):
+        return None
+    for kind in STEP_KINDS:
+        if kind in step:
+            return kind
+    return None
+
+
+def is_known_step(step) -> bool:
+    return step_kind(step) in KNOWN_STEP_KINDS
+
+
+def classify_step(step) -> str:
+    if not is_step_mapping(step):
+        return "not-mapping"
+    kind = step_kind(step)
+    return kind if kind is not None else "unknown"
+
+
+def normalize_steps(raw) -> list | None:
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        return raw
+    return None
+
+
+def steps_of_reference(reference) -> list | None:
+    if not isinstance(reference, dict):
+        return None
+    return normalize_steps(reference.get("steps"))
+
+
+def classify_reference(reference) -> str:
+    steps = steps_of_reference(reference)
+    if steps is None:
+        return "malformed-reference"
+    if not steps:
+        return "empty-steps"
+    for step in steps:
+        if not is_known_step(step):
+            return "unknown-step"
+    return "ok"
+
+
+def validate_step(step) -> list[str]:
+    errors = []
+    if not is_step_mapping(step):
+        return ["스텝이 객체가 아니다"]
+    kind = step_kind(step)
+    if kind is None:
+        return [f"알 수 없는 기준 풀이 단계 {list(step)}"]
+    if kind == "run":
+        if not isinstance(step.get("run"), list):
+            errors.append("run 이 목록이 아니다")
+    elif kind == "copy":
+        spec = step.get("copy")
+        if not isinstance(spec, dict):
+            errors.append("copy 가 객체가 아니다")
+        else:
+            if "from" not in spec:
+                errors.append("copy.from 이 없다")
+            if "to" not in spec:
+                errors.append("copy.to 가 없다")
+    elif kind == "write_json":
+        spec = step.get("write_json")
+        if not isinstance(spec, dict):
+            errors.append("write_json 이 객체가 아니다")
+        else:
+            if "to" not in spec:
+                errors.append("write_json.to 가 없다")
+            if "body" not in spec:
+                errors.append("write_json.body 가 없다")
+    elif kind == "keyring_from":
+        spec = step.get("keyring_from")
+        if not isinstance(spec, dict):
+            errors.append("keyring_from 이 객체가 아니다")
+        else:
+            for key in ("key", "out", "keyId"):
+                if key not in spec:
+                    errors.append(f"keyring_from.{key} 가 없다")
+    elif kind == "answer":
+        spec = step.get("answer")
+        if not isinstance(spec, dict):
+            errors.append("answer 가 객체가 아니다")
+    return errors
+
+
+def validate_reference(reference) -> list[str]:
+    if not isinstance(reference, dict):
+        return ["기준 풀이가 객체가 아니다"]
+    steps = steps_of_reference(reference)
+    if steps is None:
+        return ["steps 가 목록이 아니다"]
+    if not steps:
+        return ["steps 가 비었다"]
+    errors = []
+    for index, step in enumerate(steps):
+        for item in validate_step(step):
+            errors.append(f"steps[{index}]: {item}")
+    return errors
+
+
+def walk_strings(value):
+    """중첩 구조 안의 문자열을 깊이 우선으로 낸다."""
+    if is_str(value):
+        yield value
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from walk_strings(item)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from walk_strings(item)
+
+
+def collect_sub_names_from_token(token) -> list[str]:
+    return extract_sub_names(token)
+
+
+def collect_sub_names_from_step(step) -> list[str]:
+    names = []
+    for text in walk_strings(step):
+        names.extend(extract_sub_names(text))
+    return names
+
+
+def collect_sub_names(reference) -> list[str]:
+    """기준 풀이 전 스텝에서 등장하는 `{sub:}` 이름. 등장 순, 중복 제거."""
+    steps = steps_of_reference(reference) or []
+    out = []
+    seen = set()
+    for step in steps:
+        for name in collect_sub_names_from_step(step):
+            if name in seen:
+                continue
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def submit_mapping(task) -> dict:
+    if not isinstance(task, dict):
+        return {}
+    submit = task.get("submit")
+    return submit if isinstance(submit, dict) else {}
+
+
+def submit_kind(task) -> str:
+    kind = submit_mapping(task).get("kind")
+    return kind if is_str(kind) else ""
+
+
+def submit_files(task) -> list[str]:
+    """submit.files 중 상대경로로 쓸 수 있는 것만. 선언 순, 중복 제거."""
+    raw = submit_mapping(task).get("files")
+    if not isinstance(raw, list):
+        return []
+    out = []
+    seen = set()
+    for item in raw:
+        safe = normalize_rel(item)
+        if safe is None or safe in seen:
+            continue
+        seen.add(safe)
+        out.append(safe)
+    return out
+
+
+def declared_artifacts(task, reference=None) -> list[str]:
+    """과제가 요구하는 산출 파일. submit.files 가 있으면 그것만."""
+    files = submit_files(task)
+    if files:
+        return list(files)
+    if reference is None:
+        return []
+    # answer 전용 과제는 산출 파일이 없어도 된다. {sub:} 이름을 요구 목록으로
+    # 승격하지 않는다 — 중간 산출(키, 임시 hwp)까지 제출 계약으로 오인한다.
+    return []
+
+
+def expected_artifacts(task, reference=None) -> list[str]:
+    return declared_artifacts(task, reference)
+
+
+def list_submission_files(sub_dir) -> list[str]:
+    """제출 폴더 아래 파일의 상대경로(`/`). 없으면 빈 목록."""
+    if not is_str(sub_dir) or not os.path.isdir(sub_dir):
+        return []
+    found = []
+    for root, _dirs, files in os.walk(sub_dir):
+        for name in files:
+            full = os.path.join(root, name)
+            rel = os.path.relpath(full, sub_dir).replace("\\", "/")
+            found.append(rel)
+    found.sort()
+    return found
+
+
+def missing_artifacts(sub_dir, expected) -> list[str]:
+    """expected 중 파일이 아닌 것. 순서는 expected 순."""
+    if not isinstance(expected, (list, tuple)):
+        return []
+    missing = []
+    for name in expected:
+        if not is_str(name) or not name:
+            continue
+        path = os.path.join(sub_dir, *name.replace("\\", "/").split("/"))
+        if not os.path.isfile(path):
+            missing.append(name)
+    return missing
+
+
+def artifact_status(sub_dir, expected) -> dict:
+    missing = missing_artifacts(sub_dir, expected)
+    return {
+        "expected": list(expected) if isinstance(expected, (list, tuple)) else [],
+        "present": [name for name in (expected or []) if name not in missing],
+        "missing": missing,
+        "ok": not missing,
+    }
+
+
+def format_task_failure(pack_id, task_id, reason) -> str:
+    return f"{pack_id}/{task_id}: {reason}"
+
+
+def format_missing_artifact(pack_id, task_id, missing) -> str:
+    names = ", ".join(missing) if missing else "(없음)"
+    return format_task_failure(pack_id, task_id, f"부재 산출: {names}")
+
+
+def check_built_artifacts(sub_dir, task, reference=None) -> str | None:
+    """선언된 산출이 없으면 `부재 산출:` 문구, 있으면 None. pack/task 는 비운다."""
+    expected = expected_artifacts(task, reference)
+    if not expected:
+        return None
+    missing = missing_artifacts(sub_dir, expected)
+    if not missing:
+        return None
+    return format_missing_artifact("", task_id_of(task), missing)
+
+
+def missing_artifact_message(pack_id, task, sub_dir, reference=None) -> str | None:
+    expected = expected_artifacts(task, reference)
+    if not expected:
+        return None
+    missing = missing_artifacts(sub_dir, expected)
+    if not missing:
+        return None
+    return format_missing_artifact(pack_id, task_id_of(task), missing)
+
+
+def score_is_pass(result) -> bool:
+    """채점 봉투의 pass 만 본다. 비-dict·키 없음은 실패."""
+    if not isinstance(result, dict):
+        return False
+    return bool(result.get("pass"))
+
+
+def normalize_score(result) -> dict:
+    """채점 결과를 최소 봉투로. 비-dict 는 pass=False + error."""
+    if not isinstance(result, dict):
+        return {"pass": False, "error": "채점 결과가 dict 가 아니다"}
+    out = {"pass": bool(result.get("pass"))}
+    if "error" in result:
+        out["error"] = result.get("error")
+    if "id" in result:
+        out["id"] = result.get("id")
+    if "checks" in result:
+        out["checks"] = result.get("checks")
+    return out
+
+
+def failed_check_lines(checks) -> list[str]:
+    """실패한 검사의 `이름: 이유` 목록. 비-dict 칸은 건너뛴다."""
+    if not isinstance(checks, list):
+        return []
+    failed = []
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        if check.get("ok"):
+            continue
+        name = check.get("name") or check.get("op") or "검사"
+        failed.append(f"{name}: {check.get('error', '판정 불일치')}")
+    return failed
+
+
+def fold_score_result(result) -> dict:
+    """채점 봉투를 통과/실패 자리로 접는다. 순수."""
+    if score_is_pass(result):
+        return {"ok": True, "kind": "ok", "reason": None, "failedChecks": []}
+    if not isinstance(result, dict):
+        return {"ok": False, "kind": "failed-score",
+                "reason": "채점 결과가 dict 가 아니다", "failedChecks": []}
+    if result.get("error"):
+        return {"ok": False, "kind": "failed-score",
+                "reason": result.get("error"), "failedChecks": []}
+    failed = failed_check_lines(result.get("checks") or [])
+    reason = "; ".join(failed) if failed else "채점 실패"
+    return {"ok": False, "kind": "failed-score", "reason": reason, "failedChecks": failed}
+
+
+def score_failure_message(pack_id, task_id, result) -> str | None:
+    """verify_built_task 가 쓰는 한 줄. 통과면 None."""
+    folded = fold_score_result(result)
+    if folded["ok"]:
+        return None
+    return format_task_failure(pack_id, task_id, folded["reason"])
+
+
+def empty_counts() -> dict:
+    return {key: 0 for key in COUNT_KEYS}
+
+
+def bump_count(counts, key, amount=1) -> dict:
+    if not isinstance(counts, dict):
+        counts = empty_counts()
+    counts[key] = int(counts.get(key) or 0) + amount
+    return counts
+
+
+def format_summary(counts) -> str:
+    """사람용 한 줄. 기존 왕복 요약 형식을 유지한다."""
+    if not isinstance(counts, dict):
+        counts = empty_counts()
+    built = int(counts.get("built") or 0)
+    failed = int(counts.get("failed") or 0)
+    skipped = int(counts.get("skipped") or 0)
+    return f"기준 풀이 왕복: 성공 {built} · 실패 {failed} · 기준 풀이 없음 {skipped}"
+
+
+def format_summary_detail(counts) -> str:
+    """실패를 부재 산출·채점 실패·조립 오류로 나눈 부가 줄."""
+    if not isinstance(counts, dict):
+        counts = empty_counts()
+    return (
+        f"  내역: 부재 산출 {int(counts.get('missingArtifact') or 0)}"
+        f" · 채점 실패 {int(counts.get('failedScore') or 0)}"
+        f" · 조립 오류 {int(counts.get('buildError') or 0)}"
+    )
+
+
+def summary_exit(counts) -> int:
+    if not isinstance(counts, dict):
+        return 1
+    return 0 if int(counts.get("failed") or 0) == 0 else 1
+
+
+def allow_exits_of(step) -> list:
+    if not is_step_mapping(step):
+        return list(DEFAULT_ALLOW_EXITS)
+    raw = step.get("allowExits", list(DEFAULT_ALLOW_EXITS))
+    if not isinstance(raw, (list, tuple)):
+        return list(DEFAULT_ALLOW_EXITS)
+    return list(raw)
+
+
+def write_json_file(path, body) -> None:
+    payload = json.dumps(body, ensure_ascii=False, indent=2) + "\n"
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(payload)
+
+
+def write_answer_file(sub_dir, answer) -> str | None:
+    if not answer:
+        return None
+    path = os.path.join(sub_dir, ANSWER_FILENAME)
+    write_json_file(path, answer)
+    return path
+
+
+def apply_copy_step(step, task, sub_dir) -> str:
+    spec = step["copy"]
+    src = resolve_copy_source(spec["from"], task, sub_dir)
+    dest = resolve(spec["to"], task, sub_dir)
+    ensure_parent_dir(dest, sub_dir)
+    shutil.copyfile(src, dest)
+    return dest
+
+
+def apply_write_json_step(step, task, sub_dir) -> str:
+    spec = step["write_json"]
+    path = resolve(spec["to"], task, sub_dir)
+    body = resolve_write_json_body(spec["body"], task, sub_dir)
+    write_json_file(path, body)
+    return path
+
+
+def apply_keyring_step(step, task, sub_dir) -> str:
+    spec = step["keyring_from"]
+    with io.open(resolve(spec["key"], task, sub_dir), encoding="utf-8") as fh:
+        key = json.load(fh)
+    keyring = {"schemaVersion": "1.0", "kind": "keyring",
+               "keys": [{"keyId": spec["keyId"], "publicKey": key["publicKey"],
+                         "revoked": None}]}
+    path = resolve(spec["out"], task, sub_dir)
+    write_json_file(path, keyring)
+    return path
+
+
+def apply_answer_step(step, bin_path, task, sub_dir, answer) -> dict:
+    for key, spec in step["answer"].items():
+        if "const" in spec:
+            answer[key] = spec["const"]
+            continue
+        env = run_step(bin_path, spec["cmd"], task, sub_dir,
+                       spec.get("allowExits", list(DEFAULT_ALLOW_EXITS)))
+        if env is None:
+            raise RuntimeError(f"{task_id_of(task)}: 답안 봉투 파싱 실패")
+        value = dig(env, spec.get("path", ""))
+        answer[key] = len(value) if spec.get("len") else value
+    return answer
+
+
+def apply_step(step, bin_path, pack_id, task, sub_dir, answer) -> str:
+    kind = step_kind(step)
+    if kind == "run":
+        run_step(bin_path, step["run"], task, sub_dir, allow_exits_of(step))
+        return "run"
+    if kind == "copy":
+        apply_copy_step(step, task, sub_dir)
+        return "copy"
+    if kind == "write_json":
+        apply_write_json_step(step, task, sub_dir)
+        return "write_json"
+    if kind == "keyring_from":
+        apply_keyring_step(step, task, sub_dir)
+        return "keyring_from"
+    if kind == "answer":
+        apply_answer_step(step, bin_path, task, sub_dir, answer)
+        return "answer"
+    raise RuntimeError(f"{task_id_of(task)}: 알 수 없는 기준 풀이 단계 {list(step)}")
+
+
 def run_step(bin_path, args, task, sub_dir, allow_exits):
-    resolved = [resolve(a, task, sub_dir) for a in args]
+    resolved = resolve_args(args, task, sub_dir)
     proc = subprocess.run([bin_path] + resolved, cwd=ROOT, capture_output=True)
     out = proc.stdout.decode("utf-8", errors="replace")
     if proc.returncode not in allow_exits:
+        stderr = proc.stderr.decode("utf-8", "replace")[:ERROR_HEAD_LIMIT]
         raise RuntimeError(
             f"기준 풀이 실패 (exit {proc.returncode}, 허용 {allow_exits}): "
-            f"{' '.join(resolved[:4])}\n  {proc.stderr.decode('utf-8', 'replace')[:300]}")
+            f"{' '.join(str(item) for item in resolved[:4])}\n  {stderr}")
     try:
         return json.loads(out)
     except ValueError:
         return None
 
 
+def submission_dir(sub_root, pack_id, task) -> str:
+    return os.path.join(sub_root, pack_id, task_id_of(task))
+
+
+def pack_submission_root(sub_root, pack_id) -> str:
+    return os.path.join(sub_root, pack_id)
+
+
 def build_task(bin_path, pack_id, task, reference, sub_root):
-    sub_dir = os.path.join(sub_root, pack_id, task["id"])
+    sub_dir = submission_dir(sub_root, pack_id, task)
     shutil.rmtree(sub_dir, ignore_errors=True)
     os.makedirs(sub_dir, exist_ok=True)
     answer = {}
-    for step in reference["steps"]:
-        if "run" in step:
-            run_step(bin_path, step["run"], task, sub_dir, step.get("allowExits", [0]))
-        elif "copy" in step:
-            src = os.path.join(ROOT, resolve(step["copy"]["from"], task, sub_dir))
-            shutil.copyfile(src, resolve(step["copy"]["to"], task, sub_dir))
-        elif "write_json" in step:
-            # 과제가 요구하는 부속 파일(정책·명세서 등)을 기준 풀이가 직접 쓴다.
-            spec = step["write_json"]
-            path = resolve(spec["to"], task, sub_dir)
-            body = json.loads(json.dumps(spec["body"]).replace(
-                "{input}", task["input"].replace("\\", "/")))
-            io.open(path, "w", encoding="utf-8", newline="\n").write(
-                json.dumps(body, ensure_ascii=False, indent=2) + "\n")
-        elif "keyring_from" in step:
-            # 발급한 키의 공개키로 키링을 조립한다 — 서명 과제의 채점 재료.
-            spec = step["keyring_from"]
-            with io.open(resolve(spec["key"], task, sub_dir), encoding="utf-8") as fh:
-                key = json.load(fh)
-            keyring = {"schemaVersion": "1.0", "kind": "keyring",
-                       "keys": [{"keyId": spec["keyId"], "publicKey": key["publicKey"],
-                                 "revoked": None}]}
-            io.open(resolve(spec["out"], task, sub_dir), "w", encoding="utf-8",
-                    newline="\n").write(json.dumps(keyring, ensure_ascii=False, indent=2) + "\n")
-        elif "answer" in step:
-            for key, spec in step["answer"].items():
-                if "const" in spec:
-                    answer[key] = spec["const"]
-                    continue
-                env = run_step(bin_path, spec["cmd"], task, sub_dir,
-                               spec.get("allowExits", [0]))
-                if env is None:
-                    raise RuntimeError(f"{task['id']}: 답안 봉투 파싱 실패")
-                value = dig(env, spec.get("path", ""))
-                # 개수를 묻는 과제(len_answer_eq)는 배열이 아니라 길이가 답이다.
-                answer[key] = len(value) if spec.get("len") else value
-        else:
-            raise RuntimeError(f"{task['id']}: 알 수 없는 기준 풀이 단계 {list(step)}")
-    if answer:
-        io.open(os.path.join(sub_dir, "answer.json"), "w", encoding="utf-8",
-                newline="\n").write(json.dumps(answer, ensure_ascii=False, indent=2) + "\n")
+    steps = steps_of_reference(reference)
+    if steps is None:
+        raise RuntimeError(f"{task_id_of(task)}: steps 가 목록이 아니다")
+    for step in steps:
+        apply_step(step, bin_path, pack_id, task, sub_dir, answer)
+    write_answer_file(sub_dir, answer)
     return sub_dir
 
 
 def verify_built_task(bin_path, pack_id, task, sub_root):
     """방금 만든 제출물을 같은 pack 경로에서 실제 채점한다."""
-    result = runner.score_task(task, os.path.join(sub_root, pack_id), bin_path)
-    if result.get("pass"):
-        return None
-    if result.get("error"):
-        return f"{pack_id}/{task['id']}: {result['error']}"
-    failed = []
-    for check in result.get("checks", []):
-        if not check.get("ok"):
-            name = check.get("name", check.get("op", "검사"))
-            failed.append(f"{name}: {check.get('error', '판정 불일치')}")
-    return f"{pack_id}/{task['id']}: " + "; ".join(failed or ["채점 실패"])
+    result = runner.score_task(task, pack_submission_root(sub_root, pack_id), bin_path)
+    return score_failure_message(pack_id, task_id_of(task), result)
 
 
-def main():
+def inspect_built_task(bin_path, pack_id, task, sub_root, reference=None) -> dict:
+    """부재 산출을 먼저 보고, 없으면 채점한다. 순수 접기 + 채점 호출."""
+    sub_dir = submission_dir(sub_root, pack_id, task)
+    missing = missing_artifact_message(pack_id, task, sub_dir, reference)
+    if missing:
+        return {
+            "ok": False,
+            "kind": "missing-artifact",
+            "pack": pack_id,
+            "task": task_id_of(task),
+            "message": missing,
+            "missing": missing_artifacts(sub_dir, expected_artifacts(task, reference)),
+        }
+    failure = verify_built_task(bin_path, pack_id, task, sub_root)
+    if failure:
+        return {
+            "ok": False,
+            "kind": "failed-score",
+            "pack": pack_id,
+            "task": task_id_of(task),
+            "message": failure,
+        }
+    return {
+        "ok": True,
+        "kind": "ok",
+        "pack": pack_id,
+        "task": task_id_of(task),
+        "message": None,
+    }
+
+
+def reference_path(pack_id, task_id) -> str:
+    return os.path.join(PACKS_DIR, pack_id, "reference", f"{task_id}.json")
+
+
+def load_reference(path):
+    with io.open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def process_one_task(bin_path, pack_id, task, reference, sub_root, counts) -> dict:
+    """한 과제를 조립·검증하고 counts 를 갱신한다."""
+    try:
+        build_task(bin_path, pack_id, task, reference, sub_root)
+        inspected = inspect_built_task(bin_path, pack_id, task, sub_root, reference)
+    except CATCHABLE_EXCEPTIONS as exc:
+        bump_count(counts, "failed")
+        bump_count(counts, "buildError")
+        message = format_task_failure(pack_id, task_id_of(task), exc)
+        print(f"  X {message}")
+        return {"ok": False, "kind": "build-error", "message": message}
+    if inspected["ok"]:
+        bump_count(counts, "built")
+        return inspected
+    bump_count(counts, "failed")
+    if inspected["kind"] == "missing-artifact":
+        bump_count(counts, "missingArtifact")
+    elif inspected["kind"] == "failed-score":
+        bump_count(counts, "failedScore")
+    print(f"  X {inspected['message']}")
+    return inspected
+
+
+def process_pack(bin_path, pack_id, sub_root, counts) -> None:
+    ref_dir = os.path.join(PACKS_DIR, pack_id, "reference")
+    if not os.path.isdir(ref_dir):
+        print(f"[{pack_id}] 기준 풀이 없음 — 건너뜀")
+        return
+    _manifest, tasks = runner.load_pack(pack_id)
+    for task in tasks:
+        ref_path = reference_path(pack_id, task_id_of(task))
+        if not os.path.exists(ref_path):
+            bump_count(counts, "skipped")
+            continue
+        try:
+            reference = load_reference(ref_path)
+        except CATCHABLE_EXCEPTIONS as exc:
+            bump_count(counts, "failed")
+            bump_count(counts, "buildError")
+            print(f"  X {format_task_failure(pack_id, task_id_of(task), exc)}")
+            continue
+        process_one_task(bin_path, pack_id, task, reference, sub_root, counts)
+
+
+def parse_args(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--agent", default="claude-fable-5")
     ap.add_argument("--pack", action="append", default=None)
     ap.add_argument("--bin", default=None)
-    a = ap.parse_args()
+    return ap.parse_args(argv)
+
+
+def cli_flag_names() -> tuple[str, ...]:
+    return CLI_FLAGS
+
+
+def main(argv=None):
+    a = parse_args(argv)
 
     bin_path = runner.find_bin(a.bin)
     sub_root = os.path.join(runner.GYM, "submissions", a.agent)
     pack_ids = a.pack or runner.discover_packs()
 
-    built = failed = skipped = 0
+    counts = empty_counts()
     for pack_id in pack_ids:
-        ref_dir = os.path.join(PACKS_DIR, pack_id, "reference")
-        if not os.path.isdir(ref_dir):
-            print(f"[{pack_id}] 기준 풀이 없음 — 건너뜀")
-            continue
-        _manifest, tasks = runner.load_pack(pack_id)
-        for task in tasks:
-            ref_path = os.path.join(ref_dir, f"{task['id']}.json")
-            if not os.path.exists(ref_path):
-                skipped += 1
-                continue
-            with io.open(ref_path, encoding="utf-8") as fh:
-                reference = json.load(fh)
-            try:
-                build_task(bin_path, pack_id, task, reference, sub_root)
-                failure = verify_built_task(bin_path, pack_id, task, sub_root)
-                if failure:
-                    failed += 1
-                    print(f"  X {failure}")
-                else:
-                    built += 1
-            except (RuntimeError, OSError, KeyError, IndexError, TypeError) as e:
-                failed += 1
-                print(f"  X {pack_id}/{task['id']}: {e}")
-    print(f"기준 풀이 왕복: 성공 {built} · 실패 {failed} · 기준 풀이 없음 {skipped}")
-    return 0 if failed == 0 else 1
+        process_pack(bin_path, pack_id, sub_root, counts)
+    print(format_summary(counts))
+    if int(counts.get("failed") or 0):
+        print(format_summary_detail(counts))
+    return summary_exit(counts)
 
 
 if __name__ == "__main__":

--- a/mydocs/pr_body_draft_5273.md
+++ b/mydocs/pr_body_draft_5273.md
@@ -1,0 +1,39 @@
+> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
+> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.
+
+## 변경 요약
+
+기준 풀이 조립기(`gym/tools/build_baseline.py`)의 자리표 치환·부재 산출·실패 보고를 고도화한다. 새 CLI 플래그와 새 pack 은 없다.
+
+- 한 문자열의 `{sub:}` 를 전부 바꾼다. 세 개 이상·`{input}` 혼합·닫히지 않은 `{sub:` 도 시험으로 고정한다.
+- `{sub:}` 이름은 제출 폴더 안의 상대경로만 허용한다. 부모·절대·드라이브·UNC·홈은 `RuntimeError` 로 그 과제만 실패한다.
+- `submit.files` 가 선언한 파일이 없으면 채점 전에 `부재 산출:` 로 보고한다. `score_task` 를 부르지 않는다.
+- 채점 실패는 `pack/task: 이유` 한 줄을 유지한다. 검사 이름을 남기고, 비-dict·`pass` 키 없음은 통과로 접지 않는다.
+- CLI 는 `--agent` / `--pack` / `--bin` 만. `resolve` · `build_task` · `verify_built_task` 서명은 그대로다.
+
+## 관련 이슈
+
+closes #5273
+
+## 테스트
+
+- [x] `python -m unittest scripts.tests.test_gym_build_baseline -q` 통과 (128 ran, 0 failed)
+- [x] `python -m unittest scripts.tests.test_gym_packs -q` 통과 (18 ran, 0 failed; `BaselineResolveTests` 기존 3칸 + 자리표 3개·부재 산출·검사 이름)
+- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
+- [x] **`cargo fmt --all -- --check` 통과**
+- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
+- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
+- [ ] `cargo test` 통과 (해당 없음 — Python/문서만)
+- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)
+- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음)
+- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
+- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과 (해당 없음)
+
+## 성능 영향 및 측정 결과 (해당하는 경우)
+
+- 예상 영향: 영향 없음
+- 재현·측정: 단위 시험은 바이너리 없이 돈다. 라이브 왕복은 기존과 같이 rhwp 가 필요하다.
+
+## 스크린샷
+
+해당 없음.

--- a/mydocs/working/gym_build_baseline.md
+++ b/mydocs/working/gym_build_baseline.md
@@ -1,0 +1,501 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_build_baseline.md
+last_verified: 2026-08-18
+---
+
+# gym 기준 풀이 조립기 — 자리표·부재 산출·실패 보고 고도화
+
+Issue: #5273
+Branch: `feat/gym-build-baseline-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/build_baseline.py` 의 공개 서명(`resolve` · `build_task` ·
+`verify_built_task`)은 그대로 두고, 한 문자열의 여러 `{sub:}` ·
+닫히지 않은 자리표 · 불안전 제출 경로 · 부재 산출 · 실패 보고를 순수
+함수로 분리했다. 새 CLI 플래그와 새 pack 은 없다.
+`score.py` · `runner.py` · `trajectory.py` · `expert-challenges` ·
+`studio-e2e` · `render-tree` · `tutorial` · `PARK.md` ·
+`release_gate.py` 는 열지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_build_baseline`
+- `python -m unittest scripts.tests.test_gym_packs.BaselineResolveTests`
+- `python gym/tools/audit.py`
+- `cargo fmt --all -- --check`
+
+## 2. 배경
+
+원 도입(#4653)은 pack 마다 `reference/<과제ID>.json` 을 두고 기준
+풀이를 실행해 제출물을 만든 뒤 채점하는 왕복기를 넣었다. #4664 는
+한 문자열의 여러 `{sub:}` 를 모두 바꾸게 했다. 다세대 계획서가
+input·output 을 모두 `{sub:}` 로 가리키는데 첫 하나만 바꾸면 다음
+세대가 입력을 잃기 때문이다. #4689 는 채점 경로를 `os.path.join` 으로
+붙여 Windows 에서도 같은 pack 폴더를 보게 했다.
+
+그 상태의 빈틈:
+
+1. `{sub:}` 가 세 개 이상인 계획서 JSON 을 시험이 고정하지 않았다.
+   두 개만 바꾸는 구현이 다시 들어와도 기존 세 테스트는 통과한다.
+2. `{input}` 이 문자열 안에 박힌 토큰은 그대로 남았다. 토큰 전체가
+   `{input}` 일 때만 바꿨다. 계획서 JSON 이 입력을 자리표로 두면
+   리터럴 `{input}` 파일이 생긴다.
+3. 닫히지 않은 `{sub:` 는 `str.split("}", 1)` 이 `ValueError` 를
+   올렸다. `main` 이 `ValueError` 를 잡지 않아 전 왕복이 죽었다.
+4. `{sub:../escape}` 를 거부하지 않았다. 기준 풀이 하나가 제출 폴더
+   밖으로 쓸 수 있었다.
+5. 생성 성공 뒤에 `submit.files` 가 있는지 보지 않았다. 산출이 없어도
+   채점 봉투의 `error` 나 `file_exists` 실패로만 남았다. "부재
+   산출"과 "채점 실패"가 한 줄로 섞였다.
+6. 채점 결과가 비-dict 이거나 `pass` 키가 없으면
+   `result.get("pass")` 가 `AttributeError` 를 올리거나 공란을
+   "채점 실패"로 뭉갰다. 검사 이름을 남기는 자리는 있었지만 비-dict
+   자리는 시험이 없었다.
+7. 카탈로그가 코드 주석에만 있어 문서·시험이 같은 표를 공유하지
+   않았다.
+
+이슈 #5273 의 DoD 는 `additions >= 3000`, 자리표 치환·부재 산출·실패
+보고를 시험으로 고정, `unittest` + `audit.py`, PR 전
+`cargo fmt --all -- --check` 다. 새 CLI/pack 금지, 열린 PR
+(5210–5272) 파일 미수정.
+
+판정 세 칸(여러 `{sub:}` 치환, pack 경로 채점, `pack/task: 이유`
+한 줄)을 다섯 칸으로 늘리면 기존 `BaselineResolveTests` 가 깨진다.
+그래서 그 세 칸은 유지하고, 부재 산출은 채점 **앞**에 새 자리로
+열었다. 채점 한 줄 형식은 그대로다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/build_baseline.py`
+
+- `TOKEN_KINDS` — `exact-input` · `exact-sub` · `embedded-sub` ·
+  `embedded-input` · `mixed` · `literal` · `unclosed-sub` ·
+  `not-str`. 문서·시험이 같은 표를 본다.
+- `classify_token` / `extract_sub_names` / `unique_sub_names` /
+  `extract_placeholders` / `count_sub_placeholders` /
+  `has_unclosed_sub` / `has_unresolved_placeholder`.
+- `resolve` — 공개 서명 유지. 세 개 이상의 `{sub:}` 를 전부 바꾸고,
+  혼합 토큰의 `{input}` 도 바꾼다. 닫히지 않은 `{sub:` · 불안전
+  이름은 `RuntimeError`.
+- `normalize_rel` / `unsafe_rel_reason` / `join_sub_path` —
+  절대·드라이브·UNC·홈·부모 경로는 쓰지 않는다. 중첩 제출 경로는
+  부모를 만든다.
+- `STEP_KINDS` / `step_kind` / `classify_reference` /
+  `validate_reference` / `collect_sub_names`.
+- `submit_files` / `expected_artifacts` / `missing_artifacts` /
+  `missing_artifact_message` — `submit.files` 만 요구 산출이다.
+  `{sub:}` 이름을 승격하지 않는다.
+- `inspect_built_task` — 부재면 `score_task` 를 부르지 않는다.
+- `fold_score_result` / `score_failure_message` /
+  `verify_built_task` — 비-dict·키 없음은 통과가 아니다. 기존
+  `pack-b/T02: 제출 폴더 없음` 한 줄은 유지.
+- `process_one_task` / `empty_counts` / `format_summary` /
+  `format_summary_detail` — 실패를 부재·채점·조립으로 나눈다. 사람용
+  한 줄은 예전 형식.
+- `CATCHABLE_EXCEPTIONS` 에 `ValueError` · `JSONDecodeError` 를
+  넣었다. `FATAL_EXCEPTIONS` 는 다시 올린다.
+- `parse_args` / `CLI_FLAGS` — `--agent` · `--pack` · `--bin` 만.
+- `write_json` 본문의 `{sub:}` 도 치환한다. `copy.from` 이 절대
+  경로면 ROOT 를 붙이지 않는다. `answer` 의 `const` 는 라이브 호출
+  없이 쓴다.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_build_baseline.py` — 순수 함수·목킹 채점.
+바이너리 없음.
+
+`scripts/tests/test_gym_packs.py` `BaselineResolveTests` 에 세 칸을
+더했다.
+
+- `test_three_sub_placeholders_all_resolve`
+- `test_missing_artifact_is_reported_before_score`
+- `test_failed_score_lists_check_names`
+
+기존 세 칸은 그대로 통과해야 한다.
+
+### 3.3 문서
+
+- `gym/docs/build_baseline.md` — 규약 정본.
+- `mydocs/working/gym_build_baseline.md` — 이 기록.
+
+## 4. 자리표 표
+
+| 입력 | 분류 | 출력 요지 |
+|---|---|---|
+| `{input}` | exact-input | `task.input` 원본 구분자 |
+| `{sub:o.hwp}` | exact-sub | `join(sub, o.hwp)`, mkdir, 이스케이프 없음 |
+| `{"a":"{sub:a}","b":"{sub:b}"}` | embedded-sub | 둘 다 경로, `\\` 이스케이프 |
+| `{"a":"{sub:a}","b":"{sub:b}","c":"{sub:c}"}` | embedded-sub | 셋 다 경로 |
+| `{"in":"{input}","out":"{sub:o}"}` | mixed | input + 모든 sub |
+| `src={input}` | embedded-input | `src=` + `/` 구분자 |
+| `--json` | literal | 그대로 |
+| `{sub:o.hwp` | unclosed-sub | `RuntimeError` |
+| `{sub:../x}` | (안전 거부) | `RuntimeError (parent)` |
+| `None` | not-str | `None` |
+
+`extract_sub_names("{sub:a}-{sub:b}-{sub:a}")` 는
+`["a", "b", "a"]`. `unique_sub_names` 는 `["a", "b"]`.
+
+## 5. 부재 산출 표
+
+| `submit.files` | 제출 폴더 | `kind` | `score_task` |
+|---|---|---|---|
+| 없음 / answer | (무관) | 채점으로 | 부른다 |
+| `["edited.hwp"]` | 파일 있음 | 채점으로 | 부른다 |
+| `["edited.hwp"]` | 파일 없음 | `missing-artifact` | 부르지 않는다 |
+| `["a", "b"]` | `a` 만 | `missing-artifact` (`b`) | 부르지 않는다 |
+| `["../x"]` | (무관) | 요구 목록에서 탈락 | 요구가 비면 채점 |
+| `["o.hwp", "o.hwp"]` | 없음 | 부재 한 줄 (`o.hwp`) | 부르지 않는다 |
+
+메시지:
+
+```
+pack-b/T02: 부재 산출: edited.hwp
+pack-b/T02: 부재 산출: edited.hwp, plan.json
+```
+
+중간 산출(`{sub:key.json}`)은 이 목록에 넣지 않는다. 키가 제출
+계약이 아닌데 부재로 부르면 서명 과제가 전부 실패한다.
+
+## 6. 실패 보고 표
+
+| 채점 봉투 | 한 줄 |
+|---|---|
+| `{"pass": true}` | `None` |
+| `{"pass": false, "error": "제출 폴더 없음"}` | `pack-b/T02: 제출 폴더 없음` |
+| 검사 두 칸 실패 | `core-cli/T09: 1단계 반영: 0; 2단계 반영: 없음` |
+| `{}` | `pack/task: 채점 실패` |
+| `None` / `"x"` | `pack/task: 채점 결과가 dict 가 아니다` |
+
+`verify_built_task` 는 예전처럼 채점만 본다. 부재 산출은
+`inspect_built_task` 가 앞단에서 접는다. 기존 테스트가
+`verify_built_task` 를 직접 부르므로 그 함수에 산출 검사를 넣지
+않았다. 넣으면 "폴더만 있고 파일 없는" 픽스처가 채점 mock 에 닿지
+않아 기존 세 번째 테스트와 새 검사가 섞인다.
+
+## 7. 집계
+
+`COUNT_KEYS`:
+
+- `built`
+- `failed`
+- `skipped`
+- `missingArtifact`
+- `failedScore`
+- `buildError`
+
+`failed == missingArtifact + failedScore + buildError` 가
+`process_one_task` 경로의 불변이다. pack 단위 "기준 풀이 없음" 은
+이 합에 넣지 않는다.
+
+사람용 한 줄은 예전 세 칸만 보여 기존 스크립트·로그가 깨지지 않는다.
+실패가 있을 때만 내역 줄을 붙인다.
+
+종료 코드는 `failed == 0` 이면 0, 아니면 1. `skipped` 는 영향을
+주지 않는다.
+
+## 8. CLI
+
+```
+--agent   기본 claude-fable-5
+--pack    action=append, 기본 전 pack
+--bin     기본 러너 탐색
+```
+
+`cli_flag_names()` 가 이 튜플을 돌려준다. 시험이
+`("--agent", "--pack", "--bin")` 과 같다고 고정한다. `--json` 을
+붙이지 않았다. 이 도구의 출력은 사람용 왕복 로그다. JSON 봉투는
+감사기(trajectory·discriminate)의 몫이다.
+
+## 9. 기존 테스트를 깨지 않는 법
+
+`test_gym_packs.BaselineResolveTests` 세 칸:
+
+1. `resolve` 가
+   `'{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}'` 에서
+   `{sub:` 를 남기지 않고 `o1.hwp` · `o2.hwp` 를 포함한다.
+2. `verify_built_task` 가
+   `score_task(task, join("/tmp/sub", "pack-a"), "/tmp/rhwp")` 를
+   한 번 부른다.
+3. `{"pass": False, "error": "제출 폴더 없음"}` 이
+   `"pack-b/T02: 제출 폴더 없음"` 이다.
+
+구현이 `score_is_pass` 로 `pass` 를 읽고, `error` 가 있으면 그
+문자열을 그대로 붙인다. 접두 `부재 산출:` 을 `verify_built_task` 에
+넣지 않는다.
+
+`trajectory.py` 는 `build_task(bin, pack, task, reference, sub_root)`
+를 부른다. 스텝 적용을 `apply_step` 으로 나눴을 뿐 서명과 반환
+(제출 폴더 경로)은 같다. 부분 트라젝토리가 산출을 다 만들지 못하는
+것은 그쪽 판정(load-bearing)의 재료이므로, `build_task` 안에서 부재
+산출을 예외로 올리지 않는다.
+
+## 10. 열지 않은 파일
+
+지시가 금지한 경로:
+
+- `gym/score.py`
+- `gym/core/runner.py`
+- `gym/packs/expert-challenges/**`
+- `gym/packs/studio-e2e/**`
+- `gym/packs/render-tree/**`
+- `gym/tutorial/**`
+- `gym/PARK.md`
+- `gym/tools/release_gate.py`
+- 열린 PR 5210–5272 가 이미 고친 파일
+  (`discriminate.py`, `trajectory.py`, `fuzz_corpus.py`,
+  `coverage.py`, `robustness.py`, `pack_health.py`,
+  `competitive_bench.py`, `from_e2e.mjs`, `leaderboard.py`,
+  `release_diff.py`, `agent_session.py`, `oracle_probe.py`,
+  `gym/docs/*.md` 중 이 도구가 아닌 것, 각 pack 확장 문서)
+
+이 PR 이 만지는 파일:
+
+- `gym/tools/build_baseline.py`
+- `scripts/tests/test_gym_build_baseline.py` (신규)
+- `scripts/tests/test_gym_packs.py` (`BaselineResolveTests` 만 확장)
+- `gym/docs/build_baseline.md` (신규)
+- `mydocs/working/gym_build_baseline.md` (신규)
+
+`test_gym_packs.py` 는 5210–5272 의 파일 목록에 없었다. 기존 세
+계약을 같은 클래스에 남겨 회귀를 한 파일에서 보게 하려고 확장했다.
+
+## 11. 검증 실측
+
+작업 트리: `C:\Users\swsz9\rhwp-gym-build-baseline`
+브랜치: `feat/gym-build-baseline-hardening`
+베이스: `upstream/devel`
+
+실측 (2026-08-18, 작업 트리):
+
+```
+python -m unittest scripts.tests.test_gym_build_baseline -q
+  Ran 128 tests, OK
+
+python -m unittest scripts.tests.test_gym_packs -q
+  Ran 18 tests, OK
+
+python gym/tools/audit.py
+  gym 정합 감사: 18 pack 전부 통과 — 위반 0
+
+cargo fmt --all -- --check
+  exit 0 (crates·tests/generated 스텁은 gitignore, PR 에 넣지 않음)
+
+git diff --cached --shortstat
+  5 files changed, 3198+ insertions, 105 deletions
+```
+
+`audit.py` 는 pack 정합만 본다. 이 PR 은 pack JSON 을 건드리지
+않아 18 pack 이 통과했다.
+
+`cargo fmt --all -- --check` 는 HARD GATE 다. 이 브랜치는 `.rs` 를
+바꾸지 않는다. 스파스 워크트리라 `crates/` 를 펼치고,
+gitignore 된 `tests/generated/regression_suite_*.rs` 빈 스텁만
+로컬에 두어 cargo metadata 가 파일을 찾게 했다. 스텁은 커밋하지
+않는다.
+
+## 12. 설계 선택
+
+### 12.1 부재를 채점 앞에 둔 이유
+
+채점기가 `file_exists` 를 돌리면 부재는 결국 실패한다. 그런데
+그 실패는 "1단계 반영: 없음" 처럼 검사 이름으로 남는다. 조립기가
+파일을 안 만든 것과 기준 풀이가 틀린 검사를 남긴 것이 한 줄로
+섞인다. 왕복의 점은 "기준 풀이가 제출을 만들었는가" 와 "그 제출이
+맞는가" 를 가르는 것이다. 그래서 부재는 채점 전에 `부재 산출:`
+머리로 남긴다.
+
+### 12.2 `{sub:}` 를 요구 산출로 승격하지 않은 이유
+
+T14 는 `{sub:key.json}` 을 만들어 키링을 조립한다. `key.json` 은
+제출 계약이 아니다. `submit.files` 는
+`work.capsule.json` · `keyring.json` · `anchor.ndjson` 이다. 기준
+풀이의 `{sub:}` 전부를 요구하면 중간 파일이 없는 순간을 실패로
+부른다. 중간 파일은 다음 스텝이 소비하면 충분하다.
+
+### 12.3 `verify_built_task` 에 산출 검사를 넣지 않은 이유
+
+기존 테스트가 이 함수를 채점 전용으로 부른다. 서명을 유지하면서
+행동을 바꾸면 #4689 경로 계약과 #4664 실패 한 줄 계약이 한 함수에
+섞인다. 새 자리는 `inspect_built_task` 다. `main` /
+`process_one_task` 는 이쪽을 탄다.
+
+### 12.4 `--json` 을 붙이지 않은 이유
+
+지시가 "새 CLI/pack 없음" 이다. JSON 봉투는 감사기의 계약이다.
+조립기는 사람용 왕복 로그와 종료 코드만 낸다. 집계 dict 는
+함수로 열려 있어 시험이 바이너리 없이 본다.
+
+### 12.5 `ValueError` 를 잡기 목록에 넣은 이유
+
+닫히지 않은 자리표를 `RuntimeError` 로 올려도, 다른 자리
+(`json.loads` 본문, `int` 변환)가 `ValueError` 를 올릴 수 있다.
+한 과제의 값 오류가 전 pack 을 멈추면 왕복의 점이 사라진다.
+치명 예외만 다시 올린다.
+
+## 13. 회귀 시나리오
+
+아래 시나리오는 시험 이름과 1:1 이다. 구현을 되돌리면 이 이름들이
+실패한다.
+
+1. 한 문자열의 `{sub:}` 두 개 — `test_multiple_sub_placeholders_all_resolve`
+2. 한 문자열의 `{sub:}` 세 개 — `test_three_sub_placeholders_in_plan_json`
+3. `{input}` + `{sub:}` 혼합 — `test_mixed_resolves_input_and_all_subs`
+4. 닫히지 않은 `{sub:` — `test_unclosed_raises_runtime_error`
+5. `{sub:../x}` — `test_unsafe_embedded_sub_raises`
+6. 부재 산출이 채점을 건너뜀 — `test_missing_artifact_short_circuits_score`
+7. 산출이 있으면 채점 실패를 보고 — `test_present_artifact_then_failed_score`
+8. 기존 한 줄 — `test_failed_built_submission_reports_the_task`
+9. 검사 이름 — `test_failed_checks_are_joined`
+10. 비-dict 채점 — `test_non_dict_score_is_not_a_pass`
+11. CLI 세 플래그 — `test_no_new_flags`
+12. `write_json` 본문 자리표 — `test_replaces_input_and_sub_in_body`
+13. `const` 답 — `test_answer_const_writes_answer_json`
+14. 키링 — `test_keyring_from_reads_public_key`
+15. 요약 한 줄 — `test_format_summary_legacy_line`
+
+`BaselineResolveTests` 의 원래 세 칸 + 새 세 칸은
+`test_gym_packs.py` 가 따로 고정한다. 두 파일이 같은 계약을 두 번
+보는 것은 의도다. pack 가드는 조립기 가드를 import 하지 않을 수
+있고, 조립기 가드는 pack 가드를 돌리지 않을 수 있다.
+
+## 14. 공개 서명 동결
+
+다음 시그니처는 이 PR 이 바꾸지 않는다.
+
+```
+resolve(token, task, sub_dir)
+run_step(bin_path, args, task, sub_dir, allow_exits)
+build_task(bin_path, pack_id, task, reference, sub_root) -> sub_dir
+verify_built_task(bin_path, pack_id, task, sub_root) -> str | None
+main() -> int
+```
+
+추가된 함수는 위 다섯을 분해한 것이다. 호출자가 다섯만 알아도
+왕복은 돈다. 시험은 분해된 이름을 직접 부른다.
+
+## 15. 이후
+
+- 라이브 왕복(`--bin target/debug/rhwp`)은 이 PR 의 가드가 아니다.
+  바이너리·샘플이 있는 CI 잡이 기존처럼 돈다.
+- `trajectory.py` 가 부분 트라젝토리를 조립할 때 불안전 `{sub:}` 가
+  있으면 이제 `RuntimeError` 다. 그 자리는 원래 load-bearing 으로
+  접히므로 연극 집계를 뒤집지 않는다. 기준 풀이에 `..` 가 있으면
+  그쪽 감사가 예외를 볼 것이다. devel 기준 풀이를 훑었을 때
+  `..` 자리표는 없었다.
+- JSON 보고 봉투가 필요해지면 별 이슈로 `--json` 을 연다. 이 PR 의
+  금지 목록에 걸린다.
+
+## 16. 커밋 단위
+
+한 커밋으로 도구·시험·문서·작업 기록을 같이 올린다. 자리표만
+커밋하고 부재 산출을 다음에 올리면 왕복의 두 자리가 갈라진다.
+이슈 한 건의 DoD 가 세 자리를 같이 요구한다.
+
+## 17. 함수 책임 한 줄
+
+자리표:
+
+- `classify_token` — 토큰을 여덟 칸으로 접는다.
+- `iter_sub_placeholders` — `{sub:이름}` 의 (이름, 시작, 끝).
+- `extract_sub_names` — 등장 순, 중복 유지.
+- `unique_sub_names` — 등장 순, 중복 제거.
+- `extract_placeholders` — input/sub/unclosed 행 목록.
+- `has_unclosed_sub` — 닫히지 않은 `{sub:` 가 있는가.
+- `remaining_placeholders` — 치환 뒤에 남은 머리.
+- `resolve` — 공개 치환. exact/embedded/mixed 를 가른다.
+- `replace_embedded_subs` — 문자열 안의 `{sub:}` 전부.
+- `replace_embedded_inputs` — 문자열 안의 `{input}` 전부.
+- `resolve_args` — run 인자 목록.
+- `resolve_write_json_body` — dumps → 치환 → loads.
+
+경로:
+
+- `normalize_rel` — `/` 정규화. 불안전하면 None.
+- `unsafe_rel_reason` — empty/not-str/absolute/drive/unc/home/parent.
+- `join_sub_path` — 제출 폴더 아래. mkdir 선택.
+- `escape_json_path` — `\` → `\\`.
+- `require_safe_sub_name` — 거절이면 RuntimeError.
+
+산출:
+
+- `submit_files` — 선언 순, 안전 상대경로만.
+- `expected_artifacts` — submit.files 만.
+- `missing_artifacts` — expected 중 파일 아닌 것.
+- `artifact_status` — expected/present/missing/ok.
+- `missing_artifact_message` — `pack/task: 부재 산출: ...`.
+- `inspect_built_task` — 부재면 채점하지 않는다.
+
+채점:
+
+- `score_is_pass` — dict 이고 pass 가 참.
+- `normalize_score` — 최소 봉투.
+- `failed_check_lines` — `이름: 이유` 목록.
+- `fold_score_result` — ok/kind/reason/failedChecks.
+- `score_failure_message` — verify 한 줄.
+- `verify_built_task` — pack 경로 채점.
+
+집계:
+
+- `empty_counts` — COUNT_KEYS 0.
+- `bump_count` — 키를 더한다.
+- `format_summary` — 예전 한 줄.
+- `format_summary_detail` — 부재·채점·조립.
+- `summary_exit` — failed==0 → 0.
+
+조립:
+
+- `apply_step` — run/copy/write_json/keyring_from/answer.
+- `build_task` — 폴더를 지우고 스텝을 적용.
+- `process_one_task` — 조립+검증+집계.
+- `process_pack` — pack 의 과제 루프.
+- `main` — CLI.
+
+## 18. 시험 클래스 지도
+
+`test_gym_build_baseline.py`:
+
+- `TokenClassifyTests` — 여덟 칸.
+- `SubExtractTests` — 이름·개수·남은 자리표.
+- `PathSafetyTests` — 부모/절대/드라이브/UNC/홈.
+- `ResolveTests` — 두 개·세 개·혼합·닫힘·불안전.
+- `WriteJsonBodyTests` — 본문 자리표.
+- `StepClassifyTests` — 다섯 스텝·기준 풀이 라벨.
+- `ArtifactTests` — submit.files·부재·목록.
+- `ScoreFoldTests` — pass/error/checks/비-dict.
+- `VerifyBuiltTaskTests` — 경로·한 줄·검사 이름.
+- `InspectBuiltTaskTests` — 부재가 채점을 건너뜀.
+- `BuildTaskPureStepsTests` — copy/write_json/const/keyring.
+- `ProcessOneTaskTests` — 집계 칸.
+- `SummaryTests` — 한 줄·종료 코드.
+- `CliContractTests` — 플래그 세 개.
+- `MultiPlaceholderPlanTests` — 네 개·중첩·중복.
+- `MissingArtifactEdgeTests` — 디렉터리·중복·부분 부재.
+- `FailedScoreEdgeTests` — 빈 검사·이름 없음·pass 불일치.
+- `ProcessPackSkipTests` — pack 부재·파일 부재·JSON 파손.
+- `NormalizeScoreTests` / `main` 종료 코드.
+
+`test_gym_packs.BaselineResolveTests`:
+
+- 기존 세 칸 + 세 개 `{sub:}` + 부재 산출 + 검사 이름.
+
+## 19. 열어 본 열린 PR (만지지 않음)
+
+5210 checks · 5211 agent_session · 5212 coverage · 5213 form-journeys
+· 5214 oracle_probe · 5221 robustness · 5222 OM/LR/CD · 5225 security
+· 5226 selfdesc · 5227 pack_health · 5228 differential · 5232
+serialization · 5238 work-receipt · 5239 competitive_bench · 5240
+table-editing · 5241 from_e2e · 5242 text-editing · 5244 leaderboard
+· 5248 release_diff · 5266 automation · 5267 core/casual · 5268
+discriminate · 5269 trajectory · 5270 fuzz_corpus · 5272 release_gate.
+
+이 목록의 파일 경로와 `build_baseline.py` /
+`test_gym_build_baseline.py` / `gym/docs/build_baseline.md` /
+`mydocs/working/gym_build_baseline.md` 는 겹치지 않는다.
+`test_gym_packs.py` 는 목록에 없었다.

--- a/scripts/tests/test_gym_build_baseline.py
+++ b/scripts/tests/test_gym_build_baseline.py
@@ -1,0 +1,1050 @@
+"""[#5273] gym 기준 풀이 조립기 계약 — 자리표·부재 산출·실패 보고.
+
+바이너리 없이 순수 함수와 목킹된 채점만 시험한다. 조립(`build_task`)의
+run 경로는 목킹하고, 자리표 치환·경로 안전·산출 목록·채점 접기는
+실제 구현을 탄다.
+
+기존 `BaselineResolveTests`(test_gym_packs.py) 의 세 계약은 유지한다:
+
+- 한 문자열의 여러 `{sub:}` 를 모두 바꾼다.
+- 생성 성공만으로 통과 처리하지 않고 같은 pack 경로를 채점한다.
+- 실패한 채점은 `pack/task: 이유` 한 줄로 남긴다.
+
+이 파일이 더하는 것:
+
+- `{sub:}` 세 개 이상·`{input}` 혼합·닫히지 않은 자리표.
+- 부모/절대/드라이브/UNC/홈 제출 경로 거부.
+- `submit.files` 부재 산출을 채점 전에 보고.
+- 채점 봉투가 비-dict·키 없음·검사 실패일 때 통과로 접지 않음.
+- CLI 플래그는 `--agent` / `--pack` / `--bin` 만.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "build_baseline.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_build_baseline_hardening", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _task(task_id="T01", submit_files=None, input_path="samples/x.hwp"):
+    body = {
+        "id": task_id,
+        "tier": 1,
+        "title": "t",
+        "input": input_path,
+        "submit": {"kind": "artifact", "files": submit_files or []},
+        "checks": [],
+    }
+    if submit_files is None:
+        body["submit"] = {"kind": "answer"}
+    return body
+
+
+def _write(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        if isinstance(payload, str):
+            fh.write(payload)
+        else:
+            json.dump(payload, fh, ensure_ascii=False)
+
+
+class TokenClassifyTests(unittest.TestCase):
+    def test_catalog_has_eight_kinds(self):
+        mod = load()
+        self.assertEqual(len(mod.TOKEN_KINDS), 8)
+        self.assertIn("exact-sub", mod.TOKEN_KINDS)
+        self.assertIn("embedded-sub", mod.TOKEN_KINDS)
+        self.assertIn("mixed", mod.TOKEN_KINDS)
+        self.assertIn("unclosed-sub", mod.TOKEN_KINDS)
+
+    def test_exact_input(self):
+        mod = load()
+        self.assertEqual(mod.classify_token("{input}"), "exact-input")
+        self.assertTrue(mod.is_exact_input("{input}"))
+
+    def test_exact_sub(self):
+        mod = load()
+        self.assertEqual(mod.classify_token("{sub:edited.hwp}"), "exact-sub")
+        self.assertTrue(mod.is_exact_sub("{sub:edited.hwp}"))
+
+    def test_embedded_two_subs(self):
+        mod = load()
+        token = '{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}'
+        self.assertEqual(mod.classify_token(token), "embedded-sub")
+
+    def test_embedded_three_subs(self):
+        mod = load()
+        token = "{sub:a} then {sub:b} and {sub:c}"
+        self.assertEqual(mod.classify_token(token), "embedded-sub")
+        self.assertEqual(mod.count_sub_placeholders(token), 3)
+
+    def test_mixed_input_and_sub(self):
+        mod = load()
+        token = '{"in": "{input}", "out": "{sub:o.hwp}"}'
+        self.assertEqual(mod.classify_token(token), "mixed")
+
+    def test_embedded_input_only(self):
+        mod = load()
+        self.assertEqual(mod.classify_token("src={input}"), "embedded-input")
+
+    def test_literal(self):
+        mod = load()
+        self.assertEqual(mod.classify_token("--json"), "literal")
+        self.assertEqual(mod.classify_token("samples/x.hwp"), "literal")
+
+    def test_unclosed_sub(self):
+        mod = load()
+        self.assertEqual(mod.classify_token("{sub:o.hwp"), "unclosed-sub")
+        self.assertTrue(mod.has_unclosed_sub("{sub:o.hwp"))
+        self.assertFalse(mod.has_unclosed_sub("{sub:o.hwp}"))
+
+    def test_not_str(self):
+        mod = load()
+        self.assertEqual(mod.classify_token(None), "not-str")
+        self.assertEqual(mod.classify_token(3), "not-str")
+
+    def test_placeholder_builders(self):
+        mod = load()
+        self.assertEqual(mod.placeholder_input(), "{input}")
+        self.assertEqual(mod.placeholder_sub("o.hwp"), "{sub:o.hwp}")
+
+
+class SubExtractTests(unittest.TestCase):
+    def test_extract_keeps_order_and_duplicates(self):
+        mod = load()
+        token = "{sub:a.hwp}-{sub:b.hwp}-{sub:a.hwp}"
+        self.assertEqual(mod.extract_sub_names(token), ["a.hwp", "b.hwp", "a.hwp"])
+        self.assertEqual(mod.unique_sub_names(token), ["a.hwp", "b.hwp"])
+
+    def test_extract_empty(self):
+        mod = load()
+        self.assertEqual(mod.extract_sub_names("nope"), [])
+        self.assertEqual(mod.extract_sub_names(None), [])
+
+    def test_extract_placeholders_mixed(self):
+        mod = load()
+        found = mod.extract_placeholders("{input} -> {sub:o.hwp}")
+        kinds = [row["kind"] for row in found]
+        self.assertEqual(kinds, ["input", "sub"])
+        self.assertEqual(found[1]["name"], "o.hwp")
+
+    def test_extract_placeholders_unclosed(self):
+        mod = load()
+        found = mod.extract_placeholders("x {sub:oops")
+        self.assertEqual(found[-1]["kind"], "unclosed-sub")
+
+    def test_counts(self):
+        mod = load()
+        token = '{"a": "{input}", "b": "{sub:1}", "c": "{sub:2}"}'
+        self.assertEqual(mod.count_input_placeholders(token), 1)
+        self.assertEqual(mod.count_sub_placeholders(token), 2)
+
+    def test_remaining_placeholders(self):
+        mod = load()
+        self.assertEqual(mod.remaining_placeholders("{sub:x}"), ["{sub:"])
+        self.assertEqual(mod.remaining_placeholders("{input}"), ["{input}"])
+        self.assertEqual(mod.remaining_placeholders("done"), [])
+        self.assertTrue(mod.has_unresolved_placeholder("{sub:x}"))
+        self.assertFalse(mod.has_unresolved_placeholder("done"))
+
+
+class PathSafetyTests(unittest.TestCase):
+    def test_safe_nested_rel(self):
+        mod = load()
+        self.assertEqual(mod.normalize_rel("capsules/work.json"), "capsules/work.json")
+        self.assertIsNone(mod.unsafe_rel_reason("capsules/work.json"))
+        self.assertTrue(mod.is_safe_sub_name("capsules/work.json"))
+
+    def test_dots_and_slashes_collapse(self):
+        mod = load()
+        self.assertEqual(mod.normalize_rel("./edited.hwp"), "edited.hwp")
+        self.assertEqual(mod.normalize_rel("a//b"), "a/b")
+
+    def test_parent_rejected(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason("../escape.hwp"), "parent")
+        self.assertIsNone(mod.normalize_rel("../escape.hwp"))
+        self.assertFalse(mod.is_safe_rel("../escape.hwp"))
+
+    def test_absolute_rejected(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason("/tmp/x"), "absolute")
+
+    def test_drive_rejected(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason("C:/tmp/x"), "drive")
+
+    def test_unc_rejected(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason("//server/share"), "unc")
+
+    def test_home_rejected(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason("~/secret"), "home")
+
+    def test_empty_and_not_str(self):
+        mod = load()
+        self.assertEqual(mod.unsafe_rel_reason(""), "empty")
+        self.assertEqual(mod.unsafe_rel_reason("   "), "empty")
+        self.assertEqual(mod.unsafe_rel_reason(None), "not-str")
+        self.assertIn("empty", mod.UNSAFE_REL_REASONS)
+        self.assertIn("parent", mod.UNSAFE_REL_REASONS)
+
+    def test_join_sub_path_mkdir(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = mod.join_sub_path(tmp, "capsules/work.json", mkdir=True)
+            self.assertTrue(os.path.isdir(os.path.dirname(path)))
+            self.assertTrue(path.endswith(os.path.join("capsules", "work.json"))
+                            or path.replace("\\", "/").endswith("capsules/work.json"))
+
+    def test_join_rejects_parent(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError) as ctx:
+                mod.join_sub_path(tmp, "../escape.hwp")
+            self.assertIn("parent", str(ctx.exception))
+
+    def test_require_safe_sub_name(self):
+        mod = load()
+        self.assertEqual(mod.require_safe_sub_name("o.hwp"), "o.hwp")
+        with self.assertRaises(RuntimeError):
+            mod.require_safe_sub_name("..")
+
+    def test_escape_json_path_doubles_backslashes(self):
+        mod = load()
+        self.assertEqual(mod.escape_json_path("a\\b"), "a\\\\b")
+        self.assertEqual(mod.escape_json_path("a/b"), "a/b")
+
+
+class ResolveTests(unittest.TestCase):
+    def test_multiple_sub_placeholders_all_resolve(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}'
+            out = mod.resolve(token, {"input": "in.hwp"}, sub_dir)
+            self.assertNotIn("{sub:", out, "치환되지 않은 자리표가 남았다")
+            self.assertIn("o1.hwp", out)
+            self.assertIn("o2.hwp", out)
+
+    def test_three_sub_placeholders_in_plan_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"a": "{sub:a.hwp}", "b": "{sub:b.hwp}", "c": "{sub:c.hwp}"}'
+            out = mod.resolve(token, {"input": "in.hwp"}, sub_dir)
+            self.assertEqual(mod.count_sub_placeholders(out), 0)
+            self.assertIn("a.hwp", out)
+            self.assertIn("b.hwp", out)
+            self.assertIn("c.hwp", out)
+
+    def test_exact_input_keeps_original_separators(self):
+        mod = load()
+        task = {"input": "samples\\nested\\x.hwp"}
+        self.assertEqual(mod.resolve("{input}", task, "/tmp"), "samples\\nested\\x.hwp")
+
+    def test_exact_sub_makes_parent_and_does_not_escape(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            out = mod.resolve("{sub:capsules/work.json}", {"input": "in.hwp"}, sub_dir)
+            self.assertTrue(os.path.isdir(os.path.join(sub_dir, "capsules")))
+            self.assertTrue(out.endswith("work.json"))
+            self.assertNotIn("{sub:", out)
+
+    def test_mixed_resolves_input_and_all_subs(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"in": "{input}", "o1": "{sub:o1.hwp}", "o2": "{sub:o2.hwp}"}'
+            out = mod.resolve(token, {"input": "samples/x.hwp"}, sub_dir)
+            self.assertNotIn("{input}", out)
+            self.assertNotIn("{sub:", out)
+            self.assertIn("samples/x.hwp", out)
+            self.assertIn("o1.hwp", out)
+            self.assertIn("o2.hwp", out)
+
+    def test_embedded_input_only(self):
+        mod = load()
+        out = mod.resolve("src={input}", {"input": "samples\\a.hwp"}, "/tmp")
+        self.assertEqual(out, "src=samples/a.hwp")
+
+    def test_literal_unchanged(self):
+        mod = load()
+        self.assertEqual(mod.resolve("--json", {"input": "in.hwp"}, "/tmp"), "--json")
+
+    def test_unclosed_raises_runtime_error(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            with self.assertRaises(RuntimeError) as ctx:
+                mod.resolve("{sub:o.hwp", {"input": "in.hwp"}, sub_dir)
+            self.assertIn("닫히지 않은", str(ctx.exception))
+
+    def test_unsafe_embedded_sub_raises(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            with self.assertRaises(RuntimeError) as ctx:
+                mod.resolve('{"out": "{sub:../x.hwp}"}', {"input": "in.hwp"}, sub_dir)
+            self.assertIn("parent", str(ctx.exception))
+
+    def test_resolve_args_maps_each(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            args = ["edit", "{input}", "-o", "{sub:o.hwp}"]
+            out = mod.resolve_args(args, {"input": "in.hwp"}, sub_dir)
+            self.assertEqual(out[1], "in.hwp")
+            self.assertTrue(out[3].endswith("o.hwp"))
+
+    def test_resolve_args_rejects_non_list(self):
+        mod = load()
+        with self.assertRaises(RuntimeError):
+            mod.resolve_args("edit", {"input": "in.hwp"}, "/tmp")
+
+    def test_non_str_token_passthrough(self):
+        mod = load()
+        self.assertIsNone(mod.resolve(None, {"input": "in.hwp"}, "/tmp"))
+        self.assertEqual(mod.resolve(1, {"input": "in.hwp"}, "/tmp"), 1)
+
+
+class WriteJsonBodyTests(unittest.TestCase):
+    def test_replaces_input_and_sub_in_body(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            body = {"planVersion": "1.0", "input": "{input}", "output": "{sub:o.hwp}"}
+            out = mod.resolve_write_json_body(body, {"input": "samples\\a.hwp"}, sub_dir)
+            self.assertEqual(out["input"], "samples/a.hwp")
+            self.assertNotIn("{sub:", out["output"])
+            self.assertTrue(out["output"].endswith("o.hwp") or "o.hwp" in out["output"])
+
+    def test_body_without_placeholders_roundtrips(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            body = {"planVersion": "1.0", "steps": [{"action": "set_cell"}]}
+            out = mod.resolve_write_json_body(body, {"input": "in.hwp"}, sub_dir)
+            self.assertEqual(out["planVersion"], "1.0")
+            self.assertEqual(out["steps"][0]["action"], "set_cell")
+
+
+class StepClassifyTests(unittest.TestCase):
+    def test_known_kinds_tuple(self):
+        mod = load()
+        self.assertEqual(mod.STEP_KINDS, ("run", "copy", "write_json", "keyring_from", "answer"))
+        self.assertEqual(set(mod.STEP_KINDS), set(mod.KNOWN_STEP_KINDS))
+
+    def test_step_kind_prefers_declared_order(self):
+        mod = load()
+        self.assertEqual(mod.step_kind({"run": ["a"]}), "run")
+        self.assertEqual(mod.step_kind({"copy": {}}), "copy")
+        self.assertEqual(mod.step_kind({"write_json": {}}), "write_json")
+        self.assertEqual(mod.step_kind({"keyring_from": {}}), "keyring_from")
+        self.assertEqual(mod.step_kind({"answer": {}}), "answer")
+        self.assertIsNone(mod.step_kind({"allowExits": [0]}))
+        self.assertIsNone(mod.step_kind("run"))
+
+    def test_classify_step_unknown_and_not_mapping(self):
+        mod = load()
+        self.assertEqual(mod.classify_step({"nope": 1}), "unknown")
+        self.assertEqual(mod.classify_step(None), "not-mapping")
+
+    def test_classify_reference(self):
+        mod = load()
+        self.assertEqual(mod.classify_reference({"steps": [{"run": ["a"]}]}), "ok")
+        self.assertEqual(mod.classify_reference({"steps": []}), "empty-steps")
+        self.assertEqual(mod.classify_reference({"steps": None}), "malformed-reference")
+        self.assertEqual(mod.classify_reference("x"), "malformed-reference")
+        self.assertEqual(mod.classify_reference({"steps": [{"nope": 1}]}), "unknown-step")
+
+    def test_validate_step_and_reference(self):
+        mod = load()
+        self.assertEqual(mod.validate_step({"run": ["edit"]}), [])
+        self.assertTrue(mod.validate_step({"run": "edit"}))
+        self.assertTrue(mod.validate_step({"copy": {}}))
+        self.assertTrue(any("from" in e for e in mod.validate_step({"copy": {}})))
+        errors = mod.validate_reference({"steps": [{"copy": {"from": "a"}}]})
+        self.assertTrue(any("to" in e for e in errors))
+        self.assertEqual(mod.validate_reference("nope"), ["기준 풀이가 객체가 아니다"])
+        self.assertEqual(mod.validate_reference({"steps": []}), ["steps 가 비었다"])
+
+    def test_collect_sub_names_across_steps(self):
+        mod = load()
+        reference = {
+            "id": "T",
+            "steps": [
+                {"run": ["edit", "{input}", "-o", "{sub:a.hwp}"]},
+                {"write_json": {"to": "{sub:plan.json}", "body": {"out": "{sub:b.hwp}"}}},
+                {"keyring_from": {"key": "{sub:key.json}", "out": "{sub:keyring.json}", "keyId": "k"}},
+                {"answer": {"n": {"cmd": ["search", "{sub:a.hwp}"]}}},
+            ],
+        }
+        names = mod.collect_sub_names(reference)
+        self.assertEqual(names, ["a.hwp", "plan.json", "b.hwp", "key.json", "keyring.json"])
+
+
+class ArtifactTests(unittest.TestCase):
+    def test_submit_files_keeps_order_and_drops_unsafe(self):
+        mod = load()
+        task = _task("T", submit_files=["o.hwp", "../x", "o.hwp", "capsules/a.json"])
+        self.assertEqual(mod.submit_files(task), ["o.hwp", "capsules/a.json"])
+
+    def test_submit_files_empty_when_answer_task(self):
+        mod = load()
+        self.assertEqual(mod.submit_files(_task("T")), [])
+        self.assertEqual(mod.submit_kind(_task("T")), "answer")
+
+    def test_declared_artifacts_uses_submit_files_only(self):
+        mod = load()
+        task = _task("T", submit_files=["edited.hwp"])
+        reference = {"steps": [{"run": ["-o", "{sub:tmp.hwp}"]}]}
+        self.assertEqual(mod.declared_artifacts(task, reference), ["edited.hwp"])
+        self.assertEqual(mod.declared_artifacts(_task("T"), reference), [])
+
+    def test_missing_artifacts_reports_absent_file(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            open(os.path.join(tmp, "kept.hwp"), "w", encoding="utf-8").write("x")
+            missing = mod.missing_artifacts(tmp, ["kept.hwp", "gone.hwp", "capsules/a.json"])
+            self.assertEqual(missing, ["gone.hwp", "capsules/a.json"])
+
+    def test_missing_artifacts_empty_when_all_present(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "capsules"))
+            open(os.path.join(tmp, "edited.hwp"), "w", encoding="utf-8").write("x")
+            open(os.path.join(tmp, "capsules", "work.json"), "w", encoding="utf-8").write("{}")
+            self.assertEqual(mod.missing_artifacts(tmp, ["edited.hwp", "capsules/work.json"]), [])
+
+    def test_artifact_status(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            open(os.path.join(tmp, "a"), "w", encoding="utf-8").write("1")
+            status = mod.artifact_status(tmp, ["a", "b"])
+            self.assertFalse(status["ok"])
+            self.assertEqual(status["present"], ["a"])
+            self.assertEqual(status["missing"], ["b"])
+
+    def test_list_submission_files_sorted(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "n"))
+            open(os.path.join(tmp, "z.txt"), "w", encoding="utf-8").write("z")
+            open(os.path.join(tmp, "n", "a.txt"), "w", encoding="utf-8").write("a")
+            self.assertEqual(mod.list_submission_files(tmp), ["n/a.txt", "z.txt"])
+            self.assertEqual(mod.list_submission_files(os.path.join(tmp, "nope")), [])
+
+    def test_format_missing_artifact(self):
+        mod = load()
+        msg = mod.format_missing_artifact("pack-b", "T02", ["edited.hwp", "plan.json"])
+        self.assertEqual(msg, "pack-b/T02: 부재 산출: edited.hwp, plan.json")
+
+    def test_missing_artifact_message_none_when_no_files_declared(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(mod.missing_artifact_message("p", _task("T"), tmp))
+
+    def test_missing_artifact_message_when_declared_absent(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            task = _task("T02", submit_files=["edited.hwp"])
+            msg = mod.missing_artifact_message("pack-b", task, tmp)
+            self.assertEqual(msg, "pack-b/T02: 부재 산출: edited.hwp")
+
+    def test_missing_artifact_message_none_when_present(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            open(os.path.join(tmp, "edited.hwp"), "w", encoding="utf-8").write("x")
+            task = _task("T02", submit_files=["edited.hwp"])
+            self.assertIsNone(mod.missing_artifact_message("pack-b", task, tmp))
+
+
+class ScoreFoldTests(unittest.TestCase):
+    def test_pass_true_is_ok(self):
+        mod = load()
+        self.assertTrue(mod.score_is_pass({"pass": True}))
+        folded = mod.fold_score_result({"pass": True})
+        self.assertTrue(folded["ok"])
+        self.assertEqual(folded["kind"], "ok")
+
+    def test_error_field_is_failed_score(self):
+        mod = load()
+        folded = mod.fold_score_result({"pass": False, "error": "제출 폴더 없음"})
+        self.assertFalse(folded["ok"])
+        self.assertEqual(folded["kind"], "failed-score")
+        self.assertEqual(folded["reason"], "제출 폴더 없음")
+
+    def test_failed_checks_join_names(self):
+        mod = load()
+        result = {
+            "pass": False,
+            "checks": [
+                {"name": "1단계 반영", "ok": False, "error": "없음"},
+                {"name": "2단계 반영", "ok": True},
+                {"op": "file_exists", "ok": False},
+            ],
+        }
+        folded = mod.fold_score_result(result)
+        self.assertEqual(folded["reason"], "1단계 반영: 없음; file_exists: 판정 불일치")
+        self.assertEqual(len(folded["failedChecks"]), 2)
+
+    def test_missing_pass_key_is_failure(self):
+        mod = load()
+        self.assertFalse(mod.score_is_pass({}))
+        folded = mod.fold_score_result({})
+        self.assertFalse(folded["ok"])
+        self.assertEqual(folded["reason"], "채점 실패")
+
+    def test_none_and_non_dict(self):
+        mod = load()
+        self.assertFalse(mod.score_is_pass(None))
+        self.assertEqual(mod.fold_score_result(None)["reason"], "채점 결과가 dict 가 아니다")
+        self.assertEqual(mod.normalize_score("x")["error"], "채점 결과가 dict 가 아니다")
+
+    def test_failed_check_lines_skips_non_dict(self):
+        mod = load()
+        lines = mod.failed_check_lines([None, "x", {"ok": False, "name": "c"}])
+        self.assertEqual(lines, ["c: 판정 불일치"])
+
+    def test_score_failure_message_preserves_legacy_error_line(self):
+        mod = load()
+        msg = mod.score_failure_message("pack-b", "T02", {"pass": False, "error": "제출 폴더 없음"})
+        self.assertEqual(msg, "pack-b/T02: 제출 폴더 없음")
+
+    def test_score_failure_message_none_on_pass(self):
+        mod = load()
+        self.assertIsNone(mod.score_failure_message("p", "T", {"pass": True}))
+
+    def test_format_task_failure(self):
+        mod = load()
+        self.assertEqual(mod.format_task_failure("core-cli", "T09", "채점 실패"),
+                         "core-cli/T09: 채점 실패")
+
+
+class VerifyBuiltTaskTests(unittest.TestCase):
+    def test_scores_in_pack_directory(self):
+        mod = load()
+        task = {"id": "T01"}
+        with mock.patch.object(mod.runner, "score_task", return_value={"pass": True}) as score:
+            failure = mod.verify_built_task("/tmp/rhwp", "pack-a", task, "/tmp/sub")
+        self.assertIsNone(failure)
+        score.assert_called_once_with(task, os.path.join("/tmp/sub", "pack-a"), "/tmp/rhwp")
+
+    def test_failed_built_submission_reports_the_task(self):
+        mod = load()
+        task = {"id": "T02"}
+        with mock.patch.object(mod.runner, "score_task",
+                               return_value={"pass": False, "error": "제출 폴더 없음"}):
+            failure = mod.verify_built_task("/tmp/rhwp", "pack-b", task, "/tmp/sub")
+        self.assertEqual(failure, "pack-b/T02: 제출 폴더 없음")
+
+    def test_failed_checks_are_joined(self):
+        mod = load()
+        task = {"id": "T09"}
+        result = {
+            "pass": False,
+            "checks": [
+                {"name": "1단계 반영", "ok": False, "error": "0"},
+                {"name": "2단계 반영", "ok": False, "error": "없음"},
+            ],
+        }
+        with mock.patch.object(mod.runner, "score_task", return_value=result):
+            failure = mod.verify_built_task("/tmp/rhwp", "core-cli", task, "/tmp/sub")
+        self.assertEqual(failure, "core-cli/T09: 1단계 반영: 0; 2단계 반영: 없음")
+
+    def test_non_dict_score_is_not_a_pass(self):
+        mod = load()
+        with mock.patch.object(mod.runner, "score_task", return_value=None):
+            failure = mod.verify_built_task("/tmp/rhwp", "p", {"id": "T"}, "/tmp/sub")
+        self.assertEqual(failure, "p/T: 채점 결과가 dict 가 아니다")
+
+
+class InspectBuiltTaskTests(unittest.TestCase):
+    def test_missing_artifact_short_circuits_score(self):
+        mod = load()
+        task = _task("T02", submit_files=["edited.hwp"])
+        with tempfile.TemporaryDirectory() as root:
+            sub_dir = os.path.join(root, "pack-b", "T02")
+            os.makedirs(sub_dir)
+            with mock.patch.object(mod.runner, "score_task") as score:
+                inspected = mod.inspect_built_task("/tmp/rhwp", "pack-b", task, root)
+            score.assert_not_called()
+            self.assertEqual(inspected["kind"], "missing-artifact")
+            self.assertEqual(inspected["missing"], ["edited.hwp"])
+            self.assertIn("부재 산출", inspected["message"])
+
+    def test_present_artifact_then_failed_score(self):
+        mod = load()
+        task = _task("T02", submit_files=["edited.hwp"])
+        with tempfile.TemporaryDirectory() as root:
+            sub_dir = os.path.join(root, "pack-b", "T02")
+            os.makedirs(sub_dir)
+            open(os.path.join(sub_dir, "edited.hwp"), "w", encoding="utf-8").write("x")
+            with mock.patch.object(mod.runner, "score_task",
+                                   return_value={"pass": False, "error": "판정 불일치"}):
+                inspected = mod.inspect_built_task("/tmp/rhwp", "pack-b", task, root)
+        self.assertEqual(inspected["kind"], "failed-score")
+        self.assertEqual(inspected["message"], "pack-b/T02: 판정 불일치")
+
+    def test_ok_when_artifact_present_and_score_passes(self):
+        mod = load()
+        task = _task("T02", submit_files=["edited.hwp"])
+        with tempfile.TemporaryDirectory() as root:
+            sub_dir = os.path.join(root, "pack-b", "T02")
+            os.makedirs(sub_dir)
+            open(os.path.join(sub_dir, "edited.hwp"), "w", encoding="utf-8").write("x")
+            with mock.patch.object(mod.runner, "score_task", return_value={"pass": True}):
+                inspected = mod.inspect_built_task("/tmp/rhwp", "pack-b", task, root)
+        self.assertTrue(inspected["ok"])
+        self.assertEqual(inspected["kind"], "ok")
+
+
+class BuildTaskPureStepsTests(unittest.TestCase):
+    def test_write_json_and_copy_without_bin(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.txt")
+            open(src, "w", encoding="utf-8").write("hello")
+            # copy.from 가 절대 경로면 ROOT 를 앞에 붙이지 않는다.
+            task = _task("T", submit_files=["out.txt", "plan.json"], input_path=src)
+            reference = {
+                "id": "T",
+                "steps": [
+                    {"copy": {"from": src, "to": "{sub:out.txt}"}},
+                    {"write_json": {"to": "{sub:plan.json}",
+                                    "body": {"input": "{input}", "note": "ok"}}},
+                ],
+            }
+            sub_root = os.path.join(tmp, "sub")
+            built = mod.build_task("/bin/false", "p", task, reference, sub_root)
+            self.assertTrue(os.path.isfile(os.path.join(built, "out.txt")))
+            plan = json.loads(Path(built, "plan.json").read_text(encoding="utf-8"))
+            self.assertIn("src.txt", plan["input"].replace("\\", "/"))
+            self.assertEqual(plan["note"], "ok")
+
+    def test_unknown_step_raises(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError) as ctx:
+                mod.build_task("/bin/false", "p", _task("T"),
+                               {"steps": [{"nope": 1}]}, tmp)
+            self.assertIn("알 수 없는", str(ctx.exception))
+
+    def test_missing_steps_raises(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError) as ctx:
+                mod.build_task("/bin/false", "p", _task("T"), {"id": "T"}, tmp)
+            self.assertIn("steps", str(ctx.exception))
+
+    def test_answer_const_writes_answer_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            reference = {"steps": [{"answer": {"n": {"const": 3}}}]}
+            built = mod.build_task("/bin/false", "p", _task("T"), reference, tmp)
+            answer = json.loads(Path(built, "answer.json").read_text(encoding="utf-8"))
+            self.assertEqual(answer, {"n": 3})
+
+    def test_keyring_from_reads_public_key(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            task = _task("T", submit_files=["keyring.json"])
+            # 키 파일을 제출 폴더에 미리 둘 수 없으므로 copy 로 심는다.
+            key_src = os.path.join(tmp, "key.json")
+            _write(key_src, {"publicKey": "PUB"})
+            reference = {
+                "steps": [
+                    {"copy": {"from": key_src, "to": "{sub:key.json}"}},
+                    {"keyring_from": {"key": "{sub:key.json}", "out": "{sub:keyring.json}",
+                                      "keyId": "gym/t"}},
+                ],
+            }
+            built = mod.build_task("/bin/false", "p", task, reference, tmp)
+            keyring = json.loads(Path(built, "keyring.json").read_text(encoding="utf-8"))
+            self.assertEqual(keyring["keys"][0]["publicKey"], "PUB")
+            self.assertEqual(keyring["keys"][0]["keyId"], "gym/t")
+
+
+class ProcessOneTaskTests(unittest.TestCase):
+    def test_counts_missing_artifact(self):
+        mod = load()
+        counts = mod.empty_counts()
+        task = _task("T02", submit_files=["edited.hwp"])
+        reference = {"steps": [{"answer": {"n": {"const": 1}}}]}
+        with tempfile.TemporaryDirectory() as tmp:
+            inspected = mod.process_one_task("/bin/false", "pack-b", task, reference, tmp, counts)
+        self.assertEqual(inspected["kind"], "missing-artifact")
+        self.assertEqual(counts["failed"], 1)
+        self.assertEqual(counts["missingArtifact"], 1)
+        self.assertEqual(counts["built"], 0)
+
+    def test_counts_failed_score(self):
+        mod = load()
+        counts = mod.empty_counts()
+        task = _task("T02", submit_files=["edited.hwp"])
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "blank")
+            open(src, "w", encoding="utf-8").write("x")
+            reference = {"steps": [{"copy": {"from": src, "to": "{sub:edited.hwp}"}}]}
+            with mock.patch.object(mod.runner, "score_task",
+                                   return_value={"pass": False, "error": "판정 불일치"}):
+                inspected = mod.process_one_task("/bin/false", "pack-b", task, reference, tmp, counts)
+        self.assertEqual(inspected["kind"], "failed-score")
+        self.assertEqual(counts["failedScore"], 1)
+        self.assertEqual(counts["failed"], 1)
+
+    def test_counts_build_error_on_unsafe_sub(self):
+        mod = load()
+        counts = mod.empty_counts()
+        task = _task("T")
+        reference = {"steps": [{"run": ["edit", "-o", "{sub:../x.hwp}"]}]}
+        with tempfile.TemporaryDirectory() as tmp:
+            inspected = mod.process_one_task("/bin/false", "p", task, reference, tmp, counts)
+        self.assertEqual(inspected["kind"], "build-error")
+        self.assertEqual(counts["buildError"], 1)
+        self.assertEqual(counts["failed"], 1)
+
+    def test_counts_built_on_success(self):
+        mod = load()
+        counts = mod.empty_counts()
+        task = _task("T")
+        reference = {"steps": [{"answer": {"n": {"const": 0}}}]}
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(mod.runner, "score_task", return_value={"pass": True}):
+                inspected = mod.process_one_task("/bin/false", "p", task, reference, tmp, counts)
+        self.assertTrue(inspected["ok"])
+        self.assertEqual(counts["built"], 1)
+        self.assertEqual(counts["failed"], 0)
+
+
+class SummaryTests(unittest.TestCase):
+    def test_empty_counts_keys(self):
+        mod = load()
+        counts = mod.empty_counts()
+        for key in mod.COUNT_KEYS:
+            self.assertIn(key, counts)
+            self.assertEqual(counts[key], 0)
+
+    def test_format_summary_legacy_line(self):
+        mod = load()
+        counts = mod.empty_counts()
+        counts["built"] = 12
+        counts["failed"] = 3
+        counts["skipped"] = 1
+        self.assertEqual(mod.format_summary(counts),
+                         "기준 풀이 왕복: 성공 12 · 실패 3 · 기준 풀이 없음 1")
+
+    def test_format_summary_detail(self):
+        mod = load()
+        counts = {"missingArtifact": 2, "failedScore": 1, "buildError": 0}
+        self.assertEqual(mod.format_summary_detail(counts),
+                         "  내역: 부재 산출 2 · 채점 실패 1 · 조립 오류 0")
+
+    def test_summary_exit(self):
+        mod = load()
+        self.assertEqual(mod.summary_exit({"failed": 0}), 0)
+        self.assertEqual(mod.summary_exit({"failed": 1}), 1)
+        self.assertEqual(mod.summary_exit(None), 1)
+
+    def test_bump_count(self):
+        mod = load()
+        counts = mod.empty_counts()
+        mod.bump_count(counts, "failed", 2)
+        self.assertEqual(counts["failed"], 2)
+        created = mod.bump_count(None, "built")
+        self.assertEqual(created["built"], 1)
+
+
+class CliContractTests(unittest.TestCase):
+    def test_no_new_flags(self):
+        mod = load()
+        self.assertEqual(mod.cli_flag_names(), ("--agent", "--pack", "--bin"))
+        self.assertEqual(mod.CLI_FLAGS, ("--agent", "--pack", "--bin"))
+
+    def test_parse_args_defaults(self):
+        mod = load()
+        a = mod.parse_args([])
+        self.assertEqual(a.agent, "claude-fable-5")
+        self.assertIsNone(a.pack)
+        self.assertIsNone(a.bin)
+
+    def test_parse_args_pack_appends(self):
+        mod = load()
+        a = mod.parse_args(["--pack", "core-cli", "--pack", "text-editing", "--bin", "rhwp"])
+        self.assertEqual(a.pack, ["core-cli", "text-editing"])
+        self.assertEqual(a.bin, "rhwp")
+
+    def test_failure_kinds_catalog(self):
+        mod = load()
+        self.assertIn("missing-artifact", mod.FAILURE_KINDS)
+        self.assertIn("failed-score", mod.FAILURE_KINDS)
+        self.assertIn("unclosed-placeholder", mod.FAILURE_KINDS)
+
+    def test_catchable_includes_value_error(self):
+        mod = load()
+        self.assertIn(ValueError, mod.CATCHABLE_EXCEPTIONS)
+        self.assertFalse(mod.is_fatal_exception(RuntimeError("x")))
+        self.assertTrue(mod.is_fatal_exception(KeyboardInterrupt()))
+
+
+class CopySourceTests(unittest.TestCase):
+    def test_relative_joins_root(self):
+        mod = load()
+        src = mod.resolve_copy_source("samples/x.hwp", {"input": "samples/x.hwp"}, "/tmp")
+        self.assertEqual(src, os.path.join(mod.ROOT, "samples/x.hwp"))
+
+    def test_input_placeholder_joins_root(self):
+        mod = load()
+        src = mod.resolve_copy_source("{input}", {"input": "samples/x.hwp"}, "/tmp")
+        self.assertEqual(src, os.path.join(mod.ROOT, "samples/x.hwp"))
+
+
+class AllowExitsTests(unittest.TestCase):
+    def test_default_zero(self):
+        mod = load()
+        self.assertEqual(mod.allow_exits_of({"run": ["a"]}), [0])
+        self.assertEqual(mod.allow_exits_of(None), [0])
+
+    def test_declared_list(self):
+        mod = load()
+        self.assertEqual(mod.allow_exits_of({"run": ["a"], "allowExits": [0, 3]}), [0, 3])
+
+
+class WalkStringsTests(unittest.TestCase):
+    def test_nested(self):
+        mod = load()
+        values = list(mod.walk_strings({"a": ["{sub:x}", {"b": "{input}"}]}))
+        self.assertEqual(values, ["{sub:x}", "{input}"])
+
+
+class ReferencePathTests(unittest.TestCase):
+    def test_reference_path_uses_packs_dir(self):
+        mod = load()
+        path = mod.reference_path("core-cli", "T09")
+        self.assertTrue(path.endswith(os.path.join("core-cli", "reference", "T09.json"))
+                        or path.replace("\\", "/").endswith("core-cli/reference/T09.json"))
+
+    def test_submission_dir(self):
+        mod = load()
+        self.assertEqual(
+            mod.submission_dir("/tmp/sub", "core-cli", {"id": "T09"}),
+            os.path.join("/tmp/sub", "core-cli", "T09"),
+        )
+
+
+class TaskHelpersTests(unittest.TestCase):
+    def test_task_id_and_input(self):
+        mod = load()
+        self.assertEqual(mod.task_id_of({"id": "T09"}), "T09")
+        self.assertEqual(mod.task_id_of({}), "?")
+        self.assertEqual(mod.task_id_of(None), "?")
+        self.assertEqual(mod.task_input({"input": "a.hwp"}), "a.hwp")
+        with self.assertRaises(RuntimeError):
+            mod.task_input({})
+        with self.assertRaises(RuntimeError):
+            mod.task_input(None)
+
+
+class WriteHelpersTests(unittest.TestCase):
+    def test_write_answer_file_skips_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(mod.write_answer_file(tmp, {}))
+            self.assertFalse(os.path.exists(os.path.join(tmp, "answer.json")))
+            path = mod.write_answer_file(tmp, {"n": 1})
+            self.assertTrue(os.path.isfile(path))
+
+
+class MultiPlaceholderPlanTests(unittest.TestCase):
+    """다세대 계획서 JSON 이 한 토큰에 넣는 자리표 조합."""
+
+    def test_four_subs_and_input_leave_no_placeholder(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = (
+                '{"in":"{input}","g1":"{sub:g1.hwp}",'
+                '"g2":"{sub:g2.hwp}","g3":"{sub:g3.hwp}","g4":"{sub:g4.hwp}"}'
+            )
+            out = mod.resolve(token, {"input": "samples/a.hwp"}, sub_dir)
+            self.assertFalse(mod.has_unresolved_placeholder(out))
+            for name in ("g1.hwp", "g2.hwp", "g3.hwp", "g4.hwp"):
+                self.assertIn(name, out)
+            self.assertIn("samples/a.hwp", out)
+
+    def test_nested_capsule_and_output_together(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"capsule":"{sub:capsules/work.json}","out":"{sub:o.hwp}"}'
+            out = mod.resolve(token, {"input": "in.hwp"}, sub_dir)
+            self.assertFalse(mod.has_unresolved_placeholder(out))
+            self.assertTrue(os.path.isdir(os.path.join(sub_dir, "capsules")))
+            self.assertIn("work.json", out)
+            self.assertIn("o.hwp", out)
+
+    def test_same_sub_twice_resolves_both(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = "{sub:same.hwp} and again {sub:same.hwp}"
+            out = mod.resolve(token, {"input": "in.hwp"}, sub_dir)
+            self.assertEqual(mod.count_sub_placeholders(out), 0)
+            self.assertEqual(out.count("same.hwp"), 2)
+
+
+class MissingArtifactEdgeTests(unittest.TestCase):
+    def test_directory_instead_of_file_is_missing(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "edited.hwp"))
+            missing = mod.missing_artifacts(tmp, ["edited.hwp"])
+            self.assertEqual(missing, ["edited.hwp"])
+
+    def test_duplicate_expected_reported_once_in_submit_files(self):
+        mod = load()
+        task = _task("T", submit_files=["a.hwp", "a.hwp", "b.hwp"])
+        self.assertEqual(mod.submit_files(task), ["a.hwp", "b.hwp"])
+
+    def test_inspect_lists_only_absent(self):
+        mod = load()
+        task = _task("T", submit_files=["kept.hwp", "gone.hwp"])
+        with tempfile.TemporaryDirectory() as root:
+            sub = os.path.join(root, "p", "T")
+            os.makedirs(sub)
+            with open(os.path.join(sub, "kept.hwp"), "w", encoding="utf-8") as fh:
+                fh.write("k")
+            inspected = mod.inspect_built_task("/bin/false", "p", task, root)
+        self.assertEqual(inspected["kind"], "missing-artifact")
+        self.assertEqual(inspected["missing"], ["gone.hwp"])
+
+    def test_answer_task_does_not_require_files(self):
+        mod = load()
+        task = _task("T")
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "p", "T"))
+            with mock.patch.object(mod.runner, "score_task", return_value={"pass": True}):
+                inspected = mod.inspect_built_task("/bin/false", "p", task, root)
+        self.assertTrue(inspected["ok"])
+
+
+class FailedScoreEdgeTests(unittest.TestCase):
+    def test_empty_checks_without_error(self):
+        mod = load()
+        folded = mod.fold_score_result({"pass": False, "checks": []})
+        self.assertEqual(folded["reason"], "채점 실패")
+        self.assertEqual(folded["kind"], "failed-score")
+
+    def test_check_without_name_uses_op(self):
+        mod = load()
+        folded = mod.fold_score_result({
+            "pass": False,
+            "checks": [{"op": "file_exists", "ok": False, "error": "없음"}],
+        })
+        self.assertEqual(folded["reason"], "file_exists: 없음")
+
+    def test_check_without_name_or_op(self):
+        mod = load()
+        folded = mod.fold_score_result({"pass": False, "checks": [{"ok": False}]})
+        self.assertEqual(folded["reason"], "검사: 판정 불일치")
+
+    def test_pass_false_with_all_checks_ok_still_fails(self):
+        """봉투의 pass 가 거짓이면 검사 칸이 모두 ok 여도 통과가 아니다."""
+        mod = load()
+        folded = mod.fold_score_result({
+            "pass": False,
+            "checks": [{"name": "c", "ok": True}],
+        })
+        self.assertFalse(folded["ok"])
+        self.assertEqual(folded["reason"], "채점 실패")
+
+    def test_truthy_non_bool_pass_is_pass(self):
+        mod = load()
+        self.assertTrue(mod.score_is_pass({"pass": 1}))
+        self.assertFalse(mod.score_is_pass({"pass": 0}))
+
+
+class ProcessPackSkipTests(unittest.TestCase):
+    def test_missing_reference_dir_prints_skip(self):
+        mod = load()
+        counts = mod.empty_counts()
+        with mock.patch.object(mod, "PACKS_DIR", "/no/such/packs"):
+            with mock.patch("builtins.print") as printer:
+                mod.process_pack("/bin/false", "ghost", "/tmp", counts)
+        printer.assert_any_call("[ghost] 기준 풀이 없음 — 건너뜀")
+        self.assertEqual(counts["skipped"], 0)
+        self.assertEqual(counts["failed"], 0)
+
+    def test_missing_reference_file_bumps_skipped(self):
+        mod = load()
+        counts = mod.empty_counts()
+        with tempfile.TemporaryDirectory() as tmp:
+            packs = os.path.join(tmp, "packs")
+            ref = os.path.join(packs, "p", "reference")
+            os.makedirs(ref)
+            with mock.patch.object(mod, "PACKS_DIR", packs):
+                with mock.patch.object(mod.runner, "load_pack",
+                                       return_value=({}, [{"id": "T01"}])):
+                    mod.process_pack("/bin/false", "p", tmp, counts)
+        self.assertEqual(counts["skipped"], 1)
+
+    def test_broken_reference_json_is_build_error(self):
+        mod = load()
+        counts = mod.empty_counts()
+        with tempfile.TemporaryDirectory() as tmp:
+            packs = os.path.join(tmp, "packs")
+            ref = os.path.join(packs, "p", "reference")
+            os.makedirs(ref)
+            with open(os.path.join(ref, "T01.json"), "w", encoding="utf-8") as fh:
+                fh.write("{not-json")
+            with mock.patch.object(mod, "PACKS_DIR", packs):
+                with mock.patch.object(mod.runner, "load_pack",
+                                       return_value=({}, [{"id": "T01"}])):
+                    with mock.patch("builtins.print"):
+                        mod.process_pack("/bin/false", "p", tmp, counts)
+        self.assertEqual(counts["buildError"], 1)
+        self.assertEqual(counts["failed"], 1)
+
+
+class NormalizeScoreTests(unittest.TestCase):
+    def test_keeps_error_id_checks(self):
+        mod = load()
+        out = mod.normalize_score({
+            "pass": False, "error": "e", "id": "T", "checks": [1],
+        })
+        self.assertEqual(out["error"], "e")
+        self.assertEqual(out["id"], "T")
+        self.assertEqual(out["checks"], [1])
+        self.assertFalse(out["pass"])
+
+    def test_main_returns_one_when_failed(self):
+        mod = load()
+        args = mock.Mock(agent="a", pack=["p"], bin=None)
+        with mock.patch.object(mod, "parse_args", return_value=args):
+            with mock.patch.object(mod.runner, "find_bin", return_value="/bin/false"):
+                with mock.patch.object(mod, "process_pack",
+                                       side_effect=lambda *a: a[-1].update(failed=1, built=0)):
+                    with mock.patch("builtins.print"):
+                        code = mod.main([])
+        self.assertEqual(code, 1)
+
+    def test_main_returns_zero_when_clean(self):
+        mod = load()
+        args = mock.Mock(agent="a", pack=["p"], bin=None)
+        with mock.patch.object(mod, "parse_args", return_value=args):
+            with mock.patch.object(mod.runner, "find_bin", return_value="/bin/false"):
+                with mock.patch.object(mod, "process_pack"):
+                    with mock.patch("builtins.print"):
+                        code = mod.main([])
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_gym_packs.py
+++ b/scripts/tests/test_gym_packs.py
@@ -176,6 +176,56 @@ class BaselineResolveTests(unittest.TestCase):
 
         self.assertEqual(failure, "pack-b/T02: 제출 폴더 없음")
 
+    def test_three_sub_placeholders_all_resolve(self):
+        """다세대 계획서는 세 개 이상의 {sub:} 를 한 문자열에 넣는다(#5273)."""
+        import tempfile
+
+        build_baseline = load_module(
+            "gym_build_baseline_triple", REPO_ROOT / "gym" / "tools" / "build_baseline.py")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"a": "{sub:a.hwp}", "b": "{sub:b.hwp}", "c": "{sub:c.hwp}"}'
+            out = build_baseline.resolve(token, {"input": "in.hwp"}, sub_dir)
+            self.assertNotIn("{sub:", out)
+            self.assertIn("a.hwp", out)
+            self.assertIn("b.hwp", out)
+            self.assertIn("c.hwp", out)
+
+    def test_missing_artifact_is_reported_before_score(self):
+        """submit.files 가 선언한 산출이 없으면 채점 전에 부재를 보고한다."""
+        import tempfile
+        from unittest import mock
+
+        build_baseline = load_module(
+            "gym_build_baseline_missing", REPO_ROOT / "gym" / "tools" / "build_baseline.py")
+        task = {"id": "T02", "submit": {"kind": "artifact", "files": ["edited.hwp"]}}
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "pack-b", "T02"))
+            with mock.patch.object(build_baseline.runner, "score_task") as score:
+                inspected = build_baseline.inspect_built_task(
+                    "/tmp/rhwp", "pack-b", task, root)
+            score.assert_not_called()
+        self.assertEqual(inspected["kind"], "missing-artifact")
+        self.assertEqual(inspected["missing"], ["edited.hwp"])
+        self.assertEqual(inspected["message"], "pack-b/T02: 부재 산출: edited.hwp")
+
+    def test_failed_score_lists_check_names(self):
+        """채점 실패는 과제 ID 와 검사 이름을 남긴다. 침묵하지 않는다."""
+        from unittest import mock
+
+        build_baseline = load_module(
+            "gym_build_baseline_checks", REPO_ROOT / "gym" / "tools" / "build_baseline.py")
+        task = {"id": "T09"}
+        result = {
+            "pass": False,
+            "checks": [
+                {"name": "1단계 반영", "ok": False, "error": "없음"},
+                {"name": "2단계 반영", "ok": True},
+            ],
+        }
+        with mock.patch.object(build_baseline.runner, "score_task", return_value=result):
+            failure = build_baseline.verify_built_task("/tmp/rhwp", "core-cli", task, "/tmp/sub")
+        self.assertEqual(failure, "core-cli/T09: 1단계 반영: 없음")
+
 
 class ProfileTests(unittest.TestCase):
     def test_profiles_reference_existing_packs(self):


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

기준 풀이 조립기(`gym/tools/build_baseline.py`)의 자리표 치환·부재 산출·실패 보고를 고도화한다. 새 CLI 플래그와 새 pack 은 없다.

- 한 문자열의 `{sub:}` 를 전부 바꾼다. 세 개 이상·`{input}` 혼합·닫히지 않은 `{sub:` 도 시험으로 고정한다.
- `{sub:}` 이름은 제출 폴더 안의 상대경로만 허용한다. 부모·절대·드라이브·UNC·홈은 `RuntimeError` 로 그 과제만 실패한다.
- `submit.files` 가 선언한 파일이 없으면 채점 전에 `부재 산출:` 로 보고한다. `score_task` 를 부르지 않는다.
- 채점 실패는 `pack/task: 이유` 한 줄을 유지한다. 검사 이름을 남기고, 비-dict·`pass` 키 없음은 통과로 접지 않는다.
- CLI 는 `--agent` / `--pack` / `--bin` 만. `resolve` · `build_task` · `verify_built_task` 서명은 그대로다.

## 관련 이슈

closes #5273

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_build_baseline -q` 통과 (128 ran, 0 failed)
- [x] `python -m unittest scripts.tests.test_gym_packs -q` 통과 (18 ran, 0 failed; `BaselineResolveTests` 기존 3칸 + 자리표 3개·부재 산출·검사 이름)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [x] **`cargo fmt --all -- --check` 통과**
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [ ] `cargo test` 통과 (해당 없음 — Python/문서만)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 단위 시험은 바이너리 없이 돈다. 라이브 왕복은 기존과 같이 rhwp 가 필요하다.

## 스크린샷

해당 없음.
