### PR TITLE
feat(gym): certify/report 채점 산출 예외·문서·시험 강화 (#5275)

### DIFF
--- a/gym/certify.py
+++ b/gym/certify.py
@@ -11,11 +11,25 @@ gym 을 만점 통과했다"고 주장해도, 그게 몰래 축소한 벤치마�
 - **벤치마크 지문** — 전 pack 정의(pack.json·tasks·reference)의 sha256. 인증서가
   '무엇을' 재고 채점했는지 못박는다. 벤치마크를 몰래 줄이면 지문이 바뀌어 들킨다.
 - **바이너리 신원** — `capabilitiesSha256`. '어느 바이너리로' 냈는지 못박는다.
-- **재현 = 증명** — 같은 바이너리 + 같은 벤치마크면 누구나 같은 점수를 재현한다.
+- **재현 = 증명** — 같은 바이너리 + 같은 pack 정의면 누구나 같은 점수를 재현한다.
   `--verify` 가 다시 돌려 인증서와 대조한다: 재현되면 진짜, 아니면 위조.
 
 암호 서명이 아니라 **결정론적 재현**이 증명 원리다 — reproducible-build attestation 과
 같은 계열이라 키 관리 없이 누구나 검증할 수 있다.
+
+예외 세 자리(이슈 #5275)는 스택이 아니라 kind 로 남긴다.
+
+- **없는 스코어카드** — report.py 가 scorecard.json 없이 끝나면 `missing-scorecard`.
+  빈 인증서를 지어 만점인 척하지 않는다.
+- **깨진 JSON** — 인증서·리포트 stdout 이 객체가 아니면 `malformed-json` /
+  `malformed-cert` / `malformed-report`. 파싱 실패를 재현 성공으로 바꾸지 않는다.
+- **미가용 pack** — 리포트의 `packsUnavailable` 을 인증서 `unavailablePacks` 와
+  `unavailable-pack` 예외 칸에 옮긴다. 부재는 위조가 아니지만 숨기면 위조다.
+
+카탈로그·봉투 계약은 `gym/docs/certify_report.md` 가 정본이다. 작업 기록은
+`mydocs/working/gym_certify_report.md`. 시험은 `scripts/tests/test_gym_certify.py`.
+
+새 CLI 플래그는 없다. `--bin` `--verify` `--out` `--at` 만 쓴다.
 
 ## 사용
 
@@ -38,6 +52,384 @@ REPO_ROOT = os.path.dirname(GYM_ROOT)
 
 CERT_KIND = "gymCapabilityCertificate"
 CERT_SCHEMA = "1.0"
+REPORT_KIND = "gymCapabilityReport"
+
+# 종료 코드. 0=발급 성공 또는 재현 통과, 1=재현 불일치, 2=도구 실패.
+EXIT_OK = 0
+EXIT_VERIFY_FAIL = 1
+EXIT_TOOL_FAILED = 2
+
+# 새 플래그 없음. 시험이 argparse 옵션 집합을 이 튜플과 대조한다.
+CERT_CLI_FLAGS = ("--bin", "--verify", "--out", "--at")
+
+# 지문에 넣는 측정 입력. 문서·mydocs 는 점수를 바꾸지 않아 넣지 않는다.
+FINGERPRINT_TREES = ("packs", "core", "profiles", "tools")
+FINGERPRINT_FILES = ("score.py", "report.py", "certify.py")
+FINGERPRINT_SKIP_DIRS = frozenset({"__pycache__"})
+FINGERPRINT_SKIP_SUFFIXES = (".pyc",)
+
+CERT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "benchmarkFingerprint",
+    "report",
+    "proof",
+    "certifiedAt",
+    "exceptions",
+    "exceptionCount",
+    "unavailablePacks",
+    "trusted",
+)
+
+CERT_LIST_KEYS = ("exceptions", "unavailablePacks")
+CERT_INT_KEYS = ("exceptionCount",)
+CERT_BOOL_KEYS = ("trusted",)
+
+REPRODUCIBLE_CORE_KEYS = (
+    "benchmarkFingerprint",
+    "capabilitiesSha256",
+    "accuracy",
+    "coverage",
+    "axisProfile",
+)
+
+COVERAGE_CORE_KEYS = ("percent", "covered", "agentFacingTotal")
+
+PROOF_TEXT = "reproduce: 같은 bin + 같은 pack 정의로 --verify 하면 core 가 일치한다"
+
+# 예외 kind 카탈로그. 문서·시험이 같은 표를 본다.
+EXCEPTION_KINDS = (
+    "missing-cert",
+    "missing-bin",
+    "missing-scorecard",
+    "missing-report",
+    "malformed-json",
+    "malformed-cert",
+    "malformed-report",
+    "wrong-kind",
+    "unavailable-pack",
+    "fingerprint-empty",
+    "report-tool-failed",
+    "verify-mismatch",
+    "permission",
+    "os-error",
+    "decode-error",
+    "write-error",
+    "type-error",
+    "value-error",
+    "unexpected",
+)
+
+EXCEPTION_KIND_HELP = {
+    "missing-cert": (
+        "--verify 경로에 인증서 파일이 없다. 없는 파일을 재현 성공으로 부르지 않는다."
+    ),
+    "missing-bin": (
+        "--bin 이 비었거나 경로형 바이너리가 없어 report.py 가 시작되지 않는다."
+    ),
+    "missing-scorecard": (
+        "report.py 가 스코어카드 없이 끝났다. stderr 에 missing-scorecard 가 "
+        "보이거나 scorecard.json 부재 문구가 있다. 빈 인증서를 발급하지 않는다."
+    ),
+    "missing-report": (
+        "인증서에 report 칸이 없거나 객체가 아니다. 재현 core 를 만들 수 없다."
+    ),
+    "malformed-json": (
+        "인증서 파일 또는 report.py stdout 이 UTF-8 JSON 이 아니다. "
+        "잘린 객체·빈 파일·트레일링 콤마."
+    ),
+    "malformed-cert": (
+        "인증서가 JSON 객체(dict)가 아니다. 배열·문자열은 인증서가 아니다."
+    ),
+    "malformed-report": (
+        "리포트가 JSON 객체가 아니다. report.py 가 카드 텍스트를 stdout 에 "
+        "흘리면 --json 계약이 깨진 것이다."
+    ),
+    "wrong-kind": (
+        f"인증서 kind 가 {CERT_KIND} 가 아니다. 다른 봉투를 인증서로 들이밀면 "
+        "재현 실패(exit 1)다."
+    ),
+    "unavailable-pack": (
+        "리포트 packsUnavailable 의 pack. 부재는 위조가 아니지만 인증서가 "
+        "숨기면 축소로 오해된다. 발급 시 예외 칸에 남기고, 재현 때 집합이 "
+        "달라지면 verify-mismatch 다."
+    ),
+    "fingerprint-empty": (
+        "지문에 넣을 파일이 하나도 없다. gym_root 가 빈 디렉터리이거나 "
+        "packs/core/profiles/tools 와 score/report/certify 가 모두 없다."
+    ),
+    "report-tool-failed": (
+        "report.py 가 비-0 으로 끝났고 더 구체적인 kind 로 분류되지 않았다."
+    ),
+    "verify-mismatch": (
+        "재현 core 가 인증 시점과 다르다. 지문·바이너리 신원·정확도·커버리지·"
+        "축·미가용 pack 집합 중 하나."
+    ),
+    "permission": "인증서 파일 또는 산출 경로의 읽기·쓰기 권한이 없다.",
+    "os-error": "그 밖의 OSError. 디스크·경로·잠금.",
+    "decode-error": "인증서 파일이 UTF-8 이 아니다.",
+    "write-error": "--out 경로에 인증서를 쓰지 못했다.",
+    "type-error": "값 타입이 계약과 다르다.",
+    "value-error": "값은 있는데 형태가 틀렸다.",
+    "unexpected": "분류되지 않은 운영 예외. 치명 예외는 여기로 접지 않는다.",
+}
+
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    IsADirectoryError,
+    NotADirectoryError,
+    UnicodeError,
+    json.JSONDecodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    subprocess.SubprocessError,
+)
+
+INFORMATIONAL_KINDS = frozenset({"unavailable-pack", "fingerprint-empty"})
+
+VERIFY_PASS_MESSAGE = "✅ 인증서 재현 검증 통과 — 벤치마크·바이너리·전 점수가 재현된다(진짜)"
+VERIFY_FAIL_PREFIX = "❌ 인증서 재현 검증 실패:"
+
+KIND_MARKERS = (
+    "missing-scorecard",
+    "missing-bin",
+    "malformed-json",
+    "malformed-scorecard",
+    "malformed-report",
+    "report-tool-failed",
+    "permission",
+    "decode-error",
+)
+
+
+class CertifyError(Exception):
+    """인증서 도구가 접는 운영 예외. kind 는 EXCEPTION_KINDS 중 하나."""
+
+    def __init__(self, kind: str, message: str, **extra: object) -> None:
+        if kind not in EXCEPTION_KINDS:
+            kind = "unexpected"
+        self.kind = kind
+        self.message = message
+        self.extra = extra
+        super().__init__(message)
+
+    def as_record(self) -> dict:
+        return exception_record(self.kind, self.message, **self.extra)
+
+
+def is_json_object(value: object) -> bool:
+    return isinstance(value, dict) and not isinstance(value, bool)
+
+
+def is_json_array(value: object) -> bool:
+    return isinstance(value, list)
+
+
+def is_known_exception_kind(kind: object) -> bool:
+    return isinstance(kind, str) and kind in EXCEPTION_KINDS
+
+
+def is_fatal_exception(exc: BaseException) -> bool:
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def is_catchable_exception(exc: BaseException) -> bool:
+    if is_fatal_exception(exc):
+        return False
+    return isinstance(exc, CATCHABLE_EXCEPTIONS) or isinstance(exc, CertifyError)
+
+
+def describe_exception_kind(kind: str) -> str:
+    if kind in EXCEPTION_KIND_HELP:
+        return EXCEPTION_KIND_HELP[kind]
+    return EXCEPTION_KIND_HELP["unexpected"]
+
+
+def exception_record(kind: str, message: str, **extra: object) -> dict:
+    rec: dict = {"kind": kind if is_known_exception_kind(kind) else "unexpected",
+                 "message": message}
+    for key in ("where", "path", "pack", "role"):
+        if extra.get(key) not in (None, ""):
+            rec[key] = extra[key]
+    return rec
+
+
+def is_informational_kind(kind: str) -> bool:
+    return kind in INFORMATIONAL_KINDS
+
+
+def structural_exceptions(exceptions: list[dict]) -> list[dict]:
+    return [e for e in exceptions if not is_informational_kind(e.get("kind", ""))]
+
+
+def error_head(exc: BaseException, limit: int = 240) -> str:
+    text = str(exc).strip() or type(exc).__name__
+    if len(text) > limit:
+        return text[:limit]
+    return text
+
+
+def classify_os_error(exc: BaseException, *, role: str = "cert") -> str:
+    if isinstance(exc, CertifyError):
+        return exc.kind
+    if isinstance(exc, json.JSONDecodeError):
+        return "malformed-json"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, FileNotFoundError):
+        return "missing-cert" if role == "cert" else "missing-bin"
+    if isinstance(exc, IsADirectoryError):
+        return "malformed-cert" if role == "cert" else "malformed-report"
+    if isinstance(exc, TypeError):
+        return "type-error"
+    if isinstance(exc, ValueError):
+        return "value-error"
+    if isinstance(exc, subprocess.SubprocessError):
+        return "report-tool-failed"
+    if isinstance(exc, OSError):
+        return "os-error"
+    return "unexpected"
+
+
+def wrap_exception(exc: BaseException, *, role: str = "cert",
+                   where: str = "", path: str = "") -> CertifyError:
+    if isinstance(exc, CertifyError):
+        return exc
+    if is_fatal_exception(exc):
+        raise exc
+    kind = classify_os_error(exc, role=role)
+    return CertifyError(kind, error_head(exc), role=role, where=where, path=path)
+
+
+def load_text(path: str, *, role: str = "cert") -> str:
+    if not isinstance(path, str) or not path.strip():
+        kind = "missing-cert" if role == "cert" else "missing-bin"
+        raise CertifyError(kind, f"{role} 경로가 비었다", role=role, path=path)
+    if os.path.isdir(path):
+        kind = "malformed-cert" if role == "cert" else "malformed-report"
+        raise CertifyError(kind, f"{role} 경로가 디렉터리다: {path}",
+                           role=role, path=path)
+    if not os.path.isfile(path):
+        kind = "missing-cert" if role == "cert" else "missing-bin"
+        raise CertifyError(kind, f"{role} 파일이 없다: {path}",
+                           role=role, path=path, where="load_text")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except PermissionError as e:
+        raise CertifyError("permission", f"{role} 권한 없음: {error_head(e)}",
+                           role=role, path=path)
+    except UnicodeError as e:
+        raise CertifyError("decode-error", f"{role} UTF-8 디코드 실패: {error_head(e)}",
+                           role=role, path=path)
+    except OSError as e:
+        raise CertifyError("os-error", f"{role} 읽기 실패: {error_head(e)}",
+                           role=role, path=path)
+
+
+def parse_json_text(text: str | bytes, *, role: str = "cert") -> object:
+    if text is None:
+        raise CertifyError("malformed-json", f"{role} 본문이 없다", role=role)
+    if isinstance(text, bytes):
+        try:
+            text = text.decode("utf-8")
+        except UnicodeError as e:
+            raise CertifyError("decode-error", f"{role} UTF-8 디코드 실패: {error_head(e)}",
+                               role=role)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise CertifyError("malformed-json",
+                           f"{role} JSON 파싱 실패: {error_head(e)}",
+                           role=role, where=f"line {e.lineno}")
+
+
+def load_json_object(path: str, *, role: str = "cert") -> dict:
+    raw = load_text(path, role=role)
+    data = parse_json_text(raw, role=role)
+    if not is_json_object(data):
+        kind = "malformed-cert" if role == "cert" else "malformed-report"
+        raise CertifyError(kind, f"{role} 가 JSON 객체가 아니다",
+                           role=role, path=path)
+    return data
+
+
+def write_text(path: str, text: str) -> None:
+    try:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+    except PermissionError as e:
+        raise CertifyError("write-error", f"산출 권한 없음: {error_head(e)}", path=path)
+    except OSError as e:
+        raise CertifyError("write-error", f"산출 기록 실패: {error_head(e)}", path=path)
+
+
+def should_skip_fingerprint_name(name: str) -> bool:
+    return name.endswith(FINGERPRINT_SKIP_SUFFIXES)
+
+
+def add_fingerprint_file(entries: list[tuple[str, bytes]], gym_root: str, path: str) -> None:
+    if not os.path.isfile(path):
+        return
+    rel = os.path.relpath(path, gym_root).replace(os.sep, "/")
+    with open(path, "rb") as fh:
+        entries.append((rel, fh.read()))
+
+
+def add_fingerprint_tree(entries: list[tuple[str, bytes]], gym_root: str, rel_dir: str) -> None:
+    root = os.path.join(gym_root, rel_dir)
+    if not os.path.isdir(root):
+        return
+    for current, dirs, files in os.walk(root):
+        dirs[:] = sorted(d for d in dirs if d not in FINGERPRINT_SKIP_DIRS)
+        for name in sorted(files):
+            if not should_skip_fingerprint_name(name):
+                add_fingerprint_file(entries, gym_root, os.path.join(current, name))
+
+
+def collect_fingerprint_entries(gym_root: str) -> list[tuple[str, bytes]]:
+    """지문에 들어가는 (상대경로, 바이트) 목록. 해시는 정렬 뒤 누적한다."""
+    entries: list[tuple[str, bytes]] = []
+    # `packs`는 과제 선언뿐 아니라 그 과제가 실제로 읽는 asset도 포함한다.
+    # 나머지는 report.py가 점수를 재는 코드 경로와 인증서 판정 자체다.
+    for rel_dir in FINGERPRINT_TREES:
+        add_fingerprint_tree(entries, gym_root, rel_dir)
+    for name in FINGERPRINT_FILES:
+        add_fingerprint_file(entries, gym_root, os.path.join(gym_root, name))
+    return entries
+
+
+def fingerprint_rel_paths(gym_root: str) -> list[str]:
+    return sorted({rel for rel, _data in collect_fingerprint_entries(gym_root)})
+
+
+def fingerprint_entry_count(gym_root: str) -> int:
+    return len(collect_fingerprint_entries(gym_root))
+
+
+def fingerprint_is_empty(gym_root: str) -> bool:
+    return fingerprint_entry_count(gym_root) == 0
+
+
+def hash_fingerprint_entries(entries: list[tuple[str, bytes]]) -> str:
+    h = hashlib.sha256()
+    for rel, data in sorted(entries):
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(hashlib.sha256(data).digest())
+    return h.hexdigest()
 
 
 def benchmark_fingerprint(gym_root: str) -> str:
