### PR TITLE
gym: core schema 검증 예외·문서·시험 고도화

### DIFF
--- a/gym/core/schema.py
+++ b/gym/core/schema.py
@@ -1,4 +1,4 @@
-"""[#4653] pack·task 스키마와 재현성 선언.
+"""[#4653][#5279] pack·task·profile 스키마와 재현성 선언.
 
 ## pack manifest (`packs/<id>/pack.json`)
 
@@ -21,11 +21,43 @@
 
 `runner` 는 **기준 실행의 신원**이다. 점수는 바이너리마다 달라질 수 있으므로
 "이 점수가 어느 바이너리에서 났는가"를 pack 과 스코어카드 양쪽에 남긴다.
+
+## 검증 API (예전 계약)
+
+    validate_pack(manifest, pack_dir, errors)
+    validate_task(task, pack, known_commands, errors)
+    validate_profile(profile, pack_ids, errors)
+
+`errors` 는 문자열 목록이다. `audit.py` 와 `test_gym_packs` 가 그 줄을 소비한다.
+한 줄의 모양은 예전과 같다: `"<where>: <message>"`.
+
+#5279 가 더한 것:
+
+1. **객체가 아니면 죽지 않는다.** manifest·과제·프로파일·checks 항목·requires·
+   runner·submit 이 목록이나 문자열이면 AttributeError 대신 칸을 남긴다.
+2. **필수 키·공란·타입을 가른다.** `필수 키 없음` 은 키가 없을 때,
+   `가 비었다` 는 키가 있는데 값이 공란일 때, `객체가 아니다` 는 타입이
+   틀릴 때다. 예전에는 이 셋이 한 줄로 뭉개지거나 예외로 죽었다.
+3. **tier 는 진짜 정수다.** `bool` 은 `int` 의 하위형이라 `True` 가 1 로
+   통과했다. 이제 거부한다. 0·6·`"1"`·`1.0`·`None` 도 예전 메시지 그대로
+   거부한다.
+4. **미등록 연산자는 계속 거절한다.** `REGISTRY` 는 `checks.py` 가 소유한다.
+   이 모듈은 읽기만 한다. 키를 더하거나 빼지 않는다.
+5. **프로파일이 없는 pack 을 가리키면 `없는 pack 참조`.** 예전 메시지
+   그대로다. packs 가 문자열이거나 중복이거나 경로이면 추가로 칸을 남긴다.
+6. **구조화 칸(`IssueList`)은 선택이다.** 평범한 `list` 를 넘기면 예전처럼
+   문자열만 쌓인다. `IssueList` 를 넘기면 `kind` 도 남는다.
+
+새 CLI 는 없다. 새 연산자도 없다. pack JSON 도 바꾸지 않는다.
+정본 규약은 `gym/docs/schema.md`, 작업 기록은 `mydocs/working/gym_schema.md`.
 """
+
+from __future__ import annotations
 
 import hashlib
 import json
 import os
+import re
 import subprocess
 
 PACK_KIND = "gymPack"
@@ -34,6 +66,18 @@ SCHEMA_VERSION = "1.0"
 
 #: 과제 파일의 필수 키.
 TASK_REQUIRED = ("id", "tier", "title", "input", "instructions", "submit", "checks")
+
+#: pack manifest 의 필수 키. 값이 공란인지는 키마다 따로 본다.
+PACK_REQUIRED = ("schemaVersion", "kind", "id", "title", "axis", "requires", "runner")
+
+#: 프로파일의 필수 키.
+PROFILE_REQUIRED = ("schemaVersion", "kind", "id", "title", "packs")
+
+#: 기준 실행 신원 키. 길이와 hex 형태는 키마다 다르다.
+RUNNER_KEYS = ("rhwpVersion", "rhwpCommit", "capabilitiesSha256")
+
+#: 제출 종류. README 의 세 칸과 같다.
+SUBMIT_KINDS = ("answer", "artifact", "pair")
 
 #: 편집 과제 — 전역 훑기 연산자를 금지한다(#4600 재발 방지).
 EDITING_AXES = ("편집", "보안")
@@ -45,87 +89,729 @@ EDITING_AXES = ("편집", "보안")
 TIER_MIN, TIER_MAX = 1, 5
 TIER_NAMES = {1: "입문", 2: "초급", 3: "중급", 4: "고급", 5: "보스"}
 
+#: pack·task·profile id 가 경로가 되지 않게. `table-editing`, `TB01`, `T10` 허용.
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
-def _fail(errors, where, message):
+#: 예전 메시지 조각. 시험이 이 문자열을 고정한다 — 바꾸면 audit 소비자가 깨진다.
+MSG_PACK_KIND = f"kind 가 {PACK_KIND} 가 아니다"
+MSG_PACK_SCHEMA = f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다"
+MSG_REQUIRES_EMPTY = "requires.commands 가 비었다 — 요구 capability 선언은 필수"
+MSG_TIER = f"tier 는 {TIER_MIN}~{TIER_MAX} 정수 (1=입문 … 5=보스)"
+MSG_CHECKS_EMPTY = "checks 가 비었다"
+MSG_PROFILE_KIND = f"kind 가 {PROFILE_KIND} 가 아니다"
+MSG_PACKS_EMPTY = "packs 가 비었다"
+MSG_MISSING_KEY_PREFIX = "필수 키 없음: "
+MSG_UNKNOWN_OP_PREFIX = "미등록 연산자: "
+MSG_MISSING_PACK_PREFIX = "없는 pack 참조: "
+MSG_GLOBAL_SCAN_NEEDLE = "전역 훑기 연산자"
+MSG_CMD_NEEDED_SUFFIX = " 는 cmd 가 필요하다"
+MSG_CMD_UNEXPECTED_NEEDLE = "는 CLI 를 부르지 않는데 cmd 가 있다"
+MSG_UNKNOWN_COMMAND_PREFIX = "CLI 에 없는 명령: "
+MSG_RUNNER_EMPTY_NEEDLE = "가 비었다 — 기준 실행 신원 선언은 필수"
+MSG_PACK_ID_MISMATCH_NEEDLE = "가 폴더 이름과 다르다"
+
+#: 스키마 칸 kind 카탈로그. 문서·시험이 같은 표를 본다.
+SCHEMA_ISSUE_KINDS = (
+    "missing-key",
+    "empty-field",
+    "bad-type",
+    "bad-kind",
+    "bad-schema-version",
+    "bad-tier",
+    "bad-id",
+    "pack-id-mismatch",
+    "unknown-op",
+    "unknown-submit-kind",
+    "empty-checks",
+    "malformed-check",
+    "malformed-cmd",
+    "malformed-submit",
+    "malformed-requires",
+    "malformed-runner",
+    "malformed-object",
+    "missing-cmd",
+    "unexpected-cmd",
+    "unknown-command",
+    "global-scan-forbidden",
+    "profile-missing-pack",
+    "empty-packs",
+    "duplicate-pack",
+    "unsafe-id",
+    "bad-runner-identity",
+    "not-a-mapping",
+    "not-a-list",
+    "duplicate-check-name",
+    "empty-commands",
+    "unexpected",
+)
+
+SCHEMA_ISSUE_HELP = {
+    "missing-key": "필수 키가 객체에 없다",
+    "empty-field": "키는 있는데 값이 공란이거나 falsy 다",
+    "bad-type": "값의 파이썬 타입이 계약과 다르다",
+    "bad-kind": "kind 가 gymPack / gymProfile 이 아니다",
+    "bad-schema-version": "schemaVersion 이 1.0 이 아니다",
+    "bad-tier": "tier 가 1~5 정수가 아니다 (bool 포함)",
+    "bad-id": "id 가 비었거나 허용 문자가 아니다",
+    "pack-id-mismatch": "pack.id 가 폴더 이름과 다르다",
+    "unknown-op": "checks[].op 가 REGISTRY 에 없다",
+    "unknown-submit-kind": "submit.kind 가 answer/artifact/pair 가 아니다",
+    "empty-checks": "checks 가 비어 통과할 칸이 없다",
+    "malformed-check": "checks 항목이 객체가 아니거나 이름/op 가 없다",
+    "malformed-cmd": "cmd 가 비지 않은 문자열 목록이 아니다",
+    "malformed-submit": "submit 이 객체가 아니거나 files 가 깨졌다",
+    "malformed-requires": "requires 가 객체가 아니거나 commands 가 목록이 아니다",
+    "malformed-runner": "runner 가 객체가 아니다",
+    "malformed-object": "루트 값이 객체가 아니다",
+    "missing-cmd": "needs_cli 연산자인데 cmd 가 없다",
+    "unexpected-cmd": "파일 연산자인데 cmd 가 있다",
+    "unknown-command": "cmd[0] 이 알려진 CLI 명령이 아니다",
+    "global-scan-forbidden": "편집·보안 축에서 전역 훑기 연산자를 썼다",
+    "profile-missing-pack": "프로파일이 없는 pack id 를 가리킨다",
+    "empty-packs": "프로파일 packs 가 비었다",
+    "duplicate-pack": "프로파일 packs 에 같은 id 가 두 번 있다",
+    "unsafe-id": "id 에 경로 구분자나 .. 가 있다",
+    "bad-runner-identity": "runner 신원의 길이·hex 가 틀렸다",
+    "not-a-mapping": "객체여야 할 자리가 객체가 아니다",
+    "not-a-list": "목록이어야 할 자리가 목록이 아니다",
+    "duplicate-check-name": "한 과제 안에서 check.name 이 겹친다",
+    "empty-commands": "requires.commands 항목이 공란이다",
+    "unexpected": "분류되지 않은 스키마 위반",
+}
+
+#: 연산자별 권장 필드. 스키마 기본 검증은 강제하지 않는다 — lint_check_fields 용.
+#: REGISTRY 키만 나열하고, 새 키를 여기서 만들어 등록하지 않는다.
+CHECK_FIELD_HINTS = {
+    "same_hash": ("files",),
+    "differs_from_input": ("file",),
+    "file_exists": ("file",),
+    "files_differ": ("files",),
+    "xml_root_eq": ("file", "value"),
+    "json_value_eq": ("file", "value"),
+    "csv_cell_eq": ("file", "row", "col", "value"),
+    "utf8_bom": ("file",),
+    "answer_eq": ("answer",),
+    "len_answer_eq": ("answer",),
+    "len_ge": ("value",),
+    "value_eq": ("value",),
+    "value_ge": ("value",),
+    "value_in": ("values",),
+    "deep_contains": ("value",),
+    "not_contains": ("value",),
+    "cell_text_eq": ("table", "row", "col", "value"),
+}
+
+#: 문서·시험에서 재사용하는 최소 유효 뼈대. 저장소 pack 을 바꾸지 않는다.
+MINIMAL_RUNNER = {
+    "rhwpVersion": "0.0.0",
+    "rhwpCommit": "c" * 40,
+    "capabilitiesSha256": "a" * 64,
+}
+
+MINIMAL_PACK = {
+    "schemaVersion": SCHEMA_VERSION,
+    "kind": PACK_KIND,
+    "id": "demo-pack",
+    "title": "데모",
+    "axis": "시험",
+    "requires": {"commands": ["info"]},
+    "runner": dict(MINIMAL_RUNNER),
+}
+
+MINIMAL_TASK = {
+    "id": "D01",
+    "tier": 1,
+    "title": "데모 과제",
+    "input": "samples/x.hwp",
+    "instructions": "제출하라",
+    "submit": {"kind": "answer"},
+    "checks": [{"name": "존재", "op": "file_exists", "file": "answer.json"}],
+}
+
+MINIMAL_PROFILE = {
+    "schemaVersion": SCHEMA_VERSION,
+    "kind": PROFILE_KIND,
+    "id": "demo",
+    "title": "데모 코스",
+    "packs": ["demo-pack"],
+}
+
+MINIMAL_CHECK_FILE = {"name": "존재", "op": "file_exists", "file": "answer.json"}
+MINIMAL_CHECK_CLI = {
+    "name": "쪽수",
+    "op": "answer_eq",
+    "answer": "pages",
+    "cmd": ["info", "{input}", "--json"],
+    "path": "pageCount",
+}
+
+
+class SchemaIssue:
+    """한 칸의 구조화 기록. 텍스트 줄은 as_text() 가 예전 계약을 지킨다."""
+
+    __slots__ = ("kind", "where", "message", "field", "got")
+
+    def __init__(self, kind, where, message, field=None, got=None):
+        self.kind = kind if kind in SCHEMA_ISSUE_KINDS else "unexpected"
+        self.where = where
+        self.message = message
+        self.field = field
+        self.got = _preview(got)
+
+    def as_text(self):
+        return f"{self.where}: {self.message}"
+
+    def as_dict(self):
+        payload = {
+            "kind": self.kind,
+            "where": self.where,
+            "message": self.message,
+        }
+        if self.field is not None:
+            payload["field"] = self.field
+        if self.got is not None:
+            payload["got"] = self.got
+        return payload
+
+
+class IssueList(list):
+    """문자열 목록 + 구조화 칸. 평범한 list 자리에 넣어도 append 계약이 산다."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.structured = []
+
+    def append_issue(self, kind, where, message, field=None, got=None):
+        issue = SchemaIssue(kind, where, message, field=field, got=got)
+        self.structured.append(issue)
+        self.append(issue.as_text())
+        return issue
+
+    def kinds(self):
+        return [item.kind for item in self.structured]
+
+    def has_kind(self, kind):
+        return any(item.kind == kind for item in self.structured)
+
+    def of_kind(self, kind):
+        return [item for item in self.structured if item.kind == kind]
+
+    def fields_of(self, kind):
+        return [item.field for item in self.of_kind(kind)]
+
+    def as_dicts(self):
+        return [item.as_dict() for item in self.structured]
+
+
+def _preview(value):
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        text = str(value)
+        return text if len(text) <= 80 else text[:77] + "..."
+    if isinstance(value, type):
+        return value.__name__
+    return type(value).__name__
+
+
+def is_known_issue_kind(kind):
+    return kind in SCHEMA_ISSUE_KINDS
+
+
+def describe_issue_kind(kind):
+    return SCHEMA_ISSUE_HELP.get(kind, SCHEMA_ISSUE_HELP["unexpected"])
+
+
+def is_valid_tier(value):
+    """1~5 정수. bool 은 거부한다 — True 가 1 로 통과하면 입문 과제가 생긴다."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return False
+    return TIER_MIN <= value <= TIER_MAX
+
+
+def is_safe_id(value):
+    if not isinstance(value, str) or not value:
+        return False
+    if value != value.strip():
+        return False
+    if value in (".", ".."):
+        return False
+    if any(sep in value for sep in ("/", "\\", ":")):
+        return False
+    return bool(SAFE_ID_RE.match(value))
+
+
+def is_commit_hex(value):
+    return isinstance(value, str) and bool(COMMIT_RE.match(value))
+
+
+def is_sha256_hex(value):
+    return isinstance(value, str) and bool(SHA256_RE.match(value))
+
+
+def is_nonempty_str(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def is_mapping(value):
+    return isinstance(value, dict)
+
+
+def is_str_list(value):
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def is_nonempty_str_list(value):
+    return is_str_list(value) and bool(value) and all(item.strip() for item in value)
+
+
+def is_known_submit_kind(value):
+    return value in SUBMIT_KINDS
+
+
+def is_editing_axis(axis):
+    if not isinstance(axis, str):
+        return False
+    return any(axis.startswith(prefix) for prefix in EDITING_AXES)
+
+
+def check_registry():
+    """checks.REGISTRY 의 읽기 전용 손잡이. 이 모듈은 등록부를 고치지 않는다."""
+    from . import checks as registry
+    return registry
+
+
+def registered_ops():
+    return frozenset(check_registry().REGISTRY)
+
+
+def is_registered_op(op):
+    return op in check_registry().REGISTRY
+
+
+def is_global_scan_op(op):
+    return op in check_registry().GLOBAL_SCAN_OPS
+
+
+def op_needs_cli(op):
+    return check_registry().needs_cli(op)
+
+
+def lint_check_fields(check):
+    """연산자가 권장하는 필드가 빠졌는지. 기본 validate_task 는 이걸 강제하지 않는다."""
+    if not is_mapping(check):
+        return ("<not-a-mapping>",)
+    op = check.get("op")
+    hints = CHECK_FIELD_HINTS.get(op)
+    if not hints:
+        return ()
+    return tuple(field for field in hints if field not in check)
+
+
+def _fail(errors, where, message, kind="unexpected", field=None, got=None):
+    """errors 가 IssueList 면 kind 를 남기고, 아니면 예전 문자열만 남긴다."""
+    if errors is None:
+        return
+    append_issue = getattr(errors, "append_issue", None)
+    if callable(append_issue):
+        append_issue(kind, where, message, field=field, got=got)
+        return
     errors.append(f"{where}: {message}")
 
 
+def collect_pack(manifest, pack_dir):
+    issues = IssueList()
+    validate_pack(manifest, pack_dir, issues)
+    return issues
+
+
+def collect_task(task, pack, known_commands=None):
+    issues = IssueList()
+    validate_task(task, pack, known_commands, issues)
+    return issues
+
+
+def collect_profile(profile, pack_ids):
+    issues = IssueList()
+    validate_profile(profile, pack_ids, issues)
+    return issues
+
+
+def _axis_of(task, pack):
+    if is_mapping(task) and is_nonempty_str(task.get("axis")):
+        return task["axis"]
+    if is_mapping(pack) and is_nonempty_str(pack.get("axis")):
+        return pack["axis"]
+    return ""
+
+
+def _task_where(pack, task):
+    pack_id = pack.get("id") if is_mapping(pack) else None
+    task_id = task.get("id") if is_mapping(task) else None
+    return f"{pack_id}/{task_id}"
+
+
+def _profile_where(profile):
+    ident = profile.get("id") if is_mapping(profile) else None
+    return f"profiles/{ident}"
+
+
 def validate_pack(manifest, pack_dir, errors):
-    where = os.path.basename(pack_dir)
+    where = os.path.basename(pack_dir) if pack_dir else "<pack>"
+    if not is_mapping(manifest):
+        _fail(errors, where, "pack.json 이 객체가 아니다",
+              kind="not-a-mapping", field="manifest", got=type(manifest))
+        return
+
     if manifest.get("kind") != PACK_KIND:
-        _fail(errors, where, f"kind 가 {PACK_KIND} 가 아니다")
+        _fail(errors, where, MSG_PACK_KIND,
+              kind="bad-kind", field="kind", got=manifest.get("kind"))
     if manifest.get("schemaVersion") != SCHEMA_VERSION:
-        _fail(errors, where, f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
-    if manifest.get("id") != where:
-        _fail(errors, where, f"pack id({manifest.get('id')}) 가 폴더 이름과 다르다")
+        _fail(errors, where, MSG_PACK_SCHEMA,
+              kind="bad-schema-version", field="schemaVersion",
+              got=manifest.get("schemaVersion"))
+
+    pack_id = manifest.get("id")
+    if pack_id != where:
+        _fail(errors, where, f"pack id({pack_id}) 가 폴더 이름과 다르다",
+              kind="pack-id-mismatch", field="id", got=pack_id)
+    if pack_id is not None and not is_safe_id(pack_id):
+        _fail(errors, where, f"pack id({pack_id}) 가 안전하지 않다",
+              kind="unsafe-id", field="id", got=pack_id)
+
     for key in ("title", "axis"):
-        if not manifest.get(key):
-            _fail(errors, where, f"{key} 가 비었다")
-    requires = manifest.get("requires", {})
-    if not isinstance(requires.get("commands"), list) or not requires["commands"]:
-        _fail(errors, where, "requires.commands 가 비었다 — 요구 capability 선언은 필수")
-    runner = manifest.get("runner", {})
-    for key in ("rhwpVersion", "rhwpCommit", "capabilitiesSha256"):
-        if not runner.get(key):
-            _fail(errors, where, f"runner.{key} 가 비었다 — 기준 실행 신원 선언은 필수")
+        value = manifest.get(key)
+        if not value:
+            _fail(errors, where, f"{key} 가 비었다",
+                  kind="empty-field", field=key, got=value)
+        elif not isinstance(value, str):
+            _fail(errors, where, f"{key} 가 문자열이 아니다",
+                  kind="bad-type", field=key, got=type(value))
+
+    _validate_requires(manifest.get("requires", {}), where, errors)
+    _validate_runner(manifest.get("runner", {}), where, errors)
+
+
+def _validate_requires(requires, where, errors):
+    if not is_mapping(requires):
+        _fail(errors, where, "requires 가 객체가 아니다",
+              kind="malformed-requires", field="requires", got=type(requires))
+        return
+    commands = requires.get("commands")
+    if not isinstance(commands, list) or not commands:
+        _fail(errors, where, MSG_REQUIRES_EMPTY,
+              kind="empty-commands", field="requires.commands", got=commands)
+        return
+    bad = [item for item in commands if not is_nonempty_str(item)]
+    if bad:
+        _fail(errors, where, "requires.commands 항목이 빈 문자열이다",
+              kind="empty-commands", field="requires.commands", got=bad[0])
+
+
+def _validate_runner(runner, where, errors):
+    if not is_mapping(runner):
+        _fail(errors, where, "runner 가 객체가 아니다",
+              kind="malformed-runner", field="runner", got=type(runner))
+        return
+    for key in RUNNER_KEYS:
+        value = runner.get(key)
+        if not value:
+            _fail(errors, where, f"runner.{key} 가 비었다 — 기준 실행 신원 선언은 필수",
+                  kind="empty-field", field=f"runner.{key}", got=value)
+            continue
+        if not isinstance(value, str):
+            _fail(errors, where, f"runner.{key} 가 문자열이 아니다",
+                  kind="bad-type", field=f"runner.{key}", got=type(value))
+            continue
+        if key == "rhwpCommit" and not is_commit_hex(value):
+            _fail(errors, where, "runner.rhwpCommit 이 40자리 hex 가 아니다",
+                  kind="bad-runner-identity", field="runner.rhwpCommit", got=value)
+        if key == "capabilitiesSha256" and not is_sha256_hex(value):
+            _fail(errors, where, "runner.capabilitiesSha256 이 64자리 hex 가 아니다",
+                  kind="bad-runner-identity", field="runner.capabilitiesSha256",
+                  got=value)
 
 
 def validate_task(task, pack, known_commands, errors):
-    where = f"{pack.get('id')}/{task.get('id')}"
+    if not is_mapping(pack):
+        pack = {}
+    if not is_mapping(task):
+        _fail(errors, _task_where(pack, {}), "과제가 객체가 아니다",
+              kind="not-a-mapping", field="task", got=type(task))
+        return
+
+    where = _task_where(pack, task)
     for key in TASK_REQUIRED:
         if key not in task:
-            _fail(errors, where, f"필수 키 없음: {key}")
-    if not isinstance(task.get("tier"), int) or not TIER_MIN <= task.get("tier", 0) <= TIER_MAX:
-        _fail(errors, where, f"tier 는 {TIER_MIN}~{TIER_MAX} 정수 (1=입문 … 5=보스)")
-    if not task.get("checks"):
-        _fail(errors, where, "checks 가 비었다")
+            _fail(errors, where, f"{MSG_MISSING_KEY_PREFIX}{key}",
+                  kind="missing-key", field=key)
 
-    from . import checks as check_registry
+    task_id = task.get("id")
+    if "id" in task:
+        if not is_nonempty_str(task_id):
+            _fail(errors, where, "id 가 비었다",
+                  kind="empty-field", field="id", got=task_id)
+        elif not is_safe_id(task_id):
+            _fail(errors, where, f"id({task_id}) 가 안전하지 않다",
+                  kind="unsafe-id", field="id", got=task_id)
 
-    editing = any(task.get("axis", pack.get("axis", "")).startswith(a) for a in EDITING_AXES)
-    for check in task.get("checks", []):
-        op = check.get("op")
-        if op not in check_registry.REGISTRY:
-            _fail(errors, where, f"미등록 연산자: {op}")
+    for key in ("title", "input", "instructions"):
+        if key not in task:
             continue
-        if editing and op in check_registry.GLOBAL_SCAN_OPS and not check.get("allowGlobalScan"):
-            _fail(errors, where,
-                  f"편집 과제에 전역 훑기 연산자({op}) — 좌표를 지목하는 연산자를 쓰거나 "
-                  "allowGlobalScan 으로 사유를 명시하라(#4600)")
-        cmd = check.get("cmd")
-        if check_registry.needs_cli(op):
-            if not cmd:
-                _fail(errors, where, f"{op} 는 cmd 가 필요하다")
-            elif known_commands is not None and cmd[0] not in known_commands:
-                _fail(errors, where, f"CLI 에 없는 명령: {cmd[0]}")
-        elif cmd:
-            _fail(errors, where, f"{op} 는 CLI 를 부르지 않는데 cmd 가 있다")
+        value = task.get(key)
+        if not isinstance(value, str):
+            _fail(errors, where, f"{key} 는 문자열이어야 한다",
+                  kind="bad-type", field=key, got=type(value))
+        elif not value.strip():
+            _fail(errors, where, f"{key} 가 비었다",
+                  kind="empty-field", field=key, got=value)
+
+    if "tier" in task and not is_valid_tier(task.get("tier")):
+        _fail(errors, where, MSG_TIER,
+              kind="bad-tier", field="tier", got=task.get("tier"))
+    elif "tier" not in task:
+        # 필수 키 없음과 별도로, 예전 코드도 빠진 tier 를 범위 밖으로 한 번 더 남겼다.
+        _fail(errors, where, MSG_TIER,
+              kind="bad-tier", field="tier", got=None)
+
+    if "submit" in task:
+        _validate_submit(task.get("submit"), where, errors)
+
+    checks = task.get("checks")
+    if "checks" not in task:
+        _fail(errors, where, MSG_CHECKS_EMPTY,
+              kind="empty-checks", field="checks", got=None)
+    elif not isinstance(checks, list):
+        _fail(errors, where, "checks 가 목록이 아니다",
+              kind="not-a-list", field="checks", got=type(checks))
+    elif not checks:
+        _fail(errors, where, MSG_CHECKS_EMPTY,
+              kind="empty-checks", field="checks", got=checks)
+    else:
+        _validate_checks(checks, task, pack, known_commands, where, errors)
+
+
+def _validate_submit(submit, where, errors):
+    if not is_mapping(submit):
+        _fail(errors, where, "submit 이 객체가 아니다",
+              kind="malformed-submit", field="submit", got=type(submit))
+        return
+    kind = submit.get("kind")
+    if not kind:
+        _fail(errors, where, "submit.kind 가 비었다",
+              kind="empty-field", field="submit.kind", got=kind)
+    elif not is_known_submit_kind(kind):
+        _fail(errors, where, f"submit.kind 가 알려진 값이 아니다: {kind}",
+              kind="unknown-submit-kind", field="submit.kind", got=kind)
+    files = submit.get("files")
+    if files is None:
+        return
+    if not isinstance(files, list):
+        _fail(errors, where, "submit.files 가 목록이 아니다",
+              kind="malformed-submit", field="submit.files", got=type(files))
+        return
+    if not files:
+        _fail(errors, where, "submit.files 가 비었다",
+              kind="empty-field", field="submit.files", got=files)
+        return
+    if not is_nonempty_str_list(files):
+        _fail(errors, where, "submit.files 항목이 빈 문자열이다",
+              kind="malformed-submit", field="submit.files")
+
+
+def _validate_checks(checks, task, pack, known_commands, where, errors):
+    registry = check_registry()
+    editing = is_editing_axis(_axis_of(task, pack))
+    seen_names = []
+    for index, check in enumerate(checks):
+        _validate_one_check(
+            check, index, editing, known_commands, registry, where, errors, seen_names)
+
+
+def _validate_one_check(check, index, editing, known_commands, registry, where, errors,
+                        seen_names):
+    label = f"checks[{index}]"
+    if not is_mapping(check):
+        _fail(errors, where, f"{label} 가 객체가 아니다",
+              kind="malformed-check", field=label, got=type(check))
+        return
+
+    name = check.get("name")
+    if not is_nonempty_str(name):
+        _fail(errors, where, f"{label} 이름 없음",
+              kind="malformed-check", field=f"{label}.name", got=name)
+    elif name in seen_names:
+        _fail(errors, where, f"{label} 이름 중복: {name}",
+              kind="duplicate-check-name", field=f"{label}.name", got=name)
+    else:
+        seen_names.append(name)
+
+    op = check.get("op")
+    if op not in registry.REGISTRY:
+        _fail(errors, where, f"{MSG_UNKNOWN_OP_PREFIX}{op}",
+              kind="unknown-op", field=f"{label}.op", got=op)
+        return
+    if editing and op in registry.GLOBAL_SCAN_OPS and not check.get("allowGlobalScan"):
+        _fail(errors, where,
+              f"편집 과제에 전역 훑기 연산자({op}) — 좌표를 지목하는 연산자를 쓰거나 "
+              "allowGlobalScan 으로 사유를 명시하라(#4600)",
+              kind="global-scan-forbidden", field=f"{label}.op", got=op)
+
+    cmd = check.get("cmd")
+    if registry.needs_cli(op):
+        if not cmd:
+            _fail(errors, where, f"{op}{MSG_CMD_NEEDED_SUFFIX}",
+                  kind="missing-cmd", field=f"{label}.cmd", got=cmd)
+            return
+        if not is_nonempty_str_list(cmd):
+            _fail(errors, where, f"{op} 의 cmd 가 문자열 목록이 아니다",
+                  kind="malformed-cmd", field=f"{label}.cmd", got=type(cmd))
+            return
+        if known_commands is not None and cmd[0] not in known_commands:
+            _fail(errors, where, f"{MSG_UNKNOWN_COMMAND_PREFIX}{cmd[0]}",
+                  kind="unknown-command", field=f"{label}.cmd", got=cmd[0])
+    elif cmd:
+        _fail(errors, where, f"{op} 는 CLI 를 부르지 않는데 cmd 가 있다",
+              kind="unexpected-cmd", field=f"{label}.cmd", got=cmd)
 
 
 def validate_profile(profile, pack_ids, errors):
-    where = f"profiles/{profile.get('id')}"
+    if not is_mapping(profile):
+        _fail(errors, "profiles/<unknown>", "프로파일이 객체가 아니다",
+              kind="not-a-mapping", field="profile", got=type(profile))
+        return
+
+    where = _profile_where(profile)
     if profile.get("kind") != PROFILE_KIND:
-        _fail(errors, where, f"kind 가 {PROFILE_KIND} 가 아니다")
-    if not profile.get("packs"):
-        _fail(errors, where, "packs 가 비었다")
-    for pid in profile.get("packs", []):
-        if pid not in pack_ids:
-            _fail(errors, where, f"없는 pack 참조: {pid}")
+        _fail(errors, where, MSG_PROFILE_KIND,
+              kind="bad-kind", field="kind", got=profile.get("kind"))
+    if "schemaVersion" in profile and profile.get("schemaVersion") != SCHEMA_VERSION:
+        _fail(errors, where, f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다",
+              kind="bad-schema-version", field="schemaVersion",
+              got=profile.get("schemaVersion"))
+
+    ident = profile.get("id")
+    if ident is not None and not is_safe_id(ident):
+        _fail(errors, where, f"profile id({ident}) 가 안전하지 않다",
+              kind="unsafe-id", field="id", got=ident)
+    if "title" in profile and not is_nonempty_str(profile.get("title")):
+        _fail(errors, where, "title 가 비었다",
+              kind="empty-field", field="title", got=profile.get("title"))
+
+    packs = profile.get("packs")
+    if not packs:
+        _fail(errors, where, MSG_PACKS_EMPTY,
+              kind="empty-packs", field="packs", got=packs)
+        return
+    if not isinstance(packs, list):
+        _fail(errors, where, "packs 가 목록이 아니다",
+              kind="not-a-list", field="packs", got=type(packs))
+        return
+
+    known = set(pack_ids) if pack_ids is not None else set()
+    seen = set()
+    for pid in packs:
+        if not is_nonempty_str(pid):
+            _fail(errors, where, "packs 항목이 빈 문자열이다",
+                  kind="empty-field", field="packs", got=pid)
+            continue
+        if not is_safe_id(pid):
+            _fail(errors, where, f"packs 항목({pid}) 이 안전하지 않다",
+                  kind="unsafe-id", field="packs", got=pid)
+        if pid in seen:
+            _fail(errors, where, f"packs 항목 중복: {pid}",
+                  kind="duplicate-pack", field="packs", got=pid)
+        else:
+            seen.add(pid)
+        if pack_ids is not None and pid not in known:
+            _fail(errors, where, f"{MSG_MISSING_PACK_PREFIX}{pid}",
+                  kind="profile-missing-pack", field="packs", got=pid)
+
+
+def parse_capabilities_payload(raw):
+    """capabilities stdout 을 객체로. 깨지면 None. 예외를 밖으로 던지지 않는다."""
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        text = raw
+    else:
+        try:
+            text = raw.decode("utf-8")
+        except (UnicodeError, AttributeError, TypeError):
+            return None
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        return None
+    return payload if is_mapping(payload) else None
+
+
+def parse_command_names(raw):
+    payload = parse_capabilities_payload(raw)
+    if payload is None:
+        return None
+    commands = payload.get("commands")
+    if not isinstance(commands, list):
+        return None
+    names = set()
+    for item in commands:
+        if is_mapping(item) and is_nonempty_str(item.get("name")):
+            names.add(item["name"])
+    return names
+
+
+def parse_capabilities_version(raw):
+    payload = parse_capabilities_payload(raw)
+    if payload is None:
+        return ""
+    version = payload.get("version", "")
+    return version if isinstance(version, str) else ""
 
 
 def capabilities_digest(bin_path):
     """`rhwp capabilities` 원문의 sha256 — 명령 표면의 지문."""
+    if not bin_path:
+        raise ValueError("bin_path 가 비었다")
     proc = subprocess.run([bin_path, "capabilities"], capture_output=True)
-    raw = proc.stdout
+    raw = proc.stdout or b""
     return hashlib.sha256(raw).hexdigest(), raw
 
 
 def known_commands(bin_path):
+    """capabilities 의 명령 이름 집합. 파싱 실패는 None — 명령 검사를 건너뛴다.
+
+    TypeError·UnicodeError 도 같은 None 이다. 예전에는 ValueError·KeyError 만
+    잡아서 목록이 깨지면 채점 전체가 죽었다. 빈 집합과 None 은 다르다: 빈
+    집합은 '명령을 읽었고 하나도 없다', None 은 '읽지 못했다'.
+    """
     _, raw = capabilities_digest(bin_path)
     try:
         return {c["name"] for c in json.loads(raw.decode("utf-8"))["commands"]}
-    except (ValueError, KeyError):
+    except (ValueError, KeyError, TypeError, UnicodeError, AttributeError):
         return None
+
+
+def try_known_commands(bin_path):
+    """known_commands 와 같되 바이너리 부재는 None. 채점기가 삼킬 자리를 가른다."""
+    try:
+        return known_commands(bin_path)
+    except OSError:
+        return None
+
+
+def git_head(repo_root):
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+        )
+    except OSError:
+        return ""
+    text = (proc.stdout or b"").decode("utf-8", errors="replace").strip()
+    return text if is_commit_hex(text) or text else text
 
 
 def runner_identity(bin_path, repo_root):
@@ -134,12 +820,121 @@ def runner_identity(bin_path, repo_root):
     version = ""
     try:
         version = json.loads(raw.decode("utf-8")).get("version", "")
-    except ValueError:
-        pass
-    commit = ""
+    except (ValueError, TypeError, UnicodeError, AttributeError):
+        version = parse_capabilities_version(raw)
+    if not isinstance(version, str):
+        version = ""
+    commit = git_head(repo_root)
+    return {
+        "rhwpVersion": version,
+        "rhwpCommit": commit,
+        "capabilitiesSha256": digest,
+    }
+
+
+def load_json_mapping(path, errors=None, where=None):
+    """JSON 객체를 읽는다. 실패하면 (None, 이유) 이고 errors 에도 남긴다."""
+    label = where or os.path.basename(path)
     try:
-        commit = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_root,
-                                capture_output=True).stdout.decode("utf-8").strip()
-    except OSError:
-        pass
-    return {"rhwpVersion": version, "rhwpCommit": commit, "capabilitiesSha256": digest}
+        with open(path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except FileNotFoundError:
+        _fail(errors, label, "파일이 없다", kind="missing-key", field="path", got=path)
+        return None
+    except (OSError, UnicodeError) as exc:
+        _fail(errors, label, f"읽기 실패: {exc}",
+              kind="unexpected", field="path", got=path)
+        return None
+    except ValueError as exc:
+        _fail(errors, label, f"JSON 파싱 실패: {exc}",
+              kind="malformed-object", field="path", got=path)
+        return None
+    if not is_mapping(payload):
+        _fail(errors, label, "JSON 루트가 객체가 아니다",
+              kind="not-a-mapping", field="root", got=type(payload))
+        return None
+    return payload
+
+
+def discover_pack_ids(packs_dir):
+    if not os.path.isdir(packs_dir):
+        return []
+    found = []
+    for name in sorted(os.listdir(packs_dir)):
+        if os.path.isfile(os.path.join(packs_dir, name, "pack.json")):
+            found.append(name)
+    return found
+
+
+def iter_task_paths(pack_dir):
+    tasks_dir = os.path.join(pack_dir, "tasks")
+    if not os.path.isdir(tasks_dir):
+        return
+    for name in sorted(os.listdir(tasks_dir)):
+        if name.endswith(".json"):
+            yield os.path.join(tasks_dir, name)
+
+
+def iter_profile_paths(profiles_dir):
+    if not os.path.isdir(profiles_dir):
+        return
+    for name in sorted(os.listdir(profiles_dir)):
+        if name.endswith(".json"):
+            yield os.path.join(profiles_dir, name)
+
+
+def validate_gym_tree(gym_root, errors=None, known_commands=None):
+    """gym/ 아래 pack·과제·프로파일을 전수 검증. audit.py 를 바꾸지 않는 읽기 경로."""
+    if errors is None:
+        errors = IssueList()
+    packs_dir = os.path.join(gym_root, "packs")
+    profiles_dir = os.path.join(gym_root, "profiles")
+    pack_ids = discover_pack_ids(packs_dir)
+    for pid in pack_ids:
+        pack_dir = os.path.join(packs_dir, pid)
+        manifest = load_json_mapping(
+            os.path.join(pack_dir, "pack.json"), errors, pid)
+        if manifest is None:
+            continue
+        validate_pack(manifest, pack_dir, errors)
+        for task_path in iter_task_paths(pack_dir):
+            task = load_json_mapping(
+                task_path, errors, f"{pid}/{os.path.basename(task_path)}")
+            if task is None:
+                continue
+            validate_task(task, manifest, known_commands, errors)
+    known = set(pack_ids)
+    for profile_path in iter_profile_paths(profiles_dir):
+        profile = load_json_mapping(
+            profile_path, errors, f"profiles/{os.path.basename(profile_path)}")
+        if profile is None:
+            continue
+        validate_profile(profile, known, errors)
+    return errors
+
+
+def clone_minimal_pack(**overrides):
+    body = json.loads(json.dumps(MINIMAL_PACK))
+    body.update(overrides)
+    return body
+
+
+def clone_minimal_task(**overrides):
+    body = json.loads(json.dumps(MINIMAL_TASK))
+    body.update(overrides)
+    return body
+
+
+def clone_minimal_profile(**overrides):
+    body = json.loads(json.dumps(MINIMAL_PROFILE))
+    body.update(overrides)
+    return body
+
+
+def format_issue_catalog():
+    """문서·시험이 같은 표를 그리기 위한 (kind, help) 목록."""
+    return [(kind, SCHEMA_ISSUE_HELP[kind]) for kind in SCHEMA_ISSUE_KINDS]
+
+
+def issue_kind_count():
+    return len(SCHEMA_ISSUE_KINDS)

--- a/gym/docs/schema.md
+++ b/gym/docs/schema.md
@@ -1,0 +1,481 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/schema.md
+last_verified: 2026-08-18
+---
+
+# gym pack·task·profile 스키마 규약
+
+이 문서는 `gym/core/schema.py` 의 **검증 계약**을 고정한다. 작업 기록은
+[`mydocs/working/gym_schema.md`](../../mydocs/working/gym_schema.md) 를 본다.
+기계 시험은 `scripts/tests/test_gym_schema.py`(예외 칸)와
+`scripts/tests/test_gym_packs.py`(저장소 나무 성공 칸)가 지킨다.
+
+채점 엔진(`runner.py`)·연산자 등록부(`checks.py`)·감사기(`audit.py`)·점수
+진입점(`score.py`)은 이 문서의 대상이 아니다. 스키마는 그 도구들이 소비하는
+**선언의 모양**만 본다. 새 CLI 플래그는 없다. `REGISTRY` 키를 더하거나 빼지
+않는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+운동장은 pack 이 늘수록 "선언만 있고 돌지 않는 과제"의 위험이 커진다.
+`validate_pack` / `validate_task` / `validate_profile` 이 그 선언을 막는다.
+그런데 예전의 세 함수는 성공한 나무만 잘 보았다.
+
+- 과제 JSON 이 목록이면 `task.get` 에서 AttributeError. 감사기 한 pack 이 죽는다.
+- `checks` 가 객체면 키 문자열을 순회하다 `str.get` 으로 죽는다.
+- `tier: true` 는 `bool` 이 `int` 의 하위형이라 입문 과제로 통과한다.
+- `submit.kind` 가 `zip` 이어도 아무도 안 막는다.
+- 프로파일 `packs` 가 문자열이면 글자 하나하나를 pack id 로 본다.
+- 미등록 연산자는 거절했지만, 그 거절이 kind 로 남지 않아 시험이 메시지
+  조각에만 매였다.
+
+#5279 는 그 자리를 **죽이지 않고 칸으로 남긴다.** 점수는 바꾸지 않는다.
+채점 성공 경로는 그대로다. 저장소에 이미 있는 pack 은 통과해야 한다.
+
+부재를 실패로 위장하지 않는 결은 여기에도 같다. 스키마 위반은 0점이 아니라
+**등재 거부**다. 바이너리가 없어서 명령을 못 읽는 자리(`known_commands is
+None`)는 명령 존재 검사를 건너뛴다. 그 자리는 채점기가 unavailable 로 본다.
+
+## 2. 검증 API
+
+예전 시그니처를 지킨다. `audit.py` 와 `test_gym_packs` 가 이 세 함수를
+직접 부른다.
+
+```text
+validate_pack(manifest, pack_dir, errors)
+validate_task(task, pack, known_commands, errors)
+validate_profile(profile, pack_ids, errors)
+```
+
+`errors` 는 문자열 목록이다. 한 줄의 모양은 예전과 같다.
+
+```text
+<where>: <message>
+```
+
+예:
+
+```text
+table-editing: requires.commands 가 비었다 — 요구 capability 선언은 필수
+table-editing/TB01: 필수 키 없음: input
+table-editing/TB01: tier 는 1~5 정수 (1=입문 … 5=보스)
+table-editing/TB01: 미등록 연산자: ghost_op
+profiles/starter: 없는 pack 참조: no-such-pack
+```
+
+`errors` 자리에 `IssueList` 를 넘기면 같은 문자열과 함께 `kind` 가 남는다.
+평범한 `list` 를 넘기면 문자열만 쌓인다. 두 경로의 텍스트는 같아야 한다.
+
+선택 API:
+
+| 함수 | 역할 |
+|---|---|
+| `collect_pack` / `collect_task` / `collect_profile` | `IssueList` 를 만들어 돌려준다 |
+| `validate_gym_tree(gym_root)` | `packs/`·`profiles/` 전수. audit.py 를 바꾸지 않는 읽기 경로 |
+| `load_json_mapping(path)` | 깨진 JSON·배열 루트·부재를 칸으로 |
+| `registered_ops()` | `checks.REGISTRY` 키의 읽기 전용 집합 |
+| `is_valid_tier` / `is_safe_id` / `is_known_submit_kind` | 단위 판정 |
+| `lint_check_fields(check)` | 연산자 권장 필드. 기본 검증은 강제하지 않는다 |
+
+새 진입점 스크립트는 없다. `python gym/core/schema.py` 를 실행하지 않는다.
+
+## 3. 상수 — 바꾸면 나무가 흔들린다
+
+| 이름 | 값 | 의미 |
+|---|---|---|
+| `PACK_KIND` | `gymPack` | pack.json `kind` |
+| `PROFILE_KIND` | `gymProfile` | profiles/*.json `kind` |
+| `SCHEMA_VERSION` | `1.0` | 선언 버전. 2.0 으로 몰래 올리지 않는다 |
+| `TIER_MIN` / `TIER_MAX` | 1 / 5 | 입문…보스 |
+| `TIER_NAMES` | 1=입문 … 5=보스 | 놀이공원 키 제한 |
+| `SUBMIT_KINDS` | answer, artifact, pair | README 의 세 칸 |
+| `EDITING_AXES` | 편집, 보안 | 이 접두로 시작하면 전역 훑기 금지 |
+| `TASK_REQUIRED` | id, tier, title, input, instructions, submit, checks | 과제 필수 키 |
+| `PACK_REQUIRED` | schemaVersion, kind, id, title, axis, requires, runner | pack 필수 키 |
+| `PROFILE_REQUIRED` | schemaVersion, kind, id, title, packs | 프로파일 필수 키 |
+| `RUNNER_KEYS` | rhwpVersion, rhwpCommit, capabilitiesSha256 | 기준 실행 신원 |
+
+`REGISTRY` 와 `GLOBAL_SCAN_OPS` 와 `needs_cli` 는 `checks.py` 가 소유한다.
+스키마는 `from . import checks` 로 읽기만 한다. 키를 추가·삭제·이름 바꾸기
+하지 않는다. 열린 PR 5210 이 그 등록부를 키우고 있다.
+
+## 4. pack 검증
+
+대상: `packs/<id>/pack.json`. `where` 는 폴더 이름이다.
+
+통과 조건:
+
+1. 루트가 객체다. 목록·문자열·`null` 이면 `not-a-mapping` 이고 나머지 검사는
+   하지 않는다(죽어 본 자리를 한 칸으로 접는다).
+2. `kind == gymPack`. 아니면 `bad-kind`. 메시지: `kind 가 gymPack 가 아니다`.
+3. `schemaVersion == 1.0`. 아니면 `bad-schema-version`.
+4. `id` 가 폴더 이름과 같다. 아니면 `pack-id-mismatch`.
+5. `id` 가 안전하다(`SAFE_ID_RE`, 경로 구분자 없음). 아니면 `unsafe-id`.
+6. `title`·`axis` 가 비지 않은 문자열. 공란은 `empty-field`, 숫자·목록은
+   `bad-type`.
+7. `requires` 가 객체이고 `commands` 가 비지 않은 문자열 목록. 비면 예전
+   메시지 그대로 `requires.commands 가 비었다 — 요구 capability 선언은 필수`.
+   항목이 `""` 이면 `empty-commands`.
+8. `runner` 가 객체이고 세 키가 비지 않은 문자열. `rhwpCommit` 은 40자리
+   hex, `capabilitiesSha256` 은 64자리 hex. 길이·문자가 틀리면
+   `bad-runner-identity`.
+
+`requires.commands` 가 비었다는 것은 "이 pack 을 채점할 capability 를
+선언하지 않았다"는 뜻이다. 명령이 바이너리에 없는 자리와 다르다. 후자는
+채점기의 `unavailable` 이다.
+
+## 5. task 검증
+
+대상: `packs/<id>/tasks/<ID>.json`. `where` 는 `<pack.id>/<task.id>` 다.
+
+### 5.1 필수 키
+
+`TASK_REQUIRED` 의 각 키가 없으면 `missing-key` 이고 메시지는
+`필수 키 없음: <key>` 다. 이 조각은 이슈 본문이 명시한 첫 자리이며
+`test_gym_packs` 이전부터 있었다.
+
+키가 있는데 값이 공란이면 `empty-field` 다. 키가 없는 것과 한 줄로 뭉개지
+않는다.
+
+`id` 는 비지 않은 안전 id 다. `../T01`, `T 01`, 빈 문자열은 거절한다.
+
+`title`·`input`·`instructions` 는 문자열이어야 한다. 숫자·목록은 `bad-type`.
+
+### 5.2 tier
+
+`is_valid_tier` 만 통과한다.
+
+| 값 | 결과 | 이유 |
+|---|---|---|
+| 1, 2, 3, 4, 5 | 통과 | 입문…보스 |
+| 0, 6, -1, 99 | `bad-tier` | 범위 밖 |
+| `true`, `false` | `bad-tier` | bool 은 int 의 하위형 |
+| `"1"`, `1.0`, `null` | `bad-tier` | 타입이 아님 |
+| 키 없음 | `missing-key` + `bad-tier` | 예전 코드도 두 줄을 남겼다 |
+
+메시지는 예전과 같다: `tier 는 1~5 정수 (1=입문 … 5=보스)`.
+
+bool 을 받는 것은 입문 과제가 실수로 생기는 구멍이다. JSON `true` 가
+Python `True` 가 되고, `isinstance(True, int)` 가 참이라 예전 검사가
+속았다.
+
+### 5.3 submit
+
+`submit` 은 객체다. `kind` 는 `answer` / `artifact` / `pair` 만.
+그 외는 `unknown-submit-kind`.
+
+`files` 는 없어도 된다(`T01` 의 answer 가 그렇다). 있으면 비지 않은 문자열
+목록이어야 한다. 빈 목록·문자열 하나·공란 항목은 `malformed-submit` 또는
+`empty-field`.
+
+원본 픽스처를 덮어쓰는 경로는 스키마가 아니라 채점·과제 지시가 막는다.
+스키마는 선언의 모양만 본다.
+
+### 5.4 checks
+
+| 자리 | kind | 예전 메시지 |
+|---|---|---|
+| 키 없음 또는 `[]` | `empty-checks` | `checks 가 비었다` |
+| 객체·문자열·숫자 | `not-a-list` | (예전엔 AttributeError) |
+| 항목이 객체 아님 | `malformed-check` | (예전엔 AttributeError) |
+| `name` 공란 | `malformed-check` | (예전에 스키마는 안 봄, 시험만 봄) |
+| `name` 중복 | `duplicate-check-name` | (신규) |
+| `op` 미등록 | `unknown-op` | `미등록 연산자: <op>` |
+| 편집 축 + 전역 훑기, 사유 없음 | `global-scan-forbidden` | `전역 훑기 연산자` 포함 |
+| `needs_cli` 인데 `cmd` 없음 | `missing-cmd` | `<op> 는 cmd 가 필요하다` |
+| 파일 연산자인데 `cmd` 있음 | `unexpected-cmd` | `<op> 는 CLI 를 부르지 않는데 cmd 가 있다` |
+| `cmd` 가 문자열 목록 아님 | `malformed-cmd` | (예전엔 `cmd[0]` 이 글자 하나) |
+| `known_commands` 가 집합이고 `cmd[0]` 부재 | `unknown-command` | `CLI 에 없는 명령: <name>` |
+
+`known_commands is None` 이면 명령 존재 검사를 건너뛴다. 바이너리 없이
+스키마·연산자 계약만 보는 경로(`audit.py`, `test_gym_packs`)가 이 값이다.
+
+`op` 가 미등록이면 그 항목의 cmd 검사는 하지 않는다. 없는 연산자에게
+cmd 를 요구하는 것은 거짓말이다.
+
+### 5.5 전역 훑기
+
+`EDITING_AXES = ("편집", "보안")`. 과제 `axis` 가 있으면 그것을, 없으면
+pack `axis` 를 본다. `startswith` 이라 `편집 (표 좌표 지정)` 도 편집이다.
+
+`GLOBAL_SCAN_OPS` 는 `checks.py` 의 `{deep_contains, not_contains}` 다.
+스키마가 이 집합을 늘리지 않는다. 편집·보안 축에서 쓰려면
+`allowGlobalScan` 에 사유 문자열을 남긴다(#4600).
+
+## 6. profile 검증
+
+대상: `gym/profiles/<id>.json`. `where` 는 `profiles/<id>` 다.
+
+1. 루트가 객체. 아니면 `not-a-mapping`.
+2. `kind == gymProfile`. 아니면 `bad-kind`. 메시지: `kind 가 gymProfile 가 아니다`.
+3. `schemaVersion` 이 있으면 `1.0` 이어야 한다. 키가 없는 기존 파일은
+   이 칸을 내지 않는다(저장소 프로파일은 모두 가지고 있다).
+4. `id` 가 있으면 안전해야 한다.
+5. `packs` 가 비면 `empty-packs`. 메시지: `packs 가 비었다`.
+6. `packs` 가 목록이 아니면 `not-a-list`. 문자열을 글자로 쪼개지 않는다.
+7. 항목이 공란이면 `empty-field`, 경로면 `unsafe-id`, 중복이면
+   `duplicate-pack`.
+8. `pack_ids` 가 주어졌고 항목이 그 집합에 없으면 `profile-missing-pack`.
+   메시지: `없는 pack 참조: <id>`. 이슈 본문의 네 번째 자리다.
+
+`pack_ids is None` 이면 존재 검사를 건너뛴다. pack 나무를 아직 모를 때
+모양만 보는 경로다.
+
+프로파일은 pack 을 **고르는** 도구이지 점수를 뭉치는 도구가 아니다.
+스키마도 그 결을 지킨다. packs 목록의 합산 규칙을 만들지 않는다.
+
+## 7. 이슈 kind 카탈로그
+
+`SCHEMA_ISSUE_KINDS` 와 `SCHEMA_ISSUE_HELP` 가 같은 표다. 시험
+`CatalogTests` 가 길이·중복·도움말을 고정한다. 모르는 kind 는
+`unexpected` 도움말로 접힌다.
+
+| kind | 한 줄 |
+|---|---|
+| `missing-key` | 필수 키가 객체에 없다 |
+| `empty-field` | 키는 있는데 값이 공란이거나 falsy 다 |
+| `bad-type` | 값의 파이썬 타입이 계약과 다르다 |
+| `bad-kind` | kind 가 gymPack / gymProfile 이 아니다 |
+| `bad-schema-version` | schemaVersion 이 1.0 이 아니다 |
+| `bad-tier` | tier 가 1~5 정수가 아니다 (bool 포함) |
+| `bad-id` | id 가 비었거나 허용 문자가 아니다 |
+| `pack-id-mismatch` | pack.id 가 폴더 이름과 다르다 |
+| `unknown-op` | checks[].op 가 REGISTRY 에 없다 |
+| `unknown-submit-kind` | submit.kind 가 answer/artifact/pair 가 아니다 |
+| `empty-checks` | checks 가 비어 통과할 칸이 없다 |
+| `malformed-check` | checks 항목이 객체가 아니거나 이름/op 가 없다 |
+| `malformed-cmd` | cmd 가 비지 않은 문자열 목록이 아니다 |
+| `malformed-submit` | submit 이 객체가 아니거나 files 가 깨졌다 |
+| `malformed-requires` | requires 가 객체가 아니거나 commands 가 목록이 아니다 |
+| `malformed-runner` | runner 가 객체가 아니다 |
+| `malformed-object` | JSON 파싱 실패 또는 루트가 객체가 아니다 |
+| `missing-cmd` | needs_cli 연산자인데 cmd 가 없다 |
+| `unexpected-cmd` | 파일 연산자인데 cmd 가 있다 |
+| `unknown-command` | cmd[0] 이 알려진 CLI 명령이 아니다 |
+| `global-scan-forbidden` | 편집·보안 축에서 전역 훑기 연산자를 썼다 |
+| `profile-missing-pack` | 프로파일이 없는 pack id 를 가리킨다 |
+| `empty-packs` | 프로파일 packs 가 비었다 |
+| `duplicate-pack` | 프로파일 packs 에 같은 id 가 두 번 있다 |
+| `unsafe-id` | id 에 경로 구분자나 .. 가 있다 |
+| `bad-runner-identity` | runner 신원의 길이·hex 가 틀렸다 |
+| `not-a-mapping` | 객체여야 할 자리가 객체가 아니다 |
+| `not-a-list` | 목록이어야 할 자리가 목록이 아니다 |
+| `duplicate-check-name` | 한 과제 안에서 check.name 이 겹친다 |
+| `empty-commands` | requires.commands 가 비었거나 항목이 공란이다 |
+| `unexpected` | 분류되지 않은 스키마 위반 |
+
+kind 를 늘릴 때는 도움말과 시험을 같이 늘린다. 도움말 없는 kind 는
+카탈로그 시험이 막는다.
+
+## 8. 안전 id
+
+`is_safe_id` 가 허용하는 것:
+
+- 첫 글자 `[A-Za-z0-9]`
+- 나머지 `[A-Za-z0-9._-]*`
+- 앞뒤 공백 없음
+- `/` `\` `:` `..` `.` 없음
+
+그래서 `table-editing`, `core-cli`, `TB01`, `T10`, `render-tree`,
+`studio-e2e`, `self-description` 은 통과하고 `../x`, `T 01`, `한글`,
+`-leading` 은 거절한다.
+
+pack id 와 폴더 이름이 같다는 검사와 겹친다. 폴더가 `../x` 이면 둘 다
+불이 난다. 경로 구분자로 pack 을 고르면 채점기가 디렉터리를 벗어난다.
+스키마가 그 입구를 막는다.
+
+## 9. capabilities 와 실행 신원
+
+이 세 함수의 **바깥 계약**은 예전과 같다. `runner.py` 가 그대로 부른다.
+
+```text
+capabilities_digest(bin_path) -> (sha256, raw)
+known_commands(bin_path) -> set[str] | None
+runner_identity(bin_path, repo_root) -> {rhwpVersion, rhwpCommit, capabilitiesSha256}
+```
+
+hardening:
+
+- `bin_path` 가 비면 `ValueError`. 빈 문자열로 `subprocess.run` 을 부르지
+  않는다.
+- stdout 이 `None` 이면 빈 바이트로 해시를 남긴다.
+- `known_commands` 는 `TypeError`·`UnicodeError`·`AttributeError` 도 None
+  으로 접는다. 예전에는 `ValueError`·`KeyError` 만 잡아 목록이 깨지면
+  채점 전체가 죽었다.
+- 빈 집합과 None 은 다르다. 빈 집합은 "명령을 읽었고 하나도 없다".
+- `try_known_commands` 는 바이너리 부재(`OSError`)를 None 으로 접는 선택
+  경로다. `known_commands` 자체는 예전처럼 예외를 던질 수 있다.
+- `parse_capabilities_payload` / `parse_command_names` /
+  `parse_capabilities_version` 은 예외를 밖으로 던지지 않는다.
+
+`runner.rhwpCommit` 의 40자리 hex 와 `capabilitiesSha256` 의 64자리 hex 는
+pack 선언을 검증할 때 본다. 실행 시점 `runner_identity` 가 빈 커밋을 돌려줄
+수는 있다(git 이 없는 자리). 그 빈 값은 pack 에 넣으면 `empty-field` 다.
+
+## 10. 나무 전수
+
+`validate_gym_tree(gym_root)` 는 `gym/packs/*/pack.json` 과
+`gym/packs/*/tasks/*.json` 과 `gym/profiles/*.json` 을 읽는다. JSON 이
+깨지면 `malformed-object`, 루트가 배열이면 `not-a-mapping`, 파일이 없으면
+그 pack 만 건너뛴다. 한 파일이 죽어도 나머지를 본다.
+
+이 함수는 `audit.py` 를 대체하지 않는다. 감사기는 기준 풀이 짝·고아
+reference·전역 과제 ID 충돌을 추가로 본다. 스키마 나무는 선언의 모양만
+본다. 두 도구를 한 파일로 합치지 않는다 — 감사기는 열린 이웃 PR 의
+대상이 될 수 있고, 이슈는 그 파일을 고치지 말라고 했다.
+
+## 11. 연산자 필드 힌트
+
+`CHECK_FIELD_HINTS` 는 devel 에 있는 `REGISTRY` 키만 나열한다. 새 키를
+여기서 만들어 등록하지 않는다. `lint_check_fields(check)` 가 빠진 필드를
+돌려준다.
+
+기본 `validate_task` 는 이 힌트를 **강제하지 않는다.** 연산자의 필수
+인자는 채점 시점의 연산자 구현이 실패로 남긴다. 스키마가 힌트를 강제로
+올리면, 열린 PR 5210 이 등록부에 키를 더하는 순간 힌트 표와 어긋난다.
+
+힌트 표에 있는 키가 `REGISTRY` 에 없는 것은 시험이 막는다. `REGISTRY` 에
+있는 키가 힌트 표에 없는 것도 막는다 — devel 표면이 흔들리면 시험을
+고친다. 등록부 자체는 고치지 않는다.
+
+## 12. 하지 않는 것
+
+- 새 CLI 플래그, 새 연산자, 새 pack, 새 프로파일.
+- `checks.REGISTRY` 변경. `GLOBAL_SCAN_OPS` 변경. `needs_cli` 뒤집기.
+- `audit.py`, `certify.py`, `report.py`, `score.py`, `runner.py` 수정.
+- tutorial 문서 수정.
+- 열린 PR 5210–5278 이 만진 파일 수정.
+- 성공한 과제의 점수를 바꾸기.
+- 부재(명령 없음)를 스키마 위반으로 바꾸기.
+- `schemaVersion` 을 2.0 으로 올리기.
+
+## 13. 사용 예
+
+저장소 나무가 깨끗한지(감사기와 같은 성공 칸):
+
+```bash
+python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_schema
+python gym/tools/audit.py
+```
+
+임시 나무가 네 자리를 남기는지:
+
+```python
+from gym.core import schema
+
+task = {"id": "X", "tier": 0, "checks": [{"name": "c", "op": "ghost"}]}
+print(schema.collect_task(task, {"id": "p"}).kinds())
+# missing-key, bad-tier, unknown-op, ...
+
+profile = {"kind": "gymProfile", "id": "z", "title": "z", "packs": ["ghost"]}
+print(schema.collect_profile(profile, {"core-cli"}).kinds())
+# profile-missing-pack
+```
+
+`IssueList.kinds()` / `has_kind` / `of_kind` / `as_dicts` 가 시험이 쓰는
+손잡이다. 문자열 목록만 받는 예전 호출자는 손대지 않아도 된다.
+
+## 14. 최소 뼈대
+
+시험과 문서가 같은 상수를 쓴다. 저장소 pack 을 바꾸지 않는다.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "kind": "gymPack",
+  "id": "demo-pack",
+  "title": "데모",
+  "axis": "시험",
+  "requires": {"commands": ["info"]},
+  "runner": {
+    "rhwpVersion": "0.0.0",
+    "rhwpCommit": "<40 hex>",
+    "capabilitiesSha256": "<64 hex>"
+  }
+}
+```
+
+```json
+{
+  "id": "D01",
+  "tier": 1,
+  "title": "데모 과제",
+  "input": "samples/x.hwp",
+  "instructions": "제출하라",
+  "submit": {"kind": "answer"},
+  "checks": [{"name": "존재", "op": "file_exists", "file": "answer.json"}]
+}
+```
+
+```json
+{
+  "schemaVersion": "1.0",
+  "kind": "gymProfile",
+  "id": "demo",
+  "title": "데모 코스",
+  "packs": ["demo-pack"]
+}
+```
+
+`schema.MINIMAL_PACK` / `MINIMAL_TASK` / `MINIMAL_PROFILE` 과 같다.
+`clone_minimal_*` 는 깊은 복사다. 시험이 한 뼈대를 더럽혀도 다음 칸이
+깨끗하다.
+
+## 15. 메시지 조각 — 바꾸면 소비자가 깨진다
+
+아래 조각은 `audit.py` 출력과 `test_gym_packs` 와 이 모듈의
+`MSG_*` 상수가 공유한다. 뜻을 바꾸려면 시험을 먼저 고친다.
+
+| 조각 | 자리 |
+|---|---|
+| `kind 가 gymPack 가 아니다` | pack kind |
+| `schemaVersion 이 1.0 이 아니다` | pack / profile 버전 |
+| `pack id(...) 가 폴더 이름과 다르다` | pack id |
+| `<key> 가 비었다` | title / axis / runner.* |
+| `requires.commands 가 비었다 — 요구 capability 선언은 필수` | requires |
+| `runner.<key> 가 비었다 — 기준 실행 신원 선언은 필수` | runner |
+| `필수 키 없음: <key>` | task |
+| `tier 는 1~5 정수 (1=입문 … 5=보스)` | tier |
+| `checks 가 비었다` | checks |
+| `미등록 연산자: <op>` | op |
+| `편집 과제에 전역 훑기 연산자(<op>)` | 전역 훑기 |
+| `<op> 는 cmd 가 필요하다` | cmd 부재 |
+| `CLI 에 없는 명령: <name>` | 명령 표면 |
+| `<op> 는 CLI 를 부르지 않는데 cmd 가 있다` | 파일 연산자 + cmd |
+| `kind 가 gymProfile 가 아니다` | profile kind |
+| `packs 가 비었다` | profile packs |
+| `없는 pack 참조: <id>` | profile 대상 |
+
+새 칸은 새 문장을 쓴다. 예전 문장을 재사용하지 않는다. 한 문장이 두
+kind 를 겸하면 시험이 갈라지지 못한다.
+
+## 16. IssueList 손잡이
+
+`IssueList` 는 `list` 의 하위형이다. `audit.py` 처럼 평범한 목록을 넘기면
+이 손잡이는 쓰이지 않는다. 시험과 도구가 kind 로 가르고 싶을 때만 쓴다.
+
+| 손잡이 | 반환 | 쓰임 |
+|---|---|---|
+| `append_issue(kind, where, message, field=, got=)` | `SchemaIssue` | `_fail` 가 부른다 |
+| `kinds()` | kind 문자열 목록 (등장 순) | 한 호출의 칸 종류 |
+| `has_kind(kind)` | bool | 네 자리 재현 시험 |
+| `of_kind(kind)` | `SchemaIssue` 목록 | 같은 kind 의 필드 |
+| `fields_of(kind)` | field 목록 | `missing-key` 의 빠진 키 |
+| `as_dicts()` | JSON 으로 남길 수 있는 목록 | 기계 봉투 |
+
+`SchemaIssue.as_text()` 는 평범한 list 에 쌓이는 줄과 같다.
+`as_dict()` 는 `field`·`got` 가 있을 때만 그 키를 넣는다. `got` 는 80
+글자로 접힌다. 객체는 타입 이름만 남긴다.
+
+모르는 kind 를 생성자에 넘기면 `unexpected` 로 접힌다. 카탈로그에 없는
+이름을 시험이 발명하지 못하게 한다.
+
+## 17. 관련 문서
+
+- 운동장 입구: [`gym/README.md`](../README.md)
+- 테마파크 지도: [`gym/PARK.md`](../PARK.md) — 이 PR 은 고치지 않는다
+- 채점 연산자 목록: 열린 PR 5210 의 `gym/docs/checks.md` (이 브랜치에 없음)
+- 채점기 예외 경로: 열린 PR 5278 의 `gym/docs/score_runner.md` (이 브랜치에 없음)
+- 작업 기록: [`mydocs/working/gym_schema.md`](../../mydocs/working/gym_schema.md)

--- a/mydocs/working/gym_schema.md
+++ b/mydocs/working/gym_schema.md
@@ -1,0 +1,323 @@
+---
+kind: working
+status: active
+canonical: gym/docs/schema.md
+last_verified: 2026-08-18
+---
+
+# gym 코어 스키마 검증 고도화 — 작업 기록 (#5279)
+
+정본 규약은 [`gym/docs/schema.md`](../../gym/docs/schema.md) 다. 이 문서는
+왜 그 칸이 생겼는지, 어떤 예외를 실패로 고정했는지, 단위시험이 무엇을
+재현하는지를 남긴다. pack JSON 과 `checks.REGISTRY` 는 여기서 바꾸지 않는다.
+
+## 한 줄 결론
+
+`gym/core/schema.py` 의 pack/task/profile 검증이 객체 아님·공란·bool tier·
+미등록 연산자·없는 pack 참조에서 죽거나 한 줄로 뭉개지던 자리를 kind 로
+남긴다. 새 CLI 는 없다. 열린 PR 파일은 그대로다.
+
+## 배경
+
+gym 4부(#4653)가 선언 검증을 `schema.py` 한곳으로 모았다. `audit.py` 는
+그 함수를 전 pack 에 돌리고, `test_gym_packs` 는 저장소 나무가 깨끗한지
+본다. 그 성공 칸은 이미 단단하다.
+
+약한 칸은 실패 경로였다.
+
+1. **필수 키가 빠지면** `필수 키 없음` 은 남겼지만, 같은 함수가 `checks` 를
+   순회하다 타입이 틀리면 예외로 죽었다. 감사기 한 pack 이 그 예외로
+   멈춘다.
+2. **tier 가 범위 밖이면** 메시지는 있었지만 `True` 가 1 로 통과했다.
+3. **미등록 연산자** 는 거절했지만 kind 가 없어 시험이 한글 조각에만
+   매였다. 등록부를 읽기만 해야 하는데, 실수로 키를 더하기 쉬운 자리였다.
+4. **프로파일이 없는 pack 을 가리키면** `없는 pack 참조` 는 있었지만
+   `packs` 가 문자열이면 글자를 순회했다.
+
+#5279 는 그 네 자리를 명시했다. 스키마 모듈만 고친다. 채점기·감사기·
+연산자 등록부·tutorial 은 이웃 PR 이 이미 붙잡고 있다.
+
+## 하지 않은 것 (경계)
+
+이 작업은 아래를 의도적으로 건드리지 않았다.
+
+- `gym/core/checks.py` 의 `REGISTRY` / `GLOBAL_SCAN_OPS` / `needs_cli`.
+  PR 5210 이 지목 연산자를 더하는 중이다.
+- `gym/core/runner.py`, `gym/score.py`. PR 5278 이 채점기 예외 경로를
+  고치는 중이다.
+- `gym/tools/audit.py`, `gym/certify.py`, `gym/report.py`.
+- `gym/tutorial/**`, `gym/PARK.md`, `gym/INVITE.md`.
+- 열린 PR 5210–5278 이 추가·수정한 모든 파일.
+- 저장소 pack JSON, 프로파일 JSON, 기준 풀이.
+
+성공 칸의 메시지는 그대로다. `test_gym_packs` 가 기대한 조각
+(`필수 키 없음`, `tier 는 1~5`, `미등록 연산자`, `없는 pack 참조`,
+`checks 가 비었다`, `packs 가 비었다`)을 바꾸지 않았다.
+
+## 설계
+
+### 문자열 목록은 그대로, kind 는 선택
+
+`audit.py` 는 `issues: list[str]` 에 줄을 쌓는다. 그 계약을 깨면 감사기를
+고쳐야 하고, 감사기는 금지 목록에 있다.
+
+그래서 `_fail(errors, where, message, kind=..., field=..., got=...)` 는
+`errors` 가 `append_issue` 를 가진 때만 구조화한다. 평범한 list 는
+예전처럼 `"<where>: <message>"` 만 받는다.
+
+`IssueList` 는 list 의 하위형이다. `append` 계약이 살아 있고, 추가로
+`structured` / `has_kind` / `of_kind` / `as_dicts` 를 준다.
+
+### 객체가 아니면 즉시 접는다
+
+`validate_pack` / `validate_task` / `validate_profile` 의 첫 분기는
+`is_mapping`. 목록·문자열·`None` 은 `not-a-mapping` 한 칸이고 return
+한다. 그 다음 `.get` 을 부르지 않는다.
+
+`validate_task` 의 `pack` 이 객체가 아니면 빈 객체로 본다. 과제 하나를
+검증하는데 pack 축만 못 읽는 자리와, 과제 자체가 깨진 자리를 가른다.
+
+`checks` 항목·`requires`·`runner`·`submit` 도 같은 결이다. 항목 하나가
+문자열이어도 다음 항목을 본다.
+
+### bool tier
+
+```python
+isinstance(True, int)  # True
+```
+
+예전 검사 `isinstance(task.get("tier"), int) and 1 <= tier <= 5` 는
+`True` 를 1 로, `False` 를 범위 밖으로 본다. `False` 는 우연히 거절되고
+`True` 는 입문이 된다. JSON `true` 가 그대로 들어온다.
+
+`is_valid_tier` 는 `isinstance(value, bool)` 을 먼저 거절한다. 메시지
+조각은 예전 `MSG_TIER` 그대로다. 시험이 `True`/`False`/`"1"`/`1.0`/`None`
+을 각각 남긴다.
+
+### REGISTRY 는 읽기만
+
+`registered_ops()` / `is_registered_op` / `op_needs_cli` /
+`is_global_scan_op` 는 `from . import checks` 뒤에 등록부를 읽는다.
+`schema.REGISTRY` 를 만들지 않는다. 시험
+`RegistryIsolationTests` 가 `hasattr(schema, "REGISTRY")` 가 거짓인지,
+`registered_ops()` 가 `frozenset(checks.REGISTRY)` 와 같은지, 미등록
+연산자를 본 뒤에 등록부 키가 그대로인지 본다.
+
+`CHECK_FIELD_HINTS` 는 devel 키만 나열한다. 기본 검증은 힌트를 강제하지
+않는다. 5210 이 키를 더하면 힌트 표는 후속이 따라가면 된다. 이 브랜치가
+등록부에 키를 더해 맞추지 않는다.
+
+### 프로파일 없는 pack
+
+예전: `for pid in profile.get("packs", []): if pid not in pack_ids`.
+`packs` 가 `"core-cli"` 문자열이면 `c`,`o`,`r`,`e`,`-` … 각각이
+`없는 pack 참조` 가 된다. 한 칸이어야 할 자리가 일곱 칸이 된다.
+
+이제 목록이 아니면 `not-a-list` 한 칸이다. 목록인데 대상이 없으면
+`profile-missing-pack` 이고 메시지는 `없는 pack 참조: <id>` 그대로다.
+
+`pack_ids is None` 이면 존재 검사를 건너뛴다. 모양만 보는 호출자를 위해
+남긴 구멍이다. `validate_gym_tree` 는 발견한 pack id 집합을 넘긴다.
+
+## 네 자리 재현
+
+이슈 본문이 적은 네 자리다. 시험 클래스 이름과 같다.
+
+### 필수 키 없음 — `TaskMissingKeyTests`
+
+```python
+body = clone_minimal_task()
+del body["input"]
+issues = collect_task(body, pack)
+assert issues.has_kind("missing-key")
+assert "input" in issues.fields_of("missing-key")
+assert any("필수 키 없음: input" in line for line in issues)
+```
+
+빈 객체는 일곱 키를 모두 남긴다. 키가 있는데 값이 `""` 이면 `missing-key`
+가 아니라 `empty-field` 다. 이 가름이 예전에 없었다.
+
+### 나쁜 tier — `TaskTierTests`
+
+```python
+for tier in (0, 6, True, False, "1", 1.0, None):
+    assert collect_task(clone_minimal_task(tier=tier), pack).has_kind("bad-tier")
+for tier in (1, 2, 3, 4, 5):
+    assert list(collect_task(clone_minimal_task(tier=tier), pack)) == []
+```
+
+0 과 6 은 `test_gym_packs.TierRangeTests` 가 이미 본다. 이 파일은 그
+메시지를 유지한 채 bool·문자·실수를 더한다.
+
+### 미등록 연산자 — `TaskUnknownOpTests`
+
+```python
+issues = collect_task(clone_minimal_task(
+    checks=[{"name": "x", "op": "not_an_op"}]), pack)
+assert any("미등록 연산자: not_an_op" in line for line in issues)
+assert "not_an_op" not in checks.REGISTRY
+```
+
+`op` 가 빠지면 `미등록 연산자: None` 이다. 빈 문자열도 같다. 등록부에
+없는 이름을 넣어도 등록부는 그대로다.
+
+### 프로파일 없는 pack — `ProfileMissingPackTests`
+
+```python
+issues = collect_profile(clone_minimal_profile(packs=["no-such-pack"]),
+                         {"demo-pack"})
+assert issues.has_kind("profile-missing-pack")
+assert any("없는 pack 참조: no-such-pack" in line for line in issues)
+```
+
+`packs=["demo-pack"]` 은 통과한다. `packs=[]` 는 `packs 가 비었다`.
+`packs="demo-pack"` 은 `not-a-list`.
+
+## 추가로 막은 자리
+
+네 자리만 막으면 같은 부류의 구멍이 남는다. 같은 결로 옆 칸을 메웠다.
+
+- pack `requires` 가 목록이면 `malformed-requires`. 예전엔
+  `list.get` 으로 죽었다.
+- pack `runner` 가 문자열이면 `malformed-runner`.
+- runner commit/sha 가 hex 가 아니면 `bad-runner-identity`.
+  `test_gym_packs` 가 이미 길이를 본다. 스키마가 그 길이와 문자를 같이
+  본다.
+- `submit.kind` 가 `zip` 이면 `unknown-submit-kind`.
+- `cmd` 가 문자열이면 `malformed-cmd`. 예전엔 `cmd[0]` 이 `"i"` 가 되어
+  `CLI 에 없는 명령: i` 가 나왔다.
+- 편집 축 + `deep_contains` 는 예전 메시지를 유지한 채
+  `global-scan-forbidden` kind 를 붙인다.
+- 한 과제 안 `check.name` 중복은 `duplicate-check-name`.
+- id 의 `../` 는 `unsafe-id`.
+- 깨진 JSON 파일은 `validate_gym_tree` 가 `malformed-object` 로 남기고
+  다음 파일을 본다.
+
+## capabilities 경로
+
+`runner.py` 가 `known_commands(bin_path)` 와
+`runner_identity(bin_path, ROOT)` 를 부른다. 바깥 반환 모양을 바꾸면
+채점기가 깨지고, 채점기는 금지 목록에 있다.
+
+그래서:
+
+- `capabilities_digest` 는 계속 `(digest, raw)` 를 돌려준다. 빈
+  `bin_path` 만 `ValueError` 로 거절한다.
+- `known_commands` 는 계속 `set | None` 이다. 잡은 예외만
+  `TypeError`·`UnicodeError`·`AttributeError` 로 넓혔다. 명령 항목이
+  문자열이어서 `c["name"]` 이 죽던 자리가 None 이 된다.
+- 빈 집합과 None 을 섞지 않는다. 파싱에 실패하면 None 이다. 명령을
+  읽었는데 이름이 없으면 빈 집합이다. 후자는 정상 JSON `{"commands":[]}`
+  의 결과로, 예전 집합 내포도 그렇게 동작한다.
+- `try_known_commands` 는 바이너리 부재를 None 으로 접는 **새** 함수다.
+  `known_commands` 를 바꾸지 않으려고 옆에 두었다.
+- `parse_*` 도움말은 예외를 던지지 않는다. 시험이 깨진 UTF-8, 배열
+  루트, 이름 없는 항목을 직접 넣는다.
+
+`runner_identity` 의 버전 파싱이 죽지 않게 `TypeError` 등을 더 잡았다.
+git 부재는 예전처럼 빈 커밋이다.
+
+## 저장소 나무
+
+강화가 기존 pack 을 깨면 이 PR 은 등재될 수 없다. 그래서 시험이
+
+- 모든 `pack.json`
+- 모든 `tasks/*.json`
+- 모든 `profiles/*.json`
+- `validate_gym_tree(gym/)`
+
+을 다시 돌린다. 2026-08-18 devel 나무는 위반 0 이다. `audit.py` 도
+같은 성공 칸을 본다. 감사기는 기준 풀이 짝을 추가로 보고, 스키마 나무는
+선언만 본다.
+
+힌트 표(`CHECK_FIELD_HINTS`)가 devel `REGISTRY` 키와 같은지도 본다.
+키가 빠지면 시험을 고친다. 등록부에 키를 더해 맞추지 않는다.
+
+## 시험 지도
+
+`scripts/tests/test_gym_schema.py` 의 클래스와 이슈 본문의 대응.
+
+| 클래스 | 자리 |
+|---|---|
+| `CatalogTests` | kind 카탈로그, 상수, 메시지 조각 |
+| `HelperTests` | tier/id/hex/clone |
+| `IssueListTests` | 평범한 list 와 IssueList |
+| `PackMissingAndTypeTests` | pack 키·타입·runner |
+| `TaskMissingKeyTests` | 필수 키 없음 |
+| `TaskTierTests` | 나쁜 tier |
+| `TaskUnknownOpTests` | 미등록 연산자 |
+| `TaskCheckShapeTests` | checks 뼈대 |
+| `TaskSubmitTests` | submit.kind |
+| `TaskCmdTests` | cmd 유무·형태 |
+| `TaskGlobalScanTests` | 편집 축 전역 훑기 |
+| `ProfileMissingPackTests` | 없는 pack 참조 |
+| `ExistingTreeTests` | 저장소 나무 성공 칸 |
+| `CapabilitiesTests` | digest·known_commands |
+| `RunnerIdentityTests` | runner_identity·git_head |
+| `TreeWalkTests` | 임시 나무 전수 |
+| `RegistryIsolationTests` | REGISTRY 를 건드리지 않음 |
+| `MessageCompatibilityTests` | 예전 메시지 조각 |
+
+`test_gym_packs.py` 는 고치지 않았다. 성공 칸의 소유권은 그 파일에
+남겨 둔다. 이 파일은 예외 칸만 더한다.
+
+## 검증
+
+로컬에서 돌리는 것:
+
+```bash
+python -m unittest scripts.tests.test_gym_schema scripts.tests.test_gym_packs
+python gym/tools/audit.py
+```
+
+Rust 표면은 바꾸지 않았다. `cargo fmt --all -- --check` 는 PR 전 하드
+게이트로 한 번 돌린다. clippy/test 는 해당 없다.
+
+`audit.py` 가 통과해야 한다. 스키마가 저장소 나무에 새 칸을 내면 감사기
+exit 1 이다. 그 경우 스키마를 느슨하게 되돌리지 않고, 나무가 이미
+어긋난 것인지를 먼저 본다. 2026-08-18 devel 나무는 깨끗했다.
+
+## 크기와 범위
+
+이슈 DoD 는 additions >= 3000 이다. 이 브랜치의 삽입은
+
+- `gym/core/schema.py` 고도화 (카탈로그·IssueList·타입 가드·나무 전수)
+- `scripts/tests/test_gym_schema.py` 예외 칸
+- `gym/docs/schema.md` 정본 규약
+- `mydocs/working/gym_schema.md` 이 기록
+
+네 파일에만 모인다. 금지 파일에 공백을 넣어 숫자를 채우지 않는다.
+
+## 후속
+
+- PR 5210 이 등록부에 키를 더하면 `CHECK_FIELD_HINTS` 를 같은 키로
+  따라가면 된다. 기본 검증은 계속 힌트를 강제하지 않는 편이 안전하다.
+- PR 5278 이 채점기 예외 kind 를 남기면, 스키마 kind 와 이름을 맞출지
+  한 번 보면 좋다. 지금은 두 카탈로그가 다른 층이다(선언 vs 실행).
+- 프로파일 `schemaVersion` 을 필수로 올릴지는 후속. 지금은 키가 있을
+  때만 1.0 을 강제한다.
+- `validate_gym_tree` 를 감사기에 붙이는 것도 후속. 이 이슈는 감사기를
+  고치지 않는다.
+
+## 모르는 키는 거절하지 않는다
+
+pack 의 `description`, 과제의 `notes`·자체 `axis`, 프로파일의 설명
+문자열은 스키마가 보지 않는다. 후속이 필드를 더해도 이 모듈을 고칠
+필요가 없게 하려는 결이다. 필수 키만 강제하고, 나머지는 채점기나
+문서가 소비한다.
+
+hex 는 대소문자를 가리지 않는다. pack 선언의 commit/sha 가 대문자로
+들어와도 통과한다. `is_commit_hex` / `is_sha256_hex` 가 그 자리를 본다.
+
+`validate_gym_tree(..., known_commands={"info"})` 는 임시 나무에서
+명령 표면을 넘기는 시험 경로다. 저장소 전수는 `None` 으로 돌려
+바이너리 없이 선언만 본다.
+
+## 관련
+
+- 이슈: [#5279](https://github.com/edwardkim/rhwp/issues/5279)
+- 스키마 원점: [#4653](https://github.com/edwardkim/rhwp/issues/4653)
+- 전역 훑기 금지: [#4600](https://github.com/edwardkim/rhwp/issues/4600)
+- 티어 1~5: [#4664](https://github.com/edwardkim/rhwp/issues/4664)
+- 지목 연산자 PR: #5210 (파일 미수정)
+- 채점기 예외 PR: #5278 (파일 미수정)

--- a/scripts/tests/test_gym_schema.py
+++ b/scripts/tests/test_gym_schema.py
@@ -1,0 +1,1428 @@
+"""[#5279] gym/core/schema.py 예외 경로·카탈로그·기존 나무 계약.
+
+성공 칸(저장소 pack 전수가 스키마를 지킨다)은 test_gym_packs 가 이미 본다.
+이 파일은 그 칸을 바꾸지 않고, 예전이 죽거나 한 줄로 뭉개던 자리를 kind 로
+고정한다.
+
+커버하는 네 자리(이슈 본문):
+- 필수 키 없음
+- 나쁜 tier (0·6·bool·문자열·실수)
+- 미등록 연산자
+- 프로파일이 없는 pack 을 가리킴
+
+새 CLI 는 없다. REGISTRY 는 읽기만 한다. audit.py / runner.py / checks.py 는
+이 시험에서 고치지 않는다.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+PACKS = GYM / "packs"
+PROFILES = GYM / "profiles"
+
+
+def load_schema():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import schema
+    return schema
+
+
+def load_checks():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import checks
+    return checks
+
+
+def _pack(**overrides):
+    schema = load_schema()
+    return schema.clone_minimal_pack(**overrides)
+
+
+def _task(**overrides):
+    schema = load_schema()
+    return schema.clone_minimal_task(**overrides)
+
+
+def _profile(**overrides):
+    schema = load_schema()
+    return schema.clone_minimal_profile(**overrides)
+
+
+def _plain(fn, *args):
+    errors = []
+    fn(*args, errors)
+    return errors
+
+
+def _issues(fn, *args):
+    schema = load_schema()
+    collected = schema.IssueList()
+    fn(*args, collected)
+    return collected
+
+
+def _read(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _write(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(payload, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_issue_kinds_are_unique_and_documented(self):
+        kinds = self.s.SCHEMA_ISSUE_KINDS
+        self.assertEqual(len(kinds), len(set(kinds)))
+        self.assertGreaterEqual(len(kinds), 25)
+        for kind in kinds:
+            self.assertTrue(self.s.is_known_issue_kind(kind), kind)
+            self.assertTrue(self.s.SCHEMA_ISSUE_HELP[kind], kind)
+            self.assertTrue(self.s.describe_issue_kind(kind), kind)
+
+    def test_unknown_kind_falls_back_to_unexpected_help(self):
+        self.assertEqual(
+            self.s.describe_issue_kind("not-a-kind"),
+            self.s.SCHEMA_ISSUE_HELP["unexpected"],
+        )
+
+    def test_format_issue_catalog_matches_constants(self):
+        catalog = self.s.format_issue_catalog()
+        self.assertEqual(len(catalog), self.s.issue_kind_count())
+        self.assertEqual([row[0] for row in catalog], list(self.s.SCHEMA_ISSUE_KINDS))
+
+    def test_required_key_tuples_are_stable(self):
+        self.assertEqual(
+            self.s.TASK_REQUIRED,
+            ("id", "tier", "title", "input", "instructions", "submit", "checks"),
+        )
+        self.assertEqual(
+            self.s.PACK_REQUIRED,
+            ("schemaVersion", "kind", "id", "title", "axis", "requires", "runner"),
+        )
+        self.assertEqual(
+            self.s.PROFILE_REQUIRED,
+            ("schemaVersion", "kind", "id", "title", "packs"),
+        )
+        self.assertEqual(
+            self.s.RUNNER_KEYS,
+            ("rhwpVersion", "rhwpCommit", "capabilitiesSha256"),
+        )
+
+    def test_submit_kinds_are_exactly_three(self):
+        self.assertEqual(self.s.SUBMIT_KINDS, ("answer", "artifact", "pair"))
+        self.assertTrue(self.s.is_known_submit_kind("answer"))
+        self.assertTrue(self.s.is_known_submit_kind("artifact"))
+        self.assertTrue(self.s.is_known_submit_kind("pair"))
+        self.assertFalse(self.s.is_known_submit_kind("json"))
+        self.assertFalse(self.s.is_known_submit_kind(""))
+
+    def test_schema_version_and_kinds_unchanged(self):
+        self.assertEqual(self.s.SCHEMA_VERSION, "1.0")
+        self.assertEqual(self.s.PACK_KIND, "gymPack")
+        self.assertEqual(self.s.PROFILE_KIND, "gymProfile")
+        self.assertEqual(self.s.TIER_MIN, 1)
+        self.assertEqual(self.s.TIER_MAX, 5)
+        self.assertEqual(self.s.TIER_NAMES[1], "입문")
+        self.assertEqual(self.s.TIER_NAMES[5], "보스")
+        self.assertEqual(self.s.EDITING_AXES, ("편집", "보안"))
+
+    def test_legacy_message_fragments_are_stable(self):
+        self.assertIn("gymPack", self.s.MSG_PACK_KIND)
+        self.assertIn("1.0", self.s.MSG_PACK_SCHEMA)
+        self.assertIn("requires.commands", self.s.MSG_REQUIRES_EMPTY)
+        self.assertIn("1~5", self.s.MSG_TIER)
+        self.assertEqual(self.s.MSG_CHECKS_EMPTY, "checks 가 비었다")
+        self.assertIn("gymProfile", self.s.MSG_PROFILE_KIND)
+        self.assertEqual(self.s.MSG_PACKS_EMPTY, "packs 가 비었다")
+        self.assertEqual(self.s.MSG_MISSING_KEY_PREFIX, "필수 키 없음: ")
+        self.assertEqual(self.s.MSG_UNKNOWN_OP_PREFIX, "미등록 연산자: ")
+        self.assertEqual(self.s.MSG_MISSING_PACK_PREFIX, "없는 pack 참조: ")
+
+
+class HelperTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_valid_tiers_are_one_through_five(self):
+        for tier in (1, 2, 3, 4, 5):
+            self.assertTrue(self.s.is_valid_tier(tier), tier)
+
+    def test_invalid_tiers_include_bool_and_text(self):
+        for value in (0, 6, -1, True, False, "1", 1.0, None, [], {}, 99):
+            self.assertFalse(self.s.is_valid_tier(value), value)
+
+    def test_safe_ids_accept_pack_and_task_shapes(self):
+        for ident in ("table-editing", "TB01", "T10", "core-cli", "render-tree",
+                      "self-description", "casual-rides", "studio-e2e"):
+            self.assertTrue(self.s.is_safe_id(ident), ident)
+
+    def test_unsafe_ids_reject_paths_and_blanks(self):
+        for ident in ("", "  ", ".", "..", "../x", "a/b", "a\\b", "C:x",
+                      " spaced", "x y", "-leading", "_no", "한글"):
+            self.assertFalse(self.s.is_safe_id(ident), ident)
+
+    def test_commit_and_sha_hex(self):
+        self.assertTrue(self.s.is_commit_hex("c" * 40))
+        self.assertTrue(self.s.is_commit_hex("A" * 40))
+        self.assertFalse(self.s.is_commit_hex("c" * 39))
+        self.assertFalse(self.s.is_commit_hex("c" * 41))
+        self.assertFalse(self.s.is_commit_hex("g" * 40))
+        self.assertTrue(self.s.is_sha256_hex("a" * 64))
+        self.assertFalse(self.s.is_sha256_hex("a" * 63))
+        self.assertFalse(self.s.is_sha256_hex("z" * 64))
+
+    def test_nonempty_str_and_list_helpers(self):
+        self.assertTrue(self.s.is_nonempty_str("x"))
+        self.assertFalse(self.s.is_nonempty_str("  "))
+        self.assertFalse(self.s.is_nonempty_str(1))
+        self.assertTrue(self.s.is_nonempty_str_list(["a", "b"]))
+        self.assertFalse(self.s.is_nonempty_str_list(["a", ""]))
+        self.assertFalse(self.s.is_nonempty_str_list([]))
+        self.assertFalse(self.s.is_str_list(["a", 1]))
+        self.assertTrue(self.s.is_mapping({}))
+        self.assertFalse(self.s.is_mapping([]))
+
+    def test_editing_axis_prefixes(self):
+        self.assertTrue(self.s.is_editing_axis("편집 (표 좌표 지정)"))
+        self.assertTrue(self.s.is_editing_axis("보안 (은닉)"))
+        self.assertFalse(self.s.is_editing_axis("자동화"))
+        self.assertFalse(self.s.is_editing_axis(""))
+        self.assertFalse(self.s.is_editing_axis(None))
+
+    def test_clone_helpers_do_not_alias(self):
+        one = self.s.clone_minimal_task(id="X1")
+        two = self.s.clone_minimal_task(id="X2")
+        self.assertEqual(one["id"], "X1")
+        self.assertEqual(two["id"], "X2")
+        one["checks"].append({"name": "extra"})
+        self.assertEqual(len(two["checks"]), 1)
+
+
+class IssueListTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_plain_list_still_gets_legacy_strings(self):
+        errors = []
+        self.s.validate_task({"id": "X"}, {"id": "p"}, None, errors)
+        self.assertTrue(any(item.startswith("p/X: 필수 키 없음:") for item in errors))
+        self.assertTrue(all(isinstance(item, str) for item in errors))
+
+    def test_issue_list_records_kind_and_text(self):
+        issues = self.s.collect_task({"id": "X"}, {"id": "p"})
+        self.assertTrue(issues.has_kind("missing-key"))
+        self.assertTrue(issues.of_kind("missing-key"))
+        self.assertIn("tier", issues.fields_of("missing-key"))
+        self.assertTrue(issues.as_dicts())
+        self.assertEqual(issues[0], issues.structured[0].as_text())
+
+    def test_unknown_kind_coerces_to_unexpected(self):
+        issue = self.s.SchemaIssue("not-real", "here", "msg")
+        self.assertEqual(issue.kind, "unexpected")
+
+    def test_preview_truncates_long_strings(self):
+        long = "x" * 200
+        issue = self.s.SchemaIssue("empty-field", "w", "m", field="f", got=long)
+        self.assertEqual(len(issue.got), 80)
+        self.assertTrue(issue.got.endswith("..."))
+
+    def test_preview_uses_type_name_for_objects(self):
+        issue = self.s.SchemaIssue("not-a-mapping", "w", "m", got={"a": 1})
+        self.assertEqual(issue.got, "dict")
+        issue = self.s.SchemaIssue("bad-type", "w", "m", got=list)
+        self.assertEqual(issue.got, "list")
+
+    def test_collect_wrappers_return_issue_list(self):
+        pack_issues = self.s.collect_pack("nope", "demo-pack")
+        self.assertTrue(pack_issues.has_kind("not-a-mapping"))
+        profile_issues = self.s.collect_profile("nope", {"demo-pack"})
+        self.assertTrue(profile_issues.has_kind("not-a-mapping"))
+
+
+class PackMissingAndTypeTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_valid_minimal_pack_is_clean(self):
+        issues = self.s.collect_pack(_pack(), "demo-pack")
+        self.assertEqual(list(issues), [])
+
+    def test_folder_name_mismatch(self):
+        issues = self.s.collect_pack(_pack(), "other-pack")
+        self.assertTrue(issues.has_kind("pack-id-mismatch"))
+        self.assertTrue(any("폴더 이름과 다르다" in line for line in issues))
+
+    def test_bad_kind_and_schema_version(self):
+        issues = self.s.collect_pack(_pack(kind="nope", schemaVersion="2.0"), "demo-pack")
+        self.assertTrue(issues.has_kind("bad-kind"))
+        self.assertTrue(issues.has_kind("bad-schema-version"))
+        self.assertTrue(any("gymPack" in line for line in issues))
+        self.assertTrue(any("1.0" in line for line in issues))
+
+    def test_empty_title_and_axis(self):
+        issues = self.s.collect_pack(_pack(title="", axis=""), "demo-pack")
+        self.assertTrue(issues.has_kind("empty-field"))
+        self.assertIn("title", issues.fields_of("empty-field"))
+        self.assertIn("axis", issues.fields_of("empty-field"))
+
+    def test_non_string_title(self):
+        issues = self.s.collect_pack(_pack(title=12), "demo-pack")
+        self.assertTrue(issues.has_kind("bad-type"))
+
+    def test_requires_missing_or_empty(self):
+        for requires in ({}, {"commands": []}, {"commands": None}):
+            body = _pack()
+            body["requires"] = requires
+            issues = self.s.collect_pack(body, "demo-pack")
+            self.assertTrue(issues.has_kind("empty-commands"), requires)
+            self.assertTrue(any("requires.commands 가 비었다" in line for line in issues))
+
+    def test_requires_not_an_object(self):
+        body = _pack()
+        body["requires"] = ["info"]
+        issues = self.s.collect_pack(body, "demo-pack")
+        self.assertTrue(issues.has_kind("malformed-requires"))
+
+    def test_requires_blank_command_item(self):
+        body = _pack()
+        body["requires"] = {"commands": ["info", "  "]}
+        issues = self.s.collect_pack(body, "demo-pack")
+        self.assertTrue(issues.has_kind("empty-commands"))
+
+    def test_runner_missing_each_key(self):
+        for key in self.s.RUNNER_KEYS:
+            body = _pack()
+            body["runner"] = dict(self.s.MINIMAL_RUNNER)
+            body["runner"][key] = ""
+            issues = self.s.collect_pack(body, "demo-pack")
+            self.assertTrue(issues.has_kind("empty-field"), key)
+            self.assertTrue(any(f"runner.{key} 가 비었다" in line for line in issues), key)
+
+    def test_runner_not_an_object(self):
+        body = _pack()
+        body["runner"] = "nope"
+        issues = self.s.collect_pack(body, "demo-pack")
+        self.assertTrue(issues.has_kind("malformed-runner"))
+
+    def test_runner_commit_and_digest_must_be_hex(self):
+        body = _pack()
+        body["runner"] = dict(self.s.MINIMAL_RUNNER)
+        body["runner"]["rhwpCommit"] = "not-a-commit"
+        body["runner"]["capabilitiesSha256"] = "short"
+        issues = self.s.collect_pack(body, "demo-pack")
+        self.assertTrue(issues.has_kind("bad-runner-identity"))
+        self.assertEqual(len(issues.of_kind("bad-runner-identity")), 2)
+
+    def test_runner_non_string_version(self):
+        body = _pack()
+        body["runner"] = dict(self.s.MINIMAL_RUNNER)
+        body["runner"]["rhwpVersion"] = 1
+        issues = self.s.collect_pack(body, "demo-pack")
+        self.assertTrue(issues.has_kind("bad-type"))
+
+    def test_unsafe_pack_id(self):
+        issues = self.s.collect_pack(_pack(id="../x"), "../x")
+        self.assertTrue(issues.has_kind("unsafe-id"))
+
+    def test_non_mapping_manifest_does_not_raise(self):
+        for payload in (None, [], "x", 1):
+            issues = self.s.collect_pack(payload, "demo-pack")
+            self.assertTrue(issues.has_kind("not-a-mapping"), payload)
+
+    def test_plain_list_messages_keep_where_prefix(self):
+        errors = _plain(self.s.validate_pack, _pack(title=""), "demo-pack")
+        self.assertTrue(errors[0].startswith("demo-pack: "))
+
+
+class TaskMissingKeyTests(unittest.TestCase):
+    """이슈 본문: 필수 키 없음."""
+
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_each_required_key_reports_missing(self):
+        for key in self.s.TASK_REQUIRED:
+            body = _task()
+            del body[key]
+            issues = self.s.collect_task(body, self.pack)
+            self.assertTrue(issues.has_kind("missing-key"), key)
+            self.assertIn(key, issues.fields_of("missing-key"))
+            self.assertTrue(
+                any(f"필수 키 없음: {key}" in line for line in issues), key)
+
+    def test_empty_task_reports_all_required_keys(self):
+        issues = self.s.collect_task({}, {"id": "p"})
+        for key in self.s.TASK_REQUIRED:
+            self.assertIn(key, issues.fields_of("missing-key"), key)
+
+    def test_empty_string_fields_are_not_missing_keys(self):
+        body = _task(title="  ", input="", instructions="")
+        issues = self.s.collect_task(body, self.pack)
+        self.assertFalse(issues.has_kind("missing-key"))
+        self.assertTrue(issues.has_kind("empty-field"))
+        self.assertIn("title", issues.fields_of("empty-field"))
+        self.assertIn("input", issues.fields_of("empty-field"))
+        self.assertIn("instructions", issues.fields_of("empty-field"))
+
+    def test_non_string_title_input_instructions(self):
+        body = _task(title=1, input=2, instructions=3)
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("bad-type"))
+        self.assertGreaterEqual(len(issues.of_kind("bad-type")), 3)
+
+    def test_empty_id_and_path_id(self):
+        issues = self.s.collect_task(_task(id=""), self.pack)
+        self.assertTrue(issues.has_kind("empty-field"))
+        issues = self.s.collect_task(_task(id="../T01"), self.pack)
+        self.assertTrue(issues.has_kind("unsafe-id"))
+
+    def test_non_mapping_task_does_not_raise(self):
+        for payload in (None, [], "task", 1):
+            issues = self.s.collect_task(payload, self.pack)
+            self.assertTrue(issues.has_kind("not-a-mapping"), payload)
+
+    def test_non_mapping_pack_is_tolerated(self):
+        issues = self.s.collect_task(_task(), None)
+        self.assertEqual(list(issues), [])
+
+
+class TaskTierTests(unittest.TestCase):
+    """이슈 본문: 나쁜 tier."""
+
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_tiers_one_and_five_pass(self):
+        for tier in (1, 2, 3, 4, 5):
+            issues = self.s.collect_task(_task(tier=tier), self.pack)
+            self.assertEqual(list(issues), [], tier)
+
+    def test_tiers_zero_and_six_keep_legacy_message(self):
+        for tier in (0, 6):
+            issues = self.s.collect_task(_task(tier=tier), self.pack)
+            self.assertTrue(issues.has_kind("bad-tier"), tier)
+            self.assertTrue(any("tier" in line for line in issues), tier)
+            self.assertTrue(any(self.s.MSG_TIER in line for line in issues), tier)
+
+    def test_bool_tier_is_rejected(self):
+        for value in (True, False):
+            issues = self.s.collect_task(_task(tier=value), self.pack)
+            self.assertTrue(issues.has_kind("bad-tier"), value)
+            self.assertTrue(any(self.s.MSG_TIER in line for line in issues), value)
+
+    def test_string_and_float_tier_are_rejected(self):
+        for value in ("1", "5", 1.0, 2.5, None, [1], {"n": 1}):
+            issues = self.s.collect_task(_task(tier=value), self.pack)
+            self.assertTrue(issues.has_kind("bad-tier"), value)
+
+    def test_missing_tier_is_both_missing_key_and_bad_tier(self):
+        body = _task()
+        del body["tier"]
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("missing-key"))
+        self.assertTrue(issues.has_kind("bad-tier"))
+
+
+class TaskUnknownOpTests(unittest.TestCase):
+    """이슈 본문: 미등록 연산자."""
+
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_unknown_op_keeps_legacy_message(self):
+        body = _task(checks=[{"name": "x", "op": "not_an_op"}])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("unknown-op"))
+        self.assertTrue(any("미등록 연산자: not_an_op" in line for line in issues))
+
+    def test_none_op_is_unknown(self):
+        body = _task(checks=[{"name": "x"}])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("unknown-op"))
+        self.assertTrue(any("미등록 연산자: None" in line for line in issues))
+
+    def test_registered_file_op_without_cmd_passes(self):
+        body = _task(checks=[{"name": "존재", "op": "file_exists", "file": "a.json"}])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertEqual(list(issues), [])
+
+    def test_registry_is_not_mutated_when_unknown_op_is_seen(self):
+        checks = load_checks()
+        before = set(checks.REGISTRY)
+        body = _task(checks=[{"name": "x", "op": "invented_op"}])
+        self.s.collect_task(body, self.pack)
+        self.assertEqual(set(checks.REGISTRY), before)
+        self.assertNotIn("invented_op", checks.REGISTRY)
+
+    def test_registered_ops_helper_matches_registry_keys(self):
+        checks = load_checks()
+        self.assertEqual(self.s.registered_ops(), frozenset(checks.REGISTRY))
+        for op in checks.REGISTRY:
+            self.assertTrue(self.s.is_registered_op(op), op)
+        self.assertFalse(self.s.is_registered_op("invented_op"))
+
+
+class TaskCheckShapeTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_empty_checks_keeps_legacy_message(self):
+        issues = self.s.collect_task(_task(checks=[]), self.pack)
+        self.assertTrue(issues.has_kind("empty-checks"))
+        self.assertTrue(any("checks 가 비었다" in line for line in issues))
+
+    def test_missing_checks_also_says_empty(self):
+        body = _task()
+        del body["checks"]
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("empty-checks"))
+        self.assertTrue(issues.has_kind("missing-key"))
+
+    def test_checks_must_be_a_list(self):
+        for payload in ({"op": "file_exists"}, "file_exists", 1):
+            issues = self.s.collect_task(_task(checks=payload), self.pack)
+            self.assertTrue(issues.has_kind("not-a-list"), payload)
+
+    def test_check_item_must_be_object(self):
+        body = _task(checks=["file_exists", 1, None])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("malformed-check"))
+        self.assertEqual(len(issues.of_kind("malformed-check")), 3)
+
+    def test_check_without_name(self):
+        body = _task(checks=[{"op": "file_exists", "file": "a.json"}])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("malformed-check"))
+        self.assertTrue(any("이름 없음" in line for line in issues))
+
+    def test_duplicate_check_names(self):
+        body = _task(checks=[
+            {"name": "존재", "op": "file_exists", "file": "a.json"},
+            {"name": "존재", "op": "file_exists", "file": "b.json"},
+        ])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("duplicate-check-name"))
+
+    def test_lint_check_fields_for_known_ops(self):
+        missing = self.s.lint_check_fields({"op": "file_exists"})
+        self.assertEqual(missing, ("file",))
+        missing = self.s.lint_check_fields({"op": "csv_cell_eq", "file": "a.csv"})
+        self.assertEqual(missing, ("row", "col", "value"))
+        self.assertEqual(self.s.lint_check_fields("nope"), ("<not-a-mapping>",))
+        self.assertEqual(self.s.lint_check_fields({"op": "file_exists", "file": "a"}), ())
+
+
+class TaskSubmitTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_known_submit_kinds_pass(self):
+        for kind in self.s.SUBMIT_KINDS:
+            issues = self.s.collect_task(_task(submit={"kind": kind}), self.pack)
+            self.assertEqual(list(issues), [], kind)
+
+    def test_unknown_submit_kind(self):
+        issues = self.s.collect_task(_task(submit={"kind": "zip"}), self.pack)
+        self.assertTrue(issues.has_kind("unknown-submit-kind"))
+        self.assertTrue(any("zip" in line for line in issues))
+
+    def test_submit_must_be_object(self):
+        issues = self.s.collect_task(_task(submit="answer"), self.pack)
+        self.assertTrue(issues.has_kind("malformed-submit"))
+
+    def test_empty_submit_kind(self):
+        issues = self.s.collect_task(_task(submit={}), self.pack)
+        self.assertTrue(issues.has_kind("empty-field"))
+
+    def test_submit_files_must_be_nonempty_strings(self):
+        issues = self.s.collect_task(
+            _task(submit={"kind": "artifact", "files": []}), self.pack)
+        self.assertTrue(issues.has_kind("empty-field"))
+        issues = self.s.collect_task(
+            _task(submit={"kind": "artifact", "files": "out.hwp"}), self.pack)
+        self.assertTrue(issues.has_kind("malformed-submit"))
+        issues = self.s.collect_task(
+            _task(submit={"kind": "pair", "files": ["o1.hwp", ""]}), self.pack)
+        self.assertTrue(issues.has_kind("malformed-submit"))
+
+    def test_submit_files_may_be_omitted(self):
+        issues = self.s.collect_task(_task(submit={"kind": "answer"}), self.pack)
+        self.assertEqual(list(issues), [])
+
+
+class TaskCmdTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_cli_op_requires_cmd(self):
+        body = _task(checks=[{"name": "쪽수", "op": "answer_eq", "answer": "pages"}])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("missing-cmd"))
+        self.assertTrue(any("answer_eq 는 cmd 가 필요하다" in line for line in issues))
+
+    def test_file_op_rejects_cmd(self):
+        body = _task(checks=[{
+            "name": "존재",
+            "op": "file_exists",
+            "file": "a.json",
+            "cmd": ["info"],
+        }])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("unexpected-cmd"))
+        self.assertTrue(any("CLI 를 부르지 않는데 cmd 가 있다" in line for line in issues))
+
+    def test_cmd_must_be_string_list(self):
+        body = _task(checks=[{
+            "name": "쪽수",
+            "op": "answer_eq",
+            "answer": "pages",
+            "cmd": "info {input} --json",
+        }])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("malformed-cmd"))
+
+    def test_cmd_rejects_blank_items(self):
+        body = _task(checks=[{
+            "name": "쪽수",
+            "op": "answer_eq",
+            "answer": "pages",
+            "cmd": ["info", ""],
+        }])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertTrue(issues.has_kind("malformed-cmd"))
+
+    def test_unknown_command_when_surface_is_known(self):
+        body = _task(checks=[{
+            "name": "쪽수",
+            "op": "answer_eq",
+            "answer": "pages",
+            "cmd": ["not-a-cli", "{input}", "--json"],
+        }])
+        issues = self.s.collect_task(body, self.pack, {"info", "edit"})
+        self.assertTrue(issues.has_kind("unknown-command"))
+        self.assertTrue(any("CLI 에 없는 명령: not-a-cli" in line for line in issues))
+
+    def test_known_command_passes(self):
+        body = _task(checks=[{
+            "name": "쪽수",
+            "op": "answer_eq",
+            "answer": "pages",
+            "cmd": ["info", "{input}", "--json"],
+        }])
+        issues = self.s.collect_task(body, self.pack, {"info"})
+        self.assertEqual(list(issues), [])
+
+    def test_known_commands_none_skips_surface_check(self):
+        body = _task(checks=[{
+            "name": "쪽수",
+            "op": "answer_eq",
+            "answer": "pages",
+            "cmd": ["not-a-cli", "{input}"],
+        }])
+        issues = self.s.collect_task(body, self.pack, None)
+        self.assertFalse(issues.has_kind("unknown-command"))
+
+
+class TaskGlobalScanTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_editing_axis_rejects_deep_contains(self):
+        pack = _pack(axis="편집 (표 좌표 지정)")
+        body = _task(checks=[{
+            "name": "어딘가",
+            "op": "deep_contains",
+            "value": "x",
+            "cmd": ["export-tables", "{input}", "--json"],
+        }])
+        issues = self.s.collect_task(body, pack)
+        self.assertTrue(issues.has_kind("global-scan-forbidden"))
+        self.assertTrue(any("전역 훑기 연산자" in line for line in issues))
+
+    def test_security_axis_rejects_not_contains_without_reason(self):
+        pack = _pack(axis="보안 (은닉)")
+        body = _task(checks=[{
+            "name": "지움",
+            "op": "not_contains",
+            "value": "x",
+            "cmd": ["inspect", "{input}", "--json"],
+        }])
+        issues = self.s.collect_task(body, pack)
+        self.assertTrue(issues.has_kind("global-scan-forbidden"))
+
+    def test_allow_global_scan_reason_permits_it(self):
+        pack = _pack(axis="편집")
+        body = _task(checks=[{
+            "name": "어딘가",
+            "op": "deep_contains",
+            "value": "x",
+            "cmd": ["export-tables", "{input}", "--json"],
+            "allowGlobalScan": "코퍼스 스윕 예외",
+        }])
+        issues = self.s.collect_task(body, pack)
+        self.assertFalse(issues.has_kind("global-scan-forbidden"))
+
+    def test_task_axis_overrides_pack_axis(self):
+        pack = _pack(axis="자동화")
+        body = _task(axis="편집", checks=[{
+            "name": "어딘가",
+            "op": "deep_contains",
+            "value": "x",
+            "cmd": ["info", "{input}", "--json"],
+        }])
+        issues = self.s.collect_task(body, pack)
+        self.assertTrue(issues.has_kind("global-scan-forbidden"))
+
+    def test_non_editing_axis_allows_global_scan(self):
+        pack = _pack(axis="자동화")
+        body = _task(checks=[{
+            "name": "어딘가",
+            "op": "deep_contains",
+            "value": "x",
+            "cmd": ["info", "{input}", "--json"],
+        }])
+        issues = self.s.collect_task(body, pack)
+        self.assertFalse(issues.has_kind("global-scan-forbidden"))
+
+    def test_global_scan_ops_are_exactly_the_registry_set(self):
+        checks = load_checks()
+        self.assertEqual(checks.GLOBAL_SCAN_OPS, {"deep_contains", "not_contains"})
+        self.assertTrue(self.s.is_global_scan_op("deep_contains"))
+        self.assertFalse(self.s.is_global_scan_op("file_exists"))
+
+
+class ProfileMissingPackTests(unittest.TestCase):
+    """이슈 본문: 프로파일이 없는 pack 을 가리킴."""
+
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_known_pack_passes(self):
+        issues = self.s.collect_profile(_profile(), {"demo-pack"})
+        self.assertEqual(list(issues), [])
+
+    def test_missing_pack_keeps_legacy_message(self):
+        issues = self.s.collect_profile(
+            _profile(packs=["no-such-pack"]), {"demo-pack"})
+        self.assertTrue(issues.has_kind("profile-missing-pack"))
+        self.assertTrue(any("없는 pack 참조: no-such-pack" in line for line in issues))
+
+    def test_empty_packs_keeps_legacy_message(self):
+        issues = self.s.collect_profile(_profile(packs=[]), {"demo-pack"})
+        self.assertTrue(issues.has_kind("empty-packs"))
+        self.assertTrue(any("packs 가 비었다" in line for line in issues))
+
+    def test_none_packs_is_empty(self):
+        body = _profile()
+        body["packs"] = None
+        issues = self.s.collect_profile(body, {"demo-pack"})
+        self.assertTrue(issues.has_kind("empty-packs"))
+
+    def test_packs_must_be_a_list(self):
+        issues = self.s.collect_profile(_profile(packs="demo-pack"), {"demo-pack"})
+        self.assertTrue(issues.has_kind("not-a-list"))
+
+    def test_duplicate_pack_entries(self):
+        issues = self.s.collect_profile(
+            _profile(packs=["demo-pack", "demo-pack"]), {"demo-pack"})
+        self.assertTrue(issues.has_kind("duplicate-pack"))
+
+    def test_blank_and_unsafe_pack_entries(self):
+        issues = self.s.collect_profile(
+            _profile(packs=["demo-pack", "  ", "../x"]), {"demo-pack"})
+        self.assertTrue(issues.has_kind("empty-field"))
+        self.assertTrue(issues.has_kind("unsafe-id"))
+
+    def test_bad_profile_kind(self):
+        issues = self.s.collect_profile(_profile(kind="gymPack"), {"demo-pack"})
+        self.assertTrue(issues.has_kind("bad-kind"))
+        self.assertTrue(any("gymProfile" in line for line in issues))
+
+    def test_bad_profile_schema_version(self):
+        issues = self.s.collect_profile(
+            _profile(schemaVersion="9.9"), {"demo-pack"})
+        self.assertTrue(issues.has_kind("bad-schema-version"))
+
+    def test_unsafe_profile_id(self):
+        issues = self.s.collect_profile(_profile(id="a/b"), {"demo-pack"})
+        self.assertTrue(issues.has_kind("unsafe-id"))
+
+    def test_empty_title(self):
+        issues = self.s.collect_profile(_profile(title=""), {"demo-pack"})
+        self.assertTrue(issues.has_kind("empty-field"))
+
+    def test_pack_ids_none_skips_existence_check(self):
+        issues = self.s.collect_profile(_profile(packs=["ghost"]), None)
+        self.assertFalse(issues.has_kind("profile-missing-pack"))
+
+    def test_non_mapping_profile_does_not_raise(self):
+        issues = self.s.collect_profile(["demo-pack"], {"demo-pack"})
+        self.assertTrue(issues.has_kind("not-a-mapping"))
+
+
+class ExistingTreeTests(unittest.TestCase):
+    """저장소에 있는 pack·과제·프로파일은 강화 뒤에도 통과해야 한다."""
+
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_every_shipped_pack_still_validates(self):
+        errors = []
+        for path in sorted(PACKS.glob("*/pack.json")):
+            self.s.validate_pack(_read(path), str(path.parent), errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_every_shipped_task_still_validates(self):
+        errors = []
+        for pack_dir in sorted(p.parent for p in PACKS.glob("*/pack.json")):
+            manifest = _read(pack_dir / "pack.json")
+            for task_path in sorted((pack_dir / "tasks").glob("*.json")):
+                self.s.validate_task(_read(task_path), manifest, None, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_every_shipped_profile_still_validates(self):
+        errors = []
+        ids = {p.parent.name for p in PACKS.glob("*/pack.json")}
+        for path in sorted(PROFILES.glob("*.json")):
+            self.s.validate_profile(_read(path), ids, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_validate_gym_tree_on_repo_is_clean(self):
+        issues = self.s.validate_gym_tree(str(GYM))
+        self.assertEqual(list(issues), [], "\n".join(issues))
+
+    def test_shipped_tasks_have_no_unknown_ops(self):
+        known = self.s.registered_ops()
+        unknown = []
+        for task_path in PACKS.glob("*/tasks/*.json"):
+            task = _read(task_path)
+            for check in task.get("checks", []):
+                if check.get("op") not in known:
+                    unknown.append(f"{task_path.name}:{check.get('op')}")
+        self.assertEqual(unknown, [])
+
+    def test_shipped_submit_kinds_are_known(self):
+        bad = []
+        for task_path in PACKS.glob("*/tasks/*.json"):
+            kind = _read(task_path).get("submit", {}).get("kind")
+            if kind not in self.s.SUBMIT_KINDS:
+                bad.append(f"{task_path.name}:{kind}")
+        self.assertEqual(bad, [])
+
+    def test_shipped_tiers_are_one_through_five(self):
+        bad = []
+        for task_path in PACKS.glob("*/tasks/*.json"):
+            tier = _read(task_path).get("tier")
+            if not self.s.is_valid_tier(tier):
+                bad.append(f"{task_path.name}:{tier}")
+        self.assertEqual(bad, [])
+
+    def test_collect_wrappers_agree_with_plain_list(self):
+        manifest = _read(PACKS / "table-editing" / "pack.json")
+        task = _read(PACKS / "table-editing" / "tasks" / "TB01.json")
+        plain = []
+        self.s.validate_task(task, manifest, None, plain)
+        issues = self.s.collect_task(task, manifest)
+        self.assertEqual(plain, list(issues))
+
+
+class CapabilitiesTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_parse_capabilities_payload_accepts_object(self):
+        raw = json.dumps({"version": "0.8.3", "commands": [{"name": "info"}]}).encode()
+        payload = self.s.parse_capabilities_payload(raw)
+        self.assertEqual(payload["version"], "0.8.3")
+        self.assertEqual(self.s.parse_command_names(raw), {"info"})
+        self.assertEqual(self.s.parse_capabilities_version(raw), "0.8.3")
+
+    def test_parse_capabilities_payload_rejects_garbage(self):
+        self.assertIsNone(self.s.parse_capabilities_payload(None))
+        self.assertIsNone(self.s.parse_capabilities_payload(b"not-json"))
+        self.assertIsNone(self.s.parse_capabilities_payload(b"[1, 2]"))
+        self.assertIsNone(self.s.parse_capabilities_payload(b"\xff\xfe"))
+
+    def test_parse_command_names_skips_bad_items(self):
+        raw = json.dumps({
+            "commands": [
+                {"name": "info"},
+                {"name": ""},
+                "info",
+                {"title": "no-name"},
+                None,
+            ],
+        }).encode()
+        self.assertEqual(self.s.parse_command_names(raw), {"info"})
+
+    def test_parse_command_names_none_when_commands_missing(self):
+        self.assertIsNone(self.s.parse_command_names(b"{}"))
+        self.assertIsNone(self.s.parse_command_names(b'{"commands": "info"}'))
+
+    def test_parse_version_non_string_is_empty(self):
+        self.assertEqual(
+            self.s.parse_capabilities_version(b'{"version": 1}'), "")
+
+    def test_capabilities_digest_rejects_empty_path(self):
+        with self.assertRaises(ValueError):
+            self.s.capabilities_digest("")
+
+    def test_known_commands_none_on_bad_json(self):
+        with mock.patch.object(self.s, "capabilities_digest", return_value=("a" * 64, b"nope")):
+            self.assertIsNone(self.s.known_commands("rhwp"))
+
+    def test_known_commands_set_on_good_json(self):
+        raw = json.dumps({"commands": [{"name": "info"}, {"name": "edit"}]}).encode()
+        with mock.patch.object(self.s, "capabilities_digest", return_value=("a" * 64, raw)):
+            self.assertEqual(self.s.known_commands("rhwp"), {"info", "edit"})
+
+    def test_known_commands_none_when_item_is_not_mapping(self):
+        raw = json.dumps({"commands": ["info"]}).encode()
+        with mock.patch.object(self.s, "capabilities_digest", return_value=("a" * 64, raw)):
+            self.assertIsNone(self.s.known_commands("rhwp"))
+
+    def test_try_known_commands_none_on_oserror(self):
+        with mock.patch.object(self.s, "known_commands", side_effect=FileNotFoundError):
+            self.assertIsNone(self.s.try_known_commands("missing-bin"))
+
+    def test_capabilities_digest_hashes_stdout(self):
+        raw = b'{"commands":[]}'
+        completed = mock.Mock(stdout=raw)
+
+        def fake_run(argv, capture_output=False):
+            self.assertEqual(argv[1], "capabilities")
+            self.assertTrue(capture_output)
+            return completed
+
+        with mock.patch.object(self.s.subprocess, "run", side_effect=fake_run):
+            digest, got = self.s.capabilities_digest("rhwp")
+        self.assertEqual(got, raw)
+        self.assertEqual(digest, hashlib.sha256(raw).hexdigest())
+
+    def test_capabilities_digest_treats_none_stdout_as_empty(self):
+        with mock.patch.object(self.s.subprocess, "run", return_value=mock.Mock(stdout=None)):
+            digest, raw = self.s.capabilities_digest("rhwp")
+        self.assertEqual(raw, b"")
+        self.assertEqual(digest, hashlib.sha256(b"").hexdigest())
+
+
+class RunnerIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_runner_identity_reads_version_and_commit(self):
+        raw = json.dumps({"version": "0.8.3", "commands": []}).encode()
+        with mock.patch.object(self.s, "capabilities_digest", return_value=("b" * 64, raw)):
+            with mock.patch.object(self.s, "git_head", return_value="c" * 40):
+                ident = self.s.runner_identity("rhwp", str(REPO_ROOT))
+        self.assertEqual(ident["rhwpVersion"], "0.8.3")
+        self.assertEqual(ident["rhwpCommit"], "c" * 40)
+        self.assertEqual(ident["capabilitiesSha256"], "b" * 64)
+
+    def test_runner_identity_bad_json_leaves_empty_version(self):
+        with mock.patch.object(self.s, "capabilities_digest", return_value=("b" * 64, b"nope")):
+            with mock.patch.object(self.s, "git_head", return_value=""):
+                ident = self.s.runner_identity("rhwp", str(REPO_ROOT))
+        self.assertEqual(ident["rhwpVersion"], "")
+        self.assertEqual(ident["capabilitiesSha256"], "b" * 64)
+
+    def test_git_head_oserror_is_empty(self):
+        with mock.patch.object(self.s.subprocess, "run", side_effect=OSError):
+            self.assertEqual(self.s.git_head(str(REPO_ROOT)), "")
+
+    def test_git_head_reads_stdout(self):
+        with mock.patch.object(
+            self.s.subprocess, "run",
+            return_value=mock.Mock(stdout=("d" * 40 + "\n").encode()),
+        ):
+            self.assertEqual(self.s.git_head(str(REPO_ROOT)), "d" * 40)
+
+
+class TreeWalkTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def _plant(self, root, pack_id="demo-pack", task=None, profile=None, manifest=None):
+        pack_dir = os.path.join(root, "packs", pack_id)
+        os.makedirs(os.path.join(pack_dir, "tasks"), exist_ok=True)
+        _write(os.path.join(pack_dir, "pack.json"), manifest or _pack(id=pack_id))
+        _write(os.path.join(pack_dir, "tasks", "D01.json"), task or _task())
+        os.makedirs(os.path.join(root, "profiles"), exist_ok=True)
+        _write(
+            os.path.join(root, "profiles", "demo.json"),
+            profile or _profile(packs=[pack_id]),
+        )
+        return root
+
+    def test_clean_tree_has_no_issues(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues = self.s.validate_gym_tree(self._plant(tmp))
+        self.assertEqual(list(issues), [])
+
+    def test_tree_reports_missing_task_keys(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues = self.s.validate_gym_tree(self._plant(tmp, task={"id": "D01"}))
+        self.assertTrue(issues.has_kind("missing-key"))
+
+    def test_tree_reports_bad_tier(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues = self.s.validate_gym_tree(self._plant(tmp, task=_task(tier=9)))
+        self.assertTrue(issues.has_kind("bad-tier"))
+
+    def test_tree_reports_unknown_op(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues = self.s.validate_gym_tree(self._plant(
+                tmp, task=_task(checks=[{"name": "x", "op": "ghost_op"}])))
+        self.assertTrue(issues.has_kind("unknown-op"))
+
+    def test_tree_reports_profile_missing_pack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues = self.s.validate_gym_tree(self._plant(
+                tmp, profile=_profile(packs=["ghost-pack"])))
+        self.assertTrue(issues.has_kind("profile-missing-pack"))
+
+    def test_tree_reports_broken_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._plant(tmp)
+            broken = os.path.join(tmp, "packs", "demo-pack", "tasks", "D01.json")
+            with open(broken, "w", encoding="utf-8") as fh:
+                fh.write("{")
+            issues = self.s.validate_gym_tree(tmp)
+        self.assertTrue(issues.has_kind("malformed-object"))
+
+    def test_tree_reports_json_array_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._plant(tmp)
+            path = os.path.join(tmp, "profiles", "demo.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("[]")
+            issues = self.s.validate_gym_tree(tmp)
+        self.assertTrue(issues.has_kind("not-a-mapping"))
+
+    def test_load_json_mapping_missing_file(self):
+        issues = self.s.IssueList()
+        payload = self.s.load_json_mapping(
+            os.path.join("no", "such", "file.json"), issues, "ghost")
+        self.assertIsNone(payload)
+        self.assertTrue(issues.has_kind("missing-key"))
+
+    def test_discover_pack_ids_ignores_plain_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "orphan"))
+            self.assertEqual(self.s.discover_pack_ids(tmp), [])
+            os.makedirs(os.path.join(tmp, "demo-pack"))
+            _write(os.path.join(tmp, "demo-pack", "pack.json"), _pack())
+            self.assertEqual(self.s.discover_pack_ids(tmp), ["demo-pack"])
+
+    def test_iter_task_paths_skips_non_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks = os.path.join(tmp, "tasks")
+            os.makedirs(tasks)
+            with open(os.path.join(tasks, "notes.txt"), "w", encoding="utf-8") as fh:
+                fh.write("x")
+            _write(os.path.join(tasks, "D01.json"), _task())
+            names = [os.path.basename(p) for p in self.s.iter_task_paths(tmp)]
+        self.assertEqual(names, ["D01.json"])
+
+    def test_iter_helpers_on_missing_dirs(self):
+        missing = os.path.join("no", "such", "dir")
+        self.assertEqual(self.s.discover_pack_ids(missing), [])
+        self.assertEqual(list(self.s.iter_task_paths(missing)), [])
+        self.assertEqual(list(self.s.iter_profile_paths(missing)), [])
+
+
+class RegistryIsolationTests(unittest.TestCase):
+    def test_schema_does_not_redefine_registry(self):
+        schema = load_schema()
+        checks = load_checks()
+        self.assertFalse(hasattr(schema, "REGISTRY"))
+        self.assertTrue(hasattr(checks, "REGISTRY"))
+        self.assertIn("file_exists", checks.REGISTRY)
+        self.assertIn("answer_eq", checks.REGISTRY)
+        self.assertEqual(schema.registered_ops(), frozenset(checks.REGISTRY))
+
+    def test_needs_cli_matches_registry_flag(self):
+        schema = load_schema()
+        checks = load_checks()
+        for op, (_fn, needs) in checks.REGISTRY.items():
+            self.assertEqual(schema.op_needs_cli(op), needs, op)
+
+    def test_field_hints_only_name_existing_ops(self):
+        schema = load_schema()
+        checks = load_checks()
+        extra = set(schema.CHECK_FIELD_HINTS) - set(checks.REGISTRY)
+        self.assertEqual(extra, set())
+
+
+class MessageCompatibilityTests(unittest.TestCase):
+    """test_gym_packs / audit.py 가 기대하는 조각이 남아 있는지."""
+
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_pack_messages(self):
+        errors = _plain(self.s.validate_pack, {"kind": "x"}, "folder")
+        blob = "\n".join(errors)
+        self.assertIn("kind 가 gymPack 가 아니다", blob)
+        self.assertIn("schemaVersion 이 1.0 이 아니다", blob)
+        self.assertIn("폴더 이름과 다르다", blob)
+        self.assertIn("title 가 비었다", blob)
+        self.assertIn("axis 가 비었다", blob)
+        self.assertIn("requires.commands 가 비었다", blob)
+        self.assertIn("runner.rhwpVersion 가 비었다", blob)
+
+    def test_task_messages(self):
+        errors = _plain(self.s.validate_task, {"id": "X", "tier": 0}, {"id": "p"}, None)
+        blob = "\n".join(errors)
+        self.assertIn("필수 키 없음: title", blob)
+        self.assertIn("tier 는 1~5 정수", blob)
+        self.assertIn("checks 가 비었다", blob)
+
+    def test_unknown_op_message(self):
+        errors = _plain(
+            self.s.validate_task,
+            _task(checks=[{"name": "c", "op": "ghost"}]),
+            {"id": "p"},
+            None,
+        )
+        self.assertTrue(any("미등록 연산자: ghost" in line for line in errors))
+
+    def test_profile_messages(self):
+        errors = _plain(
+            self.s.validate_profile,
+            {"id": "z", "kind": "nope", "packs": ["ghost"]},
+            {"demo-pack"},
+        )
+        blob = "\n".join(errors)
+        self.assertIn("kind 가 gymProfile 가 아니다", blob)
+        self.assertIn("없는 pack 참조: ghost", blob)
+
+    def test_profile_empty_packs_message(self):
+        errors = _plain(self.s.validate_profile, {"id": "z", "kind": "gymProfile"}, set())
+        self.assertTrue(any("packs 가 비었다" in line for line in errors))
+
+
+class FailHelperTests(unittest.TestCase):
+    def test_fail_on_none_is_noop(self):
+        schema = load_schema()
+        schema._fail(None, "w", "m")
+
+    def test_fail_on_plain_list(self):
+        schema = load_schema()
+        errors = []
+        schema._fail(errors, "here", "boom", kind="bad-tier", field="tier", got=0)
+        self.assertEqual(errors, ["here: boom"])
+
+    def test_issue_as_dict_omits_empty_optional(self):
+        schema = load_schema()
+        issue = schema.SchemaIssue("bad-tier", "p/X", "tier 는 1~5 정수")
+        self.assertEqual(
+            issue.as_dict(),
+            {"kind": "bad-tier", "where": "p/X", "message": "tier 는 1~5 정수"},
+        )
+        issue = schema.SchemaIssue("bad-tier", "p/X", "m", field="tier", got=9)
+        self.assertEqual(issue.as_dict()["field"], "tier")
+        self.assertEqual(issue.as_dict()["got"], "9")
+
+
+class MinimalFixtureTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_minimal_constants_round_trip(self):
+        self.assertEqual(self.s.MINIMAL_PACK["kind"], "gymPack")
+        self.assertEqual(self.s.MINIMAL_TASK["tier"], 1)
+        self.assertEqual(self.s.MINIMAL_PROFILE["packs"], ["demo-pack"])
+        self.assertEqual(len(self.s.MINIMAL_RUNNER["rhwpCommit"]), 40)
+        self.assertEqual(len(self.s.MINIMAL_RUNNER["capabilitiesSha256"]), 64)
+
+    def test_minimal_check_constants_are_registered(self):
+        self.assertTrue(self.s.is_registered_op(self.s.MINIMAL_CHECK_FILE["op"]))
+        self.assertTrue(self.s.is_registered_op(self.s.MINIMAL_CHECK_CLI["op"]))
+        self.assertFalse(self.s.op_needs_cli(self.s.MINIMAL_CHECK_FILE["op"]))
+        self.assertTrue(self.s.op_needs_cli(self.s.MINIMAL_CHECK_CLI["op"]))
+
+
+class WhereLabelTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_task_where_uses_ids(self):
+        self.assertEqual(self.s._task_where({"id": "p"}, {"id": "T01"}), "p/T01")
+        self.assertEqual(self.s._task_where(None, None), "None/None")
+
+    def test_profile_where(self):
+        self.assertEqual(self.s._profile_where({"id": "starter"}), "profiles/starter")
+        self.assertEqual(self.s._profile_where(None), "profiles/None")
+
+    def test_axis_prefers_task_then_pack(self):
+        self.assertEqual(self.s._axis_of({"axis": "편집"}, {"axis": "자동화"}), "편집")
+        self.assertEqual(self.s._axis_of({}, {"axis": "보안"}), "보안")
+        self.assertEqual(self.s._axis_of({}, {}), "")
+
+
+class LoadJsonEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_load_json_mapping_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "x.json")
+            _write(path, {"ok": True})
+            payload = self.s.load_json_mapping(path)
+        self.assertEqual(payload, {"ok": True})
+
+    def test_load_json_mapping_unicode_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "x.json")
+            with open(path, "wb") as fh:
+                fh.write(b"\xff\xfe\x00{")
+            issues = self.s.IssueList()
+            payload = self.s.load_json_mapping(path, issues, "x")
+        self.assertIsNone(payload)
+        self.assertTrue(issues)
+
+    def test_validate_gym_tree_missing_packs_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues = self.s.validate_gym_tree(tmp)
+        self.assertEqual(list(issues), [])
+
+
+class MorePackEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_empty_pack_dir_uses_fallback_where(self):
+        issues = self.s.collect_pack(_pack(), "")
+        self.assertTrue(issues.has_kind("pack-id-mismatch"))
+
+    def test_pack_id_none_is_mismatch_and_unsafe(self):
+        body = _pack()
+        body["id"] = None
+        issues = self.s.collect_pack(body, "demo-pack")
+        self.assertTrue(issues.has_kind("pack-id-mismatch"))
+
+    def test_axis_non_string(self):
+        issues = self.s.collect_pack(_pack(axis=3), "demo-pack")
+        self.assertTrue(issues.has_kind("bad-type"))
+
+
+class MoreTaskEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+        self.pack = _pack()
+
+    def test_id_whitespace_only(self):
+        issues = self.s.collect_task(_task(id="   "), self.pack)
+        self.assertTrue(issues.has_kind("empty-field"))
+
+    def test_pair_submit_with_three_files_passes(self):
+        issues = self.s.collect_task(_task(submit={
+            "kind": "pair",
+            "files": ["o1.hwp", "o2.hwp", "plan.json"],
+        }), self.pack)
+        self.assertEqual(list(issues), [])
+
+    def test_multiple_unknown_ops_all_reported(self):
+        body = _task(checks=[
+            {"name": "a", "op": "ghost_a"},
+            {"name": "b", "op": "ghost_b"},
+        ])
+        issues = self.s.collect_task(body, self.pack)
+        self.assertEqual(len(issues.of_kind("unknown-op")), 2)
+
+    def test_cli_op_with_known_and_unknown_mix(self):
+        body = _task(checks=[
+            {
+                "name": "ok",
+                "op": "answer_eq",
+                "answer": "pages",
+                "cmd": ["info", "{input}"],
+            },
+            {
+                "name": "bad",
+                "op": "value_eq",
+                "value": 1,
+                "cmd": ["missing", "{input}"],
+            },
+        ])
+        issues = self.s.collect_task(body, self.pack, {"info"})
+        self.assertTrue(issues.has_kind("unknown-command"))
+        self.assertEqual(len(issues.of_kind("unknown-command")), 1)
+
+    def test_file_ops_do_not_need_known_commands(self):
+        body = _task(checks=[
+            {"name": "a", "op": "file_exists", "file": "a.json"},
+            {"name": "b", "op": "same_hash", "files": ["a.json", "b.json"]},
+            {"name": "c", "op": "differs_from_input", "file": "a.hwp"},
+            {"name": "d", "op": "files_differ", "files": ["a.json", "b.json"]},
+            {"name": "e", "op": "utf8_bom", "file": "a.json"},
+        ])
+        issues = self.s.collect_task(body, self.pack, set())
+        self.assertEqual(list(issues), [])
+
+
+class MoreProfileEdgeTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_multiple_missing_packs(self):
+        issues = self.s.collect_profile(
+            _profile(packs=["a", "b", "demo-pack"]), {"demo-pack"})
+        self.assertEqual(len(issues.of_kind("profile-missing-pack")), 2)
+
+    def test_title_non_string(self):
+        issues = self.s.collect_profile(_profile(title=1), {"demo-pack"})
+        self.assertTrue(issues.has_kind("empty-field"))
+
+    def test_schema_version_absent_is_not_an_error(self):
+        body = _profile()
+        del body["schemaVersion"]
+        issues = self.s.collect_profile(body, {"demo-pack"})
+        self.assertFalse(issues.has_kind("bad-schema-version"))
+
+
+class OpSurfaceTests(unittest.TestCase):
+    def test_every_registry_op_is_either_cli_or_file(self):
+        schema = load_schema()
+        checks = load_checks()
+        for op in checks.REGISTRY:
+            needs = schema.op_needs_cli(op)
+            self.assertIsInstance(needs, bool, op)
+
+    def test_hint_table_covers_devel_ops(self):
+        schema = load_schema()
+        checks = load_checks()
+        missing = set(checks.REGISTRY) - set(schema.CHECK_FIELD_HINTS)
+        self.assertEqual(missing, set(), f"hints 빠진 op: {missing}")
+
+
+class ExtraUnknownKeysAreIgnoredTests(unittest.TestCase):
+    """스키마는 모르는 키를 거절하지 않는다 — 후속 필드가 들어올 자리."""
+
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_pack_extra_description_passes(self):
+        body = _pack(description="설명을 더해도 된다")
+        self.assertEqual(list(self.s.collect_pack(body, "demo-pack")), [])
+
+    def test_task_extra_axis_and_notes_pass(self):
+        body = _task(axis="자동화", notes="채점기가 안 보는 메모")
+        self.assertEqual(list(self.s.collect_task(body, _pack())), [])
+
+    def test_profile_extra_description_passes(self):
+        body = _profile(description="코스 설명")
+        self.assertEqual(list(self.s.collect_profile(body, {"demo-pack"})), [])
+
+
+class HexCaseAndIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_uppercase_commit_and_digest_pass(self):
+        body = _pack()
+        body["runner"] = {
+            "rhwpVersion": "0.8.3",
+            "rhwpCommit": "C" * 40,
+            "capabilitiesSha256": "B" * 64,
+        }
+        self.assertEqual(list(self.s.collect_pack(body, "demo-pack")), [])
+
+    def test_mixed_case_hex_passes(self):
+        self.assertTrue(self.s.is_commit_hex("AbCdEf09" * 5))
+        self.assertTrue(self.s.is_sha256_hex("Ab" * 32))
+
+    def test_runner_identity_non_string_version_becomes_empty(self):
+        raw = json.dumps({"version": 12, "commands": []}).encode()
+        with mock.patch.object(self.s, "capabilities_digest", return_value=("b" * 64, raw)):
+            with mock.patch.object(self.s, "git_head", return_value=""):
+                ident = self.s.runner_identity("rhwp", str(REPO_ROOT))
+        self.assertEqual(ident["rhwpVersion"], "")
+
+    def test_git_head_empty_stdout(self):
+        with mock.patch.object(
+            self.s.subprocess, "run", return_value=mock.Mock(stdout=b""),
+        ):
+            self.assertEqual(self.s.git_head(str(REPO_ROOT)), "")
+
+
+class TreeKnownCommandsTests(unittest.TestCase):
+    def setUp(self):
+        self.s = load_schema()
+
+    def test_tree_flags_unknown_command_when_surface_given(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = os.path.join(tmp, "packs", "demo-pack")
+            os.makedirs(os.path.join(pack_dir, "tasks"), exist_ok=True)
+            _write(os.path.join(pack_dir, "pack.json"), _pack())
+            _write(os.path.join(pack_dir, "tasks", "D01.json"), _task(checks=[{
+                "name": "쪽수",
+                "op": "answer_eq",
+                "answer": "pages",
+                "cmd": ["missing-bin-cmd", "{input}"],
+            }]))
+            os.makedirs(os.path.join(tmp, "profiles"), exist_ok=True)
+            _write(os.path.join(tmp, "profiles", "demo.json"), _profile())
+            issues = self.s.validate_gym_tree(tmp, known_commands={"info"})
+        self.assertTrue(issues.has_kind("unknown-command"))
+
+    def test_tree_skips_command_surface_when_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = os.path.join(tmp, "packs", "demo-pack")
+            os.makedirs(os.path.join(pack_dir, "tasks"), exist_ok=True)
+            _write(os.path.join(pack_dir, "pack.json"), _pack())
+            _write(os.path.join(pack_dir, "tasks", "D01.json"), _task(checks=[{
+                "name": "쪽수",
+                "op": "answer_eq",
+                "answer": "pages",
+                "cmd": ["missing-bin-cmd", "{input}"],
+            }]))
+            issues = self.s.validate_gym_tree(tmp, known_commands=None)
+        self.assertFalse(issues.has_kind("unknown-command"))
+
+
+class IssueListKindFilterTests(unittest.TestCase):
+    def test_of_kind_empty_when_absent(self):
+        schema = load_schema()
+        issues = schema.collect_task(_task(), _pack())
+        self.assertEqual(issues.of_kind("profile-missing-pack"), [])
+        self.assertFalse(issues.has_kind("profile-missing-pack"))
+
+    def test_as_dicts_round_trip_fields(self):
+        schema = load_schema()
+        body = _task()
+        del body["title"]
+        issues = schema.collect_task(body, _pack())
+        rows = [row for row in issues.as_dicts() if row["kind"] == "missing-key"]
+        self.assertTrue(any(row.get("field") == "title" for row in rows))
+        self.assertTrue(all("where" in row and "message" in row for row in rows))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

gym 스키마(`gym/core/schema.py`)가 pack·과제·프로파일 선언에서 죽거나 한 줄로 뭉개던 자리를 kind 로 남긴다. 객체 아님·공란·bool tier·미등록 연산자·없는 pack 참조는 예외가 아니라 칸이다. `errors` 는 예전처럼 `"<where>: <message>"` 문자열 목록이고, `IssueList` 를 넘기면 kind 도 남는다.

성공 칸은 그대로다. 저장소 18 pack·전 과제·전 프로파일은 강화 뒤에도 통과한다. `REGISTRY` 는 `checks.py` 가 소유하며 이 브랜치는 읽기만 한다. 새 CLI 플래그는 없다.

규약은 `gym/docs/schema.md`, 작업 기록은 `mydocs/working/gym_schema.md`. 예외 칸 시험은 `scripts/tests/test_gym_schema.py`.

이슈 본문의 네 자리:

- 필수 키 없음 → `missing-key` (`필수 키 없음: <key>`)
- 나쁜 tier(0·6·bool·문자열) → `bad-tier` (`tier 는 1~5 정수`)
- 미등록 연산자 → `unknown-op` (`미등록 연산자: <op>`)
- 프로파일이 없는 pack 을 가리킴 → `profile-missing-pack` (`없는 pack 참조: <id>`)

audit.py / certify.py / report.py / score.py / runner.py / tutorial, checks.REGISTRY, 열린 PR 5210–5278 파일은 건드리지 않았다.

## 관련 이슈

closes #5279

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_schema scripts.tests.test_gym_packs` 통과 (185)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [x] `cargo fmt --all -- --check` 통과
- [ ] `cargo test` 통과 — 해당 없음 (Python/문서만)
- [ ] `cargo clippy -- -D warnings` 통과 — 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 이 변경은 스키마 예외 경로·문서·시험이며 replay 캡슐 대상 문서 편집 계획이 아님
- [ ] `.claude/agents/` 등 capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (선언 검증 실패 시 칸을 남김, 성공 경로 동일)
- 재현·측정: 미측정. 바이너리 없이 unittest.

## 스크린샷

해당 없음.
