### PR TITLE
gym: audit 정합 감사 예외·문서·시험 고도화

### DIFF
--- a/gym/docs/audit.md
+++ b/gym/docs/audit.md
@@ -1,0 +1,479 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/audit.md
+last_verified: 2026-08-18
+---
+
+# gym 정합 감사 규약
+
+이 문서는 `gym/tools/audit.py` 의 **전 pack 정합 계약**, **위반 코드
+카탈로그**, **예외 경로**, **보고 봉투**를 고정한다. 작업 기록은
+[`mydocs/working/gym_audit.md`](../../mydocs/working/gym_audit.md) 를
+본다. 시험 계약은 `scripts/tests/test_gym_audit.py` 가 기계로 고정한다.
+
+개별 검증(`schema.validate_pack` / `validate_task`)은 pack 하나·과제
+하나만 본다. 이 도구는 **전 저장소에 걸친 정합**을 본다. 과제↔기준
+짝, 과제 ID 전역 고유, 고아 기준풀이, 빠진 `pack.json`, 스키마 위반.
+바이너리 없이 순수 파일 검사라 CI 에서 상시 돈다.
+
+이 도구는 새 CLI 를 열지 않는다. 새 pack 을 만들지 않는다. `--json`
+이외의 플래그를 추가하지 않는다. 한 pack 만 봐서 전역 ID 충돌이
+없다고 말하면 거짓말이다.
+
+## 1. 왜 이 기둥이 필요한가
+
+gym 이 자라고 기여자가 늘수록, 새 pack 이 조용히 규약을 어길 수
+있다. 그 구멍은 채점기가 아니라 정합 감사기가 막는다.
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 종점 무결성 | `discriminate.py` | 일 안 한 제출이 만점을 받나? |
+| 경로 무결성 | `trajectory.py` | 마지막 스텝을 빼도 통과하나? |
+| 전 저장소 정합 | `audit.py` (#4803 / #5277) | 빠진 기준풀이·ID 충돌·스키마 위반이 있나? |
+
+채점기는 과제가 선언한 검사를 돌린다. 과제가 기준풀이 없이
+들어와도 채점기는 "이 과제는 풀 수 있다"고 전제한다. 리더보드는
+과제 ID 로 행을 가른다. 두 pack 이 같은 ID 를 쓰면 집계가 섞인다.
+`schema.validate_task` 는 그 파일만 보고, 옆 pack 의 같은 ID 는
+모른다.
+
+그래서 감사기는 전 pack 을 한 번에 본다. CI 의
+`Validate gym scorer contracts` 가 `test_gym_audit.py` 를 돌리고,
+그 테스트가 실제 `gym/packs` 와 픽스처 네 자리(빠진 pack.json ·
+고아 기준풀이 · 중복 ID · 나쁜 스키마)를 함께 고정한다.
+
+## 2. 사용
+
+```bash
+python gym/tools/audit.py
+python gym/tools/audit.py --json
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--json` | 꺼짐 | 사람 요약 대신 `gymAudit` 봉투를 stdout 에 쓴다. |
+
+새 플래그는 없다. `--pack` / `--task` / `--out` / `--strict` /
+`--root` 는 없다. 라이브러리 `audit(packs_root)` 는 시험이 임시
+디렉터리를 넘길 수 있게 루트를 받는다. CLI 는 항상 `gym/` 을
+본다.
+
+종료 코드:
+
+| 코드 | 상수 | 의미 |
+|---|---|---|
+| 0 | `EXIT_OK` | 위반 0 · 도구 실패 없음 |
+| 1 | `EXIT_VIOLATION` | pack 정합 위반 또는 전역 ID 충돌 |
+| 2 | `EXIT_TOOL` | packs 루트 부재· packs 가 디렉터리가 아님 · 나열 실패 |
+
+`ok` 는 `issueCount == 0` **그리고** `toolFailed` 가 거짓일 때만
+true 다. 루트를 못 읽었는데 정합 0건이라고 쓰면 거짓말이다.
+
+사람 요약:
+
+```
+gym 정합 감사: 18 pack 전부 통과 — 위반 0
+```
+
+또는
+
+```
+gym 정합 감사: 위반 3건
+  [ghost] pack.json 이 없다
+  [p1] 고아 기준풀이 reference/X01.json — 짝 과제(tasks/X01.json)가 없다
+  [전역] 과제 ID 'DUP' 충돌: p1, p2
+```
+
+도구 실패:
+
+```
+gym 정합 감사: 도구 실패 — packs 루트가 없다 — 정합 0건으로 위장하지 않는다
+```
+
+## 3. 검사하는 것
+
+감사기가 한 pack 에 대해 보는 순서다. 앞 단계에서 매니페스트를
+못 읽으면 그 pack 의 과제 스캔은 하지 않는다. 없는 매니페스트를
+스키마 위반으로 위장하지 않는다.
+
+1. **packs 루트** — `packs_root/packs` 가 있어야 한다. 없으면
+   `missing-packs-root`, exit 2.
+2. **pack 폴더** — 디렉터리만 본다. `packs/notes.txt` 같은 파일은
+   무시한다. README 도 pack 이 아니다.
+3. **pack.json** — 있어야 하고, UTF-8 JSON 객체여야 한다. 없으면
+   `missing-pack-json`. 파싱 실패는 `pack-json-parse`. 배열·숫자는
+   `pack-json-not-object`.
+4. **스키마** — `schema.validate_pack(manifest, pack_dir, errors)`.
+   메시지는 `bad-schema` 로 접고, `schemaTag` 로 세부(kind /
+   schemaVersion / pack-id / title / axis / requires / runner)를
+   남긴다.
+5. **tasks / reference** — 디렉터리면 나열한다. 파일이면
+   `tasks-not-dir` / `reference-not-dir`. 나열 실패는
+   `unlistable-tasks` / `unlistable-reference`. 없는 디렉터리는
+   원 계약대로 빈 목록이다.
+6. **과제 파일** — 소문자 `.json` 만. `.JSON` · `.txt` ·
+   `.hidden.json` 은 과제가 아니다. 객체여야 하고,
+   `schema.validate_task(task, manifest, None, errors)` 로 구조를
+   본다. `known_commands=None` — 명령 존재 검사는 러너 몫이다.
+7. **파일명 ↔ id** — `X01.json` 의 `id` 는 `X01` 이어야 한다.
+   빈 id 는 `task-empty-id`. 다른 id 는
+   `task-filename-id-mismatch`.
+8. **짝 기준풀이** — 같은 이름의 `reference/X01.json` 이 있어야
+   한다. 없으면 `missing-reference`. 있으면 객체를 읽고
+   `ref.id == task.id` 인지 본다. 다르면
+   `reference-id-mismatch`.
+9. **고아 기준풀이** — `reference` 에만 있는 `.json` 은
+   `orphan-reference`. 짝짓기는 **파일 이름**이지 id 가 아니다.
+10. **pack 안 중복** — 같은 pack 의 두 파일이 같은 `id` 를 쓰면
+    `task-id-duplicate-in-pack`. 전역 충돌로 위장하지 않는다.
+11. **빈 pack** — 나열에 성공했는데 과제 `.json` 이 0 이면
+    `empty-pack`. 나열을 못 한 자리에는 빈 pack 이라고 쓰지
+    않는다.
+12. **전역 ID** — 서로 다른 pack 이 같은 `id` 를 쓰면
+    `taskIdCollisions` 와 `task-id-collision`. 같은 pack 의 이중
+    등록은 여기 넣지 않는다.
+
+## 4. 위반 코드 카탈로그
+
+`ISSUE_CODES` 는 아래 표와 같다. 코드를 추가하면 이 표와
+`ISSUE_FAMILY` · `ISSUE_TEXT` · 시험을 같이 고친다. 지금 카탈로그의
+모든 코드는 차단이다. 경고 등급을 숨기지 않는다.
+
+### 4.1 루트 (family=`root`)
+
+| 코드 | 언제 | 종료 |
+|---|---|---|
+| `missing-packs-root` | `packs/` 가 없다 | 2 |
+| `packs-not-dir` | `packs` 가 파일이다 | 2 |
+| `unlistable-packs` | `listdir` 권한·OS 오류 | 2 |
+| `empty-packs-root` | 카탈로그에만 있다. 빈 `packs/` 는 원 계약대로 위반 0 | 0 |
+
+빈 `packs/` 디렉터리는 위반이 아니다. 시험 픽스처가 폴더만 만들고
+pack 을 아직 안 넣은 상태와, 저장소에 pack 이 한 개도 없는 상태를
+도구 실패로 부르지 않는다. 실제 저장소 시험은 `packCount >= 10` 을
+따로 강제한다.
+
+### 4.2 매니페스트 (family=`manifest`)
+
+| 코드 | 한글 줄 (packs[].issues) |
+|---|---|
+| `missing-pack-json` | `pack.json 이 없다` |
+| `pack-json-parse` | `pack.json 파싱 실패: …` |
+| `pack-json-not-object` | `pack.json 이 객체가 아니다` |
+| `pack-json-unreadable` | `pack.json 을 읽을 수 없다: …` |
+
+원 계약 문구 `pack.json 이 없다` 와 `pack.json 파싱 실패` 는
+바꾸지 않는다. `test_gym_audit.py` 의 레거시 시험이 이 부분
+문자열을 본다.
+
+### 4.3 스키마 (family=`schema`)
+
+| 코드 | 의미 |
+|---|---|
+| `bad-schema` | `schema.validate_pack` 또는 `validate_task` 가 메시지를 남겼거나, 그 호출이 비치명 예외로 죽었다 |
+
+`schemaTag` 는 메시지를 다시 분류한 세부다. 코드는 항상
+`bad-schema` 다.
+
+| schemaTag | 메시지 단서 |
+|---|---|
+| `kind` | `kind` + `아니다` |
+| `schemaVersion` | `schemaVersion` |
+| `pack-id` | `폴더 이름` 또는 `pack id` |
+| `title` | `title` + `비었` |
+| `axis` | `axis` + `비었` |
+| `requires` | `requires.commands` |
+| `runner` | `runner.` |
+| `task-required` | `필수 키 없음` |
+| `tier` | `tier` |
+| `checks-empty` | `checks 가 비었` |
+| `unknown-op` | `미등록 연산자` |
+| `global-scan` | `전역 훑기` |
+| `missing-cmd` | `cmd 가 필요` |
+| `unexpected-cmd` | `cmd 가 있다` |
+| `other` | 위에 안 걸림 |
+
+스키마 함수가 `TypeError` / `RuntimeError` 로 죽어도 감사기는
+죽지 않는다. 그 문장은 `schema.validate_pack 예외: …` 로 접혀
+같은 `bad-schema` 가 된다. `KeyboardInterrupt` · `SystemExit` ·
+`MemoryError` · `GeneratorExit` 는 다시 올린다.
+
+### 4.4 배치 (family=`layout`)
+
+| 코드 | 언제 |
+|---|---|
+| `missing-tasks-dir` | 나열 문맥에서 tasks 가 없음 (예외 접기) |
+| `tasks-not-dir` | `tasks` 가 파일이다 |
+| `unlistable-tasks` | tasks 를 나열할 수 없다 |
+| `missing-reference-dir` | 나열 문맥에서 reference 가 없음 |
+| `reference-not-dir` | `reference` 가 파일이다 |
+| `unlistable-reference` | reference 를 나열할 수 없다 |
+| `empty-pack` | 나열 성공 · 과제 `.json` 0 |
+
+없는 `tasks/` 는 원 계약대로 빈 목록이다. 그 위에 고아 기준풀이가
+있으면 `orphan-reference` 와 `empty-pack` 이 같이 난다. 나열을 못
+했는데 빈 pack 이라고 쓰면 거짓말이다.
+
+### 4.5 과제 파일 (family=`task`)
+
+| 코드 | 한글 줄 |
+|---|---|
+| `task-parse` | `tasks/{name} 파싱 실패: …` |
+| `task-not-object` | `tasks/{name} 이 객체가 아니다` |
+| `task-unreadable` | `tasks/{name} 을 읽을 수 없다: …` |
+
+파싱에 실패해도 파일 이름은 짝짓기에 남는다. 같은 이름의
+기준풀이가 없으면 `missing-reference` 를 추가로 남긴다. 기준풀이가
+있으면 고아로 부르지 않는다 — 과제가 * committ 되어 있고 내용만
+깨진 것이다.
+
+### 4.6 짝짓기 (family=`pairing`)
+
+| 코드 | 한글 줄 |
+|---|---|
+| `missing-reference` | `과제 {name} 에 짝 기준풀이(reference/{name})가 없다 — 해결 가능성 미선언` |
+| `reference-parse` | `reference/{name} 파싱 실패: …` |
+| `reference-not-object` | `reference/{name} 이 객체가 아니다` |
+| `reference-unreadable` | `reference/{name} 을 읽을 수 없다: …` |
+| `reference-id-mismatch` | `reference/{name} 의 id({rid}) 가 과제 id({tid}) 와 다르다` |
+| `orphan-reference` | `고아 기준풀이 reference/{name} — 짝 과제(tasks/{name})가 없다` |
+
+짝짓기 키는 **파일 이름**이다. `Y99.json` 이 `id=Y99` 를 들고
+있으면 파일명 불일치는 identity 가족이고, 짝은 이미 맞다.
+
+### 4.7 신원 (family=`identity`)
+
+| 코드 | 한글 줄 |
+|---|---|
+| `task-empty-id` | `과제 {name} 의 id 가 비었다` |
+| `task-filename-id-mismatch` | `과제 {name} 의 id({tid}) 가 파일 이름과 다르다` |
+| `task-id-duplicate-in-pack` | `pack 안 과제 ID '{tid}' 가 여러 파일에 있다: a.json, b.json` |
+| `task-id-collision` | 전역. `packs[].issues` 가 아니라 `taskIdCollisions` |
+
+전역 충돌은 `issueCount` 에 충돌 키 수만큼 더한다. 원 계약:
+`issueCount = sum(len(p.issues)) + len(taskIdCollisions)`.
+
+### 4.8 도구 (family=`tool`)
+
+| 코드 | 언제 |
+|---|---|
+| `unexpected` | 카탈로그 밖 예외, 모르는 코드 |
+
+## 5. 보고 봉투
+
+`kind=gymAudit`, `schemaVersion=1.0`. 버전을 올리지 않는다. 키를
+빼면 `validate_report` 가 막는다. 원 계약 키는 그대로다.
+
+| 키 | 형 | 원 계약 | 의미 |
+|---|---|---|---|
+| `kind` | str | 예 | 항상 `gymAudit` |
+| `schemaVersion` | str | 예 | 항상 `1.0` |
+| `ok` | bool | 예 | 위반 0 이고 도구 실패 아님 |
+| `packCount` | int | 예 | 본 pack 폴더 수 |
+| `packs` | list | 예 | 이슈가 있는 pack 만 `{id, issues}` |
+| `taskIdCollisions` | object | 예 | `{id: [pack, …]}` · 서로 다른 pack 만 |
+| `issueCount` | int | 예 | pack 이슈 줄 + 전역 충돌 수 |
+| `taskCount` | int | 추가 | 과제 `.json` 수 |
+| `referenceCount` | int | 추가 | 기준풀이 `.json` 수 |
+| `okPacks` | list | 추가 | 이슈 없는 pack id |
+| `emptyPacks` | list | 추가 | 과제 0 인 pack id |
+| `issues` | list | 추가 | 구조화 위반 |
+| `issueCountsByCode` | object | 추가 | 코드별 건수 |
+| `issueCountsByFamily` | object | 추가 | 가족별 건수 |
+| `toolErrors` | list | 추가 | 도구 자리 오류 |
+| `missingPacksRoot` | bool | 추가 | packs 루트 부재 |
+| `toolFailed` | bool | 추가 | 도구가 전수 검사를 못 함 |
+| `exit` | int | 추가 | 0 / 1 / 2 |
+
+구조화 이슈 한 줄:
+
+```json
+{
+  "code": "orphan-reference",
+  "pack": "p1",
+  "path": "p1/reference/X01.json",
+  "message": "고아 기준풀이 reference/X01.json — 짝 과제(tasks/X01.json)가 없다",
+  "family": "pairing"
+}
+```
+
+필수 키는 `code` · `pack` · `path` · `message` · `family` 다.
+선택 키: `schemaTag`, `taskId`, `owners`.
+
+`packs[].issues` 는 **문자열 목록**이다. 구조화 객체로 바꾸지
+않는다. 레거시 시험이 `"기준풀이" in i`, `"고아" in i` 를 보기
+때문이다.
+
+## 6. 예외 경로
+
+도구가 한 파일의 파싱 실패로 죽지 않는다. 치명 예외만 다시 올린다.
+
+`FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)`
+
+접는 자리:
+
+| 자리 | 접는 것 | 접지 않는 것 |
+|---|---|---|
+| packs 루트 | 부재 · 파일 · 나열 실패 | 치명 예외 |
+| pack.json | 파싱 · 디코드 · 권한 · 비객체 | 치명 예외 |
+| tasks/reference 나열 | 권한 · OS 오류 · 파일 | 치명 예외 |
+| 과제/기준풀이 JSON | 파싱 · 디코드 · 비객체 | 치명 예외 |
+| `schema.validate_*` | TypeError · RuntimeError · ValueError | 치명 예외 |
+| pack 루프 | 그 pack 만 `unexpected` | 치명 예외 |
+
+`exception_kind(exc, context)` 는 같은 `FileNotFoundError` 라도
+문맥에 따라 코드가 갈린다.
+
+| context | FileNotFoundError |
+|---|---|
+| `packs-root` | `missing-packs-root` |
+| `pack-json` | `missing-pack-json` |
+| `listdir-tasks` | `missing-tasks-dir` |
+| `listdir-reference` | `missing-reference-dir` |
+
+`JSONDecodeError` 는 `pack-json-parse` / `task-parse` /
+`reference-parse`. `PermissionError` 는 unlistable / unreadable.
+`NotADirectoryError` 는 `*-not-dir`.
+
+`load_object` 는 JSON 이 객체인지까지 본다. 배열·숫자·문자열은
+파싱 성공이 아니라 `*-not-object` 다. `task.get("id")` 가
+`AttributeError` 로 감사기를 죽이던 구멍을 이 검사가 막는다.
+
+## 7. 순수 함수
+
+시험이 바이너리 없이 고정하는 함수다. 파일 시스템이 필요 없는
+것은 순수다.
+
+| 함수 | 순수 | 역할 |
+|---|---|---|
+| `is_fatal_exception` | 예 | 치명 여부 |
+| `truncate_head` | 예 | 오류 머리 |
+| `exception_kind` | 예 | 예외 → 코드 |
+| `exception_record` | 예 | 오류 한 줄 |
+| `issue_family` / `issue_codes` / `catalog_ids` | 예 | 카탈로그 |
+| `is_known_code` / `is_blocking_code` | 예 | 코드 소속 |
+| `format_issue_message` / `make_issue` | 예 | 구조화 이슈 |
+| `posix_rel` / `is_json_name` / `stem_of` | 예 | 이름 |
+| `pair_names` | 예 | 파일명 짝짓기 |
+| `detect_in_pack_duplicates` | 예 | pack 안 중복 |
+| `detect_global_collisions` | 예 | 전역 충돌 (서로 다른 pack) |
+| `classify_schema_message` | 예 | schemaTag |
+| `pack_issue_line` | 예 | 레거시 한글 줄 |
+| `empty_report` / `validate_report` | 예 | 봉투 계약 |
+| `format_human_report` / `format_json_report` | 예 | 출력 |
+| `resolve_exit` | 예 | 종료 코드 |
+| `list_dir_safe` / `load_json_safe` / `load_object` | 아니오 | I/O, 예외 접기 |
+| `run_validate_pack` / `run_validate_task` | 아니오 | schema 호출 |
+| `audit_one_pack` / `audit` | 아니오 | 전수 검사 |
+| `parse_args` / `main` | 아니오 | CLI |
+
+`_load` 는 원 계약의 날것 로더다. 예외를 그대로 올린다. 감사
+본문은 `load_object` 를 쓴다.
+
+## 8. 하지 않는 것
+
+- 새 CLI 플래그를 열지 않는다.
+- 새 pack · 새 과제를 만들지 않는다.
+- `certify.py` · `report.py` · `score.py` · `runner.py` ·
+  `build_baseline.py` 를 고치지 않는다.
+- `schema.py` 의 규칙을 여기서 다시 구현하지 않는다. 감싸서
+  메시지를 접을 뿐이다.
+- 명령 존재 검사를 하지 않는다. `known_commands=None`.
+- 한 pack 만 골라 통과했다고 전 저장소 정합을 선언하지 않는다.
+- 도구 실패를 위반 0 으로 위장하지 않는다.
+- 치명 예외를 삼키지 않는다.
+- `.JSON` 대문자 확장자를 과제로 치지 않는다. 원 계약은 소문자
+  `.json` 이다.
+- README · assets · 숨은 파일을 위반으로 부르지 않는다.
+
+## 9. 픽스처로 고정한 네 자리
+
+이슈 #5277 가 명시한 자리. 시험이 각각 red 로 막는다.
+
+### 9.1 빠진 pack.json
+
+```
+packs/ghost/          # 폴더만 있다
+```
+
+결과: `ok=false`, `exit=1`, 코드 `missing-pack-json`, 한글
+`pack.json 이 없다`. 과제 스캔은 하지 않는다. 없는 매니페스트를
+`bad-schema` 로 부르지 않는다.
+
+### 9.2 고아 기준풀이
+
+```
+packs/p1/pack.json
+packs/p1/reference/X01.json
+# tasks/X01.json 없음
+```
+
+결과: `orphan-reference` + `empty-pack`. 한글에 `고아` 가 있다.
+
+### 9.3 중복 과제 ID
+
+```
+packs/p1/tasks/DUP.json   id=DUP
+packs/p2/tasks/DUP.json   id=DUP
+```
+
+결과: `taskIdCollisions.DUP == ["p1", "p2"]`, 코드
+`task-id-collision`. 사람 요약에 `[전역]`.
+
+같은 pack 의 `A01.json` 과 `A01b.json` 이 둘 다 `id=A01` 이면
+`task-id-duplicate-in-pack` 이지 전역 충돌이 아니다.
+
+### 9.4 나쁜 스키마
+
+매니페스트 `kind` 가 `gymPack` 이 아니거나, `schemaVersion` 이
+`1.0` 이 아니거나, `id` 가 폴더 이름과 다르거나, `title`/`axis` 가
+비었거나, `requires.commands` 가 비었거나, `runner.*` 가 비었거나,
+과제에 필수 키가 없거나, `tier` 가 1~5 가 아니거나, `checks` 가
+비었거나, 미등록 연산자이거나, 편집 축에 전역 훑기 연산자를
+쓰거나, CLI 연산자에 `cmd` 가 없거나, 파일 연산자에 `cmd` 가
+있으면 `bad-schema`.
+
+## 10. 실제 저장소 계약
+
+`audit(gym/)` 는 다음을 만족해야 한다. CI 가 본다.
+
+- `ok is True`
+- `packCount >= 10`
+- `taskCount == referenceCount`
+- `taskIdCollisions == {}`
+- `emptyPacks == []`
+- `toolFailed is False`
+- `missingPacksRoot is False`
+- `validate_report(report) == []`
+
+새 pack 을 넣는 기여자는 이 감사기를 통과해야 한다. 기준풀이 없는
+과제, 다른 pack 과 겹치는 ID, `pack.json` 없는 폴더, 스키마를
+어긴 매니페스트는 이 관문에서 막힌다.
+
+## 11. 구현 위치
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tools/audit.py` | 감사기 |
+| `gym/core/schema.py` | pack/task 스키마 (이 도구가 감싼다, 고치지 않는다) |
+| `scripts/tests/test_gym_audit.py` | 계약 시험 |
+| `gym/docs/audit.md` | 이 문서 |
+| `mydocs/working/gym_audit.md` | 작업 기록 |
+
+CI: `.github/workflows/ci.yml` 의 `Validate gym scorer contracts`
+가 `python3 -m unittest scripts/tests/test_gym_audit.py` 를 돌린다.
+
+## 12. 변경 규칙
+
+1. 원 계약 키(`ok`, `packs`, `taskIdCollisions`, `issueCount`,
+   `packCount`, `kind`, `schemaVersion`)를 빼거나 형을 바꾸지
+   않는다.
+2. `packs[].issues` 는 문자열 목록으로 남긴다.
+3. 레거시 한글 부분 문자열(`pack.json 이 없다`, `기준풀이`,
+   `고아`, `파싱 실패`)을 바꾸지 않는다.
+4. CLI 는 `--json` 만.
+5. 코드를 추가하면 카탈로그 표·가족·문구·시험을 한 커밋에서
+   맞춘다.
+6. 치명 예외를 `except Exception` 으로 삼키지 않는다.
+7. 새 pack 을 이 도구 PR 에 섞지 않는다.

--- a/gym/tools/audit.py
+++ b/gym/tools/audit.py
@@ -21,11 +21,20 @@ CI 에서 상시 돈다.
   id 일치). 기준풀이 없는 과제는 "풀 수 있다" 는 근거가 없다.
 - **고아 기준풀이 없음** — 기준풀이는 반드시 과제를 가진다.
 - **과제 ID 전역 고유** — pack 간 ID 충돌 금지(리더보드·집계가 ID 로 과제를 가른다).
+- **pack 안 ID 중복·파일명 불일치** — 같은 pack 의 두 파일이 같은 id 를 쓰거나,
+  `X01.json` 이 `id=X02` 를 들고 있으면 집계가 파일 이름으로 과제를 가른다는
+  가정이 깨진다.
+- **예외를 위장하지 않음** — 없는 packs 루트, 읽기 실패, 객체가 아닌 JSON 은
+  도구가 죽지 않고 코드로 접힌다. 못 읽은 것을 "정합 0건" 으로 부르지 않는다.
 
 ## 사용
 
     python gym/tools/audit.py           # 전 pack 감사, 문제 있으면 exit 1
     python gym/tools/audit.py --json
+
+새 플래그는 없다. `--pack` / `--out` / `--strict` 를 열지 않는다. 전 pack 을
+도는 것이 이 감사의 점이다. 한 pack 만 봐서 전역 ID 충돌이 없다고 말하면
+거짓말이다.
 """
 
 from __future__ import annotations
@@ -41,108 +50,1215 @@ sys.path.insert(0, GYM_ROOT)
 
 from core import schema  # noqa: E402  (gym/core)
 
+REPORT_KIND = "gymAudit"
+SCHEMA_VERSION = "1.0"
 
-def _load(path):
+#: 삼키면 안 되는 예외 — 사용자가 끊었는데 정합 0건이라고 쓰면 거짓말이다.
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+#: 도구가 접는 위반 코드. 시험·문서가 같은 표를 본다.
+ISSUE_CODES = (
+    "missing-packs-root",
+    "packs-not-dir",
+    "unlistable-packs",
+    "empty-packs-root",
+    "missing-pack-json",
+    "pack-json-parse",
+    "pack-json-not-object",
+    "pack-json-unreadable",
+    "bad-schema",
+    "missing-tasks-dir",
+    "tasks-not-dir",
+    "unlistable-tasks",
+    "missing-reference-dir",
+    "reference-not-dir",
+    "unlistable-reference",
+    "empty-pack",
+    "task-parse",
+    "task-not-object",
+    "task-unreadable",
+    "task-empty-id",
+    "task-filename-id-mismatch",
+    "task-id-duplicate-in-pack",
+    "missing-reference",
+    "reference-parse",
+    "reference-not-object",
+    "reference-unreadable",
+    "reference-id-mismatch",
+    "orphan-reference",
+    "task-id-collision",
+    "unexpected",
+)
+
+#: 코드 → 가족. 가족이 늘면 문서 표와 시험을 같이 고친다.
+ISSUE_FAMILY = {
+    "missing-packs-root": "root",
+    "packs-not-dir": "root",
+    "unlistable-packs": "root",
+    "empty-packs-root": "root",
+    "missing-pack-json": "manifest",
+    "pack-json-parse": "manifest",
+    "pack-json-not-object": "manifest",
+    "pack-json-unreadable": "manifest",
+    "bad-schema": "schema",
+    "missing-tasks-dir": "layout",
+    "tasks-not-dir": "layout",
+    "unlistable-tasks": "layout",
+    "missing-reference-dir": "layout",
+    "reference-not-dir": "layout",
+    "unlistable-reference": "layout",
+    "empty-pack": "layout",
+    "task-parse": "task",
+    "task-not-object": "task",
+    "task-unreadable": "task",
+    "task-empty-id": "identity",
+    "task-filename-id-mismatch": "identity",
+    "task-id-duplicate-in-pack": "identity",
+    "missing-reference": "pairing",
+    "reference-parse": "pairing",
+    "reference-not-object": "pairing",
+    "reference-unreadable": "pairing",
+    "reference-id-mismatch": "pairing",
+    "orphan-reference": "pairing",
+    "task-id-collision": "identity",
+    "unexpected": "tool",
+}
+
+ISSUE_FAMILIES = ("root", "manifest", "schema", "layout", "task", "pairing", "identity", "tool")
+
+#: 사람 메시지 기본값. 자리표시가 있으면 format_issue_message 가 채운다.
+ISSUE_TEXT = {
+    "missing-packs-root": "packs 루트가 없다 — 정합 0건으로 위장하지 않는다",
+    "packs-not-dir": "packs 가 디렉터리가 아니다",
+    "unlistable-packs": "packs 디렉터리를 읽을 수 없다",
+    "empty-packs-root": "packs 아래에 pack 폴더가 없다",
+    "missing-pack-json": "pack.json 이 없다",
+    "pack-json-parse": "pack.json 파싱 실패",
+    "pack-json-not-object": "pack.json 이 객체가 아니다",
+    "pack-json-unreadable": "pack.json 을 읽을 수 없다",
+    "bad-schema": "스키마 위반",
+    "missing-tasks-dir": "tasks 디렉터리가 없다",
+    "tasks-not-dir": "tasks 가 디렉터리가 아니다",
+    "unlistable-tasks": "tasks 디렉터리를 읽을 수 없다",
+    "missing-reference-dir": "reference 디렉터리가 없다",
+    "reference-not-dir": "reference 가 디렉터리가 아니다",
+    "unlistable-reference": "reference 디렉터리를 읽을 수 없다",
+    "empty-pack": "과제가 없다 — 빈 pack 은 해결 가능성을 선언할 수 없다",
+    "task-parse": "과제 JSON 파싱 실패",
+    "task-not-object": "과제 JSON 이 객체가 아니다",
+    "task-unreadable": "과제 파일을 읽을 수 없다",
+    "task-empty-id": "과제 id 가 비었다",
+    "task-filename-id-mismatch": "과제 id 가 파일 이름과 다르다",
+    "task-id-duplicate-in-pack": "pack 안 과제 ID 가 여러 파일에 있다",
+    "missing-reference": "짝 기준풀이가 없다 — 해결 가능성 미선언",
+    "reference-parse": "기준풀이 JSON 파싱 실패",
+    "reference-not-object": "기준풀이 JSON 이 객체가 아니다",
+    "reference-unreadable": "기준풀이 파일을 읽을 수 없다",
+    "reference-id-mismatch": "기준풀이 id 가 과제 id 와 다르다",
+    "orphan-reference": "고아 기준풀이 — 짝 과제가 없다",
+    "task-id-collision": "과제 ID 가 여러 pack 에 있다",
+    "unexpected": "카탈로그 밖 실패",
+}
+
+#: 종료 코드. 도구 자리 실패는 정합 위반(1)과 구별한다.
+EXIT_OK = 0
+EXIT_VIOLATION = 1
+EXIT_TOOL = 2
+
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "packCount",
+    "taskCount",
+    "referenceCount",
+    "packs",
+    "okPacks",
+    "emptyPacks",
+    "taskIdCollisions",
+    "issueCount",
+    "issues",
+    "issueCountsByCode",
+    "issueCountsByFamily",
+    "toolErrors",
+    "missingPacksRoot",
+    "toolFailed",
+    "exit",
+)
+
+ISSUE_RECORD_KEYS = ("code", "pack", "path", "message", "family")
+
+ERROR_HEAD_LIMIT = 160
+
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    NotADirectoryError,
+    PermissionError,
+    TimeoutError,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    json.JSONDecodeError,
+    RuntimeError,
+)
+
+JSON_SUFFIX = ".json"
+
+
+def is_fatal_exception(exc) -> bool:
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def truncate_head(text, limit=ERROR_HEAD_LIMIT) -> str:
+    """오류 머리. None/비문자는 빈 문자열. 한도는 0 이하면 빈 값."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except FATAL_EXCEPTIONS:
+            raise
+        except Exception:
+            return ""
+    if limit is None or limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[:limit]
+
+
+def exception_kind(exc, context="json") -> str:
+    """예외를 위반/도구 코드로 접는다. 순수.
+
+    context:
+      - packs-root: packs 디렉터리 자체
+      - listdir: 디렉터리 나열
+      - json / pack-json / task / reference: JSON 읽기
+      - schema: schema.validate_* 예외
+      - audit: 그 외
+    """
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, json.JSONDecodeError):
+        if context == "pack-json":
+            return "pack-json-parse"
+        if context == "task":
+            return "task-parse"
+        if context == "reference":
+            return "reference-parse"
+        return "pack-json-parse" if context == "json" else "unexpected"
+    if isinstance(exc, UnicodeError):
+        if context == "pack-json":
+            return "pack-json-unreadable"
+        if context == "task":
+            return "task-unreadable"
+        if context == "reference":
+            return "reference-unreadable"
+        return "pack-json-unreadable"
+    if isinstance(exc, PermissionError):
+        if context == "packs-root":
+            return "unlistable-packs"
+        if context == "listdir-tasks":
+            return "unlistable-tasks"
+        if context == "listdir-reference":
+            return "unlistable-reference"
+        if context == "pack-json":
+            return "pack-json-unreadable"
+        if context == "task":
+            return "task-unreadable"
+        if context == "reference":
+            return "reference-unreadable"
+        return "unlistable-packs"
+    if isinstance(exc, FileNotFoundError):
+        if context == "packs-root":
+            return "missing-packs-root"
+        if context == "pack-json":
+            return "missing-pack-json"
+        if context == "listdir-tasks":
+            return "missing-tasks-dir"
+        if context == "listdir-reference":
+            return "missing-reference-dir"
+        return "missing-packs-root"
+    if isinstance(exc, NotADirectoryError):
+        if context == "packs-root":
+            return "packs-not-dir"
+        if context == "listdir-tasks":
+            return "tasks-not-dir"
+        if context == "listdir-reference":
+            return "reference-not-dir"
+        return "packs-not-dir"
+    if isinstance(exc, IsADirectoryError):
+        if context == "pack-json":
+            return "pack-json-unreadable"
+        if context == "task":
+            return "task-unreadable"
+        if context == "reference":
+            return "reference-unreadable"
+        return "unexpected"
+    if isinstance(exc, (TypeError, AttributeError, KeyError, IndexError)):
+        if context == "schema":
+            return "bad-schema"
+        if context == "pack-json":
+            return "pack-json-not-object"
+        if context == "task":
+            return "task-not-object"
+        if context == "reference":
+            return "reference-not-object"
+        return "unexpected"
+    if isinstance(exc, ValueError):
+        if context == "pack-json":
+            return "pack-json-parse"
+        if context == "task":
+            return "task-parse"
+        if context == "reference":
+            return "reference-parse"
+        return "unexpected"
+    if isinstance(exc, OSError):
+        if context == "packs-root":
+            return "unlistable-packs"
+        if context == "listdir-tasks":
+            return "unlistable-tasks"
+        if context == "listdir-reference":
+            return "unlistable-reference"
+        if context == "pack-json":
+            return "pack-json-unreadable"
+        if context == "task":
+            return "task-unreadable"
+        if context == "reference":
+            return "reference-unreadable"
+        return "unexpected"
+    if context == "schema":
+        return "bad-schema"
+    return "unexpected"
+
+
+def exception_record(exc, context="json", path="") -> dict:
+    """예외를 오류 한 줄로 접는다. 여기서 예외를 다시 올리지 않는다."""
+    return {
+        "context": context or "",
+        "kind": exception_kind(exc, context=context),
+        "error": type(exc).__name__ if exc is not None else "NoneType",
+        "head": truncate_head(str(exc) if exc is not None else ""),
+        "path": path or "",
+    }
+
+
+def issue_family(code: str) -> str:
+    """위반 코드의 가족. 모르는 코드는 tool."""
+    if not code:
+        return "tool"
+    return ISSUE_FAMILY.get(str(code), "tool")
+
+
+def issue_codes() -> tuple:
+    """카탈로그 코드 튜플. 시험이 이 순서를 고정한다."""
+    return ISSUE_CODES
+
+
+def catalog_ids() -> tuple:
+    """issue_codes 별칭 — 다른 도구의 catalog_ids 와 같은 이름."""
+    return ISSUE_CODES
+
+
+def is_known_code(code: str) -> bool:
+    return code in ISSUE_CODES
+
+
+def is_blocking_code(code: str) -> bool:
+    """지금 카탈로그의 모든 코드는 차단이다. 경고 등급을 숨기지 않는다."""
+    return is_known_code(code) or code == "unexpected"
+
+
+def format_issue_message(code: str, **kwargs) -> str:
+    """카탈로그 기본 문구 + 선택 자리. 순수."""
+    base = ISSUE_TEXT.get(code, ISSUE_TEXT["unexpected"])
+    if not kwargs:
+        return base
+    extra = kwargs.get("detail")
+    if extra:
+        return f"{base}: {extra}"
+    return base
+
+
+def make_issue(code: str, pack: str = "", path: str = "", message: str = "", **extra) -> dict:
+    """구조화 위반 한 줄. 모르는 코드는 unexpected 로 접는다."""
+    raw = code if is_known_code(code) else "unexpected"
+    rec = {
+        "code": raw,
+        "pack": pack or "",
+        "path": path or "",
+        "message": message or format_issue_message(raw),
+        "family": issue_family(raw),
+    }
+    for key, value in extra.items():
+        if key in rec:
+            continue
+        rec[key] = value
+    return rec
+
+
+def posix_rel(*parts) -> str:
+    """보고용 상대 경로. 백슬래시를 섞지 않는다."""
+    cleaned = [str(p).replace("\\", "/").strip("/") for p in parts if p]
+    return "/".join(cleaned)
+
+
+def is_json_name(name) -> bool:
+    """과제·기준풀이 파일로 치는 이름인가. 소문자 .json 만 (원 계약)."""
+    if not isinstance(name, str) or not name:
+        return False
+    if name in (".", ".."):
+        return False
+    return name.endswith(JSON_SUFFIX) and not name.startswith(".")
+
+
+def stem_of(name: str) -> str:
+    """`X01.json` → `X01`. 접미가 없으면 이름 그대로."""
+    if not isinstance(name, str):
+        return ""
+    if name.endswith(JSON_SUFFIX):
+        return name[: -len(JSON_SUFFIX)]
+    return name
+
+
+def json_filename(task_id: str) -> str:
+    """id → 짝 파일 이름. 빈 id 는 빈 문자열."""
+    if not task_id or not isinstance(task_id, str):
+        return ""
+    return f"{task_id}{JSON_SUFFIX}"
+
+
+def as_text(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception:
+        return ""
+
+
+def is_nonempty_str(value) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def distinct_preserve(items):
+    """중복을 제거하되 처음 본 순서를 지킨다."""
+    seen = []
+    for item in items or []:
+        if item not in seen:
+            seen.append(item)
+    return seen
+
+
+def list_dir_safe(path, context="listdir"):
+    """디렉터리 나열. 실패해도 예외를 올리지 않는다.
+
+    반환: (names: list[str], error: dict|None)
+    """
+    if not path:
+        return [], exception_record(FileNotFoundError("empty-path"), context=context, path=path or "")
+    try:
+        return sorted(os.listdir(path)), None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return [], exception_record(exc, context=context, path=path)
+    except Exception as exc:
+        return [], exception_record(exc, context=context, path=path)
+
+
+def path_kind(path: str) -> str:
+    """missing / file / dir / other. 예외는 missing 으로 접지 않고 other."""
+    if not path:
+        return "missing"
+    try:
+        if os.path.isdir(path):
+            return "dir"
+        if os.path.isfile(path):
+            return "file"
+        if os.path.lexists(path):
+            return "other"
+        return "missing"
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception:
+        return "other"
+
+
+def load_json_safe(path, context="json"):
+    """JSON 객체 읽기. 예외를 올리지 않는다.
+
+    반환: (obj, error). obj 는 파싱 성공 시의 값(객체 아니어도 그대로).
+    """
+    if not path:
+        return None, exception_record(FileNotFoundError("empty-path"), context=context, path="")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh), None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, exception_record(exc, context=context, path=path)
+    except Exception as exc:
+        return None, exception_record(exc, context=context, path=path)
+
+
+def load_object(path, context="json"):
+    """JSON 객체를 요구한다. 리스트/숫자는 not-object.
+
+    반환: (obj: dict|None, error: dict|None)
+    """
+    obj, err = load_json_safe(path, context=context)
+    if err is not None:
+        return None, err
+    if not isinstance(obj, dict):
+        kind = {
+            "pack-json": "pack-json-not-object",
+            "task": "task-not-object",
+            "reference": "reference-not-object",
+        }.get(context, "unexpected")
+        return None, {
+            "context": context,
+            "kind": kind,
+            "error": type(obj).__name__ if obj is not None else "NoneType",
+            "head": truncate_head(f"JSON 이 객체가 아니다: {type(obj).__name__}"),
+            "path": path or "",
+        }
+    return obj, None
+
+
+def _legacy_load(path):
+    """원 `_load` — 시험·외부 호출 호환. 예외를 그대로 올린다."""
     with open(path, encoding="utf-8") as fh:
         return json.load(fh)
+
+
+def _load(path):
+    return _legacy_load(path)
+
+
+def json_names_from(names):
+    """이름 목록에서 .json 만, 정렬된 튜플."""
+    if not names:
+        return []
+    return sorted(n for n in names if is_json_name(n))
+
+
+def pair_names(task_names, ref_names):
+    """파일 이름 짝짓기. 순수.
+
+    반환: {paired, missing_refs, orphans}
+    """
+    tasks = set(task_names or [])
+    refs = set(ref_names or [])
+    return {
+        "paired": sorted(tasks & refs),
+        "missing_refs": sorted(tasks - refs),
+        "orphans": sorted(refs - tasks),
+    }
+
+
+def detect_in_pack_duplicates(id_to_files: dict) -> dict:
+    """같은 pack 에서 한 id 가 여러 파일에 있으면 그 맵만 남긴다. 순수."""
+    out = {}
+    for tid, files in (id_to_files or {}).items():
+        uniq = distinct_preserve(files)
+        if tid and len(uniq) > 1:
+            out[tid] = uniq
+    return out
+
+
+def detect_global_collisions(task_id_owners: dict) -> dict:
+    """서로 다른 pack 이 같은 id 를 쓰면 충돌. 같은 pack 의 이중 등록은 제외.
+
+    순수. 값 순서는 처음 본 pack 순.
+    """
+    collisions = {}
+    for tid, owners in (task_id_owners or {}).items():
+        distinct = distinct_preserve(owners)
+        if tid and len(distinct) > 1:
+            collisions[tid] = distinct
+    return collisions
+
+
+def classify_schema_message(message: str) -> str:
+    """schema.validate_* 가 남긴 한글 문장을 세부 태그로 본다. 코드는 항상 bad-schema."""
+    text = as_text(message)
+    if "kind" in text and "아니다" in text:
+        return "kind"
+    if "schemaVersion" in text:
+        return "schemaVersion"
+    if "폴더 이름" in text or "pack id" in text:
+        return "pack-id"
+    if "title" in text and "비었" in text:
+        return "title"
+    if "axis" in text and "비었" in text:
+        return "axis"
+    if "requires.commands" in text:
+        return "requires"
+    if "runner." in text:
+        return "runner"
+    if "필수 키 없음" in text:
+        return "task-required"
+    if "tier" in text:
+        return "tier"
+    if "checks 가 비었" in text:
+        return "checks-empty"
+    if "미등록 연산자" in text:
+        return "unknown-op"
+    if "전역 훑기" in text:
+        return "global-scan"
+    if "cmd 가 필요" in text:
+        return "missing-cmd"
+    if "cmd 가 있다" in text:
+        return "unexpected-cmd"
+    return "other"
+
+
+def run_validate_pack(manifest, pack_dir) -> list:
+    """schema.validate_pack 을 감싼다. 예외는 메시지로 접는다."""
+    messages: list[str] = []
+    try:
+        schema.validate_pack(manifest, pack_dir, messages)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        messages.append(f"schema.validate_pack 예외: {exc}")
+    except Exception as exc:
+        messages.append(f"schema.validate_pack 예외: {exc}")
+    return messages
+
+
+def run_validate_task(task, manifest) -> list:
+    """schema.validate_task. known_commands=None — 명령 존재는 러너 몫."""
+    messages: list[str] = []
+    try:
+        schema.validate_task(task, manifest, None, messages)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        messages.append(f"schema.validate_task 예외: {exc}")
+    except Exception as exc:
+        messages.append(f"schema.validate_task 예외: {exc}")
+    return messages
+
+
+def pack_issue_line(code: str, **kwargs) -> str:
+    """packs[].issues 에 넣는 한글 한 줄. 원 계약 문구를 우선한다."""
+    name = kwargs.get("name", "")
+    tid = kwargs.get("tid")
+    rid = kwargs.get("rid")
+    detail = kwargs.get("detail", "")
+    files = kwargs.get("files") or []
+    owners = kwargs.get("owners") or []
+    if code == "missing-pack-json":
+        return "pack.json 이 없다"
+    if code == "pack-json-parse":
+        return f"pack.json 파싱 실패: {detail}" if detail else "pack.json 파싱 실패"
+    if code == "pack-json-not-object":
+        return "pack.json 이 객체가 아니다"
+    if code == "pack-json-unreadable":
+        return f"pack.json 을 읽을 수 없다: {detail}" if detail else "pack.json 을 읽을 수 없다"
+    if code == "bad-schema":
+        return detail or "스키마 위반"
+    if code == "empty-pack":
+        return "과제가 없다 — 빈 pack 은 해결 가능성을 선언할 수 없다"
+    if code == "unlistable-tasks":
+        return f"tasks 디렉터리를 읽을 수 없다: {detail}" if detail else "tasks 디렉터리를 읽을 수 없다"
+    if code == "unlistable-reference":
+        return f"reference 디렉터리를 읽을 수 없다: {detail}" if detail else "reference 디렉터리를 읽을 수 없다"
+    if code == "tasks-not-dir":
+        return "tasks 가 디렉터리가 아니다"
+    if code == "reference-not-dir":
+        return "reference 가 디렉터리가 아니다"
+    if code == "task-parse":
+        return f"tasks/{name} 파싱 실패: {detail}" if detail else f"tasks/{name} 파싱 실패"
+    if code == "task-not-object":
+        return f"tasks/{name} 이 객체가 아니다"
+    if code == "task-unreadable":
+        return f"tasks/{name} 을 읽을 수 없다: {detail}" if detail else f"tasks/{name} 을 읽을 수 없다"
+    if code == "task-empty-id":
+        return f"과제 {name} 의 id 가 비었다"
+    if code == "task-filename-id-mismatch":
+        return f"과제 {name} 의 id({tid}) 가 파일 이름과 다르다"
+    if code == "task-id-duplicate-in-pack":
+        joined = ", ".join(files) if files else name
+        return f"pack 안 과제 ID '{tid}' 가 여러 파일에 있다: {joined}"
+    if code == "missing-reference":
+        return f"과제 {name} 에 짝 기준풀이(reference/{name})가 없다 — 해결 가능성 미선언"
+    if code == "reference-parse":
+        return f"reference/{name} 파싱 실패: {detail}" if detail else f"reference/{name} 파싱 실패"
+    if code == "reference-not-object":
+        return f"reference/{name} 이 객체가 아니다"
+    if code == "reference-unreadable":
+        return f"reference/{name} 을 읽을 수 없다: {detail}" if detail else f"reference/{name} 을 읽을 수 없다"
+    if code == "reference-id-mismatch":
+        return f"reference/{name} 의 id({rid}) 가 과제 id({tid}) 와 다르다"
+    if code == "orphan-reference":
+        return f"고아 기준풀이 reference/{name} — 짝 과제(tasks/{name})가 없다"
+    if code == "task-id-collision":
+        return f"과제 ID '{tid}' 충돌: {', '.join(owners)}"
+    if code == "missing-tasks-dir":
+        return "tasks 디렉터리가 없다"
+    if code == "missing-reference-dir":
+        return "reference 디렉터리가 없다"
+    if detail:
+        return f"{format_issue_message(code)}: {detail}"
+    return format_issue_message(code)
+
+
+def append_issue(pack_issues, structured, code, pack, path="", **kwargs):
+    """한글 줄 + 구조화 줄을 동시에 남긴다."""
+    line = pack_issue_line(code, **kwargs)
+    pack_issues.append(line)
+    rec = make_issue(code, pack=pack, path=path, message=line)
+    tag = kwargs.get("schema_tag")
+    if tag:
+        rec["schemaTag"] = tag
+    tid = kwargs.get("tid")
+    if tid:
+        rec["taskId"] = tid
+    structured.append(rec)
+    return rec
+
+
+def empty_report() -> dict:
+    """빈 정합 봉투. 키가 빠지면 시험이 막는다."""
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": True,
+        "packCount": 0,
+        "taskCount": 0,
+        "referenceCount": 0,
+        "packs": [],
+        "okPacks": [],
+        "emptyPacks": [],
+        "taskIdCollisions": {},
+        "issueCount": 0,
+        "issues": [],
+        "issueCountsByCode": {},
+        "issueCountsByFamily": {},
+        "toolErrors": [],
+        "missingPacksRoot": False,
+        "toolFailed": False,
+        "exit": EXIT_OK,
+    }
+
+
+def count_by(items, key):
+    """구조화 이슈에서 key 별 건수. 순수."""
+    counts = {}
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        value = item.get(key) or "unexpected"
+        counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def resolve_exit(report: dict) -> int:
+    """봉투 → 종료 코드. 도구 실패가 위반보다 앞선다. 순수."""
+    if not isinstance(report, dict):
+        return EXIT_TOOL
+    if report.get("toolFailed") or report.get("missingPacksRoot"):
+        return EXIT_TOOL
+    if report.get("ok"):
+        return EXIT_OK
+    return EXIT_VIOLATION
+
+
+def validate_report(report) -> list:
+    """봉투 계약. 빈 리스트면 통과. 순수 — 예외를 올리지 않는다."""
+    problems = []
+    if not isinstance(report, dict):
+        return ["report 가 객체가 아니다"]
+    for key in REPORT_KEYS:
+        if key not in report:
+            problems.append(f"키 없음: {key}")
+    if report.get("kind") != REPORT_KIND:
+        problems.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        problems.append(f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
+    if not isinstance(report.get("ok"), bool):
+        problems.append("ok 가 bool 이 아니다")
+    if not isinstance(report.get("packCount"), int):
+        problems.append("packCount 가 int 가 아니다")
+    if not isinstance(report.get("packs"), list):
+        problems.append("packs 가 list 가 아니다")
+    if not isinstance(report.get("taskIdCollisions"), dict):
+        problems.append("taskIdCollisions 가 dict 가 아니다")
+    if not isinstance(report.get("issues"), list):
+        problems.append("issues 가 list 가 아니다")
+    if not isinstance(report.get("toolErrors"), list):
+        problems.append("toolErrors 가 list 가 아니다")
+    issue_count = report.get("issueCount")
+    if isinstance(issue_count, int) and isinstance(report.get("issues"), list):
+        # issueCount 는 원 계약대로 packs[].issues + 전역 충돌 수.
+        # 구조화 issues 길이와 같을 수도, 전역 충돌이 packs 밖에만 있을 수도 있다.
+        if issue_count < 0:
+            problems.append("issueCount 가 음수다")
+    expected_ok = (report.get("issueCount") == 0) and (not report.get("toolFailed"))
+    if isinstance(report.get("ok"), bool) and isinstance(report.get("issueCount"), int):
+        if report["ok"] != expected_ok:
+            problems.append("ok 가 issueCount/toolFailed 와 어긋난다")
+    expected_exit = resolve_exit(report)
+    if report.get("exit") not in (None, expected_exit) and report.get("exit") != expected_exit:
+        problems.append("exit 가 ok/toolFailed 와 어긋난다")
+    return problems
+
+
+def format_human_report(report: dict) -> str:
+    """사람용 요약. JSON 이 아닌 stdout 경로."""
+    if not isinstance(report, dict):
+        return "gym 정합 감사: 보고가 손상됐다\n"
+    if report.get("toolFailed") or report.get("missingPacksRoot"):
+        heads = []
+        for err in report.get("toolErrors") or []:
+            if isinstance(err, dict):
+                heads.append(err.get("head") or err.get("kind") or "도구 실패")
+        if not heads:
+            for issue in report.get("issues") or []:
+                if isinstance(issue, dict):
+                    heads.append(issue.get("message") or issue.get("code") or "")
+        detail = heads[0] if heads else "도구 실패"
+        return f"gym 정합 감사: 도구 실패 — {detail}\n"
+    if report.get("ok"):
+        return f"gym 정합 감사: {report.get('packCount', 0)} pack 전부 통과 — 위반 0\n"
+    lines = [f"gym 정합 감사: 위반 {report.get('issueCount', 0)}건"]
+    for pack in report.get("packs") or []:
+        pid = pack.get("id") if isinstance(pack, dict) else "?"
+        for issue in (pack.get("issues") if isinstance(pack, dict) else []) or []:
+            lines.append(f"  [{pid}] {issue}")
+    collisions = report.get("taskIdCollisions") or {}
+    if isinstance(collisions, dict):
+        for tid in sorted(collisions):
+            owners = collisions[tid]
+            if isinstance(owners, (list, tuple)):
+                joined = ", ".join(as_text(o) for o in owners)
+            else:
+                joined = as_text(owners)
+            lines.append(f"  [전역] 과제 ID '{tid}' 충돌: {joined}")
+    return "\n".join(lines) + "\n"
+
+
+def format_json_report(report: dict) -> str:
+    """UTF-8 · BOM 없음 · ensure_ascii=False. 끝에 개행."""
+    return json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+
+
+def parse_args(argv=None):
+    """CLI. `--json` 만. 새 플래그를 열지 않는다."""
+    ap = argparse.ArgumentParser(description="gym 전 pack 정합 감사 (해결가능·고유·정합)")
+    ap.add_argument("--json", action="store_true")
+    return ap.parse_args(argv)
+
+
+def _note_tool_error(tool_errors, structured, code, path="", detail=""):
+    rec = exception_record(None, context="audit", path=path)
+    rec["kind"] = code
+    rec["head"] = detail or format_issue_message(code)
+    rec["error"] = "AuditToolError"
+    tool_errors.append(rec)
+    structured.append(make_issue(code, pack="", path=path, message=rec["head"]))
+
+
+def audit_one_pack(pack_id: str, pack_dir: str, task_id_owners: dict) -> dict:
+    """pack 하나. 예외를 올리지 않는다(치명 제외).
+
+    반환: {id, issues, structured, taskCount, referenceCount, empty}
+    """
+    issues: list[str] = []
+    structured: list[dict] = []
+    task_count = 0
+    ref_count = 0
+    id_to_files: dict[str, list[str]] = {}
+
+    manifest_path = os.path.join(pack_dir, "pack.json")
+    kind = path_kind(manifest_path)
+    if kind == "missing":
+        append_issue(issues, structured, "missing-pack-json", pack_id, path=posix_rel(pack_id, "pack.json"))
+        return {
+            "id": pack_id,
+            "issues": issues,
+            "structured": structured,
+            "taskCount": 0,
+            "referenceCount": 0,
+            "empty": False,
+        }
+    if kind != "file":
+        append_issue(
+            issues, structured, "pack-json-unreadable", pack_id,
+            path=posix_rel(pack_id, "pack.json"),
+            detail=f"종류={kind}",
+        )
+        return {
+            "id": pack_id,
+            "issues": issues,
+            "structured": structured,
+            "taskCount": 0,
+            "referenceCount": 0,
+            "empty": False,
+        }
+
+    manifest, err = load_object(manifest_path, context="pack-json")
+    if err is not None:
+        code = err.get("kind") if is_known_code(err.get("kind")) else "pack-json-parse"
+        append_issue(
+            issues, structured, code, pack_id,
+            path=posix_rel(pack_id, "pack.json"),
+            detail=err.get("head") or err.get("error") or "",
+        )
+        return {
+            "id": pack_id,
+            "issues": issues,
+            "structured": structured,
+            "taskCount": 0,
+            "referenceCount": 0,
+            "empty": False,
+        }
+
+    for msg in run_validate_pack(manifest, pack_dir):
+        append_issue(
+            issues, structured, "bad-schema", pack_id,
+            path=posix_rel(pack_id, "pack.json"),
+            detail=msg,
+            schema_tag=classify_schema_message(msg),
+        )
+
+    tasks_dir = os.path.join(pack_dir, "tasks")
+    ref_dir = os.path.join(pack_dir, "reference")
+    task_files: list[str] = []
+    ref_files: list[str] = []
+
+    tasks_kind = path_kind(tasks_dir)
+    tasks_listed = False
+    if tasks_kind == "dir":
+        names, lerr = list_dir_safe(tasks_dir, context="listdir-tasks")
+        if lerr is not None:
+            append_issue(
+                issues, structured, "unlistable-tasks", pack_id,
+                path=posix_rel(pack_id, "tasks"),
+                detail=lerr.get("head") or lerr.get("error") or "",
+            )
+        else:
+            task_files = json_names_from(names)
+            tasks_listed = True
+    elif tasks_kind == "missing":
+        # 원 계약: 없는 tasks 는 빈 목록. 과제가 없으면 아래에서 empty-pack.
+        task_files = []
+        tasks_listed = True
+    else:
+        append_issue(
+            issues, structured, "tasks-not-dir", pack_id,
+            path=posix_rel(pack_id, "tasks"),
+        )
+
+    refs_kind = path_kind(ref_dir)
+    if refs_kind == "dir":
+        names, lerr = list_dir_safe(ref_dir, context="listdir-reference")
+        if lerr is not None:
+            append_issue(
+                issues, structured, "unlistable-reference", pack_id,
+                path=posix_rel(pack_id, "reference"),
+                detail=lerr.get("head") or lerr.get("error") or "",
+            )
+        else:
+            ref_files = json_names_from(names)
+            ref_count = len(ref_files)
+    elif refs_kind == "missing":
+        ref_files = []
+    else:
+        append_issue(
+            issues, structured, "reference-not-dir", pack_id,
+            path=posix_rel(pack_id, "reference"),
+        )
+
+    ref_set = set(ref_files)
+    task_count = len(task_files)
+
+    for name in task_files:
+        task_path = os.path.join(tasks_dir, name)
+        task, terr = load_object(task_path, context="task")
+        if terr is not None:
+            code = terr.get("kind") if is_known_code(terr.get("kind")) else "task-parse"
+            append_issue(
+                issues, structured, code, pack_id,
+                path=posix_rel(pack_id, "tasks", name),
+                name=name,
+                detail=terr.get("head") or terr.get("error") or "",
+            )
+            if name not in ref_set:
+                append_issue(
+                    issues, structured, "missing-reference", pack_id,
+                    path=posix_rel(pack_id, "reference", name),
+                    name=name,
+                )
+            continue
+
+        for msg in run_validate_task(task, manifest):
+            append_issue(
+                issues, structured, "bad-schema", pack_id,
+                path=posix_rel(pack_id, "tasks", name),
+                detail=msg,
+                schema_tag=classify_schema_message(msg),
+            )
+
+        tid = task.get("id")
+        expected = stem_of(name)
+        if not is_nonempty_str(tid):
+            append_issue(
+                issues, structured, "task-empty-id", pack_id,
+                path=posix_rel(pack_id, "tasks", name),
+                name=name,
+            )
+            tid = None
+        else:
+            id_to_files.setdefault(tid, []).append(name)
+            task_id_owners.setdefault(tid, []).append(pack_id)
+            if tid != expected:
+                append_issue(
+                    issues, structured, "task-filename-id-mismatch", pack_id,
+                    path=posix_rel(pack_id, "tasks", name),
+                    name=name,
+                    tid=tid,
+                )
+
+        if name not in ref_set:
+            append_issue(
+                issues, structured, "missing-reference", pack_id,
+                path=posix_rel(pack_id, "reference", name),
+                name=name,
+            )
+            continue
+
+        ref, rerr = load_object(os.path.join(ref_dir, name), context="reference")
+        if rerr is not None:
+            code = rerr.get("kind") if is_known_code(rerr.get("kind")) else "reference-parse"
+            append_issue(
+                issues, structured, code, pack_id,
+                path=posix_rel(pack_id, "reference", name),
+                name=name,
+                detail=rerr.get("head") or rerr.get("error") or "",
+            )
+            continue
+        rid = ref.get("id")
+        if rid != tid:
+            append_issue(
+                issues, structured, "reference-id-mismatch", pack_id,
+                path=posix_rel(pack_id, "reference", name),
+                name=name,
+                tid=tid,
+                rid=rid,
+            )
+
+    pairing = pair_names(task_files, ref_files)
+    for name in pairing["orphans"]:
+        append_issue(
+            issues, structured, "orphan-reference", pack_id,
+            path=posix_rel(pack_id, "reference", name),
+            name=name,
+        )
+
+    duplicates = detect_in_pack_duplicates(id_to_files)
+    for tid, files in sorted(duplicates.items()):
+        append_issue(
+            issues, structured, "task-id-duplicate-in-pack", pack_id,
+            path=posix_rel(pack_id, "tasks"),
+            tid=tid,
+            files=files,
+        )
+
+    empty = bool(tasks_listed and task_count == 0)
+    if empty:
+        append_issue(
+            issues, structured, "empty-pack", pack_id,
+            path=posix_rel(pack_id),
+        )
+
+    return {
+        "id": pack_id,
+        "issues": issues,
+        "structured": structured,
+        "taskCount": task_count,
+        "referenceCount": ref_count,
+        "empty": empty,
+    }
+
+
+def _coerce_root(packs_root) -> str:
+    if packs_root is None:
+        return ""
+    try:
+        return os.fspath(packs_root)
+    except FATAL_EXCEPTIONS:
+        raise
+    except Exception:
+        return str(packs_root)
 
 
 def audit(packs_root: str) -> dict:
     """전 pack 정합 감사 — 순수 파일 검사(바이너리·네트워크 없음).
 
     packs_root: `gym/packs` 를 담은 디렉토리(보통 gym/).
-    반환: {ok, packs:[{id, issues}], taskIdCollisions, issueCount}.
+    반환: 원 계약 키(ok, packs, taskIdCollisions, issueCount, packCount) +
+    구조화 이슈·도구 실패 자리.
     """
-    packs_dir = os.path.join(packs_root, "packs")
-    pack_reports = []
+    report = empty_report()
+    root = _coerce_root(packs_root)
+    packs_dir = os.path.join(root, "packs") if root else "packs"
     task_id_owners: dict[str, list[str]] = {}
+    pack_reports = []
+    structured: list[dict] = []
+    tool_errors: list[dict] = []
+    task_total = 0
+    ref_total = 0
+    empty_packs: list[str] = []
 
-    for pack_id in sorted(os.listdir(packs_dir)):
+    root_kind = path_kind(packs_dir)
+    if root_kind == "missing":
+        report["missingPacksRoot"] = True
+        report["toolFailed"] = True
+        _note_tool_error(tool_errors, structured, "missing-packs-root", path=packs_dir)
+        report["issues"] = structured
+        report["toolErrors"] = tool_errors
+        report["issueCount"] = len(structured)
+        report["ok"] = False
+        report["issueCountsByCode"] = count_by(structured, "code")
+        report["issueCountsByFamily"] = count_by(structured, "family")
+        report["exit"] = resolve_exit(report)
+        return report
+    if root_kind != "dir":
+        report["toolFailed"] = True
+        code = "packs-not-dir"
+        _note_tool_error(tool_errors, structured, code, path=packs_dir, detail=f"종류={root_kind}")
+        report["issues"] = structured
+        report["toolErrors"] = tool_errors
+        report["issueCount"] = len(structured)
+        report["ok"] = False
+        report["issueCountsByCode"] = count_by(structured, "code")
+        report["issueCountsByFamily"] = count_by(structured, "family")
+        report["exit"] = resolve_exit(report)
+        return report
+
+    names, lerr = list_dir_safe(packs_dir, context="packs-root")
+    if lerr is not None:
+        report["toolFailed"] = True
+        code = lerr.get("kind") if is_known_code(lerr.get("kind")) else "unlistable-packs"
+        _note_tool_error(
+            tool_errors, structured, code, path=packs_dir,
+            detail=lerr.get("head") or lerr.get("error") or "",
+        )
+        report["issues"] = structured
+        report["toolErrors"] = tool_errors
+        report["issueCount"] = len(structured)
+        report["ok"] = False
+        report["issueCountsByCode"] = count_by(structured, "code")
+        report["issueCountsByFamily"] = count_by(structured, "family")
+        report["exit"] = resolve_exit(report)
+        return report
+
+    pack_ids = [name for name in names if path_kind(os.path.join(packs_dir, name)) == "dir"]
+    if not pack_ids:
+        # 원 계약: 빈 packs 는 위반 0 · packCount 0. 다만 사실을 기록한다.
+        report["issues"] = structured
+        report["toolErrors"] = tool_errors
+        report["ok"] = True
+        report["exit"] = EXIT_OK
+        return report
+
+    for pack_id in pack_ids:
         pack_dir = os.path.join(packs_dir, pack_id)
-        if not os.path.isdir(pack_dir):
-            continue
-        issues: list[str] = []
-        manifest_path = os.path.join(pack_dir, "pack.json")
-        if not os.path.isfile(manifest_path):
-            pack_reports.append({"id": pack_id, "issues": ["pack.json 이 없다"]})
-            continue
         try:
-            manifest = _load(manifest_path)
-        except (ValueError, OSError) as e:
-            pack_reports.append({"id": pack_id, "issues": [f"pack.json 파싱 실패: {e}"]})
-            continue
+            one = audit_one_pack(pack_id, pack_dir, task_id_owners)
+        except FATAL_EXCEPTIONS:
+            raise
+        except CATCHABLE_EXCEPTIONS as exc:
+            rec = exception_record(exc, context="audit", path=pack_dir)
+            tool_errors.append(rec)
+            one = {
+                "id": pack_id,
+                "issues": [f"pack 감사 예외: {rec['head']}"],
+                "structured": [make_issue("unexpected", pack=pack_id, path=posix_rel(pack_id), message=rec["head"])],
+                "taskCount": 0,
+                "referenceCount": 0,
+                "empty": False,
+            }
+        pack_reports.append({"id": one["id"], "issues": list(one["issues"])})
+        structured.extend(one["structured"])
+        task_total += int(one.get("taskCount") or 0)
+        ref_total += int(one.get("referenceCount") or 0)
+        if one.get("empty"):
+            empty_packs.append(pack_id)
 
-        schema.validate_pack(manifest, pack_dir, issues)
+    collisions = detect_global_collisions(task_id_owners)
+    for tid, owners in sorted(collisions.items()):
+        line = pack_issue_line("task-id-collision", tid=tid, owners=owners)
+        structured.append(make_issue(
+            "task-id-collision",
+            pack="",
+            path="",
+            message=line,
+            taskId=tid,
+            owners=list(owners),
+        ))
 
-        tasks_dir = os.path.join(pack_dir, "tasks")
-        ref_dir = os.path.join(pack_dir, "reference")
-        task_ids: set[str] = set()
-        task_files = sorted(f for f in os.listdir(tasks_dir)) if os.path.isdir(tasks_dir) else []
-        ref_files = set(f for f in os.listdir(ref_dir)) if os.path.isdir(ref_dir) else set()
-
-        for name in task_files:
-            if not name.endswith(".json"):
-                continue
-            try:
-                task = _load(os.path.join(tasks_dir, name))
-            except (ValueError, OSError) as e:
-                issues.append(f"tasks/{name} 파싱 실패: {e}")
-                continue
-            # 명령 존재 검사만 러너에 위임(known_commands=None) — 구조는 그대로 검증.
-            schema.validate_task(task, manifest, None, issues)
-            tid = task.get("id")
-            if tid:
-                task_ids.add(tid)
-                task_id_owners.setdefault(tid, []).append(pack_id)
-            # 해결 가능성: 짝 기준풀이가 있고 id 가 맞는가.
-            if name not in ref_files:
-                issues.append(f"과제 {name} 에 짝 기준풀이(reference/{name})가 없다 — 해결 가능성 미선언")
-            else:
-                try:
-                    ref = _load(os.path.join(ref_dir, name))
-                    if ref.get("id") != tid:
-                        issues.append(f"reference/{name} 의 id({ref.get('id')}) 가 과제 id({tid}) 와 다르다")
-                except (ValueError, OSError) as e:
-                    issues.append(f"reference/{name} 파싱 실패: {e}")
-
-        # 고아 기준풀이: 과제 없는 reference.
-        task_names = {f for f in task_files if f.endswith(".json")}
-        for name in sorted(ref_files):
-            if name.endswith(".json") and name not in task_names:
-                issues.append(f"고아 기준풀이 reference/{name} — 짝 과제(tasks/{name})가 없다")
-
-        pack_reports.append({"id": pack_id, "issues": issues})
-
-    collisions = {tid: owners for tid, owners in task_id_owners.items() if len(owners) > 1}
     issue_count = sum(len(p["issues"]) for p in pack_reports) + len(collisions)
-    return {
-        "kind": "gymAudit",
-        "schemaVersion": "1.0",
-        "ok": issue_count == 0,
+    ok_packs = [p["id"] for p in pack_reports if not p["issues"]]
+    dirty = [p for p in pack_reports if p["issues"]]
+    tool_failed = bool(tool_errors)
+    report.update({
+        "ok": issue_count == 0 and not tool_failed,
         "packCount": len(pack_reports),
-        "packs": [p for p in pack_reports if p["issues"]],
+        "taskCount": task_total,
+        "referenceCount": ref_total,
+        "packs": dirty,
+        "okPacks": ok_packs,
+        "emptyPacks": empty_packs,
         "taskIdCollisions": collisions,
         "issueCount": issue_count,
-    }
+        "issues": structured,
+        "issueCountsByCode": count_by(structured, "code"),
+        "issueCountsByFamily": count_by(structured, "family"),
+        "toolErrors": tool_errors,
+        "missingPacksRoot": False,
+        "toolFailed": tool_failed,
+    })
+    report["exit"] = resolve_exit(report)
+    return report
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="gym 전 pack 정합 감사 (해결가능·고유·정합)")
-    ap.add_argument("--json", action="store_true")
-    a = ap.parse_args()
-    report = audit(GYM_ROOT)
+def main(argv=None) -> int:
+    a = parse_args(argv)
+    try:
+        report = audit(GYM_ROOT)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        report = empty_report()
+        rec = exception_record(exc, context="audit", path=GYM_ROOT)
+        report["toolFailed"] = True
+        report["ok"] = False
+        report["toolErrors"] = [rec]
+        report["issues"] = [make_issue("unexpected", message=rec["head"])]
+        report["issueCount"] = 1
+        report["issueCountsByCode"] = {"unexpected": 1}
+        report["issueCountsByFamily"] = {"tool": 1}
+        report["exit"] = EXIT_TOOL
     if a.json:
-        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
-    elif report["ok"]:
-        print(f"gym 정합 감사: {report['packCount']} pack 전부 통과 — 위반 0")
+        sys.stdout.write(format_json_report(report))
     else:
-        print(f"gym 정합 감사: 위반 {report['issueCount']}건")
-        for p in report["packs"]:
-            for issue in p["issues"]:
-                print(f"  [{p['id']}] {issue}")
-        for tid, owners in report["taskIdCollisions"].items():
-            print(f"  [전역] 과제 ID '{tid}' 충돌: {', '.join(owners)}")
-    return 0 if report["ok"] else 1
+        sys.stdout.write(format_human_report(report))
+    return int(report.get("exit", resolve_exit(report)))
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_audit.md
+++ b/mydocs/working/gym_audit.md
@@ -1,0 +1,412 @@
+---
+kind: investigation
+status: active
+canonical: gym/docs/audit.md
+last_verified: 2026-08-18
+---
+
+# gym 정합 감사 — 예외 경로·문서·시험 고도화
+
+Issue: #5277
+Branch: `feat/gym-audit-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/audit.py` 의 전 pack 정합 감사를 예외 경로까지 닫았다.
+빠진 `pack.json`, 고아 기준풀이, 전역·pack 안 과제 ID 충돌, 나쁜
+스키마를 코드로 접고, 없는 packs 루트·깨진 JSON·객체가 아닌 JSON
+에서도 도구가 죽지 않게 했다.
+
+원 계약은 유지한다.
+
+- 보고 `kind=gymAudit`, `schemaVersion=1.0`
+- `packs[].issues` 는 한글 문자열 목록
+- `taskIdCollisions` 는 `{id: [pack, …]}`
+- `issueCount = pack 이슈 줄 + 전역 충돌 수`
+- CLI 는 `--json` 만
+- `schema.validate_pack` / `validate_task` 를 다시 구현하지 않고
+  감싼다
+- 치명 예외는 삼키지 않는다
+
+새 CLI/pack 없음. `certify.py` · `report.py` · `score.py` ·
+`runner.py` · `build_baseline.py` · tutorial · expert-challenges ·
+PR 5210–5276 이 연 파일은 건드리지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_audit`
+- `python gym/tools/audit.py`
+- `cargo fmt --all -- --check` (하드 게이트, PR 전)
+
+## 2. 배경
+
+원 도구(#4803)는 전 pack 을 훑어 네 가지를 본다. 스키마, 과제↔기준
+짝, 고아 기준풀이, 전역 ID 충돌. CI 가 `test_gym_audit.py` 다섯
+자리로 고정했다.
+
+대비 `upstream/devel` 의 구현은 약 155줄, 시험은 5건이었다.
+
+그 상태의 빈틈:
+
+1. `os.listdir(packs_dir)` 가 없는 루트에서 예외를 그대로 올린다.
+   시험 픽스처가 아닌 자리에서 도구가 죽으면 CI 가 붉어져 정합
+   위반과 하네스 결함을 구분할 수 없다.
+2. `pack.json` / 과제 / 기준풀이가 배열이면 `obj.get` 이
+   `AttributeError` 로 감사기를 죽인다. "정합 위반"이 아니라
+   "도구 크래시"다.
+3. `UnicodeDecodeError` 는 `ValueError` 하위라 파싱 실패로 접히지만,
+   문맥(매니페스트·과제·기준풀이)이 한 문구로 섞인다.
+4. 같은 pack 의 두 파일이 같은 `id` 를 쓰면 전역 충돌 맵에
+   `["p1", "p1"]` 로 들어간다. 집계가 pack 을 가른다는 가정과
+   어긋난다.
+5. `X01.json` 이 `id=Y99` 를 들고 있어도 통과한다. 파일 이름으로
+   짝짓는 쪽과 id 로 집계하는 쪽이 갈린다.
+6. 카탈로그가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+7. JSON 봉투에 구조화 코드가 없다. `ok=false` 가 "고아"인지
+   "스키마"인지 "루트 부재"인지 기계가 못 가른다.
+8. 빈 pack(과제 0)은 원 구현에서 통과한다. 해결 가능성 선언이
+   없는데 정합이라고 부른다.
+
+이슈 #5277 의 DoD 는 이 빈틈을 닫는 것이다. additions >= 3000.
+unittest + audit.py. 새 CLI/pack 없음. PR 전
+`cargo fmt --all -- --check`.
+
+다른 고도화 PR(differential / discriminate / fuzz_corpus /
+release_gate)의 예외 접기 결을 따른다. 감사기의 정체성은 유지했다.
+
+- 전 pack 을 한 번에 본다. `--pack` 을 열지 않는다.
+- 바이너리를 부르지 않는다. `known_commands=None`.
+- 레거시 한글 줄을 깨지 않는다.
+- 스키마 규칙을 여기 복제하지 않는다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/audit.py`
+
+- `REPORT_KIND` / `SCHEMA_VERSION` / `ISSUE_CODES` / `ISSUE_FAMILY`
+  / `ISSUE_TEXT` / `REPORT_KEYS` / `EXIT_*` / `FATAL_EXCEPTIONS`.
+- `is_fatal_exception` · `truncate_head` · `exception_kind` ·
+  `exception_record`.
+- `make_issue` · `pack_issue_line` · `append_issue` — 한글 줄과
+  구조화 줄을 동시에 남긴다.
+- `list_dir_safe` · `load_json_safe` · `load_object` — 예외를
+  올리지 않는다.
+- `pair_names` · `detect_in_pack_duplicates` ·
+  `detect_global_collisions` — 순수.
+- `run_validate_pack` / `run_validate_task` — schema 예외를
+  메시지로 접는다. 치명 예외는 다시 올린다.
+- `classify_schema_message` — 한글 스키마 문장 → `schemaTag`.
+- `audit_one_pack` — pack 하나. 매니페스트가 없으면 과제 스캔을
+  하지 않는다.
+- `audit` — 루트 부재는 `toolFailed` + exit 2. 빈 packs 는 원
+  계약대로 위반 0.
+- `empty_report` · `validate_report` · `format_human_report` ·
+  `format_json_report` · `resolve_exit`.
+- `parse_args` / `main` — `--json` 만.
+- `_load` 는 원 날것 로더로 남긴다.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_audit.py`
+
+원 다섯 자리를 그대로 둔다.
+
+- `test_real_repo_all_packs_conform`
+- `test_missing_reference_is_flagged`
+- `test_orphan_reference_is_flagged`
+- `test_task_id_collision_across_packs_is_flagged`
+- `test_clean_fixture_passes`
+
+뒤에 카탈로그·예외 kind·순수 헬퍼·빠진 pack.json·짝짓기·중복
+ID·나쁜 스키마(매니페스트·tier·미등록 연산자·전역 훑기·cmd
+유무)·파싱/비객체/비UTF-8·루트 부재·보고 봉투·CLI·치명 예외·
+네 자리 동시 픽스처를 더한다.
+
+### 3.3 문서
+
+- `gym/docs/audit.md` — 규약 정본. 카탈로그·봉투·예외·하지 않는
+  것·네 자리 픽스처.
+- `mydocs/working/gym_audit.md` — 이 기록.
+
+## 4. 검사 순서 (구현이 지키는 것)
+
+```
+audit(packs_root)
+  ├─ packs/ 없음 → missing-packs-root, exit 2
+  ├─ packs/ 파일 → packs-not-dir, exit 2
+  ├─ listdir 실패 → unlistable-packs, exit 2
+  ├─ 폴더 0 → ok, packCount 0, exit 0
+  └─ 각 pack 폴더
+       ├─ pack.json 없음 → missing-pack-json, 다음 pack
+       ├─ 파싱/비객체/읽기 실패 → 해당 코드, 다음 pack
+       ├─ validate_pack → bad-schema*
+       ├─ tasks/reference 나열
+       ├─ 각 tasks/*.json
+       │    ├─ 파싱/비객체 → task-*, 짝 없으면 missing-reference
+       │    ├─ validate_task → bad-schema*
+       │    ├─ id 공백 → task-empty-id
+       │    ├─ id ≠ stem → task-filename-id-mismatch
+       │    ├─ reference/name 없음 → missing-reference
+       │    └─ ref.id ≠ task.id → reference-id-mismatch
+       ├─ reference 에만 있는 이름 → orphan-reference
+       ├─ pack 안 같은 id 여러 파일 → task-id-duplicate-in-pack
+       └─ 나열 성공 · 과제 0 → empty-pack
+  └─ 서로 다른 pack 의 같은 id → taskIdCollisions + task-id-collision
+```
+
+## 5. 예외 접기 표
+
+문맥이 코드를 가른다. 같은 `FileNotFoundError` 라도 자리가 다르다.
+
+| 예외 | packs-root | pack-json | task | reference | listdir-tasks |
+|---|---|---|---|---|---|
+| FileNotFoundError | missing-packs-root | missing-pack-json | (기본 루트) | (기본 루트) | missing-tasks-dir |
+| NotADirectoryError | packs-not-dir | — | — | — | tasks-not-dir |
+| PermissionError | unlistable-packs | pack-json-unreadable | task-unreadable | reference-unreadable | unlistable-tasks |
+| JSONDecodeError | — | pack-json-parse | task-parse | reference-parse | — |
+| UnicodeError | — | pack-json-unreadable | task-unreadable | reference-unreadable | — |
+| TypeError | unexpected | pack-json-not-object | task-not-object | reference-not-object | — |
+
+`load_object` 가 배열·숫자를 받으면 예외 없이 `*-not-object` 를
+만든다. `task.get` 크래시 경로를 이 검사가 없앤다.
+
+## 6. 보고 계약
+
+원 키가 빠지면 레거시 시험과 CI 가 깨진다. 추가 키는 옵트인이다.
+
+유지:
+
+```
+kind, schemaVersion, ok, packCount, packs, taskIdCollisions, issueCount
+```
+
+추가:
+
+```
+taskCount, referenceCount, okPacks, emptyPacks, issues,
+issueCountsByCode, issueCountsByFamily, toolErrors,
+missingPacksRoot, toolFailed, exit
+```
+
+`ok` 공식:
+
+```
+ok = (issueCount == 0) and (not toolFailed)
+```
+
+`exit` 공식:
+
+```
+toolFailed or missingPacksRoot → 2
+ok → 0
+그 외 → 1
+```
+
+전역 충돌의 `owners` 는 처음 본 pack 순, 중복 제거. 같은 pack 이
+두 파일에 같은 id 를 써도 `taskIdCollisions` 에는 넣지 않는다.
+
+## 7. 레거시 한글 줄
+
+바꾸면 안 되는 부분 문자열.
+
+| 코드 | 부분 문자열 |
+|---|---|
+| missing-pack-json | `pack.json 이 없다` |
+| pack-json-parse | `pack.json 파싱 실패` |
+| missing-reference | `기준풀이` |
+| orphan-reference | `고아` |
+| reference-id-mismatch | `의 id(` … `가 과제 id(` |
+| task-parse | `tasks/{name} 파싱 실패` |
+| reference-parse | `reference/{name} 파싱 실패` |
+
+사람 요약의 통과/위반 머리도 유지한다.
+
+```
+gym 정합 감사: {n} pack 전부 통과 — 위반 0
+gym 정합 감사: 위반 {n}건
+  [{pack}] {issue}
+  [전역] 과제 ID '{id}' 충돌: {owners}
+```
+
+도구 실패 머리만 새로 생겼다.
+
+```
+gym 정합 감사: 도구 실패 — {detail}
+```
+
+## 8. 건드리지 않은 것
+
+- `gym/certify.py`
+- `gym/report.py`
+- `gym/score.py`
+- `gym/core/runner.py`
+- `gym/tools/build_baseline.py`
+- `gym/tutorial/**`
+- `gym/packs/expert-challenges/**`
+- `gym/core/schema.py` · `gym/core/checks.py`
+- PR 5210–5276 이 연 파일 (다른 gym 도구·pack 확장·docs)
+- 새 CLI 플래그
+- 새 pack · 새 과제
+- 워크플로 YAML (`ci.yml` 의 unittest 목록은 이미
+  `test_gym_audit.py` 를 포함한다)
+
+## 9. 시험 지도
+
+| 클래스 | 고정하는 것 |
+|---|---|
+| `AuditTests` | 원 다섯 자리 |
+| `CatalogContractTests` | 코드·가족·문구·CLI·봉투 키 |
+| `ExceptionKindTests` | 문맥별 접기 · 치명 표시 |
+| `PureHelperTests` | 이름·짝짓기·충돌·schemaTag · validate_report |
+| `MissingPackJsonTests` | 폴더만 있는 pack, 매니페스트가 디렉터리 |
+| `OrphanAndPairingTests` | 고아 · 빠진 기준 · id 불일치 · 파일명 짝 |
+| `DuplicateIdTests` | 전역 충돌 · pack 안 중복 · 순서 |
+| `BadSchemaTests` | kind/version/id/title/requires/runner/tier/op/cmd |
+| `ParseAndShapeTests` | 깨진 JSON · 배열 · 비UTF-8 · 비상승 |
+| `RootExceptionTests` | 루트 부재 · packs 파일 · 빈 루트 · tasks 파일 |
+| `ReportShapeTests` | 봉투 · 사람/JSON 요약 · 실제 저장소 정합 |
+| `CliTests` | main exit 0/1/2 · 모르는 플래그 |
+| `FatalAndFoldTests` | KeyboardInterrupt/SystemExit/MemoryError/GeneratorExit |
+| `MixedPackTests` | 한 루트에 네 자리 혼재 |
+| `DoDCoverageTests` | 이슈가 명한 네 자리 동시 |
+| `RealRepoHonestyTests` | 실제 gym/packs 가 비어 있지 않음 |
+
+## 10. 실제 저장소에서 기대한 값
+
+devel 기준(이 브랜치가 갈라진 시점):
+
+- pack 18개 전후 (casual-rides … text-editing, showcase 포함)
+- 과제 수 = 기준풀이 수
+- 전역 충돌 0
+- 빈 pack 0
+- `python gym/tools/audit.py` exit 0
+
+숫자가 조금 달라도 `packCount >= 10` · `ok is True` 면 계약은
+유지된다. pack 을 이 PR 에서 늘리지 않으므로 숫자는 devel 과
+같다.
+
+## 11. 설계 선택
+
+### 11.1 왜 `--pack` 을 안 열었나
+
+전역 ID 충돌은 전 pack 을 봐야 한다. 한 pack 만 통과했다고 전
+저장소가 정합이라고 쓰면 거짓말이다. 이슈도 "새 CLI 없음"을
+명시했다.
+
+### 11.2 왜 스키마를 복제하지 않았나
+
+`schema.py` 는 PR 5210 이 `checks.py` 를 건드리는 자리와 붙어
+있다. 규칙을 여기 복사하면 연산자가 늘 때 감사기가 거짓
+음성을 낸다. 감싸서 메시지를 접는 쪽이 정직하다.
+
+### 11.3 왜 같은 pack 중복을 전역 충돌에서 뺐나
+
+리더보드가 pack + id 로 행을 가르면 같은 pack 의 두 파일은
+전역 충돌이 아니라 pack 내부 결함이다. `["p1", "p1"]` 을
+전역 맵에 넣으면 집계 쪽이 "두 pack"으로 오해한다. pack 안
+중복은 `task-id-duplicate-in-pack` 으로만 남긴다.
+
+### 11.4 왜 빈 packs 루트는 통과인가
+
+원 계약이 `packCount=0, issueCount=0, ok=true` 였다. 시험이
+임시 디렉터리에 `packs/` 만 만들고 끝나는 경로를 도구 실패로
+바꾸면 의미가 다르다. 실제 저장소는 `packCount >= 10` 으로
+따로 막는다.
+
+### 11.5 왜 empty-pack 을 추가했나
+
+과제 0 인 pack 은 해결 가능성을 선언할 수 없다. 원 구현은
+이를 통과시켰다. 나열에 성공한 뒤에만 이 코드를 남긴다.
+나열 실패를 빈 pack 으로 부르지 않는다.
+
+### 11.6 왜 파일명으로 짝을 짓나
+
+원 계약이 `tasks/X.json ↔ reference/X.json` 이다. id 로
+바꾸면 `Y99.json` + `id=Y99` 인 파일을 고아/미선언으로
+오인한다. 파일명 불일치는 별도 코드다.
+
+## 12. 위험과 비위험
+
+위험하지 않은 것:
+
+- 실제 저장소 pack 이 이미 정합이면 동작 변화 없음 (exit 0).
+- 레거시 시험 다섯 자리는 같은 주장을 한다.
+- 바이너리·네트워크를 부르지 않는다.
+
+주의할 것:
+
+- 빈 pack 은 이제 위반이다. devel 의 실제 pack 은 과제가
+  있으므로 영향 없다. 누군가 과제 없이 폴더만 올리면 CI 가
+  막는다. 그것이 이 이슈의 점이다.
+- pack 안 중복 ID 는 이제 명시적으로 막힌다. 예전에는 전역
+  맵에 `["p1","p1"]` 로만 보였다.
+- 파일명≠id 는 이제 위반이다. devel 의 실제 과제는 파일명과
+  id 가 같다.
+
+## 13. 검증 명령
+
+작업 트리 `C:\Users\swsz9\rhwp-gym-audit` 에서:
+
+```bash
+python -m unittest scripts.tests.test_gym_audit
+python gym/tools/audit.py
+python gym/tools/audit.py --json
+cargo fmt --all -- --check
+```
+
+unittest 가 red 면 PR 을 열지 않는다. audit.py 가 실제 gym 에서
+exit 0 이 아니면 PR 을 열지 않는다. fmt 하드 게이트를 건너뛰지
+않는다. 이 변경은 Python·문서만이라 rustfmt 대상 `.rs` 는 없다.
+
+## 14. 크기 게이트
+
+이슈 DoD: additions >= 3000 vs `upstream/devel`.
+
+의도한 증가 자리:
+
+| 파일 | 역할 |
+|---|---|
+| `gym/tools/audit.py` | 카탈로그·예외 접기·구조화 보고 |
+| `scripts/tests/test_gym_audit.py` | 원 계약 + 예외·스키마·CLI |
+| `gym/docs/audit.md` | 규약 정본 |
+| `mydocs/working/gym_audit.md` | 이 기록 |
+
+다른 파일을 부풀려 숫자를 채우지 않는다.
+
+## 15. 후속 (이 PR 밖)
+
+- pack 건강 감사(`pack_health.py`)와의 중복 메시지 정리. 그
+  도구는 지시·힌트 축이고 이 도구는 정합 축이다. 합치지 않는
+  편이 맞다.
+- profile 이 가리키는 pack id 존재 여부. `schema.validate_profile`
+  이 이미 있다. 감사기에 넣으면 CLI 없이 할 수 있으나 이슈
+  범위(스키마·기준 짝·ID 충돌) 밖이다.
+- `reference` 의 `steps` 스키마. 채점기가 읽는 자리라 여기
+  복제하지 않았다.
+
+## 16. 커밋 범위 체크리스트
+
+- [x] isolation worktree (`rhwp-gym-audit`, `rhwp-desk*` 아님)
+- [x] 브랜치 `feat/gym-audit-hardening` ← `upstream/devel`
+- [x] `gym/tools/audit.py` 고도화
+- [x] `scripts/tests/test_gym_audit.py` 확대
+- [x] `gym/docs/audit.md` 추가
+- [x] `mydocs/working/gym_audit.md` 추가
+- [x] 새 CLI/pack 없음
+- [x] 금지 파일 미수정
+- [ ] unittest 통과
+- [ ] `python gym/tools/audit.py` 통과
+- [ ] additions >= 3000
+- [ ] `cargo fmt --all -- --check`
+- [ ] 한국어 PR, `closes #5277`, `--body-file`
+
+## 17. 관련
+
+- 원 감사: #4803
+- 이 고도화: #5277
+- 스키마: `gym/core/schema.py` (#4653)
+- 비슷한 결의 고도화: #5256 fuzz_corpus, #5259 release_gate,
+  differential / discriminate 순수 시험

--- a/scripts/tests/test_gym_audit.py
+++ b/scripts/tests/test_gym_audit.py
@@ -3,19 +3,55 @@
 CI 강제: 실제 저장소의 전 pack 이 "그 방식"(해결 가능·고유·정합)을 지킨다. 비정합
 pack(짝 기준풀이 없음·과제 ID 전역 충돌)이 들어오면 이 테스트가 red 로 막는다.
 바이너리 없이 순수 파일 검사만 시험한다.
+
+확대 계약 (#5277):
+- 없는 packs 루트·읽기 실패·객체가 아닌 JSON 에서도 도구가 죽지 않는다.
+- 위반은 코드(ISSUE_CODES)로 접히고, packs[].issues 의 한글 문구는 원 계약을 지킨다.
+- 빠진 pack.json, 고아 기준풀이, 전역/pack 안 ID 충돌, 나쁜 스키마를 각각 잡는다.
+- CLI 는 `--json` 만. 새 플래그·새 pack 은 없다.
+- 치명 예외(KeyboardInterrupt · SystemExit · MemoryError · GeneratorExit)는 삼키지 않는다.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL = REPO_ROOT / "gym" / "tools" / "audit.py"
+
+LEGACY_REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "packCount",
+    "packs",
+    "taskIdCollisions",
+    "issueCount",
+)
+
+REQUIRED_CODES = (
+    "missing-pack-json",
+    "orphan-reference",
+    "task-id-collision",
+    "bad-schema",
+    "missing-reference",
+    "pack-json-parse",
+    "task-id-duplicate-in-pack",
+    "task-filename-id-mismatch",
+    "reference-id-mismatch",
+    "empty-pack",
+    "missing-packs-root",
+    "task-not-object",
+    "pack-json-not-object",
+)
 
 
 def load():
@@ -26,32 +62,100 @@ def load():
     return module
 
 
-def _write_pack(root, pid, task_id, with_ref=True):
+def _manifest(pid):
+    return {
+        "schemaVersion": "1.0",
+        "kind": "gymPack",
+        "id": pid,
+        "title": "t",
+        "axis": "조회 (x)",
+        "requires": {"commands": ["info"]},
+        "runner": {
+            "rhwpVersion": "0.8.4",
+            "rhwpCommit": "a" * 40,
+            "capabilitiesSha256": "b" * 64,
+        },
+    }
+
+
+def _task(task_id, **overrides):
+    body = {
+        "id": task_id,
+        "tier": 2,
+        "title": "t",
+        "input": "samples/x.hwp",
+        "instructions": "i",
+        "submit": {"kind": "answer"},
+        "checks": [{
+            "op": "answer_eq",
+            "answer": "p",
+            "cmd": ["info", "{input}", "--json"],
+            "path": "pageCount",
+        }],
+    }
+    body.update(overrides)
+    return body
+
+
+def _ref(task_id):
+    return {
+        "id": task_id,
+        "steps": [{
+            "answer": {
+                "p": {"cmd": ["info", "{input}", "--json"], "path": "pageCount"},
+            },
+        }],
+    }
+
+
+def _write_json(path, obj):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(obj, fh, ensure_ascii=False)
+
+
+def _write_text(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def _write_bytes(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(data)
+
+
+def _write_pack(root, pid, task_id, with_ref=True, task=None, manifest=None, ref=None):
     pd = os.path.join(root, "packs", pid)
-    os.makedirs(os.path.join(pd, "tasks"))
-    os.makedirs(os.path.join(pd, "reference"))
-    with open(os.path.join(pd, "pack.json"), "w", encoding="utf-8") as fh:
-        json.dump(
-            {"schemaVersion": "1.0", "kind": "gymPack", "id": pid, "title": "t", "axis": "조회 (x)",
-             "requires": {"commands": ["info"]},
-             "runner": {"rhwpVersion": "0.8.4", "rhwpCommit": "a" * 40, "capabilitiesSha256": "b" * 64}},
-            fh, ensure_ascii=False)
-    with open(os.path.join(pd, "tasks", f"{task_id}.json"), "w", encoding="utf-8") as fh:
-        json.dump(
-            {"id": task_id, "tier": 2, "title": "t", "input": "samples/x.hwp", "instructions": "i",
-             "submit": {"kind": "answer"},
-             "checks": [{"op": "answer_eq", "answer": "p", "cmd": ["info", "{input}", "--json"],
-                         "path": "pageCount"}]},
-            fh, ensure_ascii=False)
+    os.makedirs(os.path.join(pd, "tasks"), exist_ok=True)
+    os.makedirs(os.path.join(pd, "reference"), exist_ok=True)
+    _write_json(os.path.join(pd, "pack.json"), manifest if manifest is not None else _manifest(pid))
+    _write_json(os.path.join(pd, "tasks", f"{task_id}.json"), task if task is not None else _task(task_id))
     if with_ref:
-        with open(os.path.join(pd, "reference", f"{task_id}.json"), "w", encoding="utf-8") as fh:
-            json.dump(
-                {"id": task_id, "steps": [{"answer": {"p": {"cmd": ["info", "{input}", "--json"],
-                                                            "path": "pageCount"}}}]},
-                fh, ensure_ascii=False)
+        _write_json(
+            os.path.join(pd, "reference", f"{task_id}.json"),
+            ref if ref is not None else _ref(task_id),
+        )
+    return pd
+
+
+def _codes(report):
+    return [i.get("code") for i in report.get("issues") or [] if isinstance(i, dict)]
+
+
+def _pack_issue_text(report):
+    return [i for p in report.get("packs") or [] for i in p.get("issues") or []]
+
+
+class LoadMixin(unittest.TestCase):
+    def setUp(self):
+        self.mod = load()
 
 
 class AuditTests(unittest.TestCase):
+    """원 계약 다섯 자리 — 문구와 키를 깨면 CI 가 막는다."""
+
     def test_real_repo_all_packs_conform(self):
         report = load().audit(str(REPO_ROOT / "gym"))
         self.assertTrue(
@@ -87,6 +191,1081 @@ class AuditTests(unittest.TestCase):
             _write_pack(d, "p1", "A01", with_ref=True)
             _write_pack(d, "p2", "B01", with_ref=True)
             self.assertTrue(load().audit(d)["ok"])
+
+
+class CatalogContractTests(LoadMixin):
+    def test_kind_and_schema_stay_on_v1(self):
+        self.assertEqual(self.mod.REPORT_KIND, "gymAudit")
+        self.assertEqual(self.mod.SCHEMA_VERSION, "1.0")
+
+    def test_cli_flags_are_unchanged(self):
+        args = self.mod.parse_args([])
+        self.assertFalse(args.json)
+        args = self.mod.parse_args(["--json"])
+        self.assertTrue(args.json)
+        with self.assertRaises(SystemExit):
+            self.mod.parse_args(["--pack", "core-cli"])
+        with self.assertRaises(SystemExit):
+            self.mod.parse_args(["--out", "x.json"])
+        with self.assertRaises(SystemExit):
+            self.mod.parse_args(["--strict"])
+        with self.assertRaises(SystemExit):
+            self.mod.parse_args(["--root", "x"])
+
+    def test_issue_codes_cover_the_issued_paths(self):
+        codes = self.mod.issue_codes()
+        self.assertEqual(codes, self.mod.ISSUE_CODES)
+        self.assertEqual(codes, self.mod.catalog_ids())
+        for key in REQUIRED_CODES:
+            self.assertIn(key, codes, key)
+
+    def test_every_code_has_family_and_text(self):
+        for code in self.mod.ISSUE_CODES:
+            self.assertIn(code, self.mod.ISSUE_FAMILY, code)
+            self.assertIn(self.mod.ISSUE_FAMILY[code], self.mod.ISSUE_FAMILIES, code)
+            self.assertIn(code, self.mod.ISSUE_TEXT, code)
+            self.assertTrue(self.mod.ISSUE_TEXT[code], code)
+            self.assertTrue(self.mod.is_known_code(code))
+            self.assertTrue(self.mod.is_blocking_code(code))
+            self.assertEqual(self.mod.issue_family(code), self.mod.ISSUE_FAMILY[code])
+
+    def test_unknown_code_folds_to_tool_family(self):
+        self.assertEqual(self.mod.issue_family("not-a-code"), "tool")
+        self.assertEqual(self.mod.issue_family(""), "tool")
+        self.assertFalse(self.mod.is_known_code("not-a-code"))
+        rec = self.mod.make_issue("not-a-code", message="x")
+        self.assertEqual(rec["code"], "unexpected")
+        self.assertEqual(rec["family"], "tool")
+
+    def test_exits_are_the_audit_contract(self):
+        self.assertEqual(self.mod.EXIT_OK, 0)
+        self.assertEqual(self.mod.EXIT_VIOLATION, 1)
+        self.assertEqual(self.mod.EXIT_TOOL, 2)
+
+    def test_empty_report_has_every_key(self):
+        report = self.mod.empty_report()
+        for key in self.mod.REPORT_KEYS:
+            self.assertIn(key, report, key)
+        for key in LEGACY_REPORT_KEYS:
+            self.assertIn(key, report, key)
+        self.assertEqual(self.mod.validate_report(report), [])
+        self.assertEqual(report["kind"], "gymAudit")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["exit"], 0)
+
+    def test_legacy_load_still_exists(self):
+        self.assertTrue(callable(self.mod._load))
+
+
+class ExceptionKindTests(LoadMixin):
+    def test_fatal_exceptions_are_marked(self):
+        self.assertTrue(self.mod.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(self.mod.is_fatal_exception(SystemExit(1)))
+        self.assertTrue(self.mod.is_fatal_exception(MemoryError()))
+        self.assertTrue(self.mod.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(self.mod.is_fatal_exception(FileNotFoundError("x")))
+        self.assertFalse(self.mod.is_fatal_exception(ValueError("x")))
+        self.assertFalse(self.mod.is_fatal_exception(json.JSONDecodeError("bad", "x", 0)))
+
+    def test_file_not_found_depends_on_context(self):
+        exc = FileNotFoundError("nope")
+        self.assertEqual(self.mod.exception_kind(exc, "packs-root"), "missing-packs-root")
+        self.assertEqual(self.mod.exception_kind(exc, "pack-json"), "missing-pack-json")
+        self.assertEqual(self.mod.exception_kind(exc, "listdir-tasks"), "missing-tasks-dir")
+        self.assertEqual(self.mod.exception_kind(exc, "listdir-reference"), "missing-reference-dir")
+
+    def test_json_decode_depends_on_context(self):
+        exc = json.JSONDecodeError("bad", "x", 0)
+        self.assertEqual(self.mod.exception_kind(exc, "pack-json"), "pack-json-parse")
+        self.assertEqual(self.mod.exception_kind(exc, "task"), "task-parse")
+        self.assertEqual(self.mod.exception_kind(exc, "reference"), "reference-parse")
+
+    def test_permission_depends_on_context(self):
+        exc = PermissionError("p")
+        self.assertEqual(self.mod.exception_kind(exc, "packs-root"), "unlistable-packs")
+        self.assertEqual(self.mod.exception_kind(exc, "listdir-tasks"), "unlistable-tasks")
+        self.assertEqual(self.mod.exception_kind(exc, "listdir-reference"), "unlistable-reference")
+        self.assertEqual(self.mod.exception_kind(exc, "pack-json"), "pack-json-unreadable")
+        self.assertEqual(self.mod.exception_kind(exc, "task"), "task-unreadable")
+        self.assertEqual(self.mod.exception_kind(exc, "reference"), "reference-unreadable")
+
+    def test_not_a_directory_depends_on_context(self):
+        exc = NotADirectoryError("n")
+        self.assertEqual(self.mod.exception_kind(exc, "packs-root"), "packs-not-dir")
+        self.assertEqual(self.mod.exception_kind(exc, "listdir-tasks"), "tasks-not-dir")
+        self.assertEqual(self.mod.exception_kind(exc, "listdir-reference"), "reference-not-dir")
+
+    def test_unicode_and_type_errors(self):
+        dec = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad")
+        self.assertEqual(self.mod.exception_kind(dec, "pack-json"), "pack-json-unreadable")
+        self.assertEqual(self.mod.exception_kind(dec, "task"), "task-unreadable")
+        self.assertEqual(self.mod.exception_kind(TypeError("t"), "task"), "task-not-object")
+        self.assertEqual(self.mod.exception_kind(TypeError("t"), "pack-json"), "pack-json-not-object")
+        self.assertEqual(self.mod.exception_kind(TypeError("t"), "reference"), "reference-not-object")
+        self.assertEqual(self.mod.exception_kind(TypeError("t"), "schema"), "bad-schema")
+        self.assertEqual(self.mod.exception_kind(RuntimeError("r"), "audit"), "unexpected")
+        self.assertEqual(self.mod.exception_kind(None, "audit"), "unexpected")
+
+    def test_exception_record_does_not_raise(self):
+        rec = self.mod.exception_record(ValueError("boom"), context="pack-json", path="p/pack.json")
+        self.assertEqual(rec["context"], "pack-json")
+        self.assertEqual(rec["kind"], "pack-json-parse")
+        self.assertEqual(rec["error"], "ValueError")
+        self.assertIn("boom", rec["head"])
+        self.assertEqual(rec["path"], "p/pack.json")
+        rec_none = self.mod.exception_record(None)
+        self.assertEqual(rec_none["error"], "NoneType")
+
+    def test_truncate_head_bounds(self):
+        self.assertEqual(self.mod.truncate_head(None), "")
+        self.assertEqual(self.mod.truncate_head("abc"), "abc")
+        self.assertEqual(self.mod.truncate_head("abcdef", 3), "abc")
+        self.assertEqual(self.mod.truncate_head("abcdef", 0), "")
+        self.assertEqual(self.mod.truncate_head("abcdef", -1), "")
+        self.assertEqual(self.mod.truncate_head(12), "12")
+
+
+class PureHelperTests(LoadMixin):
+    def test_is_json_name(self):
+        self.assertTrue(self.mod.is_json_name("X01.json"))
+        self.assertFalse(self.mod.is_json_name("X01.JSON"))
+        self.assertFalse(self.mod.is_json_name("X01.txt"))
+        self.assertFalse(self.mod.is_json_name(".hidden.json"))
+        self.assertFalse(self.mod.is_json_name(""))
+        self.assertFalse(self.mod.is_json_name(None))
+        self.assertFalse(self.mod.is_json_name("."))
+        self.assertFalse(self.mod.is_json_name(".."))
+
+    def test_stem_and_json_filename(self):
+        self.assertEqual(self.mod.stem_of("X01.json"), "X01")
+        self.assertEqual(self.mod.stem_of("X01"), "X01")
+        self.assertEqual(self.mod.stem_of(None), "")
+        self.assertEqual(self.mod.json_filename("X01"), "X01.json")
+        self.assertEqual(self.mod.json_filename(""), "")
+        self.assertEqual(self.mod.json_filename(None), "")
+
+    def test_posix_rel_uses_forward_slashes(self):
+        self.assertEqual(self.mod.posix_rel("p1", "tasks", "X01.json"), "p1/tasks/X01.json")
+        self.assertEqual(self.mod.posix_rel("p1\\tasks", "X01.json"), "p1/tasks/X01.json")
+        self.assertEqual(self.mod.posix_rel("", None, "a"), "a")
+
+    def test_pair_names(self):
+        paired = self.mod.pair_names(["A.json", "B.json"], ["B.json", "C.json"])
+        self.assertEqual(paired["paired"], ["B.json"])
+        self.assertEqual(paired["missing_refs"], ["A.json"])
+        self.assertEqual(paired["orphans"], ["C.json"])
+        empty = self.mod.pair_names(None, None)
+        self.assertEqual(empty["paired"], [])
+        self.assertEqual(empty["missing_refs"], [])
+        self.assertEqual(empty["orphans"], [])
+
+    def test_detect_in_pack_duplicates(self):
+        found = self.mod.detect_in_pack_duplicates({
+            "DUP": ["A.json", "B.json"],
+            "OK": ["OK.json"],
+            "": ["empty.json", "other.json"],
+        })
+        self.assertEqual(found, {"DUP": ["A.json", "B.json"]})
+        self.assertEqual(self.mod.detect_in_pack_duplicates({}), {})
+        self.assertEqual(self.mod.detect_in_pack_duplicates(None), {})
+
+    def test_detect_global_collisions_ignores_same_pack(self):
+        collisions = self.mod.detect_global_collisions({
+            "DUP": ["p1", "p2"],
+            "SAME": ["p1", "p1"],
+            "OK": ["p3"],
+            "": ["p1", "p2"],
+        })
+        self.assertEqual(collisions, {"DUP": ["p1", "p2"]})
+        self.assertNotIn("SAME", collisions)
+
+    def test_distinct_preserve(self):
+        self.assertEqual(self.mod.distinct_preserve(["a", "b", "a", "c"]), ["a", "b", "c"])
+        self.assertEqual(self.mod.distinct_preserve(None), [])
+
+    def test_json_names_from_filters(self):
+        names = self.mod.json_names_from(["B.json", "notes.txt", "A.json", ".skip.json", "C.JSON"])
+        self.assertEqual(names, ["A.json", "B.json"])
+        self.assertEqual(self.mod.json_names_from(None), [])
+
+    def test_classify_schema_message(self):
+        cases = [
+            ("core: kind 가 gymPack 가 아니다", "kind"),
+            ("core: schemaVersion 이 1.0 이 아니다", "schemaVersion"),
+            ("core: pack id(x) 가 폴더 이름과 다르다", "pack-id"),
+            ("core: title 가 비었다", "title"),
+            ("core: axis 가 비었다", "axis"),
+            ("core: requires.commands 가 비었다", "requires"),
+            ("core: runner.rhwpVersion 가 비었다", "runner"),
+            ("p/X: 필수 키 없음: checks", "task-required"),
+            ("p/X: tier 는 1~5 정수", "tier"),
+            ("p/X: checks 가 비었다", "checks-empty"),
+            ("p/X: 미등록 연산자: nope", "unknown-op"),
+            ("p/X: 편집 과제에 전역 훑기 연산자(deep_contains)", "global-scan"),
+            ("p/X: answer_eq 는 cmd 가 필요하다", "missing-cmd"),
+            ("p/X: same_hash 는 CLI 를 부르지 않는데 cmd 가 있다", "unexpected-cmd"),
+            ("이상한 문장", "other"),
+        ]
+        for message, tag in cases:
+            self.assertEqual(self.mod.classify_schema_message(message), tag, message)
+
+    def test_make_issue_and_format_message(self):
+        rec = self.mod.make_issue("orphan-reference", pack="p1", path="p1/reference/X.json")
+        self.assertEqual(rec["code"], "orphan-reference")
+        self.assertEqual(rec["family"], "pairing")
+        self.assertIn("고아", rec["message"] + self.mod.ISSUE_TEXT["orphan-reference"])
+        self.assertIn("고아", rec["message"])
+        self.assertEqual(
+            self.mod.format_issue_message("missing-pack-json"),
+            "pack.json 이 없다",
+        )
+        self.assertIn("x", self.mod.format_issue_message("bad-schema", detail="x"))
+        self.assertIn("스키마 위반", self.mod.format_issue_message("bad-schema", detail="x"))
+
+    def test_pack_issue_line_keeps_legacy_korean(self):
+        self.assertEqual(self.mod.pack_issue_line("missing-pack-json"), "pack.json 이 없다")
+        self.assertIn("기준풀이", self.mod.pack_issue_line("missing-reference", name="X01.json"))
+        self.assertIn("고아", self.mod.pack_issue_line("orphan-reference", name="X01.json"))
+        self.assertIn("파싱 실패", self.mod.pack_issue_line("pack-json-parse", detail="boom"))
+        mismatch = self.mod.pack_issue_line(
+            "reference-id-mismatch", name="X01.json", tid="A", rid="B")
+        self.assertIn("A", mismatch)
+        self.assertIn("B", mismatch)
+
+    def test_count_by(self):
+        items = [{"code": "a", "family": "x"}, {"code": "a", "family": "y"}, {"code": "b", "family": "x"}]
+        self.assertEqual(self.mod.count_by(items, "code"), {"a": 2, "b": 1})
+        self.assertEqual(self.mod.count_by(items, "family"), {"x": 2, "y": 1})
+        self.assertEqual(self.mod.count_by(None, "code"), {})
+
+    def test_resolve_exit(self):
+        ok = self.mod.empty_report()
+        self.assertEqual(self.mod.resolve_exit(ok), 0)
+        bad = dict(ok)
+        bad["ok"] = False
+        bad["issueCount"] = 1
+        self.assertEqual(self.mod.resolve_exit(bad), 1)
+        tool = dict(ok)
+        tool["ok"] = False
+        tool["toolFailed"] = True
+        self.assertEqual(self.mod.resolve_exit(tool), 2)
+        missing = dict(ok)
+        missing["ok"] = False
+        missing["missingPacksRoot"] = True
+        self.assertEqual(self.mod.resolve_exit(missing), 2)
+        self.assertEqual(self.mod.resolve_exit("nope"), 2)
+
+    def test_validate_report_rejects_broken(self):
+        self.assertIn("객체가 아니다", self.mod.validate_report("x")[0])
+        broken = self.mod.empty_report()
+        del broken["ok"]
+        self.assertTrue(any("키 없음" in p for p in self.mod.validate_report(broken)))
+        wrong = self.mod.empty_report()
+        wrong["kind"] = "nope"
+        self.assertTrue(any("kind" in p for p in self.mod.validate_report(wrong)))
+        flip = self.mod.empty_report()
+        flip["ok"] = False
+        flip["issueCount"] = 0
+        flip["toolFailed"] = False
+        self.assertTrue(any("ok" in p for p in self.mod.validate_report(flip)))
+
+    def test_path_kind(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(self.mod.path_kind(d), "dir")
+            f = os.path.join(d, "f.txt")
+            _write_text(f, "x")
+            self.assertEqual(self.mod.path_kind(f), "file")
+            self.assertEqual(self.mod.path_kind(os.path.join(d, "missing")), "missing")
+            self.assertEqual(self.mod.path_kind(""), "missing")
+
+    def test_load_object_rejects_array(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "a.json")
+            _write_text(path, "[1, 2]")
+            obj, err = self.mod.load_object(path, context="task")
+            self.assertIsNone(obj)
+            self.assertEqual(err["kind"], "task-not-object")
+
+    def test_load_object_rejects_invalid_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "a.json")
+            _write_text(path, "{")
+            obj, err = self.mod.load_object(path, context="pack-json")
+            self.assertIsNone(obj)
+            self.assertEqual(err["kind"], "pack-json-parse")
+
+    def test_load_json_safe_missing(self):
+        obj, err = self.mod.load_json_safe(os.path.join("definitely", "missing.json"), context="task")
+        self.assertIsNone(obj)
+        self.assertIsNotNone(err)
+        self.assertIn(err["kind"], ("task-unreadable", "missing-packs-root", "task-parse"))
+
+    def test_list_dir_safe_missing(self):
+        names, err = self.mod.list_dir_safe(os.path.join("definitely", "missing"), context="listdir-tasks")
+        self.assertEqual(names, [])
+        self.assertIsNotNone(err)
+        self.assertEqual(err["kind"], "missing-tasks-dir")
+
+    def test_list_dir_safe_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_text(os.path.join(d, "a.json"), "{}")
+            names, err = self.mod.list_dir_safe(d, context="listdir-tasks")
+            self.assertIsNone(err)
+            self.assertIn("a.json", names)
+
+
+class MissingPackJsonTests(LoadMixin):
+    def test_directory_without_manifest_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "packs", "ghost", "tasks"))
+            r = self.mod.audit(d)
+            self.assertFalse(r["ok"])
+            self.assertIn("missing-pack-json", _codes(r))
+            self.assertTrue(any("pack.json 이 없다" in i for i in _pack_issue_text(r)))
+            self.assertEqual(r["exit"], 1)
+            self.assertFalse(r["toolFailed"])
+
+    def test_missing_manifest_does_not_scan_sibling_tasks(self):
+        with tempfile.TemporaryDirectory() as d:
+            pd = os.path.join(d, "packs", "ghost")
+            os.makedirs(os.path.join(pd, "tasks"))
+            _write_json(os.path.join(pd, "tasks", "X01.json"), _task("X01"))
+            r = self.mod.audit(d)
+            self.assertIn("missing-pack-json", _codes(r))
+            self.assertNotIn("missing-reference", _codes(r))
+            self.assertEqual(r["taskCount"], 0)
+
+    def test_manifest_as_directory_is_unreadable(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "packs", "ghost", "pack.json"))
+            r = self.mod.audit(d)
+            self.assertFalse(r["ok"])
+            self.assertIn("pack-json-unreadable", _codes(r))
+
+
+class OrphanAndPairingTests(LoadMixin):
+    def test_orphan_has_structured_code(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=True)
+            os.remove(os.path.join(d, "packs", "p1", "tasks", "X01.json"))
+            r = self.mod.audit(d)
+            self.assertIn("orphan-reference", _codes(r))
+            self.assertIn("empty-pack", _codes(r))
+            self.assertTrue(any("고아" in i for i in _pack_issue_text(r)))
+            self.assertIn("p1", r["emptyPacks"])
+
+    def test_missing_reference_has_structured_code(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            r = self.mod.audit(d)
+            self.assertIn("missing-reference", _codes(r))
+            self.assertTrue(any("해결 가능성" in i for i in _pack_issue_text(r)))
+
+    def test_reference_id_mismatch(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=True, ref=_ref("OTHER"))
+            r = self.mod.audit(d)
+            self.assertFalse(r["ok"])
+            self.assertIn("reference-id-mismatch", _codes(r))
+            self.assertTrue(any("OTHER" in i and "X01" in i for i in _pack_issue_text(r)))
+
+    def test_pairing_is_by_filename_not_id(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=True, task=_task("Y99"), ref=_ref("Y99"))
+            r = self.mod.audit(d)
+            self.assertIn("task-filename-id-mismatch", _codes(r))
+            self.assertNotIn("missing-reference", _codes(r))
+            self.assertNotIn("orphan-reference", _codes(r))
+
+    def test_non_json_files_are_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=True)
+            _write_text(os.path.join(d, "packs", "p1", "tasks", "notes.txt"), "nope")
+            _write_text(os.path.join(d, "packs", "p1", "reference", "readme.md"), "nope")
+            _write_text(os.path.join(d, "packs", "p1", "tasks", "X02.JSON"), "{}")
+            r = self.mod.audit(d)
+            self.assertTrue(r["ok"], r["packs"])
+            self.assertEqual(r["taskCount"], 1)
+
+    def test_two_missing_refs_are_two_issues(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            _write_json(os.path.join(d, "packs", "p1", "tasks", "X02.json"), _task("X02"))
+            r = self.mod.audit(d)
+            self.assertEqual(_codes(r).count("missing-reference"), 2)
+
+
+class DuplicateIdTests(LoadMixin):
+    def test_cross_pack_collision_is_global(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "DUP")
+            _write_pack(d, "p2", "DUP")
+            r = self.mod.audit(d)
+            self.assertEqual(r["taskIdCollisions"]["DUP"], ["p1", "p2"])
+            self.assertIn("task-id-collision", _codes(r))
+            self.assertGreaterEqual(r["issueCount"], 1)
+
+    def test_in_pack_duplicate_is_not_global_collision(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "A01")
+            _write_json(os.path.join(d, "packs", "p1", "tasks", "A01b.json"), _task("A01"))
+            _write_json(os.path.join(d, "packs", "p1", "reference", "A01b.json"), _ref("A01"))
+            r = self.mod.audit(d)
+            self.assertNotIn("A01", r["taskIdCollisions"])
+            self.assertIn("task-id-duplicate-in-pack", _codes(r))
+            self.assertTrue(any("여러 파일" in i for i in _pack_issue_text(r)))
+
+    def test_three_pack_collision_preserves_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "aa", "Z")
+            _write_pack(d, "mm", "Z")
+            _write_pack(d, "zz", "Z")
+            r = self.mod.audit(d)
+            self.assertEqual(r["taskIdCollisions"]["Z"], ["aa", "mm", "zz"])
+
+    def test_distinct_ids_do_not_collide(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "A01")
+            _write_pack(d, "p2", "B01")
+            _write_pack(d, "p3", "C01")
+            r = self.mod.audit(d)
+            self.assertEqual(r["taskIdCollisions"], {})
+            self.assertTrue(r["ok"])
+
+
+class BadSchemaTests(LoadMixin):
+    def test_wrong_kind(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["kind"] = "notPack"
+            _write_pack(d, "p1", "X01", manifest=man)
+            r = self.mod.audit(d)
+            self.assertIn("bad-schema", _codes(r))
+            self.assertTrue(any(i.get("schemaTag") == "kind" for i in r["issues"] if i.get("code") == "bad-schema"))
+
+    def test_wrong_schema_version(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["schemaVersion"] = "9.9"
+            _write_pack(d, "p1", "X01", manifest=man)
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "schemaVersion" for i in r["issues"]))
+
+    def test_pack_id_mismatch_folder(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("other")
+            _write_pack(d, "p1", "X01", manifest=man)
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "pack-id" for i in r["issues"]))
+
+    def test_empty_title_and_axis(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["title"] = ""
+            man["axis"] = ""
+            _write_pack(d, "p1", "X01", manifest=man)
+            tags = {i.get("schemaTag") for i in r_issues(self.mod.audit(d))}
+            self.assertIn("title", tags)
+            self.assertIn("axis", tags)
+
+    def test_empty_requires_commands(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["requires"] = {"commands": []}
+            _write_pack(d, "p1", "X01", manifest=man)
+            self.assertTrue(any(i.get("schemaTag") == "requires" for i in r_issues(self.mod.audit(d))))
+
+    def test_missing_runner_fields(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["runner"] = {}
+            _write_pack(d, "p1", "X01", manifest=man)
+            tags = [i.get("schemaTag") for i in r_issues(self.mod.audit(d))]
+            self.assertGreaterEqual(tags.count("runner"), 1)
+
+    def test_task_missing_required_key(self):
+        with tempfile.TemporaryDirectory() as d:
+            task = _task("X01")
+            del task["checks"]
+            _write_pack(d, "p1", "X01", task=task)
+            r = self.mod.audit(d)
+            tags = {i.get("schemaTag") for i in r["issues"] if i.get("code") == "bad-schema"}
+            self.assertTrue("task-required" in tags or "checks-empty" in tags)
+
+    def test_task_bad_tier(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", task=_task("X01", tier=9))
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "tier" for i in r["issues"]))
+
+    def test_task_unknown_operator(self):
+        with tempfile.TemporaryDirectory() as d:
+            task = _task("X01")
+            task["checks"] = [{"op": "not_a_real_op", "cmd": ["info"]}]
+            _write_pack(d, "p1", "X01", task=task)
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "unknown-op" for i in r["issues"]))
+
+    def test_editing_global_scan_is_schema(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["axis"] = "편집 (좌표 지정)"
+            task = _task("X01")
+            task["checks"] = [{
+                "op": "deep_contains",
+                "cmd": ["export-text", "{input}", "--json"],
+                "needle": "x",
+            }]
+            _write_pack(d, "p1", "X01", manifest=man, task=task)
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "global-scan" for i in r["issues"]))
+
+    def test_cli_op_missing_cmd(self):
+        with tempfile.TemporaryDirectory() as d:
+            task = _task("X01")
+            task["checks"] = [{"op": "answer_eq", "answer": "p", "path": "pageCount"}]
+            _write_pack(d, "p1", "X01", task=task)
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "missing-cmd" for i in r["issues"]))
+
+    def test_file_op_with_cmd(self):
+        with tempfile.TemporaryDirectory() as d:
+            task = _task("X01")
+            task["checks"] = [{"op": "file_exists", "cmd": ["info"]}]
+            _write_pack(d, "p1", "X01", task=task)
+            r = self.mod.audit(d)
+            self.assertTrue(any(i.get("schemaTag") == "unexpected-cmd" for i in r["issues"]))
+
+    def test_empty_task_id(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", task=_task(""), ref=_ref(""))
+            r = self.mod.audit(d)
+            self.assertIn("task-empty-id", _codes(r))
+
+    def test_schema_failures_keep_legacy_packs_issues(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["kind"] = "x"
+            _write_pack(d, "p1", "X01", manifest=man)
+            r = self.mod.audit(d)
+            self.assertTrue(_pack_issue_text(r))
+            self.assertTrue(any("kind" in i for i in _pack_issue_text(r)))
+
+
+def r_issues(report):
+    return [i for i in report.get("issues") or [] if isinstance(i, dict)]
+
+
+class ParseAndShapeTests(LoadMixin):
+    def test_pack_json_invalid(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "pack.json"), "{")
+            r = self.mod.audit(d)
+            self.assertIn("pack-json-parse", _codes(r))
+            self.assertTrue(any("파싱 실패" in i for i in _pack_issue_text(r)))
+
+    def test_pack_json_array(self):
+        with tempfile.TemporaryDirectory() as d:
+            pd = os.path.join(d, "packs", "p1")
+            os.makedirs(os.path.join(pd, "tasks"))
+            _write_text(os.path.join(pd, "pack.json"), "[1]")
+            r = self.mod.audit(d)
+            self.assertIn("pack-json-not-object", _codes(r))
+
+    def test_pack_json_number(self):
+        with tempfile.TemporaryDirectory() as d:
+            pd = os.path.join(d, "packs", "p1")
+            os.makedirs(pd)
+            _write_text(os.path.join(pd, "pack.json"), "3")
+            r = self.mod.audit(d)
+            self.assertIn("pack-json-not-object", _codes(r))
+
+    def test_task_invalid_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "tasks", "X01.json"), "{")
+            r = self.mod.audit(d)
+            self.assertIn("task-parse", _codes(r))
+            self.assertTrue(any("tasks/X01.json 파싱 실패" in i for i in _pack_issue_text(r)))
+
+    def test_task_array(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "tasks", "X01.json"), "[]")
+            r = self.mod.audit(d)
+            self.assertIn("task-not-object", _codes(r))
+
+    def test_reference_invalid_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "reference", "X01.json"), "{")
+            r = self.mod.audit(d)
+            self.assertIn("reference-parse", _codes(r))
+
+    def test_reference_array(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "reference", "X01.json"), "[]")
+            r = self.mod.audit(d)
+            self.assertIn("reference-not-object", _codes(r))
+
+    def test_non_utf8_pack_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_bytes(os.path.join(d, "packs", "p1", "pack.json"), b"\xff\xfe{")
+            r = self.mod.audit(d)
+            self.assertFalse(r["ok"])
+            codes = set(_codes(r))
+            self.assertTrue(codes & {"pack-json-parse", "pack-json-unreadable"})
+
+    def test_audit_does_not_raise_on_broken_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "tasks", "X01.json"), "not-json")
+            try:
+                r = self.mod.audit(d)
+            except Exception as exc:  # noqa: BLE001
+                self.fail(f"audit raised {exc}")
+            self.assertFalse(r["ok"])
+
+
+class RootExceptionTests(LoadMixin):
+    def test_missing_packs_root_is_tool_failure(self):
+        with tempfile.TemporaryDirectory() as d:
+            r = self.mod.audit(os.path.join(d, "no-such-gym"))
+            self.assertTrue(r["missingPacksRoot"])
+            self.assertTrue(r["toolFailed"])
+            self.assertFalse(r["ok"])
+            self.assertEqual(r["exit"], 2)
+            self.assertIn("missing-packs-root", _codes(r))
+            self.assertEqual(r["packCount"], 0)
+
+    def test_packs_as_file_is_tool_failure(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_text(os.path.join(d, "packs"), "not-a-dir")
+            r = self.mod.audit(d)
+            self.assertTrue(r["toolFailed"])
+            self.assertEqual(r["exit"], 2)
+            self.assertIn("packs-not-dir", _codes(r))
+
+    def test_empty_packs_dir_is_ok_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "packs"))
+            r = self.mod.audit(d)
+            self.assertTrue(r["ok"])
+            self.assertEqual(r["packCount"], 0)
+            self.assertEqual(r["issueCount"], 0)
+            self.assertEqual(r["exit"], 0)
+            self.assertEqual(self.mod.validate_report(r), [])
+
+    def test_loose_file_in_packs_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "A01")
+            _write_text(os.path.join(d, "packs", "notes.txt"), "ignore")
+            r = self.mod.audit(d)
+            self.assertTrue(r["ok"])
+            self.assertEqual(r["packCount"], 1)
+
+    def test_tasks_as_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            tasks = os.path.join(d, "packs", "p1", "tasks")
+            for name in os.listdir(tasks):
+                os.remove(os.path.join(tasks, name))
+            os.rmdir(tasks)
+            _write_text(tasks, "file")
+            r = self.mod.audit(d)
+            self.assertIn("tasks-not-dir", _codes(r))
+
+    def test_reference_as_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            ref = os.path.join(d, "packs", "p1", "reference")
+            for name in os.listdir(ref):
+                os.remove(os.path.join(ref, name))
+            os.rmdir(ref)
+            _write_text(ref, "file")
+            r = self.mod.audit(d)
+            self.assertIn("reference-not-dir", _codes(r))
+
+    def test_missing_tasks_dir_with_orphan_ref(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            tasks = os.path.join(d, "packs", "p1", "tasks")
+            for name in os.listdir(tasks):
+                os.remove(os.path.join(tasks, name))
+            os.rmdir(tasks)
+            r = self.mod.audit(d)
+            self.assertIn("orphan-reference", _codes(r))
+            self.assertIn("empty-pack", _codes(r))
+
+    def test_audit_none_root_does_not_raise(self):
+        r = self.mod.audit(None)
+        self.assertFalse(r["ok"])
+        self.assertTrue(r["toolFailed"] or r["missingPacksRoot"])
+
+
+class ReportShapeTests(LoadMixin):
+    def test_clean_report_validates(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "A01")
+            _write_pack(d, "p2", "B01")
+            r = self.mod.audit(d)
+            self.assertEqual(self.mod.validate_report(r), [])
+            self.assertTrue(r["ok"])
+            self.assertEqual(r["packCount"], 2)
+            self.assertEqual(r["taskCount"], 2)
+            self.assertEqual(r["referenceCount"], 2)
+            self.assertEqual(set(r["okPacks"]), {"p1", "p2"})
+            self.assertEqual(r["packs"], [])
+            self.assertEqual(r["taskIdCollisions"], {})
+            self.assertEqual(r["issueCount"], 0)
+            self.assertEqual(r["exit"], 0)
+
+    def test_dirty_packs_only_lists_offenders(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "clean", "A01")
+            _write_pack(d, "dirty", "B01", with_ref=False)
+            r = self.mod.audit(d)
+            ids = [p["id"] for p in r["packs"]]
+            self.assertEqual(ids, ["dirty"])
+            self.assertIn("clean", r["okPacks"])
+            self.assertNotIn("dirty", r["okPacks"])
+
+    def test_issue_count_is_pack_lines_plus_collisions(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "DUP")
+            _write_pack(d, "p2", "DUP")
+            r = self.mod.audit(d)
+            pack_lines = sum(len(p["issues"]) for p in r["packs"])
+            self.assertEqual(r["issueCount"], pack_lines + len(r["taskIdCollisions"]))
+
+    def test_issue_counts_by_code_and_family(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            r = self.mod.audit(d)
+            self.assertGreaterEqual(r["issueCountsByCode"].get("missing-reference", 0), 1)
+            self.assertGreaterEqual(r["issueCountsByFamily"].get("pairing", 0), 1)
+
+    def test_human_report_ok(self):
+        text = self.mod.format_human_report(self.mod.empty_report())
+        self.assertIn("전부 통과", text)
+        self.assertIn("위반 0", text)
+
+    def test_human_report_violations(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            r = self.mod.audit(d)
+            text = self.mod.format_human_report(r)
+            self.assertIn("위반", text)
+            self.assertIn("[p1]", text)
+            self.assertIn("기준풀이", text)
+
+    def test_human_report_collision(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "DUP")
+            _write_pack(d, "p2", "DUP")
+            text = self.mod.format_human_report(self.mod.audit(d))
+            self.assertIn("[전역]", text)
+            self.assertIn("DUP", text)
+            self.assertIn("p1", text)
+            self.assertIn("p2", text)
+
+    def test_human_report_tool_failure(self):
+        r = self.mod.empty_report()
+        r["ok"] = False
+        r["toolFailed"] = True
+        r["missingPacksRoot"] = True
+        r["toolErrors"] = [{"head": "packs 루트가 없다", "kind": "missing-packs-root"}]
+        text = self.mod.format_human_report(r)
+        self.assertIn("도구 실패", text)
+
+    def test_human_report_broken_input(self):
+        self.assertIn("손상", self.mod.format_human_report("nope"))
+
+    def test_json_report_is_object(self):
+        raw = self.mod.format_json_report(self.mod.empty_report())
+        parsed = json.loads(raw)
+        self.assertEqual(parsed["kind"], "gymAudit")
+        self.assertTrue(raw.endswith("\n"))
+
+    def test_real_repo_report_validates_and_counts(self):
+        r = self.mod.audit(str(REPO_ROOT / "gym"))
+        self.assertEqual(self.mod.validate_report(r), [])
+        self.assertGreaterEqual(r["taskCount"], 80)
+        self.assertEqual(r["taskCount"], r["referenceCount"])
+        self.assertGreaterEqual(len(r["okPacks"]), 10)
+        self.assertFalse(r["toolFailed"])
+        self.assertFalse(r["missingPacksRoot"])
+
+
+class CliTests(LoadMixin):
+    def test_main_json_ok(self):
+        buf = io.StringIO()
+        with mock.patch.object(self.mod, "GYM_ROOT", str(REPO_ROOT / "gym")):
+            with mock.patch.object(sys, "stdout", buf):
+                code = self.mod.main(["--json"])
+        self.assertEqual(code, 0)
+        parsed = json.loads(buf.getvalue())
+        self.assertTrue(parsed["ok"])
+        self.assertEqual(parsed["kind"], "gymAudit")
+
+    def test_main_human_ok(self):
+        buf = io.StringIO()
+        with mock.patch.object(self.mod, "GYM_ROOT", str(REPO_ROOT / "gym")):
+            with mock.patch.object(sys, "stdout", buf):
+                code = self.mod.main([])
+        self.assertEqual(code, 0)
+        self.assertIn("전부 통과", buf.getvalue())
+
+    def test_main_json_violation_exit_1(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            buf = io.StringIO()
+            with mock.patch.object(self.mod, "GYM_ROOT", d):
+                with mock.patch.object(sys, "stdout", buf):
+                    code = self.mod.main(["--json"])
+            self.assertEqual(code, 1)
+            parsed = json.loads(buf.getvalue())
+            self.assertFalse(parsed["ok"])
+            self.assertIn("missing-reference", [i["code"] for i in parsed["issues"]])
+
+    def test_main_human_violation_exit_1(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            buf = io.StringIO()
+            with mock.patch.object(self.mod, "GYM_ROOT", d):
+                with mock.patch.object(sys, "stdout", buf):
+                    code = self.mod.main([])
+            self.assertEqual(code, 1)
+            self.assertIn("위반", buf.getvalue())
+
+    def test_main_missing_root_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            buf = io.StringIO()
+            with mock.patch.object(self.mod, "GYM_ROOT", os.path.join(d, "missing")):
+                with mock.patch.object(sys, "stdout", buf):
+                    code = self.mod.main(["--json"])
+            self.assertEqual(code, 2)
+            parsed = json.loads(buf.getvalue())
+            self.assertTrue(parsed["toolFailed"])
+
+    def test_main_unknown_flag_exits(self):
+        with self.assertRaises(SystemExit):
+            self.mod.main(["--nope"])
+
+
+class FatalAndFoldTests(LoadMixin):
+    def test_audit_one_pack_does_not_swallow_keyboard_interrupt(self):
+        with tempfile.TemporaryDirectory() as d:
+            pd = _write_pack(d, "p1", "X01")
+
+            def boom(*_a, **_k):
+                raise KeyboardInterrupt()
+
+            with mock.patch.object(self.mod, "load_object", side_effect=boom):
+                with self.assertRaises(KeyboardInterrupt):
+                    self.mod.audit_one_pack("p1", pd, {})
+
+    def test_audit_does_not_swallow_system_exit(self):
+        def boom(*_a, **_k):
+            raise SystemExit(3)
+
+        with mock.patch.object(self.mod, "path_kind", side_effect=boom):
+            with self.assertRaises(SystemExit):
+                self.mod.audit("whatever")
+
+    def test_run_validate_pack_folds_nonfatal(self):
+        def boom(*_a, **_k):
+            raise RuntimeError("schema-down")
+
+        with mock.patch.object(self.mod.schema, "validate_pack", side_effect=boom):
+            msgs = self.mod.run_validate_pack(_manifest("p1"), "p1")
+        self.assertTrue(any("schema-down" in m for m in msgs))
+
+    def test_run_validate_task_folds_nonfatal(self):
+        def boom(*_a, **_k):
+            raise TypeError("task-down")
+
+        with mock.patch.object(self.mod.schema, "validate_task", side_effect=boom):
+            msgs = self.mod.run_validate_task(_task("X01"), _manifest("p1"))
+        self.assertTrue(any("task-down" in m for m in msgs))
+
+    def test_run_validate_pack_reraises_fatal(self):
+        def boom(*_a, **_k):
+            raise MemoryError()
+
+        with mock.patch.object(self.mod.schema, "validate_pack", side_effect=boom):
+            with self.assertRaises(MemoryError):
+                self.mod.run_validate_pack(_manifest("p1"), "p1")
+
+    def test_list_dir_safe_does_not_swallow_keyboard(self):
+        def boom(_path):
+            raise KeyboardInterrupt()
+
+        with mock.patch.object(os, "listdir", side_effect=boom):
+            with self.assertRaises(KeyboardInterrupt):
+                self.mod.list_dir_safe("x", context="packs-root")
+
+    def test_load_json_safe_does_not_swallow_generator_exit(self):
+        class Boom(io.StringIO):
+            def read(self, *a, **k):
+                raise GeneratorExit()
+
+        real_open = open
+
+        def fake_open(path, *a, **k):
+            if str(path).endswith(".json"):
+                return Boom("{}")
+            return real_open(path, *a, **k)
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "a.json")
+            _write_text(path, "{}")
+            with mock.patch("builtins.open", side_effect=fake_open):
+                with self.assertRaises(GeneratorExit):
+                    self.mod.load_json_safe(path, context="pack-json")
+
+
+class MixedPackTests(LoadMixin):
+    def test_one_clean_one_missing_json_one_orphan_one_dup(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "clean", "C01")
+            os.makedirs(os.path.join(d, "packs", "ghost"))
+            _write_pack(d, "orphan", "O01")
+            os.remove(os.path.join(d, "packs", "orphan", "tasks", "O01.json"))
+            _write_pack(d, "left", "SHARE")
+            _write_pack(d, "right", "SHARE")
+            r = self.mod.audit(d)
+            self.assertFalse(r["ok"])
+            codes = set(_codes(r))
+            self.assertIn("missing-pack-json", codes)
+            self.assertIn("orphan-reference", codes)
+            self.assertIn("task-id-collision", codes)
+            self.assertIn("clean", r["okPacks"])
+            self.assertIn("SHARE", r["taskIdCollisions"])
+            self.assertEqual(r["exit"], 1)
+
+    def test_bad_schema_and_missing_ref_together(self):
+        with tempfile.TemporaryDirectory() as d:
+            man = _manifest("p1")
+            man["kind"] = "x"
+            _write_pack(d, "p1", "X01", with_ref=False, manifest=man)
+            r = self.mod.audit(d)
+            codes = set(_codes(r))
+            self.assertIn("bad-schema", codes)
+            self.assertIn("missing-reference", codes)
+
+    def test_ok_packs_sorted_like_directory_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "b-pack", "B01")
+            _write_pack(d, "a-pack", "A01")
+            r = self.mod.audit(d)
+            self.assertEqual(r["okPacks"], ["a-pack", "b-pack"])
+
+    def test_readme_next_to_pack_is_not_an_issue(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01")
+            _write_text(os.path.join(d, "packs", "p1", "README.md"), "# hi")
+            os.makedirs(os.path.join(d, "packs", "p1", "assets"), exist_ok=True)
+            _write_text(os.path.join(d, "packs", "p1", "assets", "x.csv"), "a,b")
+            r = self.mod.audit(d)
+            self.assertTrue(r["ok"], r["packs"])
+
+
+class SchemaWrapAndLegacyLoadTests(LoadMixin):
+    def test_legacy_load_reads_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.json")
+            _write_json(path, {"a": 1})
+            self.assertEqual(self.mod._load(path), {"a": 1})
+
+    def test_legacy_load_raises_on_invalid(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.json")
+            _write_text(path, "{")
+            with self.assertRaises((ValueError, json.JSONDecodeError)):
+                self.mod._load(path)
+
+    def test_append_issue_writes_both_surfaces(self):
+        pack_issues = []
+        structured = []
+        rec = self.mod.append_issue(
+            pack_issues, structured, "orphan-reference", "p1",
+            path="p1/reference/X01.json", name="X01.json",
+        )
+        self.assertEqual(len(pack_issues), 1)
+        self.assertEqual(len(structured), 1)
+        self.assertIn("고아", pack_issues[0])
+        self.assertEqual(rec["code"], "orphan-reference")
+        self.assertEqual(structured[0]["pack"], "p1")
+
+
+class DoDCoverageTests(LoadMixin):
+    """이슈 #5277 가 명시한 네 자리 — 빠진 pack.json · 고아 · 중복 ID · 나쁜 스키마."""
+
+    def test_four_issued_faults_are_independent(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "packs", "no-manifest"))
+            _write_pack(d, "orphan-pack", "O01")
+            os.remove(os.path.join(d, "packs", "orphan-pack", "tasks", "O01.json"))
+            _write_pack(d, "dup-a", "SAME")
+            _write_pack(d, "dup-b", "SAME")
+            man = _manifest("bad-schema")
+            man["schemaVersion"] = "0.0"
+            _write_pack(d, "bad-schema", "S01", manifest=man)
+            r = self.mod.audit(d)
+            codes = set(_codes(r))
+            self.assertIn("missing-pack-json", codes)
+            self.assertIn("orphan-reference", codes)
+            self.assertIn("task-id-collision", codes)
+            self.assertIn("bad-schema", codes)
+            self.assertFalse(r["ok"])
+            self.assertEqual(r["exit"], 1)
+            self.assertIn("SAME", r["taskIdCollisions"])
+
+    def test_four_issued_faults_have_korean_pack_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "packs", "ghost"))
+            _write_pack(d, "orphan-pack", "O01")
+            os.remove(os.path.join(d, "packs", "orphan-pack", "tasks", "O01.json"))
+            man = _manifest("bad")
+            man["kind"] = "x"
+            _write_pack(d, "bad", "S01", manifest=man)
+            _write_pack(d, "a", "ID")
+            _write_pack(d, "b", "ID")
+            lines = "\n".join(_pack_issue_text(self.mod.audit(d)))
+            self.assertIn("pack.json 이 없다", lines)
+            self.assertIn("고아", lines)
+            self.assertIn("kind", lines)
+
+    def test_module_doc_forbids_new_cli(self):
+        text = Path(TOOL).read_text(encoding="utf-8")
+        self.assertIn("새 플래그는 없다", text)
+        self.assertIn("schema.validate_pack", text)
+        self.assertIn("고아", text)
+
+
+class RealRepoHonestyTests(LoadMixin):
+    def test_real_repo_has_no_collision_map(self):
+        r = self.mod.audit(str(REPO_ROOT / "gym"))
+        self.assertEqual(r["taskIdCollisions"], {})
+        self.assertEqual(r["emptyPacks"], [])
+        self.assertEqual(r["issueCountsByCode"], {})
+
+    def test_every_real_pack_is_in_ok_or_dirty(self):
+        r = self.mod.audit(str(REPO_ROOT / "gym"))
+        listed = {name for name in os.listdir(REPO_ROOT / "gym" / "packs")
+                  if (REPO_ROOT / "gym" / "packs" / name).is_dir()}
+        self.assertEqual(set(r["okPacks"]) | {p["id"] for p in r["packs"]}, listed)
+        self.assertEqual(len(listed), r["packCount"])
+
+    def test_audit_py_is_the_only_cli_entry(self):
+        src = Path(TOOL).read_text(encoding="utf-8")
+        self.assertIn('ap.add_argument("--json"', src)
+        self.assertEqual(src.count("add_argument"), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

`gym/tools/audit.py` 전 pack 정합 감사를 예외 경로까지 닫는다. 빠진 pack.json, 고아 기준풀이, 전역·pack 안 과제 ID 충돌, 나쁜 스키마를 코드로 접는다. 없는 packs 루트·깨진 JSON·객체가 아닌 JSON 에서도 도구가 죽지 않는다. 못 읽은 것을 정합 0건으로 위장하지 않는다.

원 계약은 유지한다. `kind=gymAudit`, `schemaVersion=1.0`, `packs[].issues` 한글 문자열, `taskIdCollisions`, `issueCount` 는 pack 이슈 줄 + 전역 충돌 수. CLI 는 `--json` 만. `schema.validate_pack` 과 `schema.validate_task` 를 감쌀 뿐 복제하지 않는다. 치명 예외는 삼키지 않는다.

새 CLI/pack 없음. certify.py · report.py · score.py · runner.py · build_baseline.py · tutorial · expert-challenges · PR 5210-5276 파일은 건드리지 않았다.

규범: `gym/docs/audit.md`. 작업 기록: `mydocs/working/gym_audit.md`.

## 관련 이슈

closes #5277

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_audit` 통과 (122)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [x] `cargo fmt --all -- --check` 통과
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 해당 없음
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — 해당 없음
- [ ] `cargo test` — 해당 없음 (Python·문서만)
- [ ] `cargo clippy -- -D warnings` — 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] 작업 증빙 첨부 — 해당 없음 (순수 파일 감사, 문서 편집 영수증 불요)
- [ ] `.claude/agents/` 변경 시 capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음. 바이너리·네트워크를 부르지 않는 순수 파일 검사다. 예외 접기와 구조화 이슈만 추가했다.
- 재현·측정: 바이너리 없이 unittest 122건과 `python gym/tools/audit.py` exit 0. 미측정(감사 로직 확대, 런타임 rhwp 경로 불변).