@@ -47,127 +439,275 @@ def benchmark_fingerprint(gym_root: str) -> str:
     코드도 결과를 바꾼다. 이 중 하나라도 바뀌면 같은 점수라도 다른 benchmark
     certification으로 취급해야 한다.
     """
-    entries = []
+    return hash_fingerprint_entries(collect_fingerprint_entries(gym_root))
 
-    def add_file(path: str) -> None:
-        if os.path.isfile(path):
-            rel = os.path.relpath(path, gym_root).replace(os.sep, "/")
-            with open(path, "rb") as fh:
-                entries.append((rel, fh.read()))
 
-    def add_tree(rel_dir: str) -> None:
-        root = os.path.join(gym_root, rel_dir)
-        if not os.path.isdir(root):
-            return
-        for current, dirs, files in os.walk(root):
-            dirs[:] = sorted(d for d in dirs if d != "__pycache__")
-            for name in sorted(files):
-                if not name.endswith(".pyc"):
-                    add_file(os.path.join(current, name))
+def mapping_or_empty(value: object) -> dict:
+    return value if is_json_object(value) else {}
 
-    # `packs`는 과제 선언뿐 아니라 그 과제가 실제로 읽는 asset도 포함한다.
-    # 나머지는 report.py가 점수를 재는 코드 경로와 인증서 판정 자체다.
-    for rel_dir in ("packs", "core", "profiles", "tools"):
-        add_tree(rel_dir)
-    for name in ("score.py", "report.py", "certify.py"):
-        add_file(os.path.join(gym_root, name))
-    h = hashlib.sha256()
-    for rel, data in sorted(entries):
-        h.update(rel.encode("utf-8"))
-        h.update(b"\0")
-        h.update(hashlib.sha256(data).digest())
-    return h.hexdigest()
+
+def coverage_core(coverage: object) -> dict:
+    cov = mapping_or_empty(coverage)
+    return {k: cov.get(k) for k in COVERAGE_CORE_KEYS}
 
 
 def reproducible_core(report: dict, fingerprint: str) -> dict:
     """인증서에서 재현으로 대조하는 필드 — 변동 메타(git commit·시각·agent 이름)는 뺀다."""
-    runner = report.get("runner") or {}
-    cov = report.get("coverage") or {}
+    report_obj = mapping_or_empty(report)
+    runner = mapping_or_empty(report_obj.get("runner"))
+    cov = mapping_or_empty(report_obj.get("coverage"))
     return {
         "benchmarkFingerprint": fingerprint,
         "capabilitiesSha256": runner.get("capabilitiesSha256"),
-        "accuracy": report.get("accuracy"),
-        "coverage": {k: cov.get(k) for k in ("percent", "covered", "agentFacingTotal")},
-        "axisProfile": report.get("axisProfile"),
+        "accuracy": report_obj.get("accuracy"),
+        "coverage": coverage_core(cov),
+        "axisProfile": report_obj.get("axisProfile"),
     }
 
 
+def extract_unavailable(report: object) -> list[str]:
+    report_obj = mapping_or_empty(report)
+    raw = report_obj.get("packsUnavailable")
+    if not is_json_array(raw):
+        return []
+    ids: list[str] = []
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            ids.append(item)
+    return ids
+
+
+def exceptions_for_unavailable(pack_ids: list[str]) -> list[dict]:
+    notes: list[dict] = []
+    for pid in pack_ids:
+        notes.append(exception_record(
+            "unavailable-pack",
+            f"pack {pid} 는 요구 명령 부재로 채점되지 않았다",
+            pack=pid,
+            where="report.packsUnavailable",
+        ))
+    return notes
+
+
+def classify_report_failure(returncode: int, stdout: str, stderr: str) -> CertifyError:
+    """report.py 비-0 을 kind 로. 스코어카드 부재를 일반 실패로 뭉개지 않는다."""
+    blob = f"{stderr}\n{stdout}"
+    for marker in KIND_MARKERS:
+        if marker in blob:
+            message = f"report.py 실패({marker}): {stderr[:300]}"
+            return CertifyError(marker if marker in EXCEPTION_KINDS else "report-tool-failed",
+                                message, where="report.py")
+    if "scorecard.json" in blob and ("없다" in blob or "남기지" in blob):
+        return CertifyError(
+            "missing-scorecard",
+            f"report.py 실패: 스코어카드 부재 — {stderr[:300]}",
+            where="report.py",
+        )
+    if "JSON" in blob and ("파싱" in blob or "Decode" in blob or "decode" in blob):
+        return CertifyError(
+            "malformed-json",
+            f"report.py 실패: JSON — {stderr[:300]}",
+            where="report.py",
+        )
+    if returncode != 0:
+        return CertifyError(
+            "report-tool-failed",
+            f"report.py 실패: {stderr[:300]}",
+            where="report.py",
+        )
+    return CertifyError("report-tool-failed", "report.py 가 빈 산출을 냈다",
+                        where="report.py")
+
+
+def load_report_json(text: str | bytes) -> dict:
+    data = parse_json_text(text, role="report")
+    if not is_json_object(data):
+        raise CertifyError("malformed-report",
+                           "report.py stdout 이 JSON 객체가 아니다",
+                           role="report")
+    return data
+
+
 def _run_report(bin_path: str) -> dict:
+    if not isinstance(bin_path, str) or not bin_path.strip():
+        raise CertifyError("missing-bin", "바이너리 경로가 비었다", role="bin")
     out = subprocess.run(
         [sys.executable, os.path.join(GYM_ROOT, "report.py"), "--bin", bin_path, "--json"],
         cwd=REPO_ROOT, capture_output=True,
     )
+    stderr = out.stderr.decode("utf-8", "replace")
+    stdout = out.stdout.decode("utf-8", "replace")
     if out.returncode != 0:
-        raise RuntimeError(f"report.py 실패: {out.stderr.decode('utf-8', 'replace')[:300]}")
-    return json.loads(out.stdout)
+        raise classify_report_failure(out.returncode, stdout, stderr)
+    if not stdout.strip():
+        raise CertifyError("malformed-report", "report.py stdout 이 비었다",
+                           role="report")
+    return load_report_json(stdout)
+
+
+def validate_cert(cert: object) -> list[str]:
+    """인증서 뼈대. 실패 이유를 사람 문구 목록으로 낸다(verify 계약)."""
+    if not is_json_object(cert):
+        return ["인증서가 JSON 객체가 아니다"]
+    diffs: list[str] = []
+    if cert.get("kind") != CERT_KIND:
+        diffs.append(f"kind 가 {CERT_KIND} 가 아니다: {cert.get('kind')}")
+    report = cert.get("report")
+    if report is None:
+        diffs.append("인증서에 report 칸이 없다")
+    elif not is_json_object(report):
+        diffs.append("인증서 report 가 JSON 객체가 아니다")
+    fp = cert.get("benchmarkFingerprint")
+    if not isinstance(fp, str) or not fp:
+        diffs.append("인증서 benchmarkFingerprint 가 비었다")
+    return diffs
+
+
+def compare_core(claimed: dict, fresh: dict) -> list[str]:
+    """재현 core 다섯 칸. 문구는 예전 시험을 깨지 않게 접두를 유지한다."""
+    diffs: list[str] = []
+    if claimed.get("benchmarkFingerprint") != fresh.get("benchmarkFingerprint"):
+        diffs.append("벤치마크 지문 불일치 — pack 정의가 인증 시점과 다르다(축소·변조 가능)")
+    if claimed.get("capabilitiesSha256") != fresh.get("capabilitiesSha256"):
+        diffs.append("바이너리 신원(capabilitiesSha256) 불일치 — 다른 바이너리다")
+    if claimed.get("accuracy") != fresh.get("accuracy"):
+        diffs.append(f"정확도 불일치: 인증 {claimed.get('accuracy')} vs 재현 {fresh.get('accuracy')}")
+    if claimed.get("coverage") != fresh.get("coverage"):
+        diffs.append(f"커버리지 불일치: 인증 {claimed.get('coverage')} vs 재현 {fresh.get('coverage')}")
+    if claimed.get("axisProfile") != fresh.get("axisProfile"):
+        diffs.append("축별 프로파일 불일치")
+    return diffs
+
+
+def compare_unavailable(claimed_ids: list[str], fresh_ids: list[str]) -> list[str]:
+    if set(claimed_ids) != set(fresh_ids):
+        return [f"미가용 pack 불일치: 인증 {sorted(claimed_ids)} vs 재현 {sorted(fresh_ids)}"]
+    return []
+
+
+def attach_cert_exceptions(cert: dict, notes: list[dict]) -> dict:
+    cert["exceptions"] = notes
+    cert["exceptionCount"] = len(notes)
+    cert["trusted"] = len(structural_exceptions(notes)) == 0
+    return cert
 
 
 def certify(bin_path: str, measured_at: str | None = None) -> dict:
     report = _run_report(bin_path)
     fp = benchmark_fingerprint(GYM_ROOT)
+    unavailable = extract_unavailable(report)
+    notes = exceptions_for_unavailable(unavailable)
+    if fingerprint_is_empty(GYM_ROOT):
+        notes.append(exception_record(
+            "fingerprint-empty",
+            "벤치마크 지문에 넣을 측정 입력이 없다",
+            where="benchmark_fingerprint",
+        ))
     cert = {
         "kind": CERT_KIND,
         "schemaVersion": CERT_SCHEMA,
         "benchmarkFingerprint": fp,
         "report": report,
-        "proof": "reproduce: 같은 bin + 같은 pack 정의로 --verify 하면 core 가 일치한다",
+        "proof": PROOF_TEXT,
+        "unavailablePacks": unavailable,
     }
+    attach_cert_exceptions(cert, notes)
     if measured_at:
         cert["certifiedAt"] = measured_at
     return cert
 
 
 def verify(cert: dict, bin_path: str) -> tuple[bool, list[str]]:
-    """인증서를 재발급해 재현 core 를 대조한다 — 위조·환경 변화를 잡는다."""
-    if cert.get("kind") != CERT_KIND:
-        return False, [f"kind 가 {CERT_KIND} 가 아니다: {cert.get('kind')}"]
-    claimed = reproducible_core(cert.get("report", {}), cert.get("benchmarkFingerprint", ""))
-    fresh_report = _run_report(bin_path)
-    fresh = reproducible_core(fresh_report, benchmark_fingerprint(GYM_ROOT))
-    diffs = []
-    if claimed["benchmarkFingerprint"] != fresh["benchmarkFingerprint"]:
-        diffs.append("벤치마크 지문 불일치 — pack 정의가 인증 시점과 다르다(축소·변조 가능)")
-    if claimed["capabilitiesSha256"] != fresh["capabilitiesSha256"]:
-        diffs.append("바이너리 신원(capabilitiesSha256) 불일치 — 다른 바이너리다")
-    if claimed["accuracy"] != fresh["accuracy"]:
-        diffs.append(f"정확도 불일치: 인증 {claimed['accuracy']} vs 재현 {fresh['accuracy']}")
-    if claimed["coverage"] != fresh["coverage"]:
-        diffs.append(f"커버리지 불일치: 인증 {claimed['coverage']} vs 재현 {fresh['coverage']}")
-    if claimed["axisProfile"] != fresh["axisProfile"]:
-        diffs.append("축별 프로파일 불일치")
+    """인증서를 재발급해 재현 core 를 대조한다 — 위조·환경 변화를 잡는다.
+
+    예전 계약: 성공은 (True, []), 실패는 (False, 이유 목록). 깨진 인증서는
+    예외를 올리지 않고 False 로 접는다. report.py 운영 실패는 kind 를 이유에 넣는다.
+    """
+    skeleton = validate_cert(cert)
+    if skeleton and (not is_json_object(cert) or cert.get("kind") != CERT_KIND
+                     or not is_json_object(cert.get("report"))):
+        # kind 불일치는 예전 문구를 그대로 쓴다.
+        if is_json_object(cert) and cert.get("kind") != CERT_KIND:
+            return False, [f"kind 가 {CERT_KIND} 가 아니다: {cert.get('kind')}"]
+        return False, skeleton
+    report = mapping_or_empty(cert.get("report") if is_json_object(cert) else None)
+    claimed = reproducible_core(report, cert.get("benchmarkFingerprint", "") if is_json_object(cert) else "")
+    try:
+        fresh_report = _run_report(bin_path)
+        fresh = reproducible_core(fresh_report, benchmark_fingerprint(GYM_ROOT))
+    except CertifyError as e:
+        return False, [f"{e.kind}: {e}"]
+    diffs = compare_core(claimed, fresh)
+    diffs.extend(compare_unavailable(extract_unavailable(report),
+                                     extract_unavailable(fresh_report)))
     return (len(diffs) == 0), diffs
 
 
-def main() -> int:
+def load_cert(path: str) -> dict:
+    return load_json_object(path, role="cert")
+
+
+def dump_cert_json(cert: dict) -> str:
+    return json.dumps(cert, ensure_ascii=False, indent=2) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="gym 능력 인증서 — 발급/재현 검증")
     ap.add_argument("--bin", required=True, help="rhwp 바이너리")
     ap.add_argument("--verify", help="검증할 인증서 JSON")
     ap.add_argument("--out", help="발급 인증서 출력 파일(생략 시 stdout)")
     ap.add_argument("--at", help="certifiedAt 메타(재현 core 에 미포함)")
-    a = ap.parse_args()
+    return ap
 
-    if a.verify:
-        with open(a.verify, encoding="utf-8") as fh:
-            cert = json.load(fh)
-        ok, diffs = verify(cert, a.bin)
-        if ok:
-            print("✅ 인증서 재현 검증 통과 — 벤치마크·바이너리·전 점수가 재현된다(진짜)")
-            return 0
-        print("❌ 인증서 재현 검증 실패:")
-        for d in diffs:
-            print(f"  - {d}")
-        return 1
 
-    cert = certify(a.bin, a.at)
-    text = json.dumps(cert, ensure_ascii=False, indent=2) + "\n"
-    if a.out:
-        with open(a.out, "w", encoding="utf-8") as fh:
-            fh.write(text)
-        r = cert["report"]
-        print(f"발급: {a.out} · 정확도 {r['accuracy']['percent']}% · 지문 {cert['benchmarkFingerprint'][:12]}")
-    else:
-        sys.stdout.write(text)
-    return 0
+def cli_flag_names(parser: argparse.ArgumentParser | None = None) -> tuple[str, ...]:
+    ap = parser or build_parser()
+    names: list[str] = []
+    for action in ap._actions:
+        for opt in action.option_strings:
+            if opt.startswith("--") and opt not in ("--help",):
+                names.append(opt)
+    return tuple(names)
+
+
+def format_issue_summary(cert: dict) -> str:
+    report = mapping_or_empty(cert.get("report"))
+    accuracy = mapping_or_empty(report.get("accuracy"))
+    pct = accuracy.get("percent")
+    fp = str(cert.get("benchmarkFingerprint") or "")
+    return f"정확도 {pct}% · 지문 {fp[:12]}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = build_parser()
+    a = ap.parse_args(argv)
+    try:
+        if a.verify:
+            cert = load_cert(a.verify)
+            ok, diffs = verify(cert, a.bin)
+            if ok:
+                print(VERIFY_PASS_MESSAGE)
+                return EXIT_OK
+            print(VERIFY_FAIL_PREFIX)
+            for item in diffs:
+                print(f"  - {item}")
+            return EXIT_VERIFY_FAIL
+
+        cert = certify(a.bin, a.at)
+        text = dump_cert_json(cert)
+        if a.out:
+            write_text(a.out, text)
+            print(f"발급: {a.out} · {format_issue_summary(cert)}")
+        else:
+            sys.stdout.write(text)
+        return EXIT_OK
+    except CertifyError as e:
+        print(f"{e.kind}: {e}", file=sys.stderr)
+        return EXIT_TOOL_FAILED
+    except CATCHABLE_EXCEPTIONS as e:
+        wrapped = wrap_exception(e, role="cert", where="main")
+        print(f"{wrapped.kind}: {wrapped}", file=sys.stderr)
+        return EXIT_TOOL_FAILED
 
 
 if __name__ == "__main__":

--- a/gym/docs/certify_report.md
+++ b/gym/docs/certify_report.md
@@ -1,0 +1,565 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/certify_report.md
+last_verified: 2026-08-18
+---
+
+# gym 능력 리포트·인증서 예외 경로 규약
+
+이 문서는 `gym/report.py` 와 `gym/certify.py` 의 **예외 경로 계약**,
+**스코어카드·JSON·미가용 pack 삼원**, **재현 core**, **보고 카드**를
+고정한다. 작업 기록은
+[`mydocs/working/gym_certify_report.md`](../../mydocs/working/gym_certify_report.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_report.py`(리포트 칸)와
+`scripts/tests/test_gym_certify.py`(인증서 칸)가 기계로 고정한다.
+
+채점기(`score.py` / `gym/core/runner.py`)·기준 풀이 조립기
+(`build_baseline.py`)·커버리지(`coverage.py`)는 이 문서의 대상이 아니다.
+리포트가 그 산출을 소비할 수는 있어도, 이 규약이 그 도구의 판정 삼원을
+바꾸지 않는다. expert-challenges pack, tutorial, PARK 도 이 문서가
+고치지 않는다.
+
+새 플래그는 없다. 리포트는 `--bin` `--scorecard` `--coverage` `--json`
+`--out` 만 쓴다. 인증서는 `--bin` `--verify` `--out` `--at` 만 쓴다.
+종료 코드도 예전과 같다. 리포트 0=합성 성공, 2=도구 실패. 인증서
+0=발급/재현 통과, 1=재현 불일치, 2=도구 실패.
+
+## 1. 왜 이 기둥이 필요한가
+
+리포트는 흩어진 계기(점수·커버리지·축·runner 신원)를 한 장으로 합친다.
+인증서는 그 한 장이 **같은 벤치마크·같은 바이너리**에서 다시 나오는지를
+결정론적으로 증명한다. 암호 서명이 아니다. 재현이 증명이다.
+
+그런데 예전이 실패를 데이터로 남기지 못하는 자리가 있었다.
+
+- `--scorecard` 경로가 없으면 `FileNotFoundError` 스택이 올라간다.
+  기계가 "없는 스코어카드"를 읽지 못한다.
+- `--bin` 모드에서 `score.py` 가 `scorecard.json` 을 안 남기면
+  `json.load(open(...))` 이 같은 스택으로 죽는다. 하위 도구 실패와
+  산출 부재가 한 줄로 접힌다.
+- 스코어카드가 `{` 로 잘리거나 배열이면 `JSONDecodeError` 또는
+  `AttributeError`. 깨진 JSON 을 0점으로 합성하면 거짓이다.
+- 미가용 pack 은 `packsUnavailable` 에 id 만 남고, 카드 한 줄로
+  접힌다. 인증서가 그 집합을 재현 대조하지 않으면 벤치마크를 몰래
+  줄여 "명령이 없는 pack 을 지운 척" 할 수 있다.
+- 인증서 `--verify` 가 없는 파일·깨진 JSON 에서 스택을 올린다.
+  재현 실패(exit 1)와 도구 실패(exit 2)가 구분되지 않는다.
+- `verify` 가 `cert.get("report", {})` 로 `report: null` 을 받으면
+  `None.get` 으로 죽는다. 위조 탐지 전에 도구가 죽는다.
+
+2026 벤치마크의 다른 위기는 false-pass 이지만, 리포트·인증서 자체의
+위기는 **false-silence** 와 **false-crash** 다. 없는 산출을 만점처럼
+합성하면 침묵이고, 깨진 입력을 스택으로 올리면 기계가 kind 를 못
+읽는다. 둘 다 능력 증명이 아니다.
+
+그래서 예외는 삼키지 않고 kind 로 남긴다. 합성 성공 칸의 숫자
+(정확도 정수 나눗셈, 축 라벨, 커버리지 분리)는 그대로다. 미가용
+pack 은 0점도 unavailable 위장도 아니다. 축 합산에서 빼고
+`packsUnavailable` 과 `unavailable-pack` 예외 칸에 같이 남긴다.
+
+## 2. 사용
+
+```bash
+python gym/report.py --bin target/debug/rhwp
+python gym/report.py --bin target/debug/rhwp --json
+python gym/report.py --scorecard sc.json --coverage cov.json
+python gym/report.py --bin target/debug/rhwp --out report.md
+
+python gym/certify.py --bin target/debug/rhwp --out cert.json
+python gym/certify.py --verify cert.json --bin target/debug/rhwp
+```
+
+리포트 인자:
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--bin` | 없음 | rhwp 바이너리. 전 pack 채점+커버리지를 돌린다. |
+| `--scorecard` | 없음 | 이미 있는 `score.py` 스코어카드 JSON. |
+| `--coverage` | 없음 | 이미 있는 `coverage.py --json` 산출. |
+| `--json` | 꺼짐 | 사람용 카드 대신 JSON 봉투. |
+| `--out` | stdout | 출력 파일. UTF-8, BOM 없음, LF. |
+
+인증서 인자:
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--bin` | 필수 | rhwp 바이너리. 발급과 재현 모두 필요하다. |
+| `--verify` | 없음 | 검증할 인증서 JSON. 있으면 재현 모드. |
+| `--out` | stdout | 발급 인증서 출력 파일. |
+| `--at` | 없음 | `certifiedAt` 메타. 재현 core 에 들어가지 않는다. |
+
+`--scorecard` 만 주고 `--coverage` 를 빼면 예전처럼 필수 인자 오류다.
+커버리지를 선택적으로 만들고 싶어도 새 플래그를 만들지 않는다. 파일
+모드의 계약은 `(--scorecard + --coverage)` 쌍이다. `--bin` 모드에서
+`coverage.py` 부재·실패는 예전처럼 빈 커버리지다.
+
+새 플래그는 없다. `--strict` `--limit` `--task` `--timeout` `--json`
+(인증서) 을 붙이지 않는다. 기계 봉투는 리포트 `--json` 과 인증서
+stdout/ `--out` JSON 이다.
+
+종료 코드:
+
+| 도구 | 코드 | 상수 | 의미 |
+|---|---|---|---|
+| report | 0 | `EXIT_OK` | 합성 성공. 미가용 pack 이 있어도 0. |
+| report | 2 | `EXIT_TOOL_FAILED` | 없는 스코어카드, 깨진 JSON, 인자 부족, 하위 도구 실패 |
+| certify | 0 | `EXIT_OK` | 발급 성공 또는 재현 통과 |
+| certify | 1 | `EXIT_VERIFY_FAIL` | 재현 core 불일치 또는 `wrong-kind` |
+| certify | 2 | `EXIT_TOOL_FAILED` | 없는 인증서, 깨진 JSON, 없는 스코어카드, report.py 실패 |
+| 둘 다 | 2 | argparse | 필수 인자 없음. 예전 argparse 계약 |
+
+도구 자리 오류를 위한 새 종료 코드를 만들지 않는다. 미가용 pack 은
+데이터가 아니라 실패가 아니므로 0 이다. 재현 불일치는 1 이다. 없는
+파일·깨진 JSON 은 2 이다. 1 과 2 를 섞으면 CI 가 위조와 하네스
+결함을 구분하지 못한다.
+
+## 3. 두 봉투 — 바꾸지 않는 칸
+
+리포트 `kind` = `gymCapabilityReport`, `schemaVersion` = `1.0`.
+인증서 `kind` = `gymCapabilityCertificate`, `schemaVersion` = `1.0`.
+이 두 칸을 올리면 리더보드·게이트·사람이 읽지 못한다.
+
+리포트 고정 키(`REPORT_KEYS`):
+
+| 키 | 의미 |
+|---|---|
+| `kind` | `gymCapabilityReport` |
+| `schemaVersion` | `1.0` |
+| `agent` | 스코어카드 agent. 없으면 null |
+| `runner` | 실행 신원. 없으면 null |
+| `accuracy` | `{score, max, percent}` — 측정된 것 통과율 |
+| `coverage` | `{percent, covered, agentFacingTotal, uncoveredByCategory}` |
+| `axisProfile` | 축 라벨별 합산. scored pack 만 |
+| `packsScored` | 스코어카드 total.packsScored |
+| `packsUnavailable` | status=`unavailable` 인 pack id 목록 |
+| `packsErrored` | status=`error` 인 pack id 목록 (부가) |
+| `exceptions` | 예외 레코드 목록 |
+| `exceptionCount` | `exceptions` 길이 |
+| `trusted` | 구조 예외가 없으면 true |
+
+부가 키 `packsErrored` · `exceptions` · `exceptionCount` · `trusted` 는
+집계를 뒤집지 않는다. `trusted` 는 정보성 kind
+(`unavailable-pack` · `empty-packs` · `empty-total`) 만 있을 때 참이다.
+깨진 JSON·비객체 스코어카드가 있으면 거짓이다.
+
+인증서 고정 키(`CERT_KEYS`):
+
+| 키 | 의미 |
+|---|---|
+| `kind` | `gymCapabilityCertificate` |
+| `schemaVersion` | `1.0` |
+| `benchmarkFingerprint` | 측정 입력 sha256 hex 64자 |
+| `report` | 리포트 봉투 전체 |
+| `proof` | 재현 방법 한 줄. 고정 문구 |
+| `certifiedAt` | `--at` 이 있을 때만. 재현 core 밖 |
+| `unavailablePacks` | 리포트 `packsUnavailable` 복사 |
+| `exceptions` | 예외 레코드 |
+| `exceptionCount` | 예외 개수 |
+| `trusted` | 구조 예외 0 이면 true |
+
+`proof` 문구는
+`reproduce: 같은 bin + 같은 pack 정의로 --verify 하면 core 가 일치한다`.
+이 문자열을 바꾸면 이미 발급된 인증서와 사람이 읽는 안내가 갈린다.
+
+정확도와 커버리지는 **다른 것**이다. 정확도는 측정된 pack 의 통과율이다.
+커버리지는 에이전트-대면 능력 중 gym 이 재는 비율이다. 한 숫자로
+뭉치면 "적게 재고 만점"과 "많이 재고 중간"이 같아진다. 카드는 두 줄을
+따로 쓴다. 커버리지가 없으면 그 줄을 뺀다.
+
+## 4. pack 상태 삼원 — 리포트가 소비하는 칸
+
+채점기가 남기는 pack `status` 는 `scored` · `unavailable` · `error`
+다. 리포트는 이 삼원을 다시 채점하지 않는다. 읽기만 한다.
+
+| status | 축 합산 | 총점 | `packsUnavailable` | `packsErrored` | 예외 kind |
+|---|---|---|---|---|---|
+| `scored` | 예 | 스코어카드 total 을 신뢰 | 아니오 | 아니오 | 없음 |
+| `unavailable` | 아니오 | 아니오 | 예 | 아니오 | `unavailable-pack` |
+| `error` | 아니오 | 아니오 | 아니오 | 예 | 없음(채점기 자리) |
+
+규칙:
+
+1. **부재는 실패가 아니다.** 오래된 바이너리에게 0점은 거짓말이다.
+   그 자리는 `unavailable` 이다. 리포트는 축에서 빼고 id 를 남긴다.
+2. **도구 실패는 부재가 아니다.** pack.json 이 깨진 것을 "명령이 없다"고
+   부르면 다음 사람이 바이너리를 탓한다. 그 자리는 `error` 이다.
+   리포트는 `packsErrored` 에만 넣고 `unavailable-pack` 을 붙이지 않는다.
+3. **error 를 unavailable 로 세지 않는다.** `packsUnavailable` 은
+   `status==unavailable` 인 id 다. `len(packs) - packsScored` 로
+   되돌리면 error 가 명령 부재로 위장된다.
+4. **없는 id 는 `?`.** pack 행에 id 가 없거나 공백이면 자리를 비우지
+   않고 `?` 로 남긴다. 침묵이 더 위험하다.
+
+`total` 의 `score` / `max` / `packsScored` 는 스코어카드가 계산한
+값이다. 리포트는 다시 합산하지 않는다. 축 프로파일만 scored pack 을
+다시 더한다. 두 숫자가 어긋나면 스코어카드 버그이지 리포트가 고치는
+칸이 아니다.
+
+## 5. 예외 kind 카탈로그 — 리포트
+
+`gym/report.py` 의 `EXCEPTION_KINDS` 와 `EXCEPTION_KIND_HELP` 가 정본이다.
+시험이 문서에 각 kind 가 백틱으로 적혔는지 대조한다.
+
+| kind | 자리 | 점수에 미치는 영향 | 종료 |
+|---|---|---|---|
+| `missing-scorecard` | `--scorecard` 파일 없음, 또는 `--bin` 후 scorecard.json 없음 | 합성하지 않음 | 2 |
+| `missing-coverage` | `--coverage` 파일 없음 | 합성하지 않음 | 2 |
+| `missing-bin` | `--bin` 값이 공백 | 하위 도구를 시작하지 않음 | 2 |
+| `missing-report-arg` | `--bin` 도 쌍도 없음 | 예전 필수 인자 문구 | 2 |
+| `malformed-json` | UTF-8 JSON 파싱 실패 | 합성하지 않음 | 2 |
+| `malformed-scorecard` | 스코어카드가 객체 아님(배열·스칼라·디렉터리) | 파일 모드 2. compile 은 빈 카드+예외 | 2 또는 0 |
+| `malformed-coverage` | 커버리지가 객체 아님 | 파일 모드 2. compile 은 빈 커버리지 | 2 또는 0 |
+| `malformed-pack-row` | packs[i] 가 객체 아님 | 그 칸만 건너뜀. trusted=false | 0 |
+| `unavailable-pack` | pack status=`unavailable` | 축·총점에서 제외. 목록+예외 | 0 |
+| `empty-packs` | packs 없음/빈 목록 | 축 빈 목록. trusted 유지 | 0 |
+| `empty-total` | total 없음 또는 max=0 | 정확도 0/0. 만점이 아님 | 0 |
+| `permission` | 읽기·쓰기 권한 없음 | 합성·기록 중단 | 2 |
+| `os-error` | 그 밖 OSError | 합성·기록 중단 | 2 |
+| `decode-error` | UTF-8 디코드 실패 | 합성하지 않음 | 2 |
+| `type-error` | 값 타입 불일치 | 해당 자리 | 2 |
+| `value-error` | 값 형태 불일치 | 해당 자리 | 2 |
+| `write-error` | `--out` 기록 실패 | 카드가 디스크에 없음 | 2 |
+| `report-tool-failed` | build_baseline/score 비-0 | 산출을 지어내지 않음 | 2 |
+| `unexpected` | 미분류 운영 예외 | 해당 자리 | 2 |
+
+`FileNotFoundError` 의 kind 는 역할에 따른다. 스코어카드 자리면
+`missing-scorecard`, 커버리지 자리면 `missing-coverage`, 바이너리
+자리면 `missing-bin`. 한 예외 타입을 한 kind 로 고정하면 없는
+스코어카드를 없는 커버리지로 부른다.
+
+`--bin` 모드에서 `coverage.py` 가 없거나 stdout 이 깨져도
+`missing-coverage` 가 아니다. 커버리지 측정기는 선택적이다. 빈
+객체를 넣고 정확도·축만 낸다. `--coverage` 를 **준** 뒤에 파일이
+없을 때만 `missing-coverage` 다.
+
+## 6. 예외 kind 카탈로그 — 인증서
+
+`gym/certify.py` 의 `EXCEPTION_KINDS` 와 `EXCEPTION_KIND_HELP` 가 정본이다.
+리포트와 이름이 같은 kind 는 같은 뜻이다. 인증서만의 자리는 아래에
+적는다.
+
+| kind | 자리 | 재현에 미치는 영향 | 종료 |
+|---|---|---|---|
+| `missing-cert` | `--verify` 파일 없음·빈 경로 | 재현을 시작하지 않음 | 2 |
+| `missing-bin` | `--bin` 공백 | report.py 를 부르지 않음 | 2 |
+| `missing-scorecard` | report.py stderr 에 스코어카드 부재 | 빈 인증서를 발급하지 않음 | 2 |
+| `missing-report` | 인증서에 report 칸이 없음 | verify 가 False | 1 |
+| `malformed-json` | 인증서 파일 또는 report stdout 파싱 실패 | 발급/검증 중단 | 2 |
+| `malformed-cert` | 인증서가 객체 아님 | 검증 중단 | 2 |
+| `malformed-report` | report stdout 이 객체 아님·빈 본문 | 발급 중단 | 2 |
+| `wrong-kind` | kind 가 `gymCapabilityCertificate` 가 아님 | 재현 실패. 예전 문구 | 1 |
+| `unavailable-pack` | 리포트 미가용 pack 을 인증서에 복사 | 발급은 0. 집합 불일치는 1 | 0 또는 1 |
+| `fingerprint-empty` | 지문 입력이 0개 | 발급은 하되 예외 칸 | 0 |
+| `report-tool-failed` | report.py 비-0, 더 구체적 분류 없음 | 발급 중단 | 2 |
+| `verify-mismatch` | 재현 core 불일치(내부 분류) | 사람 문구는 예전 접두 | 1 |
+| `permission` | 인증서 읽기·쓰기 권한 | 중단 | 2 |
+| `os-error` | 그 밖 OSError | 중단 | 2 |
+| `decode-error` | UTF-8 디코드 실패 | 중단 | 2 |
+| `write-error` | `--out` 기록 실패 | 인증서가 디스크에 없음 | 2 |
+| `type-error` | 값 타입 불일치 | 해당 자리 | 2 |
+| `value-error` | 값 형태 불일치 | 해당 자리 | 2 |
+| `unexpected` | 미분류 | 해당 자리 | 2 |
+
+`wrong-kind` 는 exit 1 이다. 다른 봉투를 인증서로 들이미는 것은
+도구 고장이 아니라 재현 실패다. 예전 `verify` 가 False 를 주던
+칸을 2 로 올리면 이미 그 exit 를 읽는 스크립트가 깨진다.
+
+`verify-mismatch` 는 카탈로그 이름이다. 사람이 보는 문구는 예전
+그대로다.
+
+- 지문: `벤치마크 지문 불일치 — pack 정의가 인증 시점과 다르다(축소·변조 가능)`
+- 바이너리: `바이너리 신원(capabilitiesSha256) 불일치 — 다른 바이너리다`
+- 정확도: `정확도 불일치: 인증 … vs 재현 …`
+- 커버리지: `커버리지 불일치: 인증 … vs 재현 …`
+- 축: `축별 프로파일 불일치`
+- 미가용: `미가용 pack 불일치: 인증 … vs 재현 …`
+
+앞 다섯 문구를 바꾸면 `test_gym_certify.py` 의 위조 탐지 칸이 깨진다.
+여섯 번째는 #5275 가 더한 칸이다. 미가용 집합이 달라지면 벤치마크가
+줄어든 것과 같은 급이다.
+
+## 7. 치명 예외 — 삼키지 않는 자리
+
+양쪽 모두 `FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)`.
+
+운영 예외(`CATCHABLE_EXCEPTIONS`)만 접는다. `except Exception` 으로
+`BaseException` 을 삼키지 않는다. 시험이 `is_fatal_exception` 과
+`is_catchable_exception` 경계를 고정한다.
+
+`wrap_exception` 이 치명 예외를 받으면 다시 던진다. ReportError /
+CertifyError 는 그대로 통과한다. FileNotFound 는 역할로 kind 가
+갈린다. JSONDecodeError 는 항상 `malformed-json` 이다. UnicodeError
+는 `decode-error` 다. PermissionError 는 `permission` 이다.
+
+bool 은 int 의 하위 타입이다. pack `score: true` 를 1점으로 세지
+않는다. `as_int` 는 `type(v) is int` 이거나 정수 float 만 받는다.
+`"3"` 과 `True` 는 기본값 0 이다.
+
+## 8. JSON 적재 계약
+
+파일 적재는 한 함수로 모은다. 리포트는 `load_json_object(path, role=)`.
+인증서는 `load_cert` / `load_json_object(path, role="cert")`.
+
+순서:
+
+1. 경로가 비었거나 공백이면 역할별 missing-*.
+2. 경로가 디렉터리면 역할별 malformed-*.
+3. 파일이 없으면 역할별 missing-*.
+4. 권한이 없으면 `permission`.
+5. UTF-8 이 아니면 `decode-error`.
+6. 그 밖 읽기 실패는 `os-error`.
+7. `json.loads` 실패는 `malformed-json`.
+8. 결과가 dict 가 아니면 역할별 malformed-*.
+
+역할 표:
+
+| role | 없음 | 비객체 |
+|---|---|---|
+| scorecard | `missing-scorecard` | `malformed-scorecard` |
+| coverage | `missing-coverage` | `malformed-coverage` |
+| bin | `missing-bin` | (해당 없음, 실행 자리) |
+| cert | `missing-cert` | `malformed-cert` |
+| report | (stdout 자리) | `malformed-report` |
+
+빈 파일은 JSON 이 아니므로 `malformed-json` 이다. `[]` 는 파싱은
+되지만 객체가 아니므로 malformed-scorecard / malformed-coverage /
+malformed-cert 다. 이 둘을 섞으면 "파일이 깨졌다"와 "배열을 카드로
+줬다"를 구분하지 못한다.
+
+기록은 UTF-8, BOM 없음, `newline="\n"`, indent=2, 끝 개행 하나.
+`write-error` 는 부모 폴더를 못 만들거나 권한이 없을 때다.
+
+## 9. 스코어카드 합성 — 죽지 않는 칸
+
+`compile_report(scorecard, coverage)` 는 순수 함수다. 파일·바이너리에
+가지 않는다. 깨진 입력을 던져도 예외를 올리지 않고 카드 + `exceptions`
+를 낸다. CLI 적재 단계는 그 앞에서 ReportError 로 끊을 수 있다.
+
+합성 규칙(예전 칸, 바꾸지 않음):
+
+1. `axis_label` 은 첫 ` (` 앞. 빈 문자열은 `미분류`.
+2. scored pack 만 축에 더한다. score/max 는 `as_int`.
+3. 축 percent 는 `100 * score // max`. max 0 이면 0.
+4. 축 정렬은 `(-percent, axis)`.
+5. 정확도는 `total.score` / `total.max` 의 같은 공식.
+6. 커버리지 `percent` 는 입력의 `coveragePercent` 를 옮긴다.
+7. `packsUnavailable` 은 unavailable pack 의 id.
+
+추가 칸:
+
+8. 각 unavailable pack 마다 `unavailable-pack` 예외 한 줄.
+9. packs 가 없거나 `[]` 이면 `empty-packs`.
+10. total 이 없거나 max 0 이면 `empty-total`.
+11. packs[i] 가 객체가 아니면 `malformed-pack-row`, 그 칸 skip.
+12. coverage 가 객체가 아니면 `malformed-coverage`, 빈 커버리지.
+13. scorecard 가 객체가 아니면 `malformed-scorecard`, 빈 카드.
+
+카드 렌더는 예전 줄을 유지한다. 정확도 줄, 선택적 커버리지 줄,
+채점 pack, 미가용 pack, runner. 뒤에 오류 pack 줄과 신뢰 줄과
+`## 예외 경로` 를 붙일 수 있다. 커버리지가 없으면 그 단어를 카드에
+쓰지 않는다. 이 불변식은 `test_coverage_is_optional` 이 지킨다.
+
+예외 레코드 키: `kind` `message` 필수. `where` `path` `pack` `role`
+은 있을 때만. 빈 문자열은 생략한다.
+
+## 10. 벤치마크 지문
+
+지문은 측정 입력의 결정론적 sha256 이다. 문서와 mydocs 는 점수를
+바꾸지 않아 넣지 않는다.
+
+넣는 것:
+
+- 트리 `packs` `core` `profiles` `tools` ( `__pycache__` 제외,
+  `.pyc` 제외)
+- 파일 `score.py` `report.py` `certify.py`
+
+알고리즘(바꾸지 않음):
+
+1. 각 파일을 `(posix 상대경로, 바이트)` 로 모은다.
+2. 상대경로로 정렬한다.
+3. 각 칸마다 `rel utf-8` + `NUL` + `sha256(bytes)` 를 누적한다.
+4. 바깥 sha256 hex 64자를 낸다.
+
+같은 바이트라도 상대경로가 다르면 지문이 다르다. pack 하나를
+다른 폴더로 옮기는 것은 다른 벤치마크다. 빈 디렉터리는 입력이
+0개다. 지문 값은 여전히 64자지만 `fingerprint-empty` 를 남긴다.
+그 인증서는 "아무것도 안 재고 봉인했다"는 뜻이다.
+
+`--at` 과 git commit 과 agent 이름은 지문에 없다. 같은 바이너리·
+같은 pack 이면 다른 날 발급해도 core 가 같다.
+
+## 11. 재현 core
+
+`reproducible_core(report, fingerprint)` 가 대조하는 다섯 칸:
+
+| 칸 | 출처 | 빠지는 것 |
+|---|---|---|
+| `benchmarkFingerprint` | 인자 | — |
+| `capabilitiesSha256` | `report.runner` | `rhwpCommit` `rhwpVersion` |
+| `accuracy` | `report.accuracy` 전체 | — |
+| `coverage` | percent / covered / agentFacingTotal | uncoveredByCategory |
+| `axisProfile` | `report.axisProfile` 전체 | — |
+
+`report` 가 객체가 아니면 빈 객체로 본다. `runner` / `coverage` 가
+객체가 아니면 빈 객체다. `None.get` 으로 죽지 않는다.
+
+`verify` 순서:
+
+1. 인증서가 객체가 아니면 False.
+2. kind 가 `gymCapabilityCertificate` 가 아니면 False. 문구는
+   `kind 가 gymCapabilityCertificate 가 아니다: …`.
+3. report 가 객체가 아니면 False.
+4. `_run_report` 가 CertifyError 면 False, 이유 `kind: message`.
+5. `compare_core` 다섯 칸.
+6. `compare_unavailable` 집합 비교. 순서는 보지 않는다.
+
+성공은 `(True, [])`. 실패는 `(False, 이유 목록)`. 예외를 올리지
+않는다. 이 시그니처를 바꾸면 기존 시험과 호출자가 깨진다.
+
+## 12. report.py 실패를 인증서가 읽는 법
+
+인증서는 리포트를 자식 프로세스로 부른다.
+`python gym/report.py --bin <bin> --json`. stdout 만 파싱한다.
+stderr 는 분류에 쓴다.
+
+비-0 이면 `classify_report_failure`:
+
+1. stderr+stdout 에 `missing-scorecard` `missing-bin` `malformed-json`
+   `malformed-scorecard` `malformed-report` `report-tool-failed`
+   `permission` `decode-error` 표식이 있으면 그 kind.
+2. `scorecard.json` 과 (`없다` 또는 `남기지`) 가 같이 있으면
+   `missing-scorecard`.
+3. `JSON` 과 파싱/decode 가 있으면 `malformed-json`.
+4. 그 밖은 `report-tool-failed`.
+
+0 인데 stdout 이 공백이면 `malformed-report`. 0 인데 JSON 객체가
+아니면 `malformed-json` 또는 `malformed-report`.
+
+예전 `_run_report` 는 `RuntimeError("report.py 실패: …")` 와
+`json.loads` 를 그대로 올렸다. 이제 CertifyError 다. `certify()` 와
+`main()` 이 잡아 exit 2 와 kind 한 줄을 stderr 에 쓴다. 빈
+인증서를 지어 만점인 척하지 않는다.
+
+## 13. 성공 칸 — 이 작업이 바꾸지 않는 것
+
+아래는 기존 시험이 지키는 칸이다. 예외 보강이 이 칸을 옮기면 회귀다.
+
+리포트:
+
+1. 편집 두 pack `3+1 / 3+3` 은 축 점수 4/6, percent 66.
+2. 정확도 5/8 = 62, 커버리지 82. 두 숫자는 다르다.
+3. 보안 unavailable pack `d` 는 축에 없고 `packsUnavailable` 에 있다.
+4. 커버리지 빈 객체면 카드에 `커버리지` 라는 단어가 없다.
+5. CLI 는 `--bin` 또는 `(--scorecard + --coverage)`.
+6. 필수 인자 없으면 문구 `필수: --bin <경로> 또는 (--scorecard + --coverage)`,
+   exit 2.
+
+인증서:
+
+1. 같은 트리의 지문은 같고 64자 hex 다.
+2. pack 과제 JSON 한 칸을 바꾸면 지문이 바뀐다.
+3. pack asset 과 `tools/build_baseline.py` 도 지문에 들어간다.
+4. 재현 core 에 `rhwpCommit` 과 `agent` 가 없다.
+5. 진짜 인증서는 verify True.
+6. 정확도 percent 위조는 "정확도" 가 들어간 이유로 False.
+7. 축소된 지문은 "벤치마크 지문" 이 들어간 이유로 False.
+
+라이브 오라클 원칙도 그대로다. 리포트는 스코어카드를 다시 채점하지
+않는다. 인증서는 리포트를 다시 합성하지 않는다. 각각 한 층을
+봉인한다.
+
+## 14. 다른 기둥과의 경계
+
+| 도구 | 축 | 이 문서와의 관계 |
+|---|---|---|
+| `score.py` / `runner.py` | 종점 채점 | 스코어카드를 생산. 이 작업이 수정하지 않음 |
+| `build_baseline.py` | 기준 풀이 조립 | `--bin` 모드가 부를 수 있음. 수정하지 않음 |
+| `coverage.py` | 측정 폭 | 선택적 입력. 수정하지 않음 |
+| `report.py` | 한 장 계기 | 이 문서의 대상 |
+| `certify.py` | 재현 증명 | 이 문서의 대상 |
+| `discriminate.py` | 약한 오라클 | 리포트·인증서를 부르지 않음 |
+| `trajectory.py` | 경로 | 리포트·인증서를 부르지 않음 |
+| `fuzz_corpus.py` | 손상 발견 | 무관 |
+| `release_gate.py` | 릴리스 차단 | 이 작업이 게이트 YAML 을 건드리지 않음 |
+| expert-challenges | 보스 pack | 수정하지 않음 |
+| tutorial / PARK | 입문 문서 | 수정하지 않음 |
+
+리포트가 `--bin` 으로 score/build_baseline 을 부르는 것은 예전
+계약이다. 그 호출에 새 플래그를 붙이지 않는다. 하위 도구가 비-0
+이면 `report-tool-failed` 다. 그 도구의 내부 kind 를 여기서 재정의
+하지 않는다.
+
+## 15. 시험 행렬
+
+바이너리 없이 돈다. 목킹은 `_run` / `_run_report` / `subprocess.run`
+만. 실제 rhwp 를 켜지 않는다.
+
+리포트 시험 (`test_gym_report.py`):
+
+| 반 | 고정하는 것 |
+|---|---|
+| 성공 칸 | 축 합산, 정확도/커버리지 분리, 미가용 제외, 선택 커버리지 |
+| 카탈로그 | kind 고유, HELP 비지 않음, 문서 백틱, CLI 플래그 불변 |
+| JSON 형태 | dict 만 객체, bool 거부, percent 공식, 축 라벨 모서리 |
+| 적재 | 없는 스코어카드/커버리지, 깨진 JSON, 배열, 빈 파일, 디렉터리 |
+| 합성 | 미가용 예외, 비객체 입력, 빈 packs, 오류 pack, bool 점수 |
+| 카드 | 예외 절, 신뢰 줄, 비객체 카드 |
+| CLI | exit 2 경로, `--json` 성공, `--out` 성공, 빈 `--bin` |
+| --bin 자리 | 산출 부재, 깨진 scorecard.json, 하위 도구 비-0 |
+
+인증서 시험 (`test_gym_certify.py`):
+
+| 반 | 고정하는 것 |
+|---|---|
+| 성공 칸 | 지문 결정성, 민감도, core 변동 메타 제외, 위조 탐지 |
+| 카탈로그 | kind 고유, 문서 백틱, CLI 플래그 불변 |
+| 지문 도우미 | 빈 루트, pyc 제외, score/report/certify 포함 |
+| 적재 | 없는 인증서, 깨진 JSON, 배열, 디렉터리 |
+| 분류 | report 실패 → missing-scorecard / malformed-json / tool-failed |
+| 미가용 | 발급 시 예외 칸, 재현 집합 대조 |
+| verify 방어 | 비객체, 없는 report, 운영 예외, 신원/커버리지/축 |
+| CLI | exit 2/1/0, 발급 stdout/--out, missing-scorecard |
+
+audit.py 는 pack 정합이다. 이 작업이 pack JSON 을 건드리지 않으므로
+감사는 통과해야 한다. 감사 실패는 범위 밖 파일을 만진 신호다.
+
+## 16. 비목표
+
+이 문서가 하지 않는 것:
+
+- 새 CLI 플래그, 새 pack, 새 과제, 새 프로파일.
+- `score.py` `runner.py` `build_baseline.py` 수정.
+- expert-challenges / tutorial / PARK 수정.
+- 열린 PR 5210–5274 가 만지는 파일 수정.
+- 인증서 암호 서명, 키링, 리더보드 입장 연동.
+- 커버리지를 `--scorecard` 단독으로 선택 가능하게 만드는 계약 변경.
+- 지문에 `gym/docs` 나 `mydocs` 를 넣는 일. 문서는 점수를 바꾸지 않는다.
+- 종료 코드 4·5 같은 새 숫자.
+- 정확도 공식의 부동소수화. 정수 나눗셈이 카드 계약이다.
+
+하지 않는 이유가 있다. 능력 증명의 값은 "어제와 같은 계기"에 있다.
+계기 자체를 바꾸면 모든 예전 인증서가 한꺼번에 거짓이 된다. 예외
+경로는 그 계기가 **죽지 않게** 만드는 일이다. 계기의 눈금을 바꾸는
+일이 아니다.
+
+## 17. 구현 좌표
+
+| 심볼 | 파일 | 역할 |
+|---|---|---|
+| `EXCEPTION_KINDS` | 양쪽 | 카탈로그 |
+| `EXCEPTION_KIND_HELP` | 양쪽 | 문서와 같은 표 |
+| `ReportError` / `CertifyError` | 각 파일 | kind 를 가진 운영 예외 |
+| `load_json_object` | 양쪽 | 파일 → 객체 |
+| `compile_report` | report.py | 순수 합성 |
+| `render_card` | report.py | 사람용 카드 |
+| `benchmark_fingerprint` | certify.py | 측정 입력 해시 |
+| `reproducible_core` | certify.py | 재현 다섯 칸 |
+| `verify` | certify.py | (ok, diffs) |
+| `classify_report_failure` | certify.py | 자식 stderr → kind |
+| `main(argv=None)` | 양쪽 | CLI. 새 플래그 없음 |
+
+시험이 문서에 백틱으로 적힌 kind 를 코드 카탈로그와 대조한다.
+카탈로그에 kind 를 더하면 이 절과 5·6절 표와 HELP 와 시험을 같이
+고친다. 코드만 고치면 문서 시험이 실패한다. 그것이 이 규약의
+강제 장치다.

--- a/gym/report.py
+++ b/gym/report.py
@@ -17,6 +17,18 @@
 이것이 다른 에이전트가 자기 능력을 재고 겨루는 **표준 계기**다 — 커버리지·정확도를
 뭉뚱그리지 않고(각각 다른 것을 잰다) 한 장에 정직하게 담는다.
 
+예외 세 자리(이슈 #5275)는 스택이 아니라 kind 로 남긴다.
+
+- **없는 스코어카드** — `missing-scorecard`. 채점 산출이 없는데 리포트를 합성하지 않는다.
+- **깨진 JSON** — `malformed-json`. 배열·잘린 파일·디코드 실패를 점수로 위장하지 않는다.
+- **미가용 pack** — `unavailable-pack`. 명령 부재는 0점이 아니다. 축 합산에서 빼고
+  `packsUnavailable` 과 예외 칸에 같이 남긴다.
+
+카탈로그·봉투 계약은 `gym/docs/certify_report.md` 가 정본이다. 작업 기록은
+`mydocs/working/gym_certify_report.md`. 시험은 `scripts/tests/test_gym_report.py`.
+
+새 CLI 플래그는 없다. `--bin` `--scorecard` `--coverage` `--json` `--out` 만 쓴다.
+
 ## 사용
 
     python gym/report.py --bin target/debug/rhwp              # 전 pack 채점+커버리지→카드
@@ -36,86 +48,662 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(HERE)
 
+REPORT_KIND = "gymCapabilityReport"
+REPORT_SCHEMA = "1.0"
+SCORECARD_KIND = "gymScorecard"
+DEFAULT_REPORT_AGENT = "_report"
+
+# 종료 코드. 0=합성 성공, 2=도구 실패(없는 스코어카드·깨진 JSON·인자 부족).
+EXIT_OK = 0
+EXIT_TOOL_FAILED = 2
+
+# 새 플래그 없음. 시험이 argparse 옵션 집합을 이 튜플과 대조한다.
+REPORT_CLI_FLAGS = ("--bin", "--scorecard", "--coverage", "--json", "--out")
+
+PACK_STATUSES = ("scored", "unavailable", "error")
+PACK_STATUS_HELP = {
+    "scored": "로드 성공, 요구 명령 충족. 축 합산·총점에 들어간다.",
+    "unavailable": "요구 명령이 바이너리에 없다. 부재는 실패가 아니다.",
+    "error": "로드·식별자·JSON·권한 실패. 도구 실패는 부재가 아니다.",
+}
+
+# JSON 보고 고정 키. 예전 칸을 유지하고 예외 칸을 뒤에 붙인다.
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "agent",
+    "runner",
+    "accuracy",
+    "coverage",
+    "axisProfile",
+    "packsScored",
+    "packsUnavailable",
+    "packsErrored",
+    "exceptions",
+    "exceptionCount",
+    "trusted",
+)
+
+REPORT_LIST_KEYS = ("axisProfile", "packsUnavailable", "packsErrored", "exceptions")
+REPORT_INT_KEYS = ("packsScored", "exceptionCount")
+REPORT_BOOL_KEYS = ("trusted",)
+ACCURACY_KEYS = ("score", "max", "percent")
+COVERAGE_KEYS = ("percent", "covered", "agentFacingTotal", "uncoveredByCategory")
+AXIS_ROW_KEYS = ("axis", "score", "max", "packs", "percent")
+EXCEPTION_RECORD_KEYS = ("kind", "message", "where", "path", "pack", "role")
+
+# 예외 kind 카탈로그. 문서·시험이 같은 표를 본다. 새 CLI 를 만들지 않는다.
+EXCEPTION_KINDS = (
+    "missing-scorecard",
+    "missing-coverage",
+    "missing-bin",
+    "missing-report-arg",
+    "malformed-json",
+    "malformed-scorecard",
+    "malformed-coverage",
+    "malformed-pack-row",
+    "unavailable-pack",
+    "empty-packs",
+    "empty-total",
+    "permission",
+    "os-error",
+    "decode-error",
+    "type-error",
+    "value-error",
+    "write-error",
+    "report-tool-failed",
+    "unexpected",
+)
+
+EXCEPTION_KIND_HELP = {
+    "missing-scorecard": (
+        "스코어카드 파일이 없다. --scorecard 경로가 비었거나, --bin 모드에서 "
+        "score.py 가 submissions/_report/scorecard.json 을 남기지 않았다. "
+        "없는 산출을 0점으로 합성하지 않는다."
+    ),
+    "missing-coverage": (
+        "커버리지 JSON 파일이 없다. --coverage 를 줬으면 파일이 있어야 한다. "
+        "--bin 모드에서 coverage.py 가 없거나 실패한 것은 선택적이라 이 kind 가 아니다."
+    ),
+    "missing-bin": (
+        "경로형 바이너리가 없거나 --bin 값이 비었다. 채점 하위 도구가 시작되지 않는다."
+    ),
+    "missing-report-arg": (
+        "--bin 도 (--scorecard + --coverage) 도 없다. 예전 필수 인자 계약 그대로 "
+        "종료 코드 2. 새 플래그를 요구하지 않는다."
+    ),
+    "malformed-json": (
+        "파일이 UTF-8 JSON 이 아니다. 잘린 객체, 트레일링 콤마, 빈 파일, BOM 만 "
+        "있는 자리. 파싱 실패를 빈 점수로 바꾸지 않는다."
+    ),
+    "malformed-scorecard": (
+        "스코어카드가 JSON 객체(dict)가 아니다. 배열·문자열·숫자는 카드가 아니다."
+    ),
+    "malformed-coverage": (
+        "커버리지 산출이 JSON 객체가 아니다. 배열이면 카테고리 집계를 할 수 없다."
+    ),
+    "malformed-pack-row": (
+        "packs 목록의 한 칸이 객체가 아니다. 그 칸만 건너뛰고 나머지는 합성한다."
+    ),
+    "unavailable-pack": (
+        "pack status=unavailable. 요구 명령이 바이너리에 없다. 축 프로파일과 "
+        "총점에 넣지 않고 packsUnavailable 과 예외 칸에 남긴다. 종료 코드는 0."
+    ),
+    "empty-packs": (
+        "스코어카드 packs 가 없거나 빈 목록이다. 정확도 0/0, 축 프로파일 빈 목록."
+    ),
+    "empty-total": (
+        "스코어카드 total 이 없거나 max 가 0 이다. 정확도 percent 는 0. "
+        "측정된 pack 이 없다는 뜻이지 만점이 아니다."
+    ),
+    "permission": "스코어카드·커버리지·산출 파일을 읽을 권한 또는 쓸 권한이 없다.",
+    "os-error": "그 밖의 OSError. 디스크·경로·잠금. 점수로 접지 않는다.",
+    "decode-error": "파일이 UTF-8 이 아니다. 디코드 실패는 malformed-json 보다 앞선다.",
+    "type-error": "값 타입이 계약과 다르다. bool 을 int 로 세지 않는다.",
+    "value-error": "값은 있는데 형태가 틀렸다. 빈 경로, 음수 아닌데 문자인 점수 등.",
+    "write-error": "--out 경로에 카드를 쓰지 못했다. stdout 대체가 아니면 실패.",
+    "report-tool-failed": (
+        "하위 도구(build_baseline.py 또는 score.py)가 비-0 으로 끝났다. "
+        "리포트는 그 산출을 지어내지 않는다."
+    ),
+    "unexpected": "분류되지 않은 운영 예외. 치명 예외는 여기로 접지 않는다.",
+}
+
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    IsADirectoryError,
+    NotADirectoryError,
+    UnicodeError,
+    json.JSONDecodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+)
+
+ROLE_MISSING_KIND = {
+    "scorecard": "missing-scorecard",
+    "coverage": "missing-coverage",
+    "bin": "missing-bin",
+}
+
+ROLE_MALFORMED_KIND = {
+    "scorecard": "malformed-scorecard",
+    "coverage": "malformed-coverage",
+}
+
+INFORMATIONAL_KINDS = frozenset({"unavailable-pack", "empty-packs", "empty-total"})
+
+USAGE_MESSAGE = "필수: --bin <경로> 또는 (--scorecard + --coverage)"
+
+
+class ReportError(Exception):
+    """리포트 도구가 접는 운영 예외. kind 는 EXCEPTION_KINDS 중 하나."""
+
+    def __init__(self, kind: str, message: str, **extra: object) -> None:
+        if kind not in EXCEPTION_KINDS:
+            kind = "unexpected"
+        self.kind = kind
+        self.message = message
+        self.extra = extra
+        super().__init__(message)
+
+    def as_record(self) -> dict:
+        return exception_record(self.kind, self.message, **self.extra)
+
+
+def is_json_object(value: object) -> bool:
+    """JSON 객체인가. bool 은 int 의 하위 타입이라 dict 만 인정한다."""
+    return isinstance(value, dict) and not isinstance(value, bool)
+
+
+def is_json_array(value: object) -> bool:
+    return isinstance(value, list)
+
+
+def is_known_exception_kind(kind: object) -> bool:
+    return isinstance(kind, str) and kind in EXCEPTION_KINDS
+
+
+def is_fatal_exception(exc: BaseException) -> bool:
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def is_catchable_exception(exc: BaseException) -> bool:
+    if is_fatal_exception(exc):
+        return False
+    return isinstance(exc, CATCHABLE_EXCEPTIONS) or isinstance(exc, ReportError)
+
+
+def describe_exception_kind(kind: str) -> str:
+    if kind in EXCEPTION_KIND_HELP:
+        return EXCEPTION_KIND_HELP[kind]
+    return EXCEPTION_KIND_HELP["unexpected"]
+
+
+def exception_record(kind: str, message: str, **extra: object) -> dict:
+    """예외 한 줄. 없는 칸은 생략한다. 기계가 같은 키로 읽는다."""
+    rec: dict = {"kind": kind if is_known_exception_kind(kind) else "unexpected",
+                 "message": message}
+    for key in ("where", "path", "pack", "role"):
+        if extra.get(key) not in (None, ""):
+            rec[key] = extra[key]
+    return rec
+
+
+def as_int(value: object, default: int = 0) -> int:
+    """점수·개수. bool 과 문자열은 기본값. 음수는 그대로 둔다(위조 탐지용)."""
+    if type(value) is bool:
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return default
+
+
+def percent_of(score: int, maximum: int) -> int:
+    """정수 나눗셈. max 가 0 이면 0. 예전 카드와 같은 공식이다."""
+    if maximum:
+        return 100 * score // maximum
+    return 0
+
 
 def axis_label(axis: str) -> str:
     """축 라벨 — 괄호 앞의 능력 차원(예: '편집 (표 좌표 지정)' → '편집')."""
     return (axis or "미분류").split(" (")[0].strip() or "미분류"
 
 
+def pack_status(pack: object) -> str | None:
+    if not is_json_object(pack):
+        return None
+    status = pack.get("status")
+    if status in PACK_STATUSES:
+        return status
+    return None
+
+
+def is_scored_pack(pack: object) -> bool:
+    return pack_status(pack) == "scored"
+
+
+def is_unavailable_pack(pack: object) -> bool:
+    return pack_status(pack) == "unavailable"
+
+
+def is_error_pack(pack: object) -> bool:
+    return pack_status(pack) == "error"
+
+
+def pack_id_of(pack: object) -> str:
+    if not is_json_object(pack):
+        return "?"
+    pid = pack.get("id")
+    if isinstance(pid, str) and pid.strip():
+        return pid
+    return "?"
+
+
+def role_missing_kind(role: str) -> str:
+    return ROLE_MISSING_KIND.get(role, "missing-scorecard")
+
+
+def role_malformed_kind(role: str) -> str:
+    return ROLE_MALFORMED_KIND.get(role, "malformed-json")
+
+
+def classify_os_error(exc: BaseException, *, role: str = "scorecard") -> str:
+    """FileNotFound 는 역할에 따라 갈린다. 없는 스코어카드를 없는 커버리지로 부르지 않는다."""
+    if isinstance(exc, ReportError):
+        return exc.kind
+    if isinstance(exc, json.JSONDecodeError):
+        return "malformed-json"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, FileNotFoundError):
+        return role_missing_kind(role)
+    if isinstance(exc, IsADirectoryError):
+        return role_malformed_kind(role)
+    if isinstance(exc, TypeError):
+        return "type-error"
+    if isinstance(exc, ValueError):
+        return "value-error"
+    if isinstance(exc, OSError):
+        return "os-error"
+    return "unexpected"
+
+
+def error_head(exc: BaseException, limit: int = 240) -> str:
+    text = str(exc).strip() or type(exc).__name__
+    if len(text) > limit:
+        return text[:limit]
+    return text
+
+
+def wrap_exception(exc: BaseException, *, role: str = "scorecard",
+                   where: str = "", path: str = "") -> ReportError:
+    if isinstance(exc, ReportError):
+        return exc
+    if is_fatal_exception(exc):
+        raise exc
+    kind = classify_os_error(exc, role=role)
+    return ReportError(kind, error_head(exc), role=role, where=where, path=path)
+
+
+def load_text(path: str, *, role: str) -> str:
+    """UTF-8 본문. 없으면 역할별 missing-*, 디코드 실패는 decode-error."""
+    if not isinstance(path, str) or not path.strip():
+        raise ReportError(role_missing_kind(role), f"{role} 경로가 비었다",
+                          role=role, path=path)
+    if os.path.isdir(path):
+        raise ReportError(role_malformed_kind(role),
+                          f"{role} 경로가 디렉터리다: {path}",
+                          role=role, path=path, where="load_text")
+    if not os.path.isfile(path):
+        raise ReportError(role_missing_kind(role),
+                          f"{role} 파일이 없다: {path}",
+                          role=role, path=path, where="load_text")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except PermissionError as e:
+        raise ReportError("permission", f"{role} 권한 없음: {error_head(e)}",
+                          role=role, path=path)
+    except UnicodeError as e:
+        raise ReportError("decode-error", f"{role} UTF-8 디코드 실패: {error_head(e)}",
+                          role=role, path=path)
+    except OSError as e:
+        raise ReportError("os-error", f"{role} 읽기 실패: {error_head(e)}",
+                          role=role, path=path)
+
+
+def parse_json_text(text: str, *, role: str) -> object:
+    if text is None:
+        raise ReportError("malformed-json", f"{role} 본문이 없다", role=role)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ReportError("malformed-json",
+                          f"{role} JSON 파싱 실패: {error_head(e)}",
+                          role=role, where=f"line {e.lineno}")
+
+
+def load_json_object(path: str, *, role: str) -> dict:
+    """파일 → JSON 객체. 배열·스칼라는 역할별 malformed-*."""
+    raw = load_text(path, role=role)
+    data = parse_json_text(raw, role=role)
+    if not is_json_object(data):
+        raise ReportError(role_malformed_kind(role),
+                          f"{role} 가 JSON 객체가 아니다",
+                          role=role, path=path)
+    return data
+
+
+def write_text(path: str, text: str) -> None:
+    try:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+    except PermissionError as e:
+        raise ReportError("write-error", f"산출 권한 없음: {error_head(e)}", path=path)
+    except OSError as e:
+        raise ReportError("write-error", f"산출 기록 실패: {error_head(e)}", path=path)
+
+
+def scorecard_path_for_agent(agent: str = DEFAULT_REPORT_AGENT) -> str:
+    return os.path.join(HERE, "submissions", agent, "scorecard.json")
+
+
+def iter_pack_rows(scorecard: object) -> list[object]:
+    if not is_json_object(scorecard):
+        return []
+    packs = scorecard.get("packs")
+    if not is_json_array(packs):
+        return []
+    return list(packs)
+
+
+def collect_unavailable_packs(scorecard: object) -> list[str]:
+    ids: list[str] = []
+    for pack in iter_pack_rows(scorecard):
+        if is_unavailable_pack(pack):
+            ids.append(pack_id_of(pack))
+    return ids
+
+
+def collect_error_packs(scorecard: object) -> list[str]:
+    ids: list[str] = []
+    for pack in iter_pack_rows(scorecard):
+        if is_error_pack(pack):
+            ids.append(pack_id_of(pack))
+    return ids
+
+
+def collect_scored_packs(scorecard: object) -> list[dict]:
+    rows: list[dict] = []
+    for pack in iter_pack_rows(scorecard):
+        if is_scored_pack(pack) and is_json_object(pack):
+            rows.append(pack)
+    return rows
+
+
+def validate_scorecard(scorecard: object) -> list[dict]:
+    """스코어카드 뼈대. 없어도 compile 이 죽지 않게 예외 목록만 낸다."""
+    notes: list[dict] = []
+    if not is_json_object(scorecard):
+        notes.append(exception_record(
+            "malformed-scorecard", "스코어카드가 JSON 객체가 아니다",
+            where="compile_report",
+        ))
+        return notes
+    packs = scorecard.get("packs")
+    if packs is None:
+        notes.append(exception_record(
+            "empty-packs", "스코어카드에 packs 칸이 없다",
+            where="scorecard.packs",
+        ))
+    elif not is_json_array(packs):
+        notes.append(exception_record(
+            "malformed-scorecard", "packs 가 목록이 아니다",
+            where="scorecard.packs",
+        ))
+    elif len(packs) == 0:
+        notes.append(exception_record(
+            "empty-packs", "스코어카드 packs 가 비었다",
+            where="scorecard.packs",
+        ))
+    else:
+        for index, pack in enumerate(packs):
+            if not is_json_object(pack):
+                notes.append(exception_record(
+                    "malformed-pack-row",
+                    f"packs[{index}] 가 객체가 아니다",
+                    where=f"scorecard.packs[{index}]",
+                ))
+                continue
+            if is_unavailable_pack(pack):
+                notes.append(exception_record(
+                    "unavailable-pack",
+                    f"pack {pack_id_of(pack)} 는 요구 명령 부재로 채점되지 않았다",
+                    pack=pack_id_of(pack),
+                    where="scorecard.packs",
+                ))
+    total = scorecard.get("total")
+    if total is None:
+        notes.append(exception_record(
+            "empty-total", "스코어카드에 total 칸이 없다",
+            where="scorecard.total",
+        ))
+    elif not is_json_object(total):
+        notes.append(exception_record(
+            "malformed-scorecard", "total 이 객체가 아니다",
+            where="scorecard.total",
+        ))
+    elif as_int(total.get("max"), 0) == 0:
+        notes.append(exception_record(
+            "empty-total", "total.max 가 0 이다 — 측정된 만점이 없다",
+            where="scorecard.total.max",
+        ))
+    return notes
+
+
+def validate_coverage(coverage: object) -> list[dict]:
+    """커버리지는 선택적. 빈 객체는 예외가 아니다. 배열만 거부한다."""
+    if coverage in (None, {}):
+        return []
+    if not is_json_object(coverage):
+        return [exception_record(
+            "malformed-coverage", "커버리지가 JSON 객체가 아니다",
+            where="coverage",
+        )]
+    return []
+
+
+def compile_axis_profile(packs: list[object]) -> list[dict]:
+    """scored pack 만 축 라벨로 합산. unavailable·error·비객체는 빠진다."""
+    by_axis: dict[str, dict] = {}
+    for pack in packs:
+        if not is_scored_pack(pack) or not is_json_object(pack):
+            continue
+        label = axis_label(pack.get("axis", "") if isinstance(pack.get("axis"), str) else "")
+        acc = by_axis.setdefault(label, {
+            "axis": label, "score": 0, "max": 0, "packs": 0,
+        })
+        acc["score"] += as_int(pack.get("score"), 0)
+        acc["max"] += as_int(pack.get("max"), 0)
+        acc["packs"] += 1
+    for acc in by_axis.values():
+        acc["percent"] = percent_of(acc["score"], acc["max"])
+    return sorted(by_axis.values(), key=lambda a: (-a["percent"], a["axis"]))
+
+
+def accuracy_from_total(total: object) -> dict:
+    if not is_json_object(total):
+        return {"score": 0, "max": 0, "percent": 0}
+    score = as_int(total.get("score"), 0)
+    maximum = as_int(total.get("max"), 0)
+    return {"score": score, "max": maximum, "percent": percent_of(score, maximum)}
+
+
+def coverage_block(coverage: object) -> dict:
+    if not is_json_object(coverage):
+        return {
+            "percent": None,
+            "covered": None,
+            "agentFacingTotal": None,
+            "uncoveredByCategory": {},
+        }
+    uncovered = coverage.get("uncoveredByCategory", {})
+    if not is_json_object(uncovered):
+        uncovered = {}
+    return {
+        "percent": coverage.get("coveragePercent"),
+        "covered": coverage.get("covered"),
+        "agentFacingTotal": coverage.get("agentFacingTotal"),
+        "uncoveredByCategory": uncovered,
+    }
+
+
+def is_informational_kind(kind: str) -> bool:
+    return kind in INFORMATIONAL_KINDS
+
+
+def structural_exceptions(exceptions: list[dict]) -> list[dict]:
+    return [e for e in exceptions if not is_informational_kind(e.get("kind", ""))]
+
+
 def compile_report(scorecard: dict, coverage: dict) -> dict:
     """순수 합성 — 바이너리·파일 접근 없음(가드가 픽스처로 시험 가능).
 
     scorecard: score.py 산출(kind gymScorecard). coverage: coverage.py 산출.
+    깨진 입력은 던지지 않고 exceptions 칸에 남긴다. 예전 칸(accuracy·coverage·
+    axisProfile·packsUnavailable)의 계산식은 그대로다.
     """
-    packs = scorecard.get("packs", [])
-    total = scorecard.get("total", {})
+    notes = validate_scorecard(scorecard)
+    notes.extend(validate_coverage(coverage))
+    if not is_json_object(scorecard):
+        scorecard = {}
+    if not is_json_object(coverage):
+        coverage = {}
 
-    by_axis: dict[str, dict] = {}
-    for p in packs:
-        if p.get("status") != "scored":
-            continue
-        label = axis_label(p.get("axis", ""))
-        acc = by_axis.setdefault(label, {"axis": label, "score": 0, "max": 0, "packs": 0})
-        acc["score"] += p.get("score", 0)
-        acc["max"] += p.get("max", 0)
-        acc["packs"] += 1
-    for acc in by_axis.values():
-        acc["percent"] = (100 * acc["score"] // acc["max"]) if acc["max"] else 0
-    axis_profile = sorted(by_axis.values(), key=lambda a: (-a["percent"], a["axis"]))
-
-    unavailable = [p["id"] for p in packs if p.get("status") == "unavailable"]
-    score_max = total.get("max", 0)
-    score_pct = (100 * total.get("score", 0) // score_max) if score_max else 0
+    packs = iter_pack_rows(scorecard)
+    total = scorecard.get("total") if is_json_object(scorecard.get("total")) else {}
+    axis_profile = compile_axis_profile(packs)
+    unavailable = collect_unavailable_packs(scorecard)
+    errored = collect_error_packs(scorecard)
+    trusted = len(structural_exceptions(notes)) == 0
 
     return {
-        "kind": "gymCapabilityReport",
-        "schemaVersion": "1.0",
-        "agent": scorecard.get("agent"),
-        "runner": scorecard.get("runner"),
+        "kind": REPORT_KIND,
+        "schemaVersion": REPORT_SCHEMA,
+        "agent": scorecard.get("agent") if is_json_object(scorecard) else None,
+        "runner": scorecard.get("runner") if is_json_object(scorecard) else None,
         # 두 축을 뭉뚱그리지 않는다 — 정확도(측정된 것 통과율)와 커버리지(측정 폭).
-        "accuracy": {"score": total.get("score", 0), "max": score_max, "percent": score_pct},
-        "coverage": {
-            "percent": coverage.get("coveragePercent"),
-            "covered": coverage.get("covered"),
-            "agentFacingTotal": coverage.get("agentFacingTotal"),
-            "uncoveredByCategory": coverage.get("uncoveredByCategory", {}),
-        },
+        "accuracy": accuracy_from_total(total),
+        "coverage": coverage_block(coverage),
         "axisProfile": axis_profile,
-        "packsScored": total.get("packsScored", 0),
+        "packsScored": as_int(total.get("packsScored"), 0) if is_json_object(total) else 0,
         "packsUnavailable": unavailable,
+        "packsErrored": errored,
+        "exceptions": notes,
+        "exceptionCount": len(notes),
+        "trusted": trusted,
     }
 
 
+def render_exceptions(exceptions: object) -> list[str]:
+    if not is_json_array(exceptions) or not exceptions:
+        return []
+    lines = ["", "## 예외 경로", ""]
+    for item in exceptions:
+        if not is_json_object(item):
+            continue
+        kind = item.get("kind") or "unexpected"
+        message = item.get("message") or ""
+        pack = item.get("pack")
+        suffix = f" (pack {pack})" if pack else ""
+        lines.append(f"- `{kind}`{suffix}: {message}")
+    return lines
+
+
 def render_card(report: dict) -> str:
-    acc = report["accuracy"]
-    cov = report["coverage"]
+    if not is_json_object(report):
+        report = {}
+    acc = report.get("accuracy") if is_json_object(report.get("accuracy")) else {}
+    cov = report.get("coverage") if is_json_object(report.get("coverage")) else {}
+    score = as_int(acc.get("score"), 0)
+    maximum = as_int(acc.get("max"), 0)
+    pct = as_int(acc.get("percent"), 0)
     lines = [
         "# gym 능력 스코어카드",
         "",
-        f"- **정확도** (측정된 것 통과): {acc['score']}/{acc['max']} ({acc['percent']}%)",
+        f"- **정확도** (측정된 것 통과): {score}/{maximum} ({pct}%)",
     ]
     if cov.get("percent") is not None:
         lines.append(
             f"- **커버리지** (에이전트-대면 측정 폭): {cov['covered']}/{cov['agentFacingTotal']}"
             f" ({cov['percent']}%)"
         )
-    lines.append(f"- **채점 pack**: {report['packsScored']}")
-    if report["packsUnavailable"]:
-        lines.append(f"- **미가용 pack**(명령 부재): {', '.join(report['packsUnavailable'])}")
+    lines.append(f"- **채점 pack**: {report.get('packsScored', 0)}")
+    unavailable = report.get("packsUnavailable") or []
+    if unavailable:
+        labels = [str(x) for x in unavailable]
+        lines.append(f"- **미가용 pack**(명령 부재): {', '.join(labels)}")
+    errored = report.get("packsErrored") or []
+    if errored:
+        lines.append(f"- **오류 pack**(도구 실패): {', '.join(str(x) for x in errored)}")
     r = report.get("runner") or {}
-    if r:
+    if is_json_object(r) and r:
         lines.append(
             f"- **runner**: v{r.get('rhwpVersion')} · {str(r.get('rhwpCommit'))[:12]}"
         )
+    if report.get("trusted") is False:
+        lines.append("- **신뢰**: 구조 예외가 있어 이 카드만으로 능력을 단정하지 않는다")
     lines += ["", "## 축별 능력 프로파일", "", "| 축 | 점수 | % |", "|---|---|---|"]
-    for a in report["axisProfile"]:
-        lines.append(f"| {a['axis']} | {a['score']}/{a['max']} | {a['percent']}% |")
+    for a in report.get("axisProfile") or []:
+        if not is_json_object(a):
+            continue
+        lines.append(f"| {a.get('axis')} | {a.get('score')}/{a.get('max')} | {a.get('percent')}% |")
     uncovered = cov.get("uncoveredByCategory") or {}
-    if uncovered:
-        flat = [n for names in uncovered.values() for n in names]
+    if is_json_object(uncovered) and uncovered:
+        flat = [n for names in uncovered.values() if is_json_array(names) for n in names]
         lines += ["", f"## 미측정 능력 (다음 성장 방향, {len(flat)}개)", "",
-                  "`" + "` · `".join(flat) + "`"]
+                  "`" + "` · `".join(str(n) for n in flat) + "`"]
+    lines += render_exceptions(report.get("exceptions"))
     return "\n".join(lines) + "\n"
+
+
+def dump_report_json(report: dict) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="gym 능력 종합 스코어카드")
+    ap.add_argument("--bin", help="rhwp 바이너리 — 전 pack 채점+커버리지를 돌린다")
+    ap.add_argument("--scorecard", help="score.py 스코어카드 JSON(이미 있으면)")
+    ap.add_argument("--coverage", help="coverage.py --json 산출(이미 있으면)")
+    ap.add_argument("--json", action="store_true", help="카드 대신 JSON")
+    ap.add_argument("--out", help="출력 파일(생략 시 stdout)")
+    return ap
+
+
+def cli_flag_names(parser: argparse.ArgumentParser | None = None) -> tuple[str, ...]:
+    ap = parser or build_parser()
+    names: list[str] = []
+    for action in ap._actions:
+        for opt in action.option_strings:
+            if opt.startswith("--") and opt not in ("--help",):
+                names.append(opt)
+    return tuple(names)
 
 
 def _run(tool_argv: list[str]) -> None:
@@ -125,19 +713,33 @@ def _run(tool_argv: list[str]) -> None:
     sys.stderr.write(out.stdout.decode("utf-8", "replace"))
     sys.stderr.write(out.stderr.decode("utf-8", "replace"))
     if out.returncode != 0:
-        raise SystemExit(f"하위 도구 실패: {os.path.basename(str(tool_argv[0]))}")
+        name = os.path.basename(str(tool_argv[0]))
+        raise ReportError(
+            "report-tool-failed",
+            f"하위 도구 실패: {name}",
+            where=name,
+        )
 
 
 def _from_bin(bin_path: str) -> tuple[dict, dict]:
     """--bin 모드: 전 pack 채점 + (있으면) 커버리지를 실제로 돌려 산출을 읽는다.
 
     커버리지 측정기(coverage.py)는 선택적이다 — 없으면 정확도·축 프로파일만 낸다.
+    스코어카드 부재·깨진 JSON 은 선택적이 아니다. missing-scorecard / malformed-json.
     """
-    _run([os.path.join(HERE, "tools", "build_baseline.py"), "--agent", "_report", "--bin", bin_path])
-    _run([os.path.join(HERE, "score.py"), "--agent", "_report", "--bin", bin_path])
-    scorecard = json.load(
-        open(os.path.join(HERE, "submissions", "_report", "scorecard.json"), encoding="utf-8")
-    )
+    if not isinstance(bin_path, str) or not bin_path.strip():
+        raise ReportError("missing-bin", "바이너리 경로가 비었다", role="bin")
+    _run([os.path.join(HERE, "tools", "build_baseline.py"), "--agent", DEFAULT_REPORT_AGENT,
+          "--bin", bin_path])
+    _run([os.path.join(HERE, "score.py"), "--agent", DEFAULT_REPORT_AGENT, "--bin", bin_path])
+    scorecard_path = scorecard_path_for_agent(DEFAULT_REPORT_AGENT)
+    if not os.path.isfile(scorecard_path):
+        raise ReportError(
+            "missing-scorecard",
+            f"score.py 가 scorecard.json 을 남기지 않았다: {scorecard_path}",
+            path=scorecard_path, role="scorecard", where="submissions/_report",
+        )
+    scorecard = load_json_object(scorecard_path, role="scorecard")
     coverage: dict = {}
     cov_tool = os.path.join(HERE, "tools", "coverage.py")
     if os.path.isfile(cov_tool):
@@ -146,38 +748,50 @@ def _from_bin(bin_path: str) -> tuple[dict, dict]:
                 [sys.executable, cov_tool, "--bin", bin_path, "--json"],
                 cwd=REPO_ROOT, capture_output=True,
             ).stdout
-            coverage = json.loads(cov_raw)
+            parsed = json.loads(cov_raw)
+            if is_json_object(parsed):
+                coverage = parsed
         except (ValueError, OSError):
             coverage = {}
     return scorecard, coverage
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="gym 능력 종합 스코어카드")
-    ap.add_argument("--bin", help="rhwp 바이너리 — 전 pack 채점+커버리지를 돌린다")
-    ap.add_argument("--scorecard", help="score.py 스코어카드 JSON(이미 있으면)")
-    ap.add_argument("--coverage", help="coverage.py --json 산출(이미 있으면)")
-    ap.add_argument("--json", action="store_true", help="카드 대신 JSON")
-    ap.add_argument("--out", help="출력 파일(생략 시 stdout)")
-    a = ap.parse_args()
+def load_inputs(args: argparse.Namespace) -> tuple[dict, dict]:
+    """CLI 입력을 스코어카드·커버리지로. 예외는 ReportError."""
+    if args.scorecard and args.coverage:
+        return (
+            load_json_object(args.scorecard, role="scorecard"),
+            load_json_object(args.coverage, role="coverage"),
+        )
+    if args.bin:
+        return _from_bin(args.bin)
+    raise ReportError("missing-report-arg", USAGE_MESSAGE)
 
-    if a.scorecard and a.coverage:
-        scorecard = json.load(open(a.scorecard, encoding="utf-8"))
-        coverage = json.load(open(a.coverage, encoding="utf-8"))
-    elif a.bin:
-        scorecard, coverage = _from_bin(a.bin)
-    else:
-        print("필수: --bin <경로> 또는 (--scorecard + --coverage)", file=sys.stderr)
-        return 2
 
-    report = compile_report(scorecard, coverage)
-    text = (json.dumps(report, ensure_ascii=False, indent=2) + "\n") if a.json else render_card(report)
-    if a.out:
-        open(a.out, "w", encoding="utf-8").write(text)
-        print(f"작성: {a.out}")
+def emit_output(report: dict, *, as_json: bool, out_path: str | None) -> int:
+    text = dump_report_json(report) if as_json else render_card(report)
+    if out_path:
+        write_text(out_path, text)
+        print(f"작성: {out_path}")
     else:
         sys.stdout.write(text)
-    return 0
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = build_parser()
+    a = ap.parse_args(argv)
+    try:
+        scorecard, coverage = load_inputs(a)
+        report = compile_report(scorecard, coverage)
+        return emit_output(report, as_json=a.json, out_path=a.out)
+    except ReportError as e:
+        print(f"{e.kind}: {e}", file=sys.stderr)
+        return EXIT_TOOL_FAILED
+    except CATCHABLE_EXCEPTIONS as e:
+        wrapped = wrap_exception(e, role="scorecard", where="main")
+        print(f"{wrapped.kind}: {wrapped}", file=sys.stderr)
+        return EXIT_TOOL_FAILED
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_certify_report.md
+++ b/mydocs/working/gym_certify_report.md
@@ -1,0 +1,307 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_certify_report.md
+last_verified: 2026-08-18
+---
+
+# gym certify/report 채점 산출 예외 경로·문서·시험 보강
+
+Issue: #5275
+Branch: `feat/gym-certify-report-hardening`
+Date: 2026-08-18
+Worktree: `C:\Users\swsz9\rhwp-gym-certify-report` (isolation, not rhwp-desk*)
+
+## 1. 결론
+
+`gym/report.py` 와 `gym/certify.py` 의 합성·재현 성공 칸은 그대로 두고,
+예전이 스택을 올리거나 미가용 pack 을 한 줄로만 접던 자리를 kind 로
+남겼다. 없는 스코어카드는 `missing-scorecard` 이지 0점이 아니다.
+깨진 JSON 은 `malformed-json` 이지 빈 카드가 아니다. 미가용 pack 은
+`unavailable-pack` 이지 축 합산의 0점이 아니다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_report scripts.tests.test_gym_certify`
+- `python gym/tools/audit.py`
+- `cargo fmt --all -- --check` (HARD GATE, PR 전)
+
+건드리지 않은 것:
+
+- `gym/score.py` · `gym/core/runner.py` · `gym/tools/build_baseline.py`
+- `gym/packs/expert-challenges` · `gym/tutorial` · `gym/PARK.md`
+- 열린 PR 5210–5274 의 파일
+- 새 CLI 플래그, 새 pack, 새 과제
+- 정확도 정수 나눗셈, 축 라벨 규칙, 지문 알고리즘, verify 시그니처
+
+규범: `gym/docs/certify_report.md`. 이 파일은 작업 기록이다.
+
+## 2. 배경
+
+원 도입은 리포트를 표준 계기로, 인증서를 재현 증명으로 두었다.
+리포트는 scorecard + coverage 를 한 장으로 합친다. 인증서는 그 장의
+재현 core(지문·바이너리 신원·정확도·커버리지·축)를 다시 돌려 대조한다.
+
+대비 `upstream/devel` 의 구현은 리포트 약 190줄, 인증서 약 180줄,
+시험은 리포트 4건·인증서 6건이었다. 성공 칸은 단단했다. 예외 칸은
+열려 있었다.
+
+그 상태의 빈틈:
+
+1. `report.main` 이 `json.load(open(scorecard))` 를 그대로 부른다.
+   파일이 없으면 FileNotFoundError. kind 가 없다. 종료 코드도 없다.
+2. `--bin` 모드가 `submissions/_report/scorecard.json` 을 같은 방식으로
+   연다. score.py 가 산출을 안 남기면 스택. 하위 도구 실패와 산출
+   부재가 구분되지 않는다.
+3. 잘린 JSON·빈 파일·배열 스코어카드가 JSONDecodeError 또는
+   AttributeError. 깨진 입력을 0점으로 합성할 위험과, 도구가 죽을
+   위험이 같이 있다.
+4. 미가용 pack 은 `p["id"]` 로만 모은다. id 가 없으면 KeyError.
+   인증서는 그 집합을 재현 대조하지 않는다. 벤치마크에서 명령 없는
+   pack 을 지우면 점수가 같아 보여도 측정 폭이 줄어든다.
+5. `certify.main --verify` 가 없는 파일·깨진 JSON 에서 스택.
+   재현 실패(1)와 도구 실패가 한 예외로 접힌다.
+6. `verify` 가 `cert.get("report", {})` 로 `report: null` 을 받으면
+   기본값이 쓰이지 않아 `None.get` 으로 죽는다.
+7. `_run_report` 가 비-0 을 RuntimeError 로 올린다. 스코어카드 부재를
+   일반 실패로 뭉갠다.
+8. 카탈로그가 코드에 없어 문서·시험이 같은 표를 공유하지 않는다.
+
+이슈 #5275 의 DoD 는 이 빈틈을 닫는 것이다. additions >= 3000.
+unittest + audit.py. PR 전 `cargo fmt --all -- --check`. 새 CLI/pack
+없음. 열린 PR 파일 미수정.
+
+채점기 보강(#5260)과 fuzz_corpus 보강(#5256)의 예외 접기를 참고하되,
+리포트·인증서의 정체성은 유지했다.
+
+- 리포트는 채점하지 않는다. 스코어카드를 읽는다.
+- 인증서는 서명하지 않는다. 재현한다.
+- 커버리지와 정확도를 한 숫자로 합치지 않는다.
+- `--scorecard` 단독 허용 같은 계약 변경을 하지 않는다.
+
+## 3. 한 일
+
+### 3.1 리포트 `gym/report.py`
+
+- `EXCEPTION_KINDS` / `EXCEPTION_KIND_HELP` — 문서·시험이 보는 표.
+- `FATAL_EXCEPTIONS` / `CATCHABLE_EXCEPTIONS` — 삼키는 경계.
+- `ReportError` — kind 를 가진 운영 예외.
+- `classify_os_error(exc, role)` — FileNotFound 는 역할로
+  `missing-scorecard` / `missing-coverage` / `missing-bin` 으로 갈린다.
+- `load_text` / `parse_json_text` / `load_json_object` — 빈 경로,
+  디렉터리, 부재, 권한, 디코드, 파싱, 비객체를 순서대로 접는다.
+- `validate_scorecard` / `validate_coverage` — compile 이 죽지 않게
+  예외 목록만 낸다.
+- `compile_report` — 예전 숫자 공식 유지. `exceptions` ·
+  `packsErrored` · `trusted` 를 뒤에 붙인다. unavailable pack 마다
+  `unavailable-pack` 한 줄.
+- `render_card` — 예전 줄 유지. 예외 절은 `## 예외 경로`. 커버리지
+  없는 카드에 `커버리지` 단어를 쓰지 않는다.
+- `_from_bin` — scorecard.json 부재는 `missing-scorecard`. 깨진
+  JSON 은 `malformed-json`. 커버리지 실패는 예전처럼 빈 객체.
+- `_run` — SystemExit 대신 `report-tool-failed`.
+- `main(argv=None)` — ReportError 를 stderr `kind: message`, exit 2.
+- CLI 플래그 불변. `REPORT_CLI_FLAGS` 를 시험이 대조한다.
+
+### 3.2 인증서 `gym/certify.py`
+
+- 같은 카탈로그 패턴. 인증서만의 kind: `missing-cert` `missing-report`
+  `malformed-cert` `malformed-report` `wrong-kind` `fingerprint-empty`
+  `verify-mismatch`.
+- 지문 알고리즘을 `collect_fingerprint_entries` +
+  `hash_fingerprint_entries` 로 쪼갰다. 해시 식은 그대로다. `.pyc` 와
+  `__pycache__` 제외도 그대로다.
+- `reproducible_core` 가 비객체 report/runner/coverage 를 빈 객체로
+  본다. `None.get` 이 없다.
+- `_run_report` 가 CertifyError. `classify_report_failure` 가 stderr
+  표식으로 `missing-scorecard` 를 일반 실패에서 가른다.
+- `certify` 가 `unavailablePacks` 와 `unavailable-pack` 예외를 붙인다.
+  `--at` 은 예전처럼 `certifiedAt` 만. core 밖.
+- `verify` 시그니처 `(bool, list[str])` 유지. 깨진 인증서는 False.
+  미가용 집합 불일치를 diffs 에 더한다. kind 불일치 문구는 예전
+  그대로.
+- `main(argv=None)` — 없는 인증서·깨진 JSON 은 exit 2. 재현 실패는
+  exit 1. 발급 성공은 0.
+
+### 3.3 시험
+
+- `scripts/tests/test_gym_report.py` — 예전 4건을 유지하고 카탈로그·
+  적재·합성·카드·CLI·`--bin` 산출 부재를 더했다.
+- `scripts/tests/test_gym_certify.py` — 예전 6건을 유지하고 카탈로그·
+  지문 도우미·적재·분류·미가용·verify 방어·CLI 를 더했다.
+- 문서 백틱 대조: 각 `EXCEPTION_KINDS` 항목이
+  `gym/docs/certify_report.md` 에 `` `kind` `` 로 적혀 있어야 한다.
+
+### 3.4 문서
+
+- `gym/docs/certify_report.md` — 규약 정본. 왜, 사용, 봉투, pack
+  삼원, kind 표 두 장, JSON 적재, 합성, 지문, 재현, 경계, 시험
+  행렬, 비목표.
+- `mydocs/working/gym_certify_report.md` — 이 기록.
+
+## 4. 예외 세 자리 (이슈 DoD)
+
+### 4.1 없는 스코어카드
+
+자리:
+
+- `python gym/report.py --scorecard missing.json --coverage cov.json`
+- `python gym/report.py --bin <bin>` 이후 `submissions/_report/scorecard.json` 없음
+- `python gym/certify.py --bin <bin>` 가 그 리포트를 부를 때
+
+동작:
+
+- 리포트 CLI: stderr `missing-scorecard: …`, exit 2. 카드를 짓지 않음.
+- 리포트 `_from_bin`: ReportError `missing-scorecard`.
+- 인증서: report.py 비-0 + 표식 → CertifyError `missing-scorecard`,
+  exit 2. 빈 인증서 없음.
+
+하지 않는 것: 빈 스코어카드를 0/0 으로 합성해 "만점 아님" 한 줄로
+접기. 그것은 침묵이다.
+
+### 4.2 깨진 JSON
+
+자리:
+
+- 스코어카드 `{` / `[]` / `""` / 숫자 스칼라
+- 커버리지 같은 형태 (`--coverage` 를 준 경우)
+- 인증서 `--verify` 같은 형태
+- report.py stdout 이 카드 텍스트이거나 잘린 JSON
+
+동작:
+
+- 파싱 실패: `malformed-json`, 파일 모드 exit 2.
+- 파싱은 되나 객체 아님: `malformed-scorecard` /
+  `malformed-coverage` / `malformed-cert` / `malformed-report`.
+- `compile_report` 에 비객체 가 직접 들어오면 던지지 않고 카드 +
+  예외. CLI 적재 단계는 그 전에 끊는다.
+
+하지 않는 것: `except Exception: scorecard = {}` 로 삼켜 0점 카드
+발급. 깨진 입력을 측정으로 위장한다.
+
+### 4.3 미가용 pack
+
+자리:
+
+- 스코어카드 pack `status=unavailable`
+- 리포트 `packsUnavailable`
+- 인증서 `unavailablePacks` 와 재현 집합 대조
+
+동작:
+
+- 축 프로파일에서 제외 (예전).
+- `packsUnavailable` 에 id (예전, id 없으면 `?`).
+- `exceptions` 에 `unavailable-pack` 한 줄 (추가).
+- `trusted` 는 그대로 true. 부재는 구조 오류가 아니다.
+- 카드에 미가용 줄 + 예외 절.
+- 인증서 발급 시 같은 목록을 복사.
+- verify 때 집합이 달라지면 "미가용 pack 불일치", exit 1.
+
+하지 않는 것: 미가용 pack 을 0점으로 축에 넣기. error pack 을
+unavailable 로 세기. 미가용 때문에 리포트 exit 를 2 로 올리기.
+
+## 5. 성공 칸 회귀 점검
+
+리포트 픽스처 SCORECARD 는 편집 2 + 조사 1 + 보안 unavailable 1.
+합성 결과는 예전과 같아야 한다.
+
+| 칸 | 값 |
+|---|---|
+| 편집 score/max/percent | 4 / 6 / 66 |
+| 조사 score | 1 |
+| 정확도 percent | 62 |
+| 커버리지 percent | 82 |
+| 축에 보안 | 없음 |
+| packsUnavailable | `["d"]` |
+
+추가로 `exceptions` 에 `unavailable-pack` / pack `d` 가 있다. 예전
+시험은 extra 키를 보지 않으므로 통과한다.
+
+인증서 픽스처 FIXED_REPORT 는 정확도 100, 지문 목킹 `FP`.
+verify True, 정확도 위조 False, 지문 위조 False. 그대로다.
+
+지문 민감도: packs/tasks JSON 변경, assets CSV 변경,
+tools/build_baseline.py 변경. 알고리즘을 쪼개도 해시 식은 같다.
+
+## 6. 경계 — 일부러 안 만진 파일
+
+이슈가 명시한 금지:
+
+- `score.py` `runner.py` `build_baseline.py`
+- expert-challenges, tutorial, PARK
+- PR 5210–5274 의 파일
+
+그래서 넣지 않은 것:
+
+- 채점기 `EXCEPTION_KINDS` 재사용 (runner 를 import 하면 그 PR 과
+  겹칠 수 있다). 리포트·인증서는 자기 카탈로그를 가진다.
+- gym/README.md · PARK.md 링크 추가. 입문 문서는 다른 이슈(#5263).
+- coverage.py 선택 실패를 `missing-coverage` 로 승격. 예전 계약은
+  선택적이다.
+- `--scorecard` 단독 허용. 새 계약이다. 이슈는 새 CLI 금지.
+
+열린 PR 파일 대조: certify.py / report.py / test_gym_certify.py /
+test_gym_report.py / gym/docs/certify_report.md /
+mydocs/working/gym_certify_report.md 는 5210–5274 에 없었다.
+
+## 7. 검증 로그
+
+작업 트리 `C:\Users\swsz9\rhwp-gym-certify-report` 에서 실행했다.
+
+```text
+python -m unittest scripts.tests.test_gym_report scripts.tests.test_gym_certify
+# Ran 151 tests in 0.280s  OK
+
+python gym/tools/audit.py
+# gym 정합 감사: 18 pack 전부 통과 — 위반 0
+
+cargo fmt --all -- --check
+# exit 0 (변경 .rs 없음. sparse 트리에 crates/ 를 보탠 뒤 통과)
+
+git diff --shortstat upstream/devel
+# 추적 4파일 + 신규 문서 2파일. insertions >= 3000
+```
+
+- unittest 151건 OK. 예전 성공 칸 10건 + 예외 칸.
+- audit: pack 정합 위반 0. pack JSON 을 안 만졌으므로.
+- rustfmt HARD GATE: `cargo fmt --all -- --check` 통과. 변경된 `.rs`
+  는 없어 별도 rustfmt 대상이 없었다.
+- size gate: 문서 포함 insertions >= 3000.
+
+## 8. PR
+
+- base: `devel`
+- title: `feat(gym): certify/report 채점 산출 예외·문서·시험 강화 (#5275)`
+- body: 한글, `--body-file`, `closes #5275`
+- 템플릿 칸: 변경 요약, 관련 이슈, 테스트, 성능.
+- `cargo fmt --all -- --check` 를 PR 전에 실행했다고 적는다.
+
+## 9. 남긴 위험 · 후속
+
+1. `--bin` 실주행은 이 작업의 unittest 가 아니다. score.py /
+   build_baseline 의 라이브 오라클은 #5260 · #5273 자리. 여기서는
+   산출 부재·깨진 JSON 을 목킹으로만 고정한다.
+2. 이미 발급된 인증서 JSON 에는 `exceptions` 칸이 없다. verify 는
+   그 칸을 core 에 넣지 않으므로 예전 인증서도 재현된다. 미가용
+   집합 대조는 report.packsUnavailable 만 본다. 예전 리포트에 그
+   칸이 있으면 그대로 비교된다.
+3. 리포트 `trusted=false` 를 리더보드가 아직 읽지 않는다. 이 작업이
+   리더보드를 건드리지 않는다. 후속이 읽으면 구조 예외 있는 카드를
+   입장에서 걸 수 있다.
+4. 지문에 `gym/docs/certify_report.md` 를 넣지 않았다. 문서를 고칠
+   때마다 모든 인증서가 무효가 되는 것을 피한다.
+5. Windows 에서 디렉터리 `json.load` 는 PermissionError 일 수 있다.
+   `load_text` 가 isdir 을 먼저 봐 malformed-* 로 접는다.
+
+## 10. 파일 목록
+
+| 경로 | 역할 |
+|---|---|
+| `gym/report.py` | 리포트 합성 + 예외 적재 |
+| `gym/certify.py` | 인증서 발급/재현 + 예외 적재 |
+| `scripts/tests/test_gym_report.py` | 리포트 계약 |
+| `scripts/tests/test_gym_certify.py` | 인증서 계약 |
+| `gym/docs/certify_report.md` | 규약 정본 |
+| `mydocs/working/gym_certify_report.md` | 이 기록 |
+
+`git add -A` 를 쓰지 않는다. 위 여섯 경로만 스테이징한다.

--- a/scripts/tests/test_gym_certify.py
+++ b/scripts/tests/test_gym_certify.py
@@ -3,20 +3,27 @@
 핵심: 인증서는 '재현 = 증명'이다. 벤치마크 지문(전 pack 정의 sha256)이 결정적이고,
 재현 core(지문·바이너리 신원·정확도·커버리지·축)가 인증 시점과 하나라도 다르면
 위조로 판정한다. 바이너리 없이 순수 로직만 시험한다(재현은 _run_report 를 목킹).
+
+예외 칸(#5275): 없는 스코어카드, 깨진 JSON, 미가용 pack 은 스택이 아니라
+kind 로 남긴다. 새 CLI 플래그는 없다. 예전 성공 칸의 문구는 그대로다.
 """
 
 from __future__ import annotations
 
 import copy
 import importlib.util
+import io
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL = REPO_ROOT / "gym" / "certify.py"
+DOCS = REPO_ROOT / "gym" / "docs" / "certify_report.md"
 
 
 def load():
@@ -36,6 +43,15 @@ FIXED_REPORT = {
     "axisProfile": [{"axis": "편집", "score": 37, "max": 37, "percent": 100}],
     "packsScored": 13,
 }
+
+
+def _write(path, payload):
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        if isinstance(payload, str):
+            fh.write(payload)
+        else:
+            json.dump(payload, fh, ensure_ascii=False)
 
 
 class CertifyTests(unittest.TestCase):
@@ -111,6 +127,537 @@ class CertifyTests(unittest.TestCase):
         ok, diffs = cov.verify(cert, "anybin")
         self.assertFalse(ok)
         self.assertTrue(any("벤치마크 지문" in d for d in diffs))
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_exception_kinds_are_unique_and_documented(self):
+        kinds = self.m.EXCEPTION_KINDS
+        self.assertEqual(len(kinds), len(set(kinds)))
+        for kind in kinds:
+            self.assertIn(kind, self.m.EXCEPTION_KIND_HELP)
+            self.assertTrue(self.m.EXCEPTION_KIND_HELP[kind])
+            self.assertTrue(self.m.is_known_exception_kind(kind))
+            self.assertTrue(self.m.describe_exception_kind(kind))
+
+    def test_docs_backtick_every_exception_kind(self):
+        text = DOCS.read_text(encoding="utf-8")
+        for kind in self.m.EXCEPTION_KINDS:
+            self.assertIn(f"`{kind}`", text, msg=kind)
+
+    def test_docs_mentions_cert_and_report_kinds(self):
+        text = DOCS.read_text(encoding="utf-8")
+        self.assertIn("`gymCapabilityCertificate`", text)
+        self.assertIn("`gymCapabilityReport`", text)
+
+    def test_cli_flags_unchanged(self):
+        names = self.m.cli_flag_names()
+        self.assertEqual(tuple(sorted(names)), tuple(sorted(self.m.CERT_CLI_FLAGS)))
+
+    def test_no_new_cli_flags(self):
+        self.assertNotIn("--json", self.m.CERT_CLI_FLAGS)
+        self.assertNotIn("--strict", self.m.CERT_CLI_FLAGS)
+        self.assertNotIn("--limit", self.m.CERT_CLI_FLAGS)
+
+    def test_reproducible_core_keys(self):
+        for key in ("benchmarkFingerprint", "capabilitiesSha256", "accuracy",
+                    "coverage", "axisProfile"):
+            self.assertIn(key, self.m.REPRODUCIBLE_CORE_KEYS)
+
+    def test_unknown_kind_not_known(self):
+        self.assertFalse(self.m.is_known_exception_kind(""))
+        self.assertFalse(self.m.is_known_exception_kind(None))
+        self.assertEqual(
+            self.m.describe_exception_kind("nope"),
+            self.m.EXCEPTION_KIND_HELP["unexpected"],
+        )
+
+
+class FingerprintHelperTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_empty_root_is_empty_fingerprint(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertTrue(self.m.fingerprint_is_empty(d))
+            self.assertEqual(self.m.fingerprint_entry_count(d), 0)
+            self.assertEqual(self.m.fingerprint_rel_paths(d), [])
+            self.assertEqual(len(self.m.benchmark_fingerprint(d)), 64)
+
+    def test_skips_pyc_and_pycache(self):
+        with tempfile.TemporaryDirectory() as d:
+            tools = os.path.join(d, "tools")
+            cache = os.path.join(tools, "__pycache__")
+            os.makedirs(cache)
+            Path(tools, "keep.py").write_text("print(1)\n", encoding="utf-8")
+            Path(tools, "skip.pyc").write_bytes(b"\x00\x01")
+            Path(cache, "keep.cpython-313.pyc").write_bytes(b"\x00")
+            paths = self.m.fingerprint_rel_paths(d)
+            self.assertEqual(paths, ["tools/keep.py"])
+
+    def test_includes_score_report_certify_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            for name in ("score.py", "report.py", "certify.py"):
+                Path(d, name).write_text(f"# {name}\n", encoding="utf-8")
+            paths = set(self.m.fingerprint_rel_paths(d))
+            self.assertEqual(paths, {"score.py", "report.py", "certify.py"})
+
+    def test_hash_same_bytes_different_relpath_differs(self):
+        a = self.m.hash_fingerprint_entries([("a.json", b"x")])
+        b = self.m.hash_fingerprint_entries([("b.json", b"x")])
+        self.assertNotEqual(a, b)
+
+    def test_should_skip_pyc_only(self):
+        self.assertTrue(self.m.should_skip_fingerprint_name("x.pyc"))
+        self.assertFalse(self.m.should_skip_fingerprint_name("x.py"))
+        self.assertFalse(self.m.should_skip_fingerprint_name("pack.json"))
+
+
+class LoadCertTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_missing_cert_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "no-cert.json")
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m.load_cert(path)
+            self.assertEqual(ctx.exception.kind, "missing-cert")
+
+    def test_empty_path_is_missing_cert(self):
+        with self.assertRaises(self.m.CertifyError) as ctx:
+            self.m.load_cert("")
+        self.assertEqual(ctx.exception.kind, "missing-cert")
+
+    def test_bad_json_cert(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bad.json")
+            _write(path, "{")
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m.load_cert(path)
+            self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_array_cert_is_malformed_cert(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "arr.json")
+            _write(path, [1, 2])
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m.load_cert(path)
+            self.assertEqual(ctx.exception.kind, "malformed-cert")
+
+    def test_empty_file_is_malformed_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "empty.json")
+            _write(path, "")
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m.load_cert(path)
+            self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_directory_is_malformed_cert(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m.load_cert(d)
+            self.assertEqual(ctx.exception.kind, "malformed-cert")
+
+    def test_valid_cert_loads(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "c.json")
+            _write(path, {"kind": "gymCapabilityCertificate", "report": {}})
+            data = self.m.load_cert(path)
+            self.assertEqual(data["kind"], "gymCapabilityCertificate")
+
+
+class ClassifyReportFailureTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_missing_scorecard_marker(self):
+        err = self.m.classify_report_failure(
+            2, "", "missing-scorecard: score.py 가 scorecard.json 을 남기지 않았다",
+        )
+        self.assertEqual(err.kind, "missing-scorecard")
+
+    def test_missing_scorecard_korean_phrase(self):
+        err = self.m.classify_report_failure(
+            2, "", "scorecard.json 파일이 없다",
+        )
+        self.assertEqual(err.kind, "missing-scorecard")
+
+    def test_malformed_json_marker(self):
+        err = self.m.classify_report_failure(2, "", "malformed-json: 파싱 실패")
+        self.assertEqual(err.kind, "malformed-json")
+
+    def test_generic_nonzero_is_report_tool_failed(self):
+        err = self.m.classify_report_failure(3, "", "하위 도구 실패: score.py")
+        self.assertEqual(err.kind, "report-tool-failed")
+
+    def test_permission_marker(self):
+        err = self.m.classify_report_failure(2, "", "permission: 권한 없음")
+        self.assertEqual(err.kind, "permission")
+
+    def test_load_report_json_rejects_array(self):
+        with self.assertRaises(self.m.CertifyError) as ctx:
+            self.m.load_report_json("[1]")
+        self.assertEqual(ctx.exception.kind, "malformed-report")
+
+    def test_load_report_json_rejects_bad_text(self):
+        with self.assertRaises(self.m.CertifyError) as ctx:
+            self.m.load_report_json("{")
+        self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_load_report_json_accepts_object(self):
+        data = self.m.load_report_json('{"kind":"gymCapabilityReport"}')
+        self.assertEqual(data["kind"], "gymCapabilityReport")
+
+    def test_run_report_empty_bin(self):
+        with self.assertRaises(self.m.CertifyError) as ctx:
+            self.m._run_report("")
+        self.assertEqual(ctx.exception.kind, "missing-bin")
+
+    def test_run_report_classifies_missing_scorecard(self):
+        fake = mock.Mock()
+        fake.returncode = 2
+        fake.stdout = b""
+        fake.stderr = "missing-scorecard: 없다".encode("utf-8")
+        with mock.patch.object(self.m.subprocess, "run", return_value=fake):
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m._run_report("bin")
+        self.assertEqual(ctx.exception.kind, "missing-scorecard")
+
+    def test_run_report_empty_stdout_is_malformed_report(self):
+        fake = mock.Mock()
+        fake.returncode = 0
+        fake.stdout = b"  "
+        fake.stderr = b""
+        with mock.patch.object(self.m.subprocess, "run", return_value=fake):
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m._run_report("bin")
+        self.assertEqual(ctx.exception.kind, "malformed-report")
+
+    def test_run_report_bad_stdout_json(self):
+        fake = mock.Mock()
+        fake.returncode = 0
+        fake.stdout = b"not-json"
+        fake.stderr = b""
+        with mock.patch.object(self.m.subprocess, "run", return_value=fake):
+            with self.assertRaises(self.m.CertifyError) as ctx:
+                self.m._run_report("bin")
+        self.assertEqual(ctx.exception.kind, "malformed-json")
+
+
+class UnavailablePackCertTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_extract_unavailable(self):
+        report = {**FIXED_REPORT, "packsUnavailable": ["sec", "xc"]}
+        self.assertEqual(self.m.extract_unavailable(report), ["sec", "xc"])
+        self.assertEqual(self.m.extract_unavailable({}), [])
+        self.assertEqual(self.m.extract_unavailable(None), [])
+        self.assertEqual(self.m.extract_unavailable({"packsUnavailable": "x"}), [])
+
+    def test_certify_attaches_unavailable_exceptions(self):
+        report = {**copy.deepcopy(FIXED_REPORT), "packsUnavailable": ["d"]}
+        self.m._run_report = lambda bin_path: report
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        self.m.fingerprint_is_empty = lambda root: False
+        cert = self.m.certify("bin")
+        self.assertEqual(cert["unavailablePacks"], ["d"])
+        kinds = [e["kind"] for e in cert["exceptions"]]
+        self.assertIn("unavailable-pack", kinds)
+        self.assertTrue(cert["trusted"])
+        self.assertEqual(cert["kind"], self.m.CERT_KIND)
+        self.assertEqual(cert["proof"], self.m.PROOF_TEXT)
+
+    def test_verify_detects_unavailable_set_change(self):
+        claimed_report = {**copy.deepcopy(FIXED_REPORT), "packsUnavailable": ["d"]}
+        fresh_report = {**copy.deepcopy(FIXED_REPORT), "packsUnavailable": ["e"]}
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        self.m._run_report = lambda bin_path: copy.deepcopy(fresh_report)
+        cert = {"kind": self.m.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": claimed_report}
+        ok, diffs = self.m.verify(cert, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("미가용 pack" in d for d in diffs))
+
+    def test_verify_same_unavailable_passes(self):
+        report = {**copy.deepcopy(FIXED_REPORT), "packsUnavailable": ["d"]}
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        self.m._run_report = lambda bin_path: copy.deepcopy(report)
+        cert = {"kind": self.m.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(report)}
+        ok, diffs = self.m.verify(cert, "bin")
+        self.assertTrue(ok, diffs)
+
+    def test_certified_at_is_not_in_core(self):
+        self.m._run_report = lambda bin_path: copy.deepcopy(FIXED_REPORT)
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        self.m.fingerprint_is_empty = lambda root: False
+        cert = self.m.certify("bin", measured_at="2026-08-18")
+        self.assertEqual(cert["certifiedAt"], "2026-08-18")
+        core = self.m.reproducible_core(cert["report"], cert["benchmarkFingerprint"])
+        self.assertNotIn("certifiedAt", core)
+
+
+class VerifyDefensiveTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_verify_wrong_kind_keeps_legacy_message(self):
+        ok, diffs = self.m.verify({"kind": "other", "report": {}}, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("kind 가" in d for d in diffs))
+
+    def test_verify_non_object_cert(self):
+        ok, diffs = self.m.verify([1, 2], "bin")  # type: ignore[arg-type]
+        self.assertFalse(ok)
+        self.assertTrue(any("객체가 아니다" in d for d in diffs))
+
+    def test_verify_missing_report(self):
+        ok, diffs = self.m.verify({"kind": self.m.CERT_KIND}, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("report" in d for d in diffs))
+
+    def test_verify_report_not_object(self):
+        ok, diffs = self.m.verify(
+            {"kind": self.m.CERT_KIND, "report": [1], "benchmarkFingerprint": "FP"},
+            "bin",
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("report" in d for d in diffs))
+
+    def test_verify_report_error_becomes_false(self):
+        def boom(_bin):
+            raise self.m.CertifyError("missing-scorecard", "없다")
+
+        self.m._run_report = boom
+        cert = {"kind": self.m.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        ok, diffs = self.m.verify(cert, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("missing-scorecard" in d for d in diffs))
+
+    def test_verify_detects_binary_identity_change(self):
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        fresh = copy.deepcopy(FIXED_REPORT)
+        fresh["runner"]["capabilitiesSha256"] = "d" * 64
+        self.m._run_report = lambda bin_path: fresh
+        cert = {"kind": self.m.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        ok, diffs = self.m.verify(cert, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("capabilitiesSha256" in d for d in diffs))
+
+    def test_verify_detects_coverage_change(self):
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        fresh = copy.deepcopy(FIXED_REPORT)
+        fresh["coverage"]["percent"] = 1
+        self.m._run_report = lambda bin_path: fresh
+        cert = {"kind": self.m.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        ok, diffs = self.m.verify(cert, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("커버리지" in d for d in diffs))
+
+    def test_verify_detects_axis_change(self):
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        fresh = copy.deepcopy(FIXED_REPORT)
+        fresh["axisProfile"] = []
+        self.m._run_report = lambda bin_path: fresh
+        cert = {"kind": self.m.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        ok, diffs = self.m.verify(cert, "bin")
+        self.assertFalse(ok)
+        self.assertTrue(any("축별" in d for d in diffs))
+
+    def test_reproducible_core_accepts_none_report(self):
+        core = self.m.reproducible_core(None, "FP")  # type: ignore[arg-type]
+        self.assertEqual(core["benchmarkFingerprint"], "FP")
+        self.assertIsNone(core["capabilitiesSha256"])
+        self.assertEqual(core["coverage"], {
+            "percent": None, "covered": None, "agentFacingTotal": None,
+        })
+
+    def test_validate_cert_empty_fingerprint(self):
+        diffs = self.m.validate_cert({
+            "kind": self.m.CERT_KIND,
+            "report": {},
+            "benchmarkFingerprint": "",
+        })
+        self.assertTrue(any("benchmarkFingerprint" in d for d in diffs))
+
+
+class MainCliTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_main_verify_missing_cert_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--bin", "b", "--verify", os.path.join(d, "no.json")])
+            self.assertEqual(code, 2)
+            self.assertIn("missing-cert", buf.getvalue())
+
+    def test_main_verify_bad_json_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bad.json")
+            _write(path, "{")
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--bin", "b", "--verify", path])
+            self.assertEqual(code, 2)
+            self.assertIn("malformed-json", buf.getvalue())
+
+    def test_main_verify_array_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "arr.json")
+            _write(path, [1])
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--bin", "b", "--verify", path])
+            self.assertEqual(code, 2)
+            self.assertIn("malformed-cert", buf.getvalue())
+
+    def test_main_verify_wrong_kind_exit_1(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "c.json")
+            _write(path, {"kind": "nope", "report": {}})
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stdout", buf):
+                code = self.m.main(["--bin", "b", "--verify", path])
+            self.assertEqual(code, 1)
+            self.assertIn("kind 가", buf.getvalue())
+
+    def test_main_verify_pass(self):
+        self.m.benchmark_fingerprint = lambda root: "FP"
+        self.m._run_report = lambda bin_path: copy.deepcopy(FIXED_REPORT)
+        # Rebind on the already-loaded module used by main via import? main is on self.m
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "c.json")
+            _write(path, {
+                "kind": self.m.CERT_KIND,
+                "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT),
+            })
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stdout", buf):
+                code = self.m.main(["--bin", "b", "--verify", path])
+            self.assertEqual(code, 0, buf.getvalue())
+            self.assertIn("통과", buf.getvalue())
+
+    def test_main_issue_stdout_json(self):
+        self.m._run_report = lambda bin_path: copy.deepcopy(FIXED_REPORT)
+        self.m.benchmark_fingerprint = lambda root: "a" * 64
+        self.m.fingerprint_is_empty = lambda root: False
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdout", buf):
+            code = self.m.main(["--bin", "b"])
+        self.assertEqual(code, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["kind"], self.m.CERT_KIND)
+        self.assertEqual(payload["report"]["accuracy"]["percent"], 100)
+
+    def test_main_issue_out_file(self):
+        self.m._run_report = lambda bin_path: {
+            **copy.deepcopy(FIXED_REPORT), "packsUnavailable": ["d"],
+        }
+        self.m.benchmark_fingerprint = lambda root: "b" * 64
+        self.m.fingerprint_is_empty = lambda root: False
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "cert.json")
+            code = self.m.main(["--bin", "b", "--out", out, "--at", "now"])
+            self.assertEqual(code, 0)
+            payload = json.loads(Path(out).read_text(encoding="utf-8"))
+            self.assertEqual(payload["certifiedAt"], "now")
+            self.assertEqual(payload["unavailablePacks"], ["d"])
+
+    def test_main_issue_missing_scorecard_exit_2(self):
+        def boom(_bin):
+            raise self.m.CertifyError("missing-scorecard", "없다")
+
+        self.m._run_report = boom
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stderr", buf):
+            code = self.m.main(["--bin", "b"])
+        self.assertEqual(code, 2)
+        self.assertIn("missing-scorecard", buf.getvalue())
+
+    def test_dump_cert_json_newline(self):
+        text = self.m.dump_cert_json({"kind": self.m.CERT_KIND})
+        self.assertTrue(text.endswith("\n"))
+
+
+class FatalCatchableTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_fatal_not_catchable(self):
+        for exc in (KeyboardInterrupt(), SystemExit(1), MemoryError(), GeneratorExit()):
+            self.assertTrue(self.m.is_fatal_exception(exc))
+            self.assertFalse(self.m.is_catchable_exception(exc))
+
+    def test_certify_error_is_catchable(self):
+        self.assertTrue(self.m.is_catchable_exception(
+            self.m.CertifyError("missing-cert", "x"),
+        ))
+
+    def test_classify_os_error_roles(self):
+        self.assertEqual(
+            self.m.classify_os_error(FileNotFoundError("x"), role="cert"),
+            "missing-cert",
+        )
+        self.assertEqual(
+            self.m.classify_os_error(FileNotFoundError("x"), role="bin"),
+            "missing-bin",
+        )
+        self.assertEqual(
+            self.m.classify_os_error(json.JSONDecodeError("m", "d", 0), role="cert"),
+            "malformed-json",
+        )
+
+    def test_wrap_reraises_fatal(self):
+        with self.assertRaises(SystemExit):
+            self.m.wrap_exception(SystemExit(2))
+
+    def test_exception_record_pack(self):
+        rec = self.m.exception_record("unavailable-pack", "부재", pack="d")
+        self.assertEqual(rec["pack"], "d")
+        rec2 = self.m.exception_record("??", "x")
+        self.assertEqual(rec2["kind"], "unexpected")
+
+    def test_certify_error_unknown_kind(self):
+        err = self.m.CertifyError("nope", "x")
+        self.assertEqual(err.kind, "unexpected")
+
+
+class CompareHelperTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_compare_core_all_match(self):
+        core = {"benchmarkFingerprint": "a", "capabilitiesSha256": "b",
+                "accuracy": 1, "coverage": 2, "axisProfile": 3}
+        self.assertEqual(self.m.compare_core(core, core), [])
+
+    def test_compare_unavailable_order_independent(self):
+        self.assertEqual(self.m.compare_unavailable(["b", "a"], ["a", "b"]), [])
+        diffs = self.m.compare_unavailable(["a"], [])
+        self.assertEqual(len(diffs), 1)
+
+    def test_mapping_or_empty(self):
+        self.assertEqual(self.m.mapping_or_empty(None), {})
+        self.assertEqual(self.m.mapping_or_empty([1]), {})
+        self.assertEqual(self.m.mapping_or_empty({"a": 1}), {"a": 1})
+
+    def test_format_issue_summary(self):
+        cert = {"benchmarkFingerprint": "abcdef1234567890",
+                "report": {"accuracy": {"percent": 62}}}
+        text = self.m.format_issue_summary(cert)
+        self.assertIn("62%", text)
+        self.assertIn("abcdef123456", text)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_report.py
+++ b/scripts/tests/test_gym_report.py
@@ -3,15 +3,26 @@
 핵심 불변식: 정확도(측정된 것 통과율)와 커버리지(측정 폭)는 **다른 것**이라 뭉뚱
 그리지 않는다. 축별 프로파일은 pack 의 axis 라벨(괄호 앞 차원)로 점수를 합산한다.
 바이너리 없이 순수 합성만 시험한다.
+
+예외 칸(#5275): 없는 스코어카드, 깨진 JSON, 미가용 pack 은 스택이 아니라
+kind 로 남긴다. 새 CLI 플래그는 없다. 예전 성공 칸의 숫자·문구는 그대로다.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-TOOL = Path(__file__).resolve().parents[2] / "gym" / "report.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "report.py"
+DOCS = REPO_ROOT / "gym" / "docs" / "certify_report.md"
 
 
 def load():
@@ -39,6 +50,15 @@ COVERAGE = {
 }
 
 
+def _write(path, payload):
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        if isinstance(payload, str):
+            fh.write(payload)
+        else:
+            json.dump(payload, fh, ensure_ascii=False)
+
+
 class ReportTests(unittest.TestCase):
     def test_axis_profile_aggregates_by_label(self):
         r = load().compile_report(SCORECARD, COVERAGE)
@@ -63,6 +83,642 @@ class ReportTests(unittest.TestCase):
         card = load().render_card(cov)
         self.assertIn("정확도", card)
         self.assertNotIn("커버리지", card)  # coverage 없으면 그 줄을 뺀다
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_exception_kinds_are_unique_and_documented(self):
+        kinds = self.m.EXCEPTION_KINDS
+        self.assertEqual(len(kinds), len(set(kinds)))
+        for kind in kinds:
+            self.assertIn(kind, self.m.EXCEPTION_KIND_HELP)
+            self.assertTrue(self.m.EXCEPTION_KIND_HELP[kind])
+            self.assertTrue(self.m.is_known_exception_kind(kind))
+            self.assertTrue(self.m.describe_exception_kind(kind))
+
+    def test_docs_backtick_every_exception_kind(self):
+        text = DOCS.read_text(encoding="utf-8")
+        for kind in self.m.EXCEPTION_KINDS:
+            self.assertIn(f"`{kind}`", text, msg=kind)
+
+    def test_docs_backtick_every_pack_status(self):
+        text = DOCS.read_text(encoding="utf-8")
+        for status in self.m.PACK_STATUSES:
+            self.assertIn(f"`{status}`", text, msg=status)
+
+    def test_report_keys_cover_legacy_and_exception_slots(self):
+        for key in ("kind", "accuracy", "coverage", "axisProfile",
+                    "packsUnavailable", "exceptions", "trusted"):
+            self.assertIn(key, self.m.REPORT_KEYS)
+
+    def test_unknown_kind_is_not_known(self):
+        self.assertFalse(self.m.is_known_exception_kind("not-a-kind"))
+        self.assertFalse(self.m.is_known_exception_kind(None))
+        self.assertFalse(self.m.is_known_exception_kind(1))
+
+    def test_describe_unknown_falls_back_to_unexpected(self):
+        self.assertEqual(
+            self.m.describe_exception_kind("??"),
+            self.m.EXCEPTION_KIND_HELP["unexpected"],
+        )
+
+    def test_cli_flags_unchanged(self):
+        names = self.m.cli_flag_names()
+        self.assertEqual(tuple(sorted(names)), tuple(sorted(self.m.REPORT_CLI_FLAGS)))
+
+    def test_no_new_cli_flag_constants(self):
+        self.assertNotIn("--limit", self.m.REPORT_CLI_FLAGS)
+        self.assertNotIn("--task", self.m.REPORT_CLI_FLAGS)
+        self.assertNotIn("--timeout", self.m.REPORT_CLI_FLAGS)
+        self.assertNotIn("--strict", self.m.REPORT_CLI_FLAGS)
+
+
+class JsonShapeTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_is_json_object_rejects_bool_list_none(self):
+        self.assertTrue(self.m.is_json_object({"a": 1}))
+        self.assertFalse(self.m.is_json_object([]))
+        self.assertFalse(self.m.is_json_object("x"))
+        self.assertFalse(self.m.is_json_object(None))
+        self.assertFalse(self.m.is_json_object(True))
+
+    def test_is_json_array(self):
+        self.assertTrue(self.m.is_json_array([]))
+        self.assertTrue(self.m.is_json_array([1]))
+        self.assertFalse(self.m.is_json_array({}))
+
+    def test_as_int_rejects_bool_and_text(self):
+        self.assertEqual(self.m.as_int(3), 3)
+        self.assertEqual(self.m.as_int(True, 0), 0)
+        self.assertEqual(self.m.as_int("3", 0), 0)
+        self.assertEqual(self.m.as_int(4.0), 4)
+        self.assertEqual(self.m.as_int(4.5, 0), 0)
+        self.assertEqual(self.m.as_int(None, 7), 7)
+
+    def test_percent_of_zero_max_is_zero(self):
+        self.assertEqual(self.m.percent_of(0, 0), 0)
+        self.assertEqual(self.m.percent_of(5, 8), 62)
+        self.assertEqual(self.m.percent_of(8, 8), 100)
+
+    def test_axis_label_edges(self):
+        self.assertEqual(self.m.axis_label("편집 (표)"), "편집")
+        self.assertEqual(self.m.axis_label(""), "미분류")
+        self.assertEqual(self.m.axis_label(None), "미분류")
+        self.assertEqual(self.m.axis_label("   "), "미분류")
+        self.assertEqual(self.m.axis_label("조사"), "조사")
+
+    def test_pack_status_helpers(self):
+        scored = {"id": "a", "status": "scored"}
+        missing = {"id": "b", "status": "unavailable"}
+        errored = {"id": "c", "status": "error"}
+        self.assertTrue(self.m.is_scored_pack(scored))
+        self.assertTrue(self.m.is_unavailable_pack(missing))
+        self.assertTrue(self.m.is_error_pack(errored))
+        self.assertFalse(self.m.is_scored_pack("nope"))
+        self.assertFalse(self.m.is_unavailable_pack({"status": "other"}))
+        self.assertEqual(self.m.pack_id_of({}), "?")
+        self.assertEqual(self.m.pack_id_of({"id": "  "}), "?")
+        self.assertEqual(self.m.pack_id_of({"id": "tb"}), "tb")
+
+
+class ExceptionRecordTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_exception_record_omits_empty_slots(self):
+        rec = self.m.exception_record("missing-scorecard", "없다")
+        self.assertEqual(rec["kind"], "missing-scorecard")
+        self.assertEqual(rec["message"], "없다")
+        self.assertNotIn("path", rec)
+        self.assertNotIn("pack", rec)
+
+    def test_exception_record_keeps_pack_and_path(self):
+        rec = self.m.exception_record(
+            "unavailable-pack", "부재", pack="d", path="sc.json", where="packs",
+        )
+        self.assertEqual(rec["pack"], "d")
+        self.assertEqual(rec["path"], "sc.json")
+        self.assertEqual(rec["where"], "packs")
+
+    def test_unknown_kind_coerced_to_unexpected(self):
+        rec = self.m.exception_record("???", "x")
+        self.assertEqual(rec["kind"], "unexpected")
+
+    def test_report_error_as_record(self):
+        err = self.m.ReportError("missing-scorecard", "없음", path="a.json")
+        rec = err.as_record()
+        self.assertEqual(rec["kind"], "missing-scorecard")
+        self.assertEqual(rec["path"], "a.json")
+
+    def test_report_error_unknown_kind_becomes_unexpected(self):
+        err = self.m.ReportError("not-real", "x")
+        self.assertEqual(err.kind, "unexpected")
+
+    def test_informational_kinds_do_not_untrust(self):
+        notes = [
+            self.m.exception_record("unavailable-pack", "부재", pack="d"),
+            self.m.exception_record("empty-total", "0"),
+        ]
+        self.assertEqual(self.m.structural_exceptions(notes), [])
+        notes.append(self.m.exception_record("malformed-json", "깨짐"))
+        self.assertEqual(len(self.m.structural_exceptions(notes)), 1)
+
+
+class FatalCatchableTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_fatal_exceptions_are_not_catchable(self):
+        for exc in (KeyboardInterrupt(), SystemExit(2), MemoryError(), GeneratorExit()):
+            self.assertTrue(self.m.is_fatal_exception(exc))
+            self.assertFalse(self.m.is_catchable_exception(exc))
+
+    def test_os_and_json_are_catchable(self):
+        self.assertTrue(self.m.is_catchable_exception(FileNotFoundError("x")))
+        self.assertTrue(self.m.is_catchable_exception(json.JSONDecodeError("m", "d", 0)))
+        self.assertTrue(self.m.is_catchable_exception(self.m.ReportError("os-error", "e")))
+
+    def test_classify_os_error_by_role(self):
+        self.assertEqual(
+            self.m.classify_os_error(FileNotFoundError("x"), role="scorecard"),
+            "missing-scorecard",
+        )
+        self.assertEqual(
+            self.m.classify_os_error(FileNotFoundError("x"), role="coverage"),
+            "missing-coverage",
+        )
+        self.assertEqual(
+            self.m.classify_os_error(FileNotFoundError("x"), role="bin"),
+            "missing-bin",
+        )
+        self.assertEqual(
+            self.m.classify_os_error(PermissionError("x"), role="scorecard"),
+            "permission",
+        )
+        self.assertEqual(
+            self.m.classify_os_error(json.JSONDecodeError("m", "d", 0), role="scorecard"),
+            "malformed-json",
+        )
+
+    def test_wrap_exception_reraises_fatal(self):
+        with self.assertRaises(KeyboardInterrupt):
+            self.m.wrap_exception(KeyboardInterrupt(), role="scorecard")
+
+    def test_wrap_exception_preserves_report_error(self):
+        err = self.m.ReportError("missing-scorecard", "없음")
+        self.assertIs(self.m.wrap_exception(err), err)
+
+
+class LoadJsonTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_missing_scorecard_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "no-such.json")
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="scorecard")
+            self.assertEqual(ctx.exception.kind, "missing-scorecard")
+
+    def test_missing_coverage_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "no-cov.json")
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="coverage")
+            self.assertEqual(ctx.exception.kind, "missing-coverage")
+
+    def test_empty_path_is_missing(self):
+        with self.assertRaises(self.m.ReportError) as ctx:
+            self.m.load_json_object("", role="scorecard")
+        self.assertEqual(ctx.exception.kind, "missing-scorecard")
+        with self.assertRaises(self.m.ReportError) as ctx:
+            self.m.load_json_object("   ", role="coverage")
+        self.assertEqual(ctx.exception.kind, "missing-coverage")
+
+    def test_bad_json_scorecard(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bad.json")
+            _write(path, "{not json")
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="scorecard")
+            self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_empty_file_is_malformed_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "empty.json")
+            _write(path, "")
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="scorecard")
+            self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_array_scorecard_is_malformed_scorecard(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "arr.json")
+            _write(path, [1, 2, 3])
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="scorecard")
+            self.assertEqual(ctx.exception.kind, "malformed-scorecard")
+
+    def test_array_coverage_is_malformed_coverage(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "arr.json")
+            _write(path, ["x"])
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="coverage")
+            self.assertEqual(ctx.exception.kind, "malformed-coverage")
+
+    def test_scalar_json_is_malformed(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "n.json")
+            _write(path, "4")
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(path, role="scorecard")
+            self.assertEqual(ctx.exception.kind, "malformed-scorecard")
+
+    def test_directory_path_is_malformed_role(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(self.m.ReportError) as ctx:
+                self.m.load_json_object(d, role="scorecard")
+            self.assertEqual(ctx.exception.kind, "malformed-scorecard")
+
+    def test_valid_object_roundtrip(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "ok.json")
+            _write(path, {"agent": "x", "packs": []})
+            data = self.m.load_json_object(path, role="scorecard")
+            self.assertEqual(data["agent"], "x")
+
+    def test_parse_json_text_none(self):
+        with self.assertRaises(self.m.ReportError) as ctx:
+            self.m.parse_json_text(None, role="scorecard")
+        self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_trailing_comma_is_malformed_json(self):
+        with self.assertRaises(self.m.ReportError) as ctx:
+            self.m.parse_json_text('{"a": 1,}', role="scorecard")
+        self.assertEqual(ctx.exception.kind, "malformed-json")
+
+
+class CompileReportExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_unavailable_pack_recorded_as_exception_and_list(self):
+        r = self.m.compile_report(SCORECARD, COVERAGE)
+        kinds = [e["kind"] for e in r["exceptions"]]
+        self.assertIn("unavailable-pack", kinds)
+        self.assertIn("d", r["packsUnavailable"])
+        self.assertTrue(r["trusted"], r["exceptions"])
+        pack_ids = [e.get("pack") for e in r["exceptions"] if e["kind"] == "unavailable-pack"]
+        self.assertEqual(pack_ids, ["d"])
+
+    def test_unavailable_does_not_change_accuracy_math(self):
+        r = self.m.compile_report(SCORECARD, COVERAGE)
+        self.assertEqual(r["accuracy"], {"score": 5, "max": 8, "percent": 62})
+        self.assertEqual(r["packsScored"], 3)
+
+    def test_missing_scorecard_object_does_not_raise(self):
+        r = self.m.compile_report(None, {})  # type: ignore[arg-type]
+        self.assertEqual(r["kind"], self.m.REPORT_KIND)
+        kinds = [e["kind"] for e in r["exceptions"]]
+        self.assertIn("malformed-scorecard", kinds)
+        self.assertFalse(r["trusted"])
+        self.assertEqual(r["accuracy"]["percent"], 0)
+        self.assertEqual(r["axisProfile"], [])
+
+    def test_array_scorecard_does_not_raise(self):
+        r = self.m.compile_report([1, 2], {})  # type: ignore[arg-type]
+        self.assertIn("malformed-scorecard", [e["kind"] for e in r["exceptions"]])
+        self.assertEqual(r["packsUnavailable"], [])
+
+    def test_empty_packs_note(self):
+        card = {"agent": "x", "total": {"score": 0, "max": 0, "packsScored": 0}, "packs": []}
+        r = self.m.compile_report(card, {})
+        kinds = [e["kind"] for e in r["exceptions"]]
+        self.assertIn("empty-packs", kinds)
+        self.assertIn("empty-total", kinds)
+        self.assertTrue(r["trusted"])
+
+    def test_missing_packs_key(self):
+        r = self.m.compile_report({"total": {"score": 1, "max": 1, "packsScored": 1}}, {})
+        self.assertIn("empty-packs", [e["kind"] for e in r["exceptions"]])
+
+    def test_packs_not_a_list(self):
+        r = self.m.compile_report({"packs": {"id": "a"}, "total": {"score": 1, "max": 1}}, {})
+        self.assertTrue(any(e["kind"] == "malformed-scorecard" for e in r["exceptions"]))
+        self.assertEqual(r["axisProfile"], [])
+
+    def test_malformed_pack_row_skipped(self):
+        card = {
+            "total": {"score": 3, "max": 3, "packsScored": 1},
+            "packs": [
+                "broken",
+                {"id": "ok", "axis": "편집", "score": 3, "max": 3, "status": "scored"},
+            ],
+        }
+        r = self.m.compile_report(card, {})
+        self.assertIn("malformed-pack-row", [e["kind"] for e in r["exceptions"]])
+        self.assertEqual(r["axisProfile"][0]["score"], 3)
+        self.assertFalse(r["trusted"])
+
+    def test_error_pack_listed_separately_from_unavailable(self):
+        card = {
+            "total": {"score": 1, "max": 1, "packsScored": 1},
+            "packs": [
+                {"id": "ok", "axis": "조사", "score": 1, "max": 1, "status": "scored"},
+                {"id": "gone", "axis": "보안", "status": "unavailable"},
+                {"id": "boom", "axis": "변환", "status": "error"},
+            ],
+        }
+        r = self.m.compile_report(card, {})
+        self.assertEqual(r["packsUnavailable"], ["gone"])
+        self.assertEqual(r["packsErrored"], ["boom"])
+        self.assertEqual([a["axis"] for a in r["axisProfile"]], ["조사"])
+
+    def test_array_coverage_note(self):
+        r = self.m.compile_report(SCORECARD, ["nope"])  # type: ignore[arg-type]
+        self.assertIn("malformed-coverage", [e["kind"] for e in r["exceptions"]])
+        self.assertIsNone(r["coverage"]["percent"])
+
+    def test_bool_score_does_not_inflate_axis(self):
+        card = {
+            "total": {"score": 0, "max": 1, "packsScored": 1},
+            "packs": [
+                {"id": "t", "axis": "편집", "score": True, "max": True, "status": "scored"},
+            ],
+        }
+        r = self.m.compile_report(card, {})
+        self.assertEqual(r["axisProfile"][0]["score"], 0)
+        self.assertEqual(r["axisProfile"][0]["max"], 0)
+
+    def test_compile_report_has_all_report_keys(self):
+        r = self.m.compile_report(SCORECARD, COVERAGE)
+        for key in self.m.REPORT_KEYS:
+            self.assertIn(key, r, msg=key)
+
+    def test_multiple_unavailable_packs(self):
+        card = {
+            "total": {"score": 0, "max": 0, "packsScored": 0},
+            "packs": [
+                {"id": "u1", "status": "unavailable"},
+                {"id": "u2", "status": "unavailable"},
+            ],
+        }
+        r = self.m.compile_report(card, {})
+        self.assertEqual(r["packsUnavailable"], ["u1", "u2"])
+        unavail = [e for e in r["exceptions"] if e["kind"] == "unavailable-pack"]
+        self.assertEqual(len(unavail), 2)
+
+
+class RenderCardExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_card_lists_unavailable_and_exception_kind(self):
+        r = self.m.compile_report(SCORECARD, COVERAGE)
+        card = self.m.render_card(r)
+        self.assertIn("미가용 pack", card)
+        self.assertIn("`unavailable-pack`", card)
+        self.assertIn("예외 경로", card)
+        self.assertIn("정확도", card)
+        self.assertIn("커버리지", card)
+
+    def test_card_without_exceptions_has_no_exception_heading(self):
+        card_in = {
+            "agent": "x",
+            "total": {"score": 1, "max": 1, "packsScored": 1},
+            "packs": [{"id": "a", "axis": "조사", "score": 1, "max": 1, "status": "scored"}],
+        }
+        r = self.m.compile_report(card_in, {})
+        text = self.m.render_card(r)
+        self.assertNotIn("예외 경로", text)
+        self.assertNotIn("커버리지", text)
+
+    def test_render_card_accepts_non_object(self):
+        text = self.m.render_card(None)  # type: ignore[arg-type]
+        self.assertIn("정확도", text)
+        self.assertTrue(text.endswith("\n"))
+
+    def test_untrusted_card_mentions_trust(self):
+        r = self.m.compile_report([1], {})  # type: ignore[arg-type]
+        text = self.m.render_card(r)
+        self.assertIn("신뢰", text)
+
+    def test_error_pack_line_on_card(self):
+        card = {
+            "total": {"score": 0, "max": 0, "packsScored": 0},
+            "packs": [{"id": "boom", "status": "error"}],
+        }
+        text = self.m.render_card(self.m.compile_report(card, {}))
+        self.assertIn("오류 pack", text)
+        self.assertIn("boom", text)
+
+
+class MainCliTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_main_missing_args_exit_2(self):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stderr", buf):
+            code = self.m.main([])
+        self.assertEqual(code, 2)
+        self.assertIn("필수", buf.getvalue())
+
+    def test_main_missing_scorecard_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            cov = os.path.join(d, "cov.json")
+            _write(cov, COVERAGE)
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--scorecard", os.path.join(d, "no.json"),
+                                    "--coverage", cov])
+            self.assertEqual(code, 2)
+            self.assertIn("missing-scorecard", buf.getvalue())
+
+    def test_main_missing_coverage_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "sc.json")
+            _write(sc, SCORECARD)
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--scorecard", sc,
+                                    "--coverage", os.path.join(d, "no.json")])
+            self.assertEqual(code, 2)
+            self.assertIn("missing-coverage", buf.getvalue())
+
+    def test_main_bad_json_scorecard_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "sc.json")
+            cov = os.path.join(d, "cov.json")
+            _write(sc, "{")
+            _write(cov, COVERAGE)
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--scorecard", sc, "--coverage", cov])
+            self.assertEqual(code, 2)
+            self.assertIn("malformed-json", buf.getvalue())
+
+    def test_main_array_scorecard_exit_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "sc.json")
+            cov = os.path.join(d, "cov.json")
+            _write(sc, [1])
+            _write(cov, COVERAGE)
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--scorecard", sc, "--coverage", cov])
+            self.assertEqual(code, 2)
+            self.assertIn("malformed-scorecard", buf.getvalue())
+
+    def test_main_success_json_stdout(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "sc.json")
+            cov = os.path.join(d, "cov.json")
+            _write(sc, SCORECARD)
+            _write(cov, COVERAGE)
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stdout", buf):
+                code = self.m.main(["--scorecard", sc, "--coverage", cov, "--json"])
+            self.assertEqual(code, 0)
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload["kind"], "gymCapabilityReport")
+            self.assertEqual(payload["accuracy"]["percent"], 62)
+            self.assertIn("d", payload["packsUnavailable"])
+            self.assertTrue(any(e["kind"] == "unavailable-pack" for e in payload["exceptions"]))
+
+    def test_main_success_out_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "sc.json")
+            cov = os.path.join(d, "cov.json")
+            out = os.path.join(d, "card.md")
+            _write(sc, SCORECARD)
+            _write(cov, COVERAGE)
+            code = self.m.main(["--scorecard", sc, "--coverage", cov, "--out", out])
+            self.assertEqual(code, 0)
+            text = Path(out).read_text(encoding="utf-8")
+            self.assertIn("정확도", text)
+            self.assertIn("`unavailable-pack`", text)
+
+    def test_main_scorecard_without_coverage_still_usage(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "sc.json")
+            _write(sc, SCORECARD)
+            buf = io.StringIO()
+            with mock.patch.object(sys, "stderr", buf):
+                code = self.m.main(["--scorecard", sc])
+            self.assertEqual(code, 2)
+            self.assertIn("필수", buf.getvalue())
+
+    def test_main_empty_bin_is_missing_bin(self):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stderr", buf):
+            code = self.m.main(["--bin", "   "])
+        self.assertEqual(code, 2)
+        self.assertIn("missing-bin", buf.getvalue())
+
+    def test_write_text_creates_parent(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "nested", "out.md")
+            self.m.write_text(path, "hello\n")
+            self.assertEqual(Path(path).read_text(encoding="utf-8"), "hello\n")
+
+    def test_dump_report_json_trailing_newline(self):
+        r = self.m.compile_report(SCORECARD, COVERAGE)
+        text = self.m.dump_report_json(r)
+        self.assertTrue(text.endswith("\n"))
+        self.assertEqual(json.loads(text)["kind"], "gymCapabilityReport")
+
+
+class FromBinExceptionTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_from_bin_missing_scorecard_after_score(self):
+        def fake_run(_argv):
+            return None
+
+        with tempfile.TemporaryDirectory() as d:
+            self.m.HERE = d
+            with mock.patch.object(self.m, "_run", fake_run):
+                with self.assertRaises(self.m.ReportError) as ctx:
+                    self.m._from_bin("dummy-bin")
+            self.assertEqual(ctx.exception.kind, "missing-scorecard")
+
+    def test_from_bin_bad_scorecard_json(self):
+        def fake_run(_argv):
+            return None
+
+        with tempfile.TemporaryDirectory() as d:
+            sc_dir = os.path.join(d, "submissions", "_report")
+            os.makedirs(sc_dir)
+            _write(os.path.join(sc_dir, "scorecard.json"), "{")
+            self.m.HERE = d
+            with mock.patch.object(self.m, "_run", fake_run):
+                with self.assertRaises(self.m.ReportError) as ctx:
+                    self.m._from_bin("dummy-bin")
+            self.assertEqual(ctx.exception.kind, "malformed-json")
+
+    def test_run_nonzero_is_report_tool_failed(self):
+        fake = mock.Mock()
+        fake.returncode = 3
+        fake.stdout = b"out"
+        fake.stderr = b"err"
+        with mock.patch.object(self.m.subprocess, "run", return_value=fake):
+            with mock.patch.object(sys, "stderr", io.StringIO()):
+                with self.assertRaises(self.m.ReportError) as ctx:
+                    self.m._run([os.path.join("gym", "score.py")])
+        self.assertEqual(ctx.exception.kind, "report-tool-failed")
+
+
+class CollectPackTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_collect_helpers_ignore_non_objects(self):
+        card = {"packs": [None, "x", {"id": "u", "status": "unavailable"}]}
+        self.assertEqual(self.m.collect_unavailable_packs(card), ["u"])
+        self.assertEqual(self.m.collect_error_packs(card), [])
+        self.assertEqual(self.m.collect_scored_packs(card), [])
+
+    def test_collect_on_non_scorecard(self):
+        self.assertEqual(self.m.collect_unavailable_packs(None), [])
+        self.assertEqual(self.m.collect_error_packs("x"), [])
+        self.assertEqual(self.m.iter_pack_rows(None), [])
+
+    def test_validate_scorecard_total_not_object(self):
+        notes = self.m.validate_scorecard({"packs": [], "total": [1]})
+        kinds = [n["kind"] for n in notes]
+        self.assertIn("malformed-scorecard", kinds)
+
+    def test_coverage_none_is_ok(self):
+        self.assertEqual(self.m.validate_coverage(None), [])
+        self.assertEqual(self.m.validate_coverage({}), [])
+
+
+class RoleKindTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load()
+
+    def test_role_tables(self):
+        self.assertEqual(self.m.role_missing_kind("scorecard"), "missing-scorecard")
+        self.assertEqual(self.m.role_missing_kind("coverage"), "missing-coverage")
+        self.assertEqual(self.m.role_missing_kind("bin"), "missing-bin")
+        self.assertEqual(self.m.role_malformed_kind("scorecard"), "malformed-scorecard")
+        self.assertEqual(self.m.role_malformed_kind("coverage"), "malformed-coverage")
+
+    def test_scorecard_path_for_agent(self):
+        path = self.m.scorecard_path_for_agent("_report")
+        self.assertTrue(path.endswith(os.path.join("submissions", "_report", "scorecard.json"))
+                        or path.replace("\\", "/").endswith("submissions/_report/scorecard.json"))
+
+    def test_pack_status_help_covers_all(self):
+        for status in self.m.PACK_STATUSES:
+            self.assertTrue(self.m.PACK_STATUS_HELP[status])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

gym/report.py 와 gym/certify.py 의 채점 산출 성공 칸은 그대로 두고, 예전이 스택을 올리거나 한 줄로만 접던 예외 자리를 kind 로 남긴다. 새 CLI/pack 은 없다.

이슈 DoD 예외 세 자리:

- **없는 스코어카드** — missing-scorecard. --scorecard 경로 부재와 --bin 모드에서 scorecard.json 을 안 남긴 자리를 0점으로 합성하지 않는다. 인증서는 report.py 실패를 같은 kind 로 읽어 빈 인증서를 짓지 않는다.
- **깨진 JSON** — malformed-json / malformed-scorecard / malformed-coverage / malformed-cert / malformed-report. 잘린 객체·빈 파일·배열을 점수로 위장하지 않는다.
- **미가용 pack** — unavailable-pack. 축 합산에서 빼고 packsUnavailable 과 예외 칸에 같이 남긴다. 인증서는 그 집합을 재현 대조한다. 부재는 실패가 아니므로 리포트 종료 코드는 0 이다.

종료 코드도 예전과 같다. 리포트 0=합성 성공, 2=도구 실패. 인증서 0=발급/재현 통과, 1=재현 불일치, 2=도구 실패.

규범: gym/docs/certify_report.md. 작업 기록: mydocs/working/gym_certify_report.md.

score.py · 
unner.py · uild_baseline.py · expert-challenges · tutorial · PARK · 열린 PR 5210–5274 파일은 건드리지 않았다.

## 관련 이슈

closes #5275

## 테스트

- [x] python -m unittest scripts.tests.test_gym_report scripts.tests.test_gym_certify 통과 (151)
- [x] python gym/tools/audit.py 통과 (18 pack, 위반 0)
- [x] **cargo fmt --all -- --check 통과** — PR 생성 직전 실행, exit 0. 변경된 .rs 없음
- [ ] 
ode scripts/rust-test-suite-manifest.mjs --check — 해당 없음
- [ ] 
ode scripts/rust-unit-test-tiers.mjs --check — 해당 없음
- [ ] cargo test — 해당 없음 (Python·문서만)
- [ ] cargo clippy -- -D warnings — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음. 순수 합성·JSON 적재·재현 대조만 보강했다. 런타임 rhwp 경로는 불변.
- 재현·측정: 바이너리 없이 unittest 151건. 미측정(예외 경로 분류).
