### PR TITLE
gym: profiles 프로파일 계약·문서·시험 고도화

### DIFF
--- a/gym/docs/profiles.md
+++ b/gym/docs/profiles.md
@@ -1,0 +1,1081 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/profiles.md
+last_verified: 2026-08-18
+---
+
+# gym 프로파일 계약
+
+이 문서는 `gym/profiles/*.json` 일곱 자리의 **선택 계약**이다. 작업
+기록·오탐 결정·시험 지도는
+[`mydocs/working/gym_profiles.md`](../../mydocs/working/gym_profiles.md)
+에 남긴다. 기계 계약은
+`scripts/tests/test_gym_profiles.py` 가 고정한다.
+
+프로파일은 pack 을 **고르는** 도구이지 점수를 뭉치는 도구가 아니다.
+`python gym/score.py --profile editor` 는 editor 가 선언한 pack 만
+채점한다. 총점은 그 pack 들의 합일 뿐이고, 능력 판독은 여전히 pack
+별 점수가 한다. 가중치·만점·과제 화이트리스트는 프로파일 JSON 에
+없다.
+
+새 CLI 는 없다. `--profile <id>` 는 예전부터 `gym/score.py` 가 받던
+자리다. 이 문서와 시험은 그 자리의 **파일 계약**을 고정한다.
+`schema.py` · `audit.py` · `certify.py` · `report.py` · `tutorial/` ·
+`PARK.md` 는 이 기둥이 고치지 않는다.
+
+## 한 줄 결론
+
+```bash
+python gym/score.py --agent <이름> --profile family
+python gym/score.py --agent <이름> --profile starter
+python gym/score.py --agent <이름> --profile editor
+python gym/score.py --agent <이름> --profile publisher
+python gym/score.py --agent <이름> --profile operator
+python gym/score.py --agent <이름> --profile boss
+python gym/score.py --agent <이름> --profile maintainer
+```
+
+일곱 자리의 파일은 `gym/profiles/<id>.json` 이다. 파일명과 `id` 가
+같고, `kind` 는 `gymProfile` 이며, `packs` 의 모든 id 는
+`gym/packs/<id>/pack.json` 을 가진다.
+
+## 1. 왜 프로파일인가
+
+운동장은 pack 으로 능력 축을 가른다. pack 이 열일곱이 되면 "전부
+달려라"는 입문도 아니고 편집 시험도 아니다. 처음 온 에이전트에게
+`casual-rides` 네 과제만 주고, 문서를 고치는 자리에는
+`text-editing` · `table-editing` · `objects-media` 를 주고, 배포
+직전 자리에는 `serialization` · `layout-rendering` · `security` 를
+준다.
+
+그 선택을 명령줄에 매번 나열하면 빠뜨린다.
+
+```bash
+python gym/score.py --agent kim --pack text-editing --pack table-editing --pack objects-media --pack core-cli
+```
+
+프로파일은 그 나열을 이름 하나로 고정한다.
+
+```bash
+python gym/score.py --agent kim --profile editor
+```
+
+선택이 파일로 남으면 시험이 지킬 수 있다. 사람이 README 표만 고치고
+JSON 을 안 고치면 시험이 red 가 된다. JSON 만 고치고 문서를 안
+고치면 같은 시험이 red 가 된다. 그 쌍이 이 기둥의 전부다.
+
+프로파일이 **하지 않는** 것:
+
+- 점수를 한 숫자로 다시 가중하지 않는다.
+- 과제 일부를 빼거나 티어를 바꾸지 않는다.
+- 바이너리 요구 명령을 완화하지 않는다. pack 이 unavailable 이면
+  프로파일을 써도 unavailable 이다.
+- 리더보드 입장을 대신 판정하지 않는다. 입장 봉투는 "채점이 유효하게
+  완주했는가"이지 "어느 프로파일인가"가 아니다.
+
+## 2. 스키마
+
+```json
+{
+  "schemaVersion": "1.0",
+  "kind": "gymProfile",
+  "id": "editor",
+  "title": "편집자",
+  "description": "문서를 실제로 고치는 능력 — 본문·표·개체 편집과 그 재검증.",
+  "packs": [
+    "core-cli",
+    "text-editing",
+    "table-editing",
+    "objects-media"
+  ]
+}
+```
+
+| 키 | 형 | 계약 |
+|---|---|---|
+| `schemaVersion` | 문자열 | 지금 `"1.0"` 만. |
+| `kind` | 문자열 | 지금 `"gymProfile"` 만. `gymPack` 이 아니다. |
+| `id` | 문자열 | 파일명 stem 과 같다. `[a-z][a-z0-9-]*`. |
+| `title` | 비어 있지 않은 문자열 | 사람용 짧은 이름. |
+| `description` | 비어 있지 않은 문자열 | 한 줄로 역할을 가리킨다. |
+| `packs` | 비어 있지 않은 문자열 배열 | 각 원소는 존재하는 pack id. 중복 금지. |
+
+허용 키는 위 여섯 개다. `weights` · `score` · `max` · `tasks` ·
+`exclude` 를 넣지 않는다. 선택기이지 채점기가 아니기 때문이다.
+
+검증은 `gym.core.schema.validate_profile(profile, pack_ids, errors)`
+가 한다. 이 기둥이 그 함수를 고치지 않는다. 시험은 현재 구현이
+거절하는 칸(빈 packs, 없는 pack, 잘못된 kind)을 픽스처로 고정한다.
+
+로드는 `gym.core.runner.load_profile(profile_id)` 가
+`gym/profiles/<id>.json` 을 UTF-8 로 읽는다. 없는 id 는
+`FileNotFoundError` 다. 이 기둥이 그 함수를 고치지 않는다.
+
+`score_all(..., profile_id=...)` 는 프로파일이 있으면
+`pack_ids = load_profile(profile_id)["packs"]` 로 덮어쓴다. 그 다음
+채점은 pack 과 같다.
+
+## 3. 일곱 자리
+
+파일은 일곱 개다. 여덟 번째 JSON 을 넣으면 시험이 red 다. 새 자리를
+만들 때는 `NAMED_PROFILE_IDS` 와 이 문서와 작업 기록을 같이 고친다.
+
+### 3.1 `family` — 가족 코스
+
+```json
+"packs": ["casual-rides"]
+```
+
+부모님·친구와 함께 도는 입문존만. 키 제한이 없는 회전목마다.
+`core-cli` 도 `self-description` 도 넣지 않는다. 도구의 결을 익히는
+자리는 `starter` 다. 가족 코스는 "읽고 세기" 만 준다.
+
+누가 타나:
+
+- 운동장을 처음 구경하는 사람.
+- 에이전트에게 "한글 문서를 셀 수 있느냐"만 묻는 자리.
+- `INVITE.md` 가 가리키는 첫 초대.
+
+누가 타지 않나:
+
+- 명령을 조합해 문서를 고치려는 자리 → `editor`.
+- 도구가 스스로를 설명하는지 보는 자리 → `starter`.
+- 사다리 완주를 보려는 자리 → `boss`.
+
+측정하는 것: 쪽수·검색·간단 조회처럼 실패해도 안전한 읽기.
+측정하지 않는 것: 편집, 변환, 보안, 자동화.
+
+`family` 와 `boss` 는 겹치지 않는다. 입문존과 보스존이 같은 pack 을
+품으면 놀이공원 지도가 거짓이다.
+
+### 3.2 `starter` — 입문
+
+```json
+"packs": ["core-cli", "self-description"]
+```
+
+처음 온 에이전트가 도구의 결을 익히는 최소 코스. `core-cli` 는
+조사·추출·편집·검증의 최소 표면이고, `self-description` 은 도구가
+스스로를 설명하는 계약이다. 두 개를 같이 도는 이유: 명령을 쓰기
+전에 명령이 무엇을 말하는지 읽어야 한다.
+
+`casual-rides` 를 넣지 않는다. 가족 코스와 입문 도구 코스는 다른
+축이다. 부모님과 함께 도는 자리와, 에이전트가 capabilities 를 읽는
+자리를 한 묶음으로 만들면 둘 다 애매해진다.
+
+`starter` 의 `core-cli` 는 `editor` 에도 들어 있다. 편집자는 입문
+코어를 지나온 자리이기 때문이다. `self-description` 은 editor 에
+넣지 않는다. 편집 능력과 자기서술 능력은 다른 축이다.
+
+### 3.3 `editor` — 편집자
+
+```json
+"packs": ["core-cli", "text-editing", "table-editing", "objects-media"]
+```
+
+문서를 실제로 고치는 능력. 본문·표·개체와 그 재검증. `core-cli` 는
+탐색과 검증의 바닥이다. 세 편집 pack 만 주고 코어를 빼면 "어디에
+있는지 모르는 채 고치기"가 된다.
+
+넣지 않는 것:
+
+- `serialization` · `layout-rendering` · `security` → `publisher`.
+- `corpus-diagnostics` · `automation` → `operator`.
+- `expert-challenges` → `boss`.
+- `table-csv` · `studio-e2e` → 전 표면(`maintainer`)에만. 편집자의
+  최소 코스가 스튜디오 e2e 까지 끌고 가지 않는다.
+
+`editor` 와 `publisher` 는 pack 을 공유하지 않는다. 고치는 능력과
+내보내기 전 확인은 다른 시험이다. 한 에이전트가 둘 다 필요하면
+두 번 돌리거나 `maintainer` 를 탄다.
+
+### 3.4 `publisher` — 배포자
+
+```json
+"packs": ["serialization", "layout-rendering", "security"]
+```
+
+내보내고 배포하기 전에 확인해야 하는 것들. 형식 왕복, 조판 판정,
+은닉·주입·유니코드·PII. 배포 직전 관문이지 편집 코스가 아니다.
+
+`security` 를 editor 에 넣지 않는 이유: 보안 스윕은 고치는 능력과
+다른 축이다. 편집자가 배포 직전 스윕까지 자동으로 끌어가면 편집
+실패와 보안 실패가 한 점수에 섞인다. 프로파일은 점수를 뭉치지
+않더라도, 한 번의 `--profile` 이 두 축을 동시에 열면 사람이 표를
+읽을 때 다시 섞는다.
+
+`layout-rendering` 을 editor 에 넣지 않는 이유: 조판 판정은 편집의
+결과가 아니라 배포물의 성질이다.
+
+### 3.5 `operator` — 운영자
+
+```json
+"packs": ["corpus-diagnostics", "automation"]
+```
+
+무더기를 다루고 이상을 좁히는 능력. 코퍼스 스윕·진단·계획·캡슐·
+서명·앵커·정산·감사. README 표에 빠져 있던 자리다. 파일은 원래
+있었고, 이 기둥이 문서와 시험을 파일에 맞춘다.
+
+`family` · `publisher` · `boss` 와 겹치지 않는다. 운영자는 입문
+놀이기구도, 배포 직전 스윕도, 보스 어트랙션도 아니다.
+
+`batch-ops` 를 넣지 않는다. 다문서 대량 처리는 전 표면의 일부이고,
+운영자의 최소 코스는 진단과 자동화 사다리다. 대량 처리까지 필요하면
+`maintainer` 또는 `--pack batch-ops` 를 더한다.
+
+### 3.6 `boss` — 보스 코스
+
+```json
+"packs": ["expert-challenges"]
+```
+
+사다리 완주급 고난도만. 한 단만 틀려도 판정이 막히는 자리.
+`family` 와 정반대 극단이다. 두 자리가 같은 pack 을 품으면 키
+제한이 거짓이다.
+
+역할 다섯 자리(`starter` · `editor` · `publisher` · `operator` ·
+`family`)는 `expert-challenges` 를 품지 않는다. 보스는 초대가
+아니라 도전이다.
+
+### 3.7 `maintainer` — 메인테이너
+
+전 표면. 검증 사다리와 자기서술까지 포함한 완주 코스.
+`packs` 는 **현재 브랜치의 `gym/packs/*/pack.json` 전부**이고,
+알파벳 정렬이다.
+
+다른 여섯 자리가 고른 pack 은 모두 maintainer 에 들어 있다.
+역할 여섯 자리의 합집합은 maintainer 의 진부분집합이다. 전 표면이
+역할 코스의 합과 같으면, 역할에 안 넣은 pack
+(`extraction` · `batch-ops` · `render-tree` · `studio-e2e` ·
+`table-csv` 등)이 입구를 잃는다.
+
+이 기둥은 `maintainer.json` 을 고치지 않는다. 다른 열린 PR 이
+pack 을 더하면 그쪽에서 정렬·추가한다. 시험은 이 브랜치의
+`packs/` 스냅샷과 파일이 같은지만 본다. 파일을 여기서 고울 이유가
+없다.
+
+정렬 규칙: maintainer 만 알파벳이다. 역할 여섯 자리는 사람이 읽는
+순서(코어 → 본문 → 표 → 개체, 변환 → 조판 → 보안, 진단 → 자동화)를
+유지한다. 알파벳으로 맞추면 `editor` 가
+`core-cli, objects-media, table-editing, text-editing` 이 되어
+문서의 이야기 순서가 깨진다.
+
+## 4. 자리 × pack 행렬
+
+아래 표는 역할 여섯 자리의 고정 묶음이다. maintainer 는 현재
+브랜치의 전 pack 이라 행을 따로 적지 않는다.
+
+| pack | family | starter | editor | publisher | operator | boss |
+|---|---|---|---|---|---|---|
+| `casual-rides` | ● | | | | | |
+| `core-cli` | | ● | ● | | | |
+| `self-description` | | ● | | | | |
+| `text-editing` | | | ● | | | |
+| `table-editing` | | | ● | | | |
+| `objects-media` | | | ● | | | |
+| `serialization` | | | | ● | | |
+| `layout-rendering` | | | | ● | | |
+| `security` | | | | ● | | |
+| `corpus-diagnostics` | | | | | ● | |
+| `automation` | | | | | ● | |
+| `expert-challenges` | | | | | | ● |
+
+역할 여섯 자리에 안 올라간 pack 은 전 표면에서만 고른다.
+
+| pack | 전 표면에만 있는 이유 |
+|---|---|
+| `extraction` | 조회 축의 확장. 입문·편집·배포의 최소 코스가 아니다. |
+| `batch-ops` | 다문서 대량 처리. 운영 최소 코스(진단+사다리)의 다음 층. |
+| `render-tree` | 렌더 트리 구조 추출. 조판 판정(`layout-rendering`)과 다른 축. |
+| `studio-e2e` | 스튜디오 e2e 에서 파생한 CLI 계약. 편집 최소 코스보다 좁고 깊다. |
+| `table-csv` | 표 CSV 왕복. `table-editing` 의 좌표 편집과 다른 왕복 계약. |
+
+다른 PR 이 `form-journeys` · `oracle-probe` · `showcase` 같은 pack
+을 더하면, 그 PR 이 `maintainer.json` 에 정렬·추가한다. 이 문서는
+그 파일을 여기서 고치지 않는다고 못 박는다. 행렬의 역할 여섯 칸은
+그 pack 을 자동으로 끌어오지 않는다.
+
+## 5. 불변식
+
+시험이 red 로 막는 것.
+
+1. `gym/profiles/` 아래 JSON 이 일곱 개다. 다른 확장자 파일이 없다.
+2. 파일명 stem = `id` = `NAMED_PROFILE_IDS` 원소.
+3. `kind` 는 `gymProfile`, `schemaVersion` 은 `1.0`.
+4. `title` · `description` 은 비어 있지 않다.
+5. `packs` 는 비어 있지 않은 문자열 배열이고 중복이 없다.
+6. 모든 pack 참조는 `gym/packs/<id>/pack.json` 을 가진다.
+7. `schema.validate_profile` 이 일곱 파일 모두에 빈 오류 목록을 준다.
+8. 역할 여섯 자리의 `packs` 는 위 3절·4절 표와 같다.
+9. `family` ∩ `boss` = ∅.
+10. `editor` ∩ `publisher` = ∅.
+11. `operator` ∩ `publisher` = ∅.
+12. `operator` ∩ `family` = ∅.
+13. 역할 다섯 + family 는 `expert-challenges` 를 품지 않는다.
+14. 어느 두 자리도 같은 `packs` 배열을 갖지 않는다.
+15. maintainer 의 packs 는 정렬되어 있고, 현재 브랜치 pack 전부와
+    같다. 다른 여섯 자리의 합은 그 진부분집합이다.
+16. 프로파일 JSON 에 `weights` / `score` / `max` / `tasks` /
+    `exclude` 가 없다.
+17. 파일은 UTF-8, BOM 없음, LF, 끝 개행, indent 2.
+18. `id` 는 `^[a-z][a-z0-9-]*$`.
+19. `gym/score.py` 는 `--profile` 을 받고
+    `runner.score_all(..., profile_id=)` 로 넘긴다.
+20. `gym/docs/profiles.md` 와 `mydocs/working/gym_profiles.md` 가
+    일곱 id 와 역할 pack 이름을 품는다.
+
+## 6. 사용
+
+```bash
+# 전 pack — 프로파일 없음
+python gym/score.py --agent <이름>
+
+# 자리 하나
+python gym/score.py --agent <이름> --profile editor
+
+# pack 을 직접 고른다. 프로파일과 같이 주면 프로파일이 이긴다
+# (score_all 이 profile_id 가 있을 때 pack_ids 를 덮어쓴다).
+python gym/score.py --agent <이름> --pack security
+
+# 제출 루트·바이너리·산출 폴더
+python gym/score.py --agent <이름> --profile publisher \
+    --submissions gym/submissions/<이름> \
+    --bin target/debug/rhwp \
+    --out gym/out/<이름>-publisher
+```
+
+종료 코드는 채점기의 계약이다. 0=만점, 3=그 외. 프로파일이 종료
+코드를 바꾸지 않는다. unavailable pack 은 0점이 아니다.
+
+없는 프로파일 id 는 지금 `load_profile` 이 `FileNotFoundError` 를
+올린다. 이 기둥은 그 칸을 새 kind 로 바꾸지 않는다. 예외 경로
+고도화는 score/runner 기둥(#5260)의 자리다. 파일을 여기서 고치면
+그 PR 과 싸운다.
+
+## 7. 자리를 고르는 법
+
+| 질문 | 자리 |
+|---|---|
+| 부모님과 5분 동안 읽고 셀 수 있나? | `family` |
+| 도구가 무엇을 할 수 있는지 스스로 말하나? | `starter` |
+| 본문·표·개체를 좌표로 고치고 재검증하나? | `editor` |
+| 저장·조판·보안을 배포 전에 확인하나? | `publisher` |
+| 폴더를 훑고 사다리로 이상을 좁히나? | `operator` |
+| 한 단만 틀려도 막히는 완주를 버티나? | `boss` |
+| 지금 운동장에 있는 pack 을 하나도 빼지 않나? | `maintainer` |
+
+두 자리가 필요하면 두 번 돈다. 한 프로파일에 두 축을 합치지 않는다.
+합치면 표가 다시 섞인다.
+
+에이전트  inviter 는 `family` 를 먼저 권한다. 담력이 붙으면
+`starter` → `editor` 또는 `publisher` 또는 `operator` → `boss`.
+`maintainer` 는 매일의 기본값이 아니다. 전 표면은 시간이 많고
+회귀를 볼 때 탄다.
+
+## 8. 새 프로파일을 넣는 법
+
+새 CLI 플래그를 만들지 않는다. 파일 하나가 자리 하나다.
+
+1. 역할이 기존 일곱과 다른지 먼저 묻는다. 편집의 부분집합이면
+   `--pack` 으로 충분하다.
+2. `gym/profiles/<id>.json` 을 만든다. `id` = 파일명.
+   `kind` = `gymProfile`. `schemaVersion` = `1.0`.
+3. `packs` 는 존재하는 pack 만. 중복 없이. 역할 자리면 이야기
+   순서, 전 표면이면 알파벳.
+4. 이 문서 3절에 자리를 적고 4절 행렬에 열을 더한다.
+5. `scripts/tests/test_gym_profiles.py` 의 `NAMED_PROFILE_IDS` ·
+   `NAMED_PACKS` · 제목/설명 토큰을 같이 고친다.
+6. 작업 기록에 "왜 기존 자리로 부족했나"를 남긴다.
+7. `python -m unittest scripts.tests.test_gym_profiles` 가 통과하는지
+   본다.
+8. `python gym/tools/audit.py` 는 pack 정합을 본다. 프로파일 파일은
+   audit 의 주 대상이 아니지만, pack 참조가 깨지면 이 시험이 먼저
+   red 다.
+
+여덟 번째 자리를 넣으면서 시험을 안 고치면
+`test_no_unexpected_profile_files` 가 red 다. 그것이 의도다.
+
+## 9. 새 pack 을 자리에 넣는 법
+
+1. pack 자체가 `audit.py` 를 통과한다 (기준풀이 짝, 전역 id).
+2. 역할 여섯 자리 중 어디에 들어가는지 이 문서 3절로 고른다.
+   어디에도 안 들어가면 maintainer 만 따른다.
+3. 역할 자리에 넣을 때는 `NAMED_PACKS` 와 3절·4절을 같이 고친다.
+4. maintainer 는 현재 브랜치의 전 pack 과 같아야 한다. **이 기둥이
+   그 파일을 고치지 않는다.** pack 을 더하는 PR 이 정렬된 한 줄을
+   추가한다.
+5. 역할 자리에 넣은 pack 은 maintainer 에도 있어야 한다. 시험
+   `test_maintainer_covers_every_other_profile_pack` 이 지킨다.
+
+다른 열린 PR 이 `form-journeys` 를 넣고 maintainer 에 한 줄을 더하면
+그 줄은 그 PR 의 것이다. 여기서 같은 줄을 더하면 병합이 싸운다.
+그래서 이 기둥은 시험을 현재 스냅샷에 고정하고 파일은 그대로 둔다.
+
+## 10. 실패 칸
+
+프로파일 기둥이 직접 채점하지 않는 실패. 그래도 자리가 어떻게
+보이는지는 여기 적는다.
+
+| 증상 | 원인 | 이 기둥이 보는가 |
+|---|---|---|
+| `FileNotFoundError: .../ghost.json` | `--profile ghost` | load_profile 계약. 엔진은 안 고친다. |
+| `없는 pack 참조` | JSON 이 사라진 pack 을 가리킴 | 시험이 red. |
+| pack `unavailable` | 바이너리에 요구 명령 없음 | 채점기 계약. 프로파일은 완화하지 않는다. |
+| 점수 0 | 과제를 틀림 | 채점기. 프로파일 JSON 에 score 가 없다. |
+| 입장 deny | 채점된 pack 0 | 입장 봉투. 프로파일 id 와 무관. |
+| audit red | 기준풀이 짝·id 충돌 | pack 정합. 프로파일 파일이 직접 원인은 아니다. |
+| 문서만 고침 | JSON 과 표가 어긋남 | 문서 토큰 시험이 red. |
+| JSON 만 고침 | 문서가 옛 묶음을 말함 | 같은 시험이 red. |
+| 여덟 번째 파일 | 카탈로그 미갱신 | inventory 시험이 red. |
+| BOM / CRLF | 편집기가 파일을 바꿈 | hygiene 시험이 red. |
+
+`validate_profile` 이 지금 거절하는 것:
+
+- `kind` 가 `gymProfile` 이 아님.
+- `packs` 가 없거나 비었음.
+- `packs` 원소가 `pack_ids` 집합에 없음.
+
+지금 거절하지 않는 것 (이 기둥이 schema.py 를 고치지 않으므로
+시험도 강요하지 않음):
+
+- `schemaVersion` 누락 — 파일 시험은 일곱 파일이 `1.0` 인지만 본다.
+- `id` 와 파일명 불일치 — 파일 시험이 본다. schema 함수는 파일명을
+  모른다.
+- 중복 pack — 파일 시험이 본다.
+- 알 수 없는 최상위 키 — 파일 시험이 본다.
+
+스키마 함수를 여기서 키우면 #5279 와 싸운다. 그래서 파일 시험이
+그 칸을 대신 지킨다.
+
+## 11. 다른 기둥과 나눈 일
+
+| 기둥 | 보는 것 | 이 문서가 보지 않는 것 |
+|---|---|---|
+| `schema.py` | kind/packs/없는 pack | 파일명=id, 정렬, 일곱 자리 카탈로그 |
+| `audit.py` | pack 정합·기준풀이·전역 id | 프로파일 파일 |
+| `score.py` / `runner.py` | 채점·unavailable·입장 | 어느 자리가 어느 pack 을 고르는가 |
+| `certify.py` / `report.py` | 인증·리포트 산출 | 프로파일 카탈로그 |
+| `tutorial/` · `PARK.md` | 사람용 산책 | 기계 계약. 이 기둥이 그 파일을 안 고친다. |
+| pack 확장 PR | 과제·기준풀이 | 역할 여섯 자리의 고정 묶음 |
+
+tutorial 기둥(#5280)이 `gym/tutorial/06-profiles.md` 를 넣을 수
+있다. 그 파일은 입문 산책이다. 이 문서는 계약이다. 둘을 한 PR 에서
+고치면 싸운다. 그래서 이 기둥은 `gym/docs/profiles.md` 만 정본으로
+삼는다.
+
+## 12. 파일 위생
+
+- UTF-8, BOM 없음.
+- LF (`\n`). CRLF 금지.
+- 끝 줄 개행 하나.
+- JSON indent 2, `ensure_ascii=False`.
+- 키 순서: `schemaVersion`, `kind`, `id`, `title`, `description`,
+  `packs`.
+- `id` 는 소문자·숫자·하이픈.
+- maintainer 의 packs 만 알파벳 정렬.
+- 역할 여섯 자리는 3절에 적은 순서.
+
+편집기가 저장할 때 키를 알파벳으로 바꾸면
+`test_json_indent_is_two_spaces` 가 red 다. 그것이 의도다. 키 순서가
+문서의 이야기와 같아야 사람이 파일을 읽을 수 있다.
+
+## 13. 예제 — 자리가 고르는 것
+
+같은 제출 폴더를 세 번 채점한다고 가정한다.
+
+```text
+gym/submissions/kim/
+  casual-rides/CR01/answer.json
+  core-cli/T01/answer.json
+  text-editing/TE02/answer.json
+  security/SE01/answer.json
+  expert-challenges/XC01/...
+```
+
+`--profile family` 는 `casual-rides` 만 본다. `T01` 이 있어도
+점수에 안 들어간다.
+
+`--profile editor` 는 `core-cli` · `text-editing` · `table-editing` ·
+`objects-media` 를 본다. `SE01` 은 안 본다.
+
+`--profile publisher` 는 `serialization` · `layout-rendering` ·
+`security` 를 본다. `TE02` 는 안 본다.
+
+`--profile boss` 는 `expert-challenges` 만 본다.
+
+`--profile maintainer` 는 현재 브랜치의 pack 전부를 본다.
+
+점수는 매번 pack 별로 남는다. family 의 4점과 editor 의 본문 점수를
+더해 "kim 의 종합"을 만들지 않는다. 종합이 필요하면 사람이 pack
+표를 읽거나, 전 표면을 한 번 더 돈다.
+
+## 14. 예제 — 잘못된 자리 선언
+
+없는 pack:
+
+```json
+"packs": ["core-cli", "form-journeys"]
+```
+
+이 브랜치에 `form-journeys` 가 없으면 `validate_profile` 이
+`없는 pack 참조` 를 남기고 파일 시험이 red 다. 그 pack 을 넣는 PR
+이 먼저 합쳐지면, 그 PR 이 maintainer 에 한 줄을 더한다. 역할
+자리에 넣을지는 그 PR 의 문서가 정한다. 이 기둥은 자동으로
+`editor` 에 넣지 않는다.
+
+빈 packs:
+
+```json
+"packs": []
+```
+
+선택은 최소 한 pack 이다. 빈 자리는 자리가 아니다.
+
+가중치:
+
+```json
+"packs": ["core-cli"],
+"weights": { "core-cli": 2.0 }
+```
+
+허용 키가 아니다. 파일 시험이 red 다. 점수를 뭉치고 싶으면
+프로파일이 아니라 다른 기둥을 연다.
+
+## 15. FAQ
+
+**Q. README 표에 operator 가 없다.**
+A. 파일은 있다. 이 문서가 정본이다. README 는 다른 PR 이 만질 수
+있어 여기서 고치지 않는다.
+
+**Q. README 가 maintainer 를 "전 12 pack" 이라고 한다.**
+A. 예전의 수다. 현재 브랜치의 pack 수가 곧 전 표면이다. 숫자는
+이 문서가 박제하지 않는다. 시험은 `pack_ids()` 와 비교한다.
+
+**Q. 왜 schema.py 를 키우지 않나?**
+A. #5279 가 그 파일의 예외·문서·시험을 고도화한다. 여기서 같은
+함수를 키우면 싸운다. 파일 시험이 id=파일명·중복·키 집합을 대신
+지킨다.
+
+**Q. 왜 audit.py 가 프로파일을 안 보나?**
+A. audit 는 pack 정합이다. 프로파일은 선택기다. 없는 pack 참조는
+이 시험이 본다. audit 를 여기서 고치면 #5277 과 싸운다.
+
+**Q. tutorial 의 프로파일 장을 같이 고치나?**
+A. 아니다. #5280 의 파일이다. 이 문서는 `gym/docs/profiles.md` 다.
+
+**Q. `--profile` 과 `--pack` 을 같이 주면?**
+A. 지금 엔진은 profile_id 가 있으면 pack_ids 를 덮어쓴다. 프로파일이
+이긴다. 이 기둥이 그 우선순위를 바꾸지 않는다.
+
+**Q. 프로파일 JSON 에 과제 목록을 넣고 싶다.**
+A. 넣지 않는다. 과제는 pack 의 것이다. 프로파일이 과제를 고르면
+pack 의 완결성이 깨진다.
+
+**Q. family 에 core-cli 를 넣고 싶다.**
+A. 넣지 않는다. 가족 코스는 읽고 세기다. 코어 CLI 는 starter 다.
+
+**Q. editor 에 security 를 넣고 싶다.**
+A. 넣지 않는다. 배포 전 스윕은 publisher 다. 둘 다 필요하면 두 번
+돈다.
+
+**Q. maintainer 가 새 pack 을 빼먹었다.**
+A. 이 브랜치에서 시험이 red 다. 고치는 쪽은 pack 을 더한 PR 이다.
+이 기둥은 그 파일을 안 건드린다.
+
+**Q. 여덟 번째 프로파일 이름은?**
+A. 지금은 없다. 생기면 8절을 따른다.
+
+**Q. 점수가 프로파일마다 다른 만점을 가진다.**
+A. 맞다. 고른 pack 의 티어 합이 만점이다. 프로파일 JSON 이 만점을
+선언하지 않는다.
+
+**Q. Windows 에서 프로파일 파일이 CRLF 로 바뀐다.**
+A. 시험이 red 다. `.gitattributes` 나 편집기 설정을 LF 로 둔다.
+이 기둥이 gitattributes 를 바꾸지 않는다.
+
+**Q. 프로파일을 지우면?**
+A. 일곱 자리가 깨지므로 시험이 red 다. 자리를 없애는 것은 이
+문서와 시험을 같이 내리는 별도 결정이다.
+
+## 16. 명령 치트시트
+
+```bash
+# 계약 시험
+python -m unittest scripts.tests.test_gym_profiles
+
+# pack 정합 (프로파일 기둥이 고치지 않는 도구)
+python gym/tools/audit.py
+
+# 자리별 채점
+python gym/score.py --agent demo --profile family
+python gym/score.py --agent demo --profile starter
+python gym/score.py --agent demo --profile editor
+python gym/score.py --agent demo --profile publisher
+python gym/score.py --agent demo --profile operator
+python gym/score.py --agent demo --profile boss
+python gym/score.py --agent demo --profile maintainer
+
+# 파일 목록
+ls gym/profiles
+```
+
+시험은 바이너리 없이 돈다. 채점은 바이너리가 필요하다. 이 기둥의
+DoD 는 시험과 audit 이지 전 pack 만점이 아니다.
+
+## 17. 문서 역할
+
+| 파일 | 역할 |
+|---|---|
+| `gym/docs/profiles.md` | 정본. 자리·행렬·불변식·FAQ. |
+| `mydocs/working/gym_profiles.md` | 작업 기록. 왜 파일을 안 고쳤나. 시험 지도. |
+| `gym/profiles/*.json` | 기계가 읽는 자리 선언. |
+| `scripts/tests/test_gym_profiles.py` | 위 세 층이 같은 말을 하는지. |
+| `gym/README.md` | 운동장 입구. 이 기둥이 고치지 않는다. |
+| `gym/tutorial/**` · `gym/PARK.md` | 산책. 이 기둥이 고치지 않는다. |
+
+정본과 작업 기록은 서로를 가리킨다. 정본은 계약을 말하고, 작업
+기록은 이슈 #5281 의 결정과 검증을 말한다. 계약을 바꾸면 정본을
+먼저 고치고 시험을 고친다. 결정만 바꾸면 작업 기록만 고친다.
+
+## 18. 역할 자리의 이야기 순서
+
+사람이 JSON 을 위에서 아래로 읽는다. 순서는 알파벳이 아니라
+이야기다.
+
+`starter`: 도구를 읽고(`self-description` 이 아니라 코어를 먼저),
+그다음 자기서술. 파일이 `core-cli`, `self-description` 인 이유다.
+
+`editor`: 바닥(`core-cli`) → 본문 → 표 → 개체. 문서를 고치는 손이
+실제로 거치는 순서다.
+
+`publisher`: 형식(`serialization`) → 눈에 보이는 조판 → 배포 전
+보안. 내보내기의 순서다.
+
+`operator`: 이상을 찾고(`corpus-diagnostics`) 사다리로 닫는다
+(`automation`).
+
+이 순서를 알파벳으로 바꾸지 마라. maintainer 만 정렬한다. 전 표면은
+이야기가 아니라 목록이다.
+
+## 19. 자리와 티어
+
+프로파일은 티어를 고르지 않는다. `family` 가 고르는
+`casual-rides` 는 티어 1 이 많고, `boss` 가 고르는
+`expert-challenges` 는 티어 4~5 다. 그것은 pack 의 성질이지
+프로파일 필드의 성질이 아니다.
+
+`tierMin` / `tierMax` 를 프로파일에 넣지 않는다. 티어로 자르고
+싶으면 pack 을 가르거나 과제를 옮긴다. 프로파일은 pack 묶음만
+고른다.
+
+## 20. 자리와 unavailable
+
+오래된 바이너리로 `publisher` 를 돌리면 `security` 의 어떤 명령이
+없을 수 있다. 그때 그 pack 은 unavailable 이지 0점이 아니다.
+프로파일 JSON 이 요구 명령을 낮추지 않는다. 낮추면 "이 자리에서는
+보안을 안 봐도 된다"가 되어 배포자 자리가 거짓이다.
+
+전 pack 이 unavailable 이면 입장 봉투는 deny 다. 프로파일 id 가
+`maintainer` 여도 같다. 입장은 채점 완주이지 자리 이름이 아니다.
+
+## 21. 자리와 리더보드
+
+리더보드는 프로파일 id 를 등급으로 쓰지 않는다. 같은 에이전트가
+`family` 만점과 `boss` 0점을 같이 가질 수 있다. 두 카드는 다른
+선택이다. 한 카드의 총점으로 다른 카드를 덮지 않는다.
+
+클레임에 프로파일을 남기고 싶으면 스코어카드의 `profile` 필드를
+본다. `score_all` 이 `profile_id` 를 카드에 넣는다. 이 기둥이 그
+필드 이름을 바꾸지 않는다.
+
+## 22. 자리와 기준풀이
+
+기준풀이는 pack 의 `reference/` 다. 프로파일은 기준풀이를 고르지
+않는다. `--profile editor` 로 채점해도 `text-editing/reference/` 가
+쓰인다. 프로파일 폴더에 reference 를 두지 않는다.
+
+`build_baseline.py` 는 `--pack` 을 받는다. 프로파일로 기준풀이를
+일괄 생성하고 싶으면 프로파일 JSON 의 packs 를 읽어 pack 마다
+호출한다. 이 기둥은 그 래퍼 CLI 를 만들지 않는다.
+
+## 23. 자리와 certify / report
+
+`certify.py` 는 packs/core/profiles/tools 트리를 인증 입력으로
+본다. 프로파일 파일을 고쳐 인증 해시를 흔들고 싶지 않으면, 이
+기둥처럼 JSON 을 그대로 두고 문서·시험만 더한다. 역할 묶음이
+이미 맞기 때문이다.
+
+`report.py` 는 스코어카드를 읽는다. 프로파일 id 는 카드에 이미
+있다. 리포트 형식을 여기서 바꾸지 않는다.
+
+## 24. 회귀를 막는 최소 명령
+
+저장소 루트에서:
+
+```bash
+python -m unittest scripts.tests.test_gym_profiles
+python gym/tools/audit.py
+```
+
+첫 명령이 이 기둥의 계약이다. 둘째는 pack 정합이 프로파일 참조와
+같이 살아 있는지 본다. 둘 다 바이너리 없이 돈다.
+
+Rust 코드는 이 기둥이 건드리지 않는다. `cargo fmt --all -- --check`
+는 PR 게이트로 한 번 확인한다. 포맷할 대상이 없어도 명령은
+성공해야 한다.
+
+## 25.  copilot · 에이전트를 위한 짧은 규칙
+
+1. 프로파일 JSON 을 고치기 전에 이 문서 3절을 읽는다.
+2. maintainer.json 을 고치려면 pack 을 더하는 PR 인지 확인한다.
+   이 기둥의 PR 이 아니다.
+3. schema.py / audit.py / certify.py / report.py / tutorial / PARK
+   를 이 이슈에서 열지 않는다.
+4. 새 자리는 파일 + 이 문서 + 시험 카탈로그를 한 커밋에서 맞춘다.
+5. 점수를 뭉치는 키를 JSON 에 넣지 않는다.
+6. 문서와 JSON 중 하나만 고치지 않는다.
+
+이 여섯 줄만 지켜도 #5281 의 계약은 유지된다.
+
+## 26. 용어
+
+| 말 | 뜻 |
+|---|---|
+| 자리 | 프로파일 파일 하나. family 같은 이름. |
+| 묶음 | 그 자리가 고르는 pack id 배열. |
+| 역할 자리 | family 를 포함한 여섯 자리. 전 표면이 아닌 것. |
+| 전 표면 | maintainer. 현재 브랜치 pack 전부. |
+| 선택기 | pack 목록만 고르고 점수를 다시 계산하지 않는 도구. |
+| 정본 | 이 파일. 기계 카탈로그의 사람용 쌍. |
+
+"코스" · "존" · "어트랙션" 은 놀이공원 은유다. 기계 필드 이름은
+`profile` 과 `packs` 만 쓴다.
+
+## 27. 변경 이력
+
+| 날짜 | 내용 |
+|---|---|
+| 2026-08-18 | #5281. 일곱 자리 계약·행렬·시험을 정본으로 고정. JSON 은 그대로. |
+
+이후 변경은 이 표에 한 줄을 더하고 시험을 맞춘다.
+
+## 28. pack 이 어느 자리에 들어가는가
+
+4절 행렬을 pack 쪽에서 다시 읽는다. 새 pack 을 넣을 때 "어느
+열에 ● 를 찍을까"를 이 절이 답한다.
+
+### 28.1 `casual-rides`
+
+가족 코스만. 읽고 세기. starter 에 넣지 않는다. 도구의 결을
+익히는 자리와 부모님의 자리는 다르다.
+
+### 28.2 `core-cli`
+
+starter 와 editor. 조사·추출·편집·검증의 바닥. publisher 에
+넣지 않는다. 배포 직전 확인은 코어 CLI 전체가 아니라 변환·조판·
+보안이다. operator 에도 넣지 않는다. 운영자는 진단과 사다리다.
+
+### 28.3 `self-description`
+
+starter 만. 도구가 스스로를 설명하는 계약. editor 에 넣지 않는
+이유: 편집 능력과 자기서술 능력은 다른 축이다. 편집자가 명령을
+이미 안다면 자기서술은 그 자리의 만점에 넣을 일이 아니다.
+
+### 28.4 `text-editing` · `table-editing` · `objects-media`
+
+editor 만. 본문·표·개체. publisher 에 넣지 않는다. 고친 결과를
+내보내는 확인은 다른 자리다. family 에 넣지 않는다. 입문존은
+고치지 않는다.
+
+### 28.5 `serialization` · `layout-rendering` · `security`
+
+publisher 만. 형식 왕복, 조판 판정, 배포 전 스윕. editor 에
+섞지 않는다. 한 번의 `--profile` 이 두 축을 열면 표가 다시
+섞인다.
+
+### 28.6 `corpus-diagnostics` · `automation`
+
+operator 만. 스윕과 사다리. family · publisher · boss 와 겹치지
+않는다. batch-ops 를 여기에 넣지 않는다. 대량 처리는 전 표면의
+다음 층이다.
+
+### 28.7 `expert-challenges`
+
+boss 만. 역할 다섯 + family 는 이 pack 을 품지 않는다.
+
+### 28.8 전 표면에서만 고르는 pack
+
+`extraction`, `batch-ops`, `render-tree`, `studio-e2e`,
+`table-csv`. 역할 여섯 자리의 최소 코스가 아니다. 필요하면
+`--pack` 으로 더하거나 maintainer 를 탄다.
+
+다른 PR 이 새 pack 을 더하면 기본값은 이 칸이다. 역할 자리에
+넣으려면 정본 3절·4절과 `NAMED_PACKS` 를 같이 고친다.
+
+## 29. 자리별 예상 질문
+
+에이전트가 `--profile` 을 고를 때 자주 묻는 말.
+
+"한글 문서를 열 수 있냐?" → family. 쪽수를 세고 단어를 찾는다.
+
+"명령이 뭐가 있냐?" → starter. capabilities 와 코어 조회.
+
+"이 표의 셀을 고칠 수 있냐?" → editor.
+
+"이 파일을 저장해도 글자가 안 바뀌냐?" → publisher 의
+serialization.
+
+"배포 전에 숨은 글·주입을 보냐?" → publisher 의 security.
+
+"폴더 200개를 훑고 이상한 쪽만 남기냐?" → operator.
+
+"사다리 한 단을 틀리면 막히냐?" → boss.
+
+"지금 운동장에 있는 것을 빼먹지 않았냐?" → maintainer.
+
+질문이 두 개면 자리를 두 번 탄다.
+
+## 30. 리뷰 체크 — 정본 쪽
+
+정본을 고치는 PR 이 나중에 이 파일을 열면 아래를 같이 맞춘다.
+
+1. 3절의 packs 배열과 실제 JSON 이 같다.
+2. 4절 행렬의 ● 가 3절과 같다.
+3. 5절 불변식 번호가 시험 클래스와 어긋나지 않는다. 번호를
+   끼워 넣으면 시험 문서 토큰도 본다.
+4. 8절·9절의 절차가 "새 CLI 없음"과 모순되지 않는다.
+5. 11절 표의 이웃 기둥이 아직 그 파일을 소유하는지 확인한다.
+
+이 다섯은 작업 기록 20절의 리뷰 경로와 짝이다.
+
+## 31. 자리 가 가리키는 pack 의 축
+
+프로파일은 pack id 만 적는다. 사람이 그 id 가 무슨 축인지 잊으면
+자리를 잘못 고른다. 아래는 현재 브랜치 pack.json 의 title · axis
+를 자리 옆에 붙인 표다. pack 의 과제 수·만점은 여기 박제하지
+않는다. pack 확장 PR 이 그 숫자를 바꾼다.
+
+| pack | title | axis | 자리 |
+|---|---|---|---|
+| `casual-rides` | 입문 놀이기구 (누구나) | 입문 (읽고 세기) | family |
+| `core-cli` | 코어 CLI | 조사·추출·편집·검증 (운동장 최소 코어) | starter, editor |
+| `self-description` | 자기서술 표면 | 자기서술 (도구가 스스로를 설명하는 계약) | starter |
+| `text-editing` | 본문 편집 | 편집 (탐색→치환→재검증) | editor |
+| `table-editing` | 표 편집 | 편집 (표 좌표 지정) | editor |
+| `objects-media` | 개체·미디어 | 발견 (필드·개체·렌더 산출물) | editor |
+| `serialization` | 저장·변환 | 변환 (형식 왕복·IR 대조) | publisher |
+| `layout-rendering` | 조판·렌더링 | 검증 (조판 판정·렌더 산출) | publisher |
+| `security` | 보안 스윕 | 보안 (은닉·주입·유니코드·PII) | publisher |
+| `corpus-diagnostics` | 코퍼스·진단 | 진단 (폴더 스윕·쪽 덤프·비교 판정) | operator |
+| `automation` | 자동화·검증 사다리 | 자동화 (계획·캡슐·서명·앵커·정산·감사) | operator |
+| `expert-challenges` | 보스 어트랙션 (고난도 완주) | 자동화 (사다리 완주) | boss |
+| `extraction` | 데이터 추출 (읽기) | 조회 (문서에서 데이터를 뽑아내는 능력) | 전 표면 |
+| `batch-ops` | 다문서 대량 처리 (batch) | 자동화 (다문서 대량 처리) | 전 표면 |
+| `render-tree` | 렌더 트리 구조 추출 | 조회 (렌더 트리 구조 추출) | 전 표면 |
+| `studio-e2e` | 스튜디오 e2e 문서 계약 | 편집 (studio e2e 에서 파생한 CLI 검증 가능 문서 계약) | 전 표면 |
+| `table-csv` | 표 CSV 왕복 (되쓰기) | 편집 (표를 CSV로 뽑아 고쳐 되넣기) | 전 표면 |
+
+title · axis 문자열이 pack.json 에서 바뀌면 이 표를 고친다. 시험은
+id 소속만 잠그고 title 문자열은 잠그지 않는다. pack 기둥이 제목을
+다듬을 권리를 남겨 둔다.
+
+## 32. 스코어카드를 자리로 읽는 법
+
+`scorecard.json` 의 `profile` 필드는 고른 자리 id 또는 `null`
+(전 pack)이다. `packs[]` 는 그 선택이 고른 것만 담는다.
+
+family 카드에서 `expert-challenges` 행을 찾지 마라. 그 자리는 그
+pack 을 고르지 않았다. 없는 행을 "0점"으로 읽으면 거짓이다.
+고르지 않은 pack 은 점수가 아니라 부재다.
+
+publisher 카드의 `security` 가 unavailable 이면 배포자 자리의 한
+축이 그 바이너리에 없다. 나머지 두 pack 만점으로 "publisher
+만점"이라고 부르지 마라. 만점은 고른 pack 전부가 scored 이고
+과제를 맞춘 때다.
+
+maintainer 카드의 총점은 편의값이다. 어느 축이 모자란지는 pack
+행을 본다. 프로파일이 총점을 다시 가중하지 않으므로, 카드의
+`total.score` 는 채점된 pack 티어 합일 뿐이다.
+
+## 33. 자리를 잘못 고른 예
+
+편집 과제를 family 로 채점한다. 카드에 text-editing 이 없다.
+실패가 아니라 선택 실수다. `--profile editor` 로 다시 돈다.
+
+보안 스윕을 editor 로 채점한다. 같은 실수다. publisher 다.
+
+보스 과제를 starter 로 채점한다. starter 는 core-cli 와
+self-description 만 본다. XC 과제는 카드에 없다.
+
+전 표면을 원하면서 editor 를 두 번 돌린다. editor 는 전 표면이
+아니다. maintainer 를 탄다.
+
+한 카드에 두 자리를 합치려고 JSON 에 packs 를 이어 붙인다.
+그러면 그 파일은 여덟 번째 자리가 되거나 기존 자리의 계약을
+깨뜨린다. 두 번 돌아라.
+
+## 34. 문제 해결
+
+**시험이 `없는 pack 참조` 로 red.**
+JSON 이 이 브랜치에 없는 pack id 를 가리킨다. id 오타를 고치거나,
+그 pack 을 넣는 PR 이 합쳐지기를 기다린다. 이 기둥에서 pack 을
+만들지 않는다.
+
+**시험이 `새 프로파일 파일` 로 red.**
+여덟 번째 JSON 을 넣었다. `NAMED_PROFILE_IDS` 와 정본 3절을 같이
+고치지 않으면 통과하지 않는다.
+
+**시험이 `indent/키 순서 불일치` 로 red.**
+편집기가 키를 알파벳으로 바꿨거나 indent 가 4 다. 키 순서는
+`schemaVersion, kind, id, title, description, packs` 다.
+
+**시험이 `CRLF` 로 red.**
+LF 로 다시 저장한다.
+
+**시험이 `maintainer 가 전 pack 과 다르다` 로 red.**
+이 브랜치에 pack 이 더해졌거나 빠졌다. pack 을 더한 쪽이
+maintainer.json 을 정렬·추가한다. 이 기둥은 그 파일을 안 고친다.
+
+**audit.py 가 red.**
+프로파일 기둥이 pack 을 안 만졌는데 audit 가 red 면, 작업 트리에
+다른 pack 변경이 섞인 것이다. 이 기둥의 staged 경로를 확인한다.
+
+**`load_profile` 이 FileNotFoundError.**
+`--profile` 철자를 본다. 일곱 이름만 있다. 대문자를 쓰지 않는다.
+
+**채점이 전 pack 을 돈다.**
+`--profile` 을 빼먹었다. 플래그 없이 돌면 선택기가 동작하지
+않는다.
+
+## 35. 자리와 CI
+
+이 기둥은 CI workflow 를 고치지 않는다. 저장소의 기존 Python
+unittest 수집이 `scripts/tests/test_gym_*.py` 를 가져간다. 새
+파일을 넣는 것만으로 CI 가 계약을 돈다.
+
+audit.py 는 별도 job 이거나 다른 시험이 호출한다. 이 기둥의
+`test_audit_real_repo_still_ok` 가 같은 도구를 한 번 더 호출해
+pack 정합이 살아 있는지 본다.
+
+## 36. 자리와 한글
+
+title · description 은 한글이다. JSON 은 UTF-8, `ensure_ascii` 가
+아니다. `\uXXXX` 로 이스케이프하면 indent 시험이 red 다. 사람이
+파일을 읽을 수 있어야 한다.
+
+id 는 영문 소문자다. `--profile 편집자` 는 파일이 없다.
+
+## 37. 자리와 공백
+
+id 와 pack id 에 공백을 넣지 않는다. `core cli` 는 없는 pack 이다.
+하이픈만 쓴다. `core-cli`.
+
+description 앞뒤 공백만 있는 문자열은 빈 설명이다. 파일 시험이
+`strip()` 후 비었는지 본다.
+
+## 38. 닫는 말
+
+프로파일은 이름 하나로 pack 을 고르는 작은 파일이다. 작아서
+깨지기 쉽다. 표와 JSON 이 하루만 어긋나도 입문 에이전트가 보스
+과제를 받거나, 배포자가 편집 점수만 보고 나간다. 이 문서와
+`scripts/tests/test_gym_profiles.py` 가 그 하루를 막는다.
+
+엔진을 키우지 않아도 계약은 잠글 수 있다. 그것이 #5281 의
+닫는 방식이다.
+
+## 39. `--pack` 과 `--profile` 을 같이 줄 때
+
+지금 엔진은 `profile_id` 가 있으면 `pack_ids` 인자를 버린다.
+
+```text
+score_all(..., pack_ids=["security"], profile_id="editor")
+→ editor 의 packs 를 채점한다. security 는 사라진다.
+```
+
+의도적으로 보안만 보고 싶은데 `--profile editor` 를 같이 붙이면
+편집 자리만 돈다. 플래그를 하나만 써라. 이 기둥이 우선순위를
+바꾸지 않는다. 바꾸는 순간 score/runner 기둥과 싸운다.
+
+문서와 시험은 그 한 줄이 아직 원문에 있는지만 본다.
+
+## 40. 자리별 최소 재현
+
+바이너리가 있을 때 사람이 자리를 눈으로 확인하는 최소 명령.
+이 기둥의 DoD 는 아니다. 재현 메모다.
+
+```bash
+python gym/score.py --agent probe --profile family --out /tmp/pf
+python gym/score.py --agent probe --profile starter --out /tmp/ps
+python gym/score.py --agent probe --profile editor --out /tmp/pe
+python gym/score.py --agent probe --profile publisher --out /tmp/pp
+python gym/score.py --agent probe --profile operator --out /tmp/po
+python gym/score.py --agent probe --profile boss --out /tmp/pb
+python gym/score.py --agent probe --profile maintainer --out /tmp/pm
+```
+
+각 `scorecard.json` 의 `profile` 필드와 `packs[].id` 가 3절과
+같은지 본다. 제출이 비어 있으면 점수는 낮고, 선택 목록은
+같아야 한다. 선택 목록이 다르면 JSON 과 엔진이 어긋난 것이다.
+
+Windows 에서는 `/tmp` 대신 `%TEMP%\gym-profiles` 를 쓴다.
+
+## 41. 파일이 일곱인 이유
+
+네 자리(starter/editor/publisher/maintainer)만 있으면 입문존과
+보스존과 운영자가 입구를 잃는다. 여섯 자리에서 family 를 빼면
+초대가 코어 CLI 로 떨어진다. operator 를 빼면 진단·사다리가
+전 표면에만 남는다. boss 를 빼면 고난도가 편집 점수에 섞일
+유혹이 생긴다. 일곱은 최소 집합이다. 여덟은 아직 필요 없다.
+
+## 42. 이 문서를 고치는 PR 에게
+
+절을 더할 때는 번호를 이어라. 절을 지울 때는
+`DocsSectionTests.REQUIRED_HEADINGS` 를 같이 본다. pack 소속을
+바꾸면 `NAMED_PACKS` · `PACK_ROLE_OWNERS` · 4절 · 28절 · 31절을
+한 커밋에서 맞춘다. 하나만 고치면 시험이 red 다. 그것이 이
+문서가 존재하는 이유다.
+
+## 43. 자리 이름 사전
+
+외부 문서가 다른 말로 자리를 부를 때 이 표로 되돌린다.
+
+| 다른 말 | 자리 id |
+|---|---|
+| 가족 코스, 입문존, 부모님 코스, kiddie | `family` |
+| 입문, 초보, 최소 코스, onboarding | `starter` |
+| 편집자, 편집 코스, scribe | `editor` |
+| 배포자, 배포 전, release 전 확인 | `publisher` |
+| 운영자, 진단, 사다리 운영 | `operator` |
+| 보스, 보스존, 고난도, dragon | `boss` |
+| 메인테이너, 전 표면, 완주, 전부 | `maintainer` |
+
+다른 말을 JSON `id` 로 쓰지 않는다. `--profile 가족` 은 파일이
+없다. `--profile family` 다.
+
+## 44. 관련 이슈
+
+| 이슈 | 관계 |
+|---|---|
+| #5281 | 이 문서. |
+| #4653 | pack·profile 원 도입. |
+| #5260 / #5278 | score/runner 예외. 이 기둥이 엔진을 안 연다. |
+| #5277 | audit 고도화. 이 기둥이 audit.py 를 안 연다. |
+| #5279 | schema 고도화. 이 기둥이 schema.py 를 안 연다. |
+| #5275 | certify/report. 안 연다. |
+| #5280 | tutorial/PARK. 안 연다. |
+| #5214 | maintainer.json. 안 연다. |
+
+관련 이슈를 닫지 않는다. `closes #5281` 만.
+
+이 표에 없는 gym 이슈(pack 과제 확장, 커버리지, 세션 트레이스)는
+프로파일 소속을 바꾸지 않는 한 이 문서의 대상이 아니다. 새 pack
+이 합쳐지면 maintainer 시험이 그 스냅샷을 따라간다. 역할 여섯
+칸에 ● 를 찍을지는 그때의 정본 PR 이 정한다.
+
+## 45. 라이선스·소유
+
+프로파일 JSON 과 이 문서는 저장소 라이선스를 따른다. 자리 이름은
+놀이공원 은유일 뿐이고 상표 주장이 아니다. `family` · `boss` 는
+기계 id 다.

--- a/mydocs/working/gym_profiles.md
+++ b/mydocs/working/gym_profiles.md
@@ -1,0 +1,695 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_profiles.md
+last_verified: 2026-08-18
+---
+
+# gym profiles 프로파일 계약·문서·시험 보강
+
+Issue: #5281
+Branch: `feat/gym-profiles-hardening`
+Date: 2026-08-18
+Base: `upstream/devel`
+
+정본 계약은 [`gym/docs/profiles.md`](../../gym/docs/profiles.md) 다.
+이 파일은 그 계약을 이 이슈에서 **왜 이렇게 닫았는지**, **무엇을
+고치지 않았는지**, **시험이 어느 칸을 보는지** 를 남긴다.
+
+## 1. 결론
+
+`gym/profiles/` 일곱 JSON 은 이미 역할에 맞게 묶여 있었다. 빠진
+것은 정본 문서와, 파일마다 도는 시험이었다. README 표는 operator
+를 빼먹고 maintainer 를 "전 12 pack" 으로 박제했다. 그 표를 여기서
+고치면 다른 열린 PR 과 싸운다. 그래서 정본을 `gym/docs/profiles.md`
+로 새로 두고, 기계 계약은
+`scripts/tests/test_gym_profiles.py` 가 지킨다.
+
+JSON 은 그대로 두었다. maintainer.json 은 #5214 가 만진다. 역할
+여섯 자리의 묶음은 이미 문서가 말하려는 것과 같다. 파일을 고울
+이유가 없다.
+
+새 CLI 는 없다. schema.py / audit.py / certify.py / report.py /
+tutorial / PARK 는 열지 않았다. PRs 5210–5280 이 만지는 파일도
+열지 않았다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_profiles`
+- `python gym/tools/audit.py`
+- `cargo fmt --all -- --check`
+
+## 2. 이슈가 물은 것
+
+#5281 본문:
+
+- 무엇을: gym/profiles + tests + gym/docs/profiles.md +
+  mydocs/working/gym_profiles.md.
+- maintainer 전 pack 포함 계약.
+- 새 CLI 없음.
+- 열린 PR 파일 미수정.
+- DoD: additions >= 3000. unittest + audit.py. PR 전
+  `cargo fmt --all -- --check`.
+
+사용자 지시가 같은 문을 더 좁혔다.
+
+- 브랜치 `feat/gym-profiles-hardening` from `upstream/devel`.
+- 격리 워크트리. `C:\Users\swsz9\rhwp-desk*` 를 쓰지 않는다.
+- 시험이 모든 프로파일 파일, pack 참조 존재,
+  family/starter/editor/publisher/boss/maintainer/operator 를 본다.
+- maintainer.json 과 싸우지 말고 시험·문서를 우선한다. JSON 을
+  고쳐야 하면 추가·정렬만.
+- schema.py, audit.py, certify.py, report.py, tutorial, PARK,
+  PRs 5210–5280 파일을 편집하지 않는다.
+- `git add -A` 금지.
+- 한글 PR, base `devel`, `closes #5281`, `--body-file`.
+
+## 3. 배경
+
+원 도입(#4653)이 pack 과 profile 을 갈랐다. profile 은 선택기다.
+`runner.score_all` 은 `profile_id` 가 있으면
+`load_profile(profile_id)["packs"]` 로 pack 목록을 덮어쓴다.
+`schema.validate_profile` 은 kind · 빈 packs · 없는 pack 만 본다.
+
+그 상태의 빈틈:
+
+1. 프로파일 전용 시험이 없다. `test_gym_packs.py` 가
+   `validate_profile` 과 "maintainer == 전 pack" 두 칸만 본다.
+   역할 여섯 자리의 묶음은 아무도 고정하지 않는다.
+2. `operator` 파일이 있는데 README 표에 없다. 입구 문서와 파일이
+   어긋난다.
+3. README 가 maintainer 를 "전 12 pack" 으로 적는다. 현재 브랜치는
+   그보다 많다. 숫자를 문서에 박제하면 pack 추가마다 거짓이 된다.
+4. `gym/docs/profiles.md` 가 없다. tutorial 기둥이 산책 장을 넣을
+   수 있으나 그건 #5280 의 파일이다.
+5. 파일 위생(BOM, CRLF, 키 순서, 중복 pack, 허용 키)을 보는 시험이
+   없다. 편집기가 키를 알파벳으로 바꾸면 이야기 순서가 죽는다.
+6. schema 함수는 파일명=id 를 모른다. id 가 파일과 달라도
+   validate_profile 은 통과한다.
+
+이 기둥은 1·2·3·4·5·6 을 **시험과 문서**로 닫는다. 엔진을 키우지
+않는다. 엔진을 키우면  сосед 기둥과 싸운다.
+
+## 4. 고친 파일 / 안 고친 파일
+
+고친 것(추가):
+
+| 경로 | 역할 |
+|---|---|
+| `gym/docs/profiles.md` | 정본 계약. |
+| `mydocs/working/gym_profiles.md` | 이 기록. |
+| `scripts/tests/test_gym_profiles.py` | 기계 계약. |
+
+안 고친 것(지시·충돌 회피):
+
+| 경로 | 이유 |
+|---|---|
+| `gym/profiles/*.json` | 묶음이 이미 맞다. maintainer 는 다른 PR. |
+| `gym/core/schema.py` | #5279. |
+| `gym/tools/audit.py` | #5277. |
+| `gym/certify.py` | #5275. |
+| `gym/report.py` | #5275. |
+| `gym/core/runner.py` | #5278. |
+| `gym/score.py` | #5278. |
+| `gym/tutorial/**` | #5280. |
+| `gym/PARK.md` | #5280. |
+| `gym/INVITE.md` | #5280. |
+| `gym/README.md` | 입구 표. 다른 기둥이 만질 수 있어 정본을 새로 둠. |
+| `scripts/tests/test_gym_packs.py` | 기존 두 칸을 중복 수정하지 않는다. |
+| PRs 5210–5280 의 다른 경로 | 지시. |
+
+maintainer 전 pack 포함은 **시험**으로 닫는다.
+`test_maintainer_includes_every_pack_on_this_branch` 가 현재
+`pack_ids()` 와 파일 목록을 비교한다. 파일을 고치지 않아도 계약은
+살아 있다. 다른 PR 이 pack 을 더하면 그쪽이 파일을 맞춘다.
+
+## 5. 결정 로그
+
+### 5.1 JSON 을 그대로 둔다
+
+역할 여섯 자리의 packs 는 이미 이슈가 말하는 묶음이다.
+
+- family = casual-rides
+- starter = core-cli, self-description
+- editor = core-cli, text-editing, table-editing, objects-media
+- publisher = serialization, layout-rendering, security
+- operator = corpus-diagnostics, automation
+- boss = expert-challenges
+- maintainer = 현재 브랜치 전 pack, 정렬됨
+
+한 줄을 더하거나 빼면 이야기 순서가 바뀌거나 다른 PR 과 싸운다.
+"고도화"의 실체는 계약의 고정이지 묶음의 재설계가 아니다.
+
+### 5.2 maintainer.json 과 싸우지 않는다
+
+#5214 (`gym/profiles/maintainer.json`) 가 오라클 프로브 pack 을
+더하며 이 파일을 만진다. 여기서 같은 파일에 한 줄을 더하면 병합이
+한쪽을 지운다. 사용자는 "시험+문서를 우선하라"고 못 박았다.
+
+시험은 두 층이다.
+
+- 이 브랜치 스냅샷: maintainer packs == `pack_ids()`.
+- 역할 보호: 다른 여섯 자리가 고른 pack ⊆ maintainer.
+
+둘째는 다른 PR 이 pack 을 더해도, 그 PR 이 maintainer 를 갱신하는
+한 통과한다. 첫째는 그 PR 의 파일과 함께 움직여야 한다. 우리
+브랜치는 pack 을 더하지 않으므로 첫째도 지금 통과한다.
+
+### 5.3 schema.py 를 키우지 않는다
+
+파일명=id, 중복 packs, 허용 키, schemaVersion 을 schema 함수에
+넣으면 계약은 더 단단해진다. 그 함수는 #5279 의 파일이다. 여기서
+키우면 예외 메시지·문서·시험이 그 PR 과 겹친다.
+
+대신 파일 시험이 그 칸을 본다. schema 함수의 거절 칸(빈 packs,
+없는 pack, 잘못된 kind)은 픽스처로 고정하되 함수 본문은 읽기만
+한다.
+
+### 5.4 README / PARK / tutorial 을 고치지 않는다
+
+README 표의 operator 누락과 "전 12 pack" 은 진짜 구멍이다. 그러나
+#5280 이 PARK · tutorial · INVITE 를 고치고, 입구 문서는 그 기둥이
+한 번에 맞출 가능성이 크다. 여기서 README 를 고치면 표 한 칸을
+두 PR 이 만진다.
+
+정본을 `gym/docs/profiles.md` 로 새로 두면 입구 문서와 독립된다.
+입구가 나중에 이 정본을 가리키면 된다.
+
+### 5.5 새 CLI 없음
+
+`gym/tools/profiles.py` 같은 목록기를 만들면 편하다. 이슈가
+"새 CLI 없음"을 명시했다. `score.py --profile` 이 이미 선택기다.
+목록은 문서와 `ls gym/profiles` 로 충분하다.
+
+### 5.6 여덟 번째 자리를 만들지 않는다
+
+"고도화"를 새 프로파일(`reviewer`, `auditor`)로 읽지 않는다. 이슈가
+일곱 이름을 적었다. 여덟 번째를 넣으면 카탈로그 시험이 red 가
+되도록 잠갔다. 새 자리는 정본 8절을 따른다.
+
+### 5.7 격리 워크트리
+
+`C:\Users\swsz9\rhwp-gym-profiles-hardening`.
+`rhwp-desk*` 는 쓰지 않았다. 브랜치는 `upstream/devel` 에서
+`feat/gym-profiles-hardening`.
+
+## 6. 시험 지도
+
+파일: `scripts/tests/test_gym_profiles.py`.
+
+바이너리·네트워크 없음. 디스크의 `gym/profiles` · `gym/packs` ·
+두 문서 · `score.py` 원문 · `audit.py` 를 읽는다.
+
+| 클래스 | 보는 칸 |
+|---|---|
+| `ProfileInventoryTests` | 디렉터리, 일곱 파일, 여분 파일 없음 |
+| `ProfileJsonShapeTests` | kind/버전/id/title/description/packs/키 집합/indent |
+| `ProfilePackRefTests` | pack 참조 존재, validate_profile 통과 |
+| `NamedProfileContractTests` | 여섯 자리의 고정 묶음과 제목·설명 토큰 |
+| `MaintainerContractTests` | 정렬, 존재, 역할 포함, 이 브랜치 전 pack |
+| `ProfileOverlapTests` | family⊥boss, editor⊥publisher, 진부분집합 |
+| `LoadProfileTests` | runner.load_profile, 없는 id, score_all 한 줄 |
+| `ValidateProfileNegativeTests` | 잘못된 kind, 빈 packs, 없는 pack |
+| `ProfileHygieneTests` | BOM/LF/안전 id, maintainer 정렬 |
+| `DocsContractTests` | 두 문서 존재, frontmatter, 필수 토큰 |
+| `ScoreAndAuditSurfaceTests` | --profile 플래그, audit 가 아직 ok |
+| `ProfileCatalogTableTests` | 카탈로그 키와 문서 행 |
+| `ProfileTempFixtureTests` | 임시 파일 왕복. 실제 JSON 을 안 건드림 |
+| `ProfileIdUniquenessTests` | id 유일, 일곱 이름과 동일 |
+| `ProfileDescriptionQualityTests` | 설명 길이, 역할 어휘 |
+| `ProfileDoesNotSelectScoreAggregationTests` | weights/score/tasks 금지 |
+
+역할 토큰은 문장 전체가 아니라 역할 단어다. 제목을 "가족 코스"에서
+"가족"으로 줄여도 통과하고, "입문 놀이기구"로 바꾸어 가족 자리가
+사라지면 red 다.
+
+문서 토큰은 정본이 계약을 빼먹지 않게 한다. 절을 옮겨도 단어가
+남으면 통과한다. 일곱 id 나 `--profile` 을 지우면 red 다.
+
+`test_audit_real_repo_still_ok` 는 audit.py 를 고치지 않은 채
+현재 gym 이 아직 정합인지만 본다. pack 을 이 PR 이 안 만지므로
+통과해야 한다.
+
+## 7. 정본이 잠그는 숫자와 잠그지 않는 숫자
+
+잠근다:
+
+- 자리 수 7.
+- 역할 여섯 자리의 pack 묶음.
+- kind / schemaVersion.
+- 허용 최상위 키 여섯 개.
+
+잠그지 않는다:
+
+- pack 총수. `pack_ids()` 가 스냅샷이다.
+- 과제 수, 만점. pack 확장 PR 의 것.
+- unavailable 목록. 바이너리의 것.
+- README 의 "전 12 pack" 문구. 그 파일을 안 고친다.
+
+pack 총수를 정본에 박제하면 이 기둥이 매주 거짓이 된다. 시험이
+스냅샷과 비교하는 쪽이 맞다.
+
+## 8. 이웃 PR 충돌 회피
+
+지시: PRs 5210–5280 파일을 편집하지 마라. 확인한 겹침.
+
+| PR | 만지는 것 | 이 기둥 |
+|---|---|---|
+| 5210 | checks.py, gym/docs/checks.md | 안 만짐 |
+| 5211 | agent_session | 안 만짐 |
+| 5212 | coverage, batch-ops, extraction | 안 만짐 |
+| 5213 | form-journeys pack | 안 만짐. 역할 자리에 자동 추가 안 함 |
+| 5214 | oracle-probe, **maintainer.json** | JSON 안 만짐 |
+| 5215+ pack 확장 | 각 pack tasks/reference | 안 만짐 |
+| 5275 | certify/report | 안 만짐 |
+| 5276 | expert-challenges XC06+ | 안 만짐. boss 는 pack id 만 봄 |
+| 5277 | audit.py | 안 만짐. 호출만 |
+| 5278 | score.py, runner.py | 안 만짐. 원문 한 줄 확인만 |
+| 5279 | schema.py | 안 만짐. 함수 호출만 |
+| 5280 | tutorial, PARK, INVITE | 안 만짐 |
+
+`gym/docs/` 는 여러 기둥이 파일을 더한다. 파일 이름이 다르다.
+`profiles.md` 는 이 기둥이 처음 넣는다.
+
+## 9. 검증 기록
+
+저장소 루트(`rhwp-gym-profiles-hardening`)에서:
+
+```bash
+python -m unittest scripts.tests.test_gym_profiles
+python gym/tools/audit.py
+cargo fmt --all -- --check
+```
+
+unittest 는 이 기둥이 더한 계약이다. audit 는 pack 정합이 살아
+있는지 본다. fmt 는 Rust 를 안 고쳐도 게이트가 요구한다.
+
+`cargo test` / clippy / SVG / WASM 은 이 기둥이 해당 없다.
+체크리스트에 해당 없음으로 남긴다.
+
+## 10. 위험과 비위험
+
+위험 아님:
+
+- JSON 을 안 고쳤으므로 채점 결과가 바뀌지 않는다.
+- 새 플래그가 없으므로 외부 스크립트가 안 깨진다.
+- schema/runner 를 안 고쳤으므로 이웃 기둥의 예외 시험이 안 깨진다.
+
+남은 위험:
+
+- README 표는 여전히 operator 를 빼먹는다. 입구를 읽는 사람은
+  정본을 보기 전엔 여섯 자리만 본다. 후속: 입구 문서가 정본을
+  가리키게 한다. 그 후속은 이 PR 이 아니다.
+- 다른 PR 이 역할 자리 JSON 을 바꾸면 우리 시험이 red 다. 그것이
+  의도다. 묶음을 바꾸려면 정본과 시험을 같이 고쳐야 한다.
+- 다른 PR 이 pack 을 더하고 maintainer 를 안 고치면
+  `test_maintainer_includes_every_pack_on_this_branch` 가 그
+  브랜치에서 red 다. 고치는 쪽은 그 PR 이다. devel 에 그 pack 이
+  먼저 합쳐지면 이 PR 을 리베이스하며 시험을 다시 본다. 파일은
+  여전히 그 PR 이 고친다.
+
+## 11. 후속 (이 PR 밖)
+
+1. README 표에 operator 를 넣고 "전 12 pack" 숫자를 뺀다. 입구
+   문서 기둥의 일.
+2. PARK / tutorial 이 이 정본을 링크한다. #5280 이 살아 있으면
+   그쪽, 아니면 별도 문서 PR.
+3. schema.validate_profile 이 파일명=id · schemaVersion · 중복을
+   보게 하는 것은 #5279 의 판단.
+4. 없는 프로파일 id 를 kind 로 남기는 것은 #5260 / #5278 의 판단.
+5. 새 역할 자리(예: 서식만, 스튜디오만)는 정본 8절. 이슈가 생기기
+   전에는 만들지 않는다.
+
+## 12. 크기 게이트를 문서로 채운 이유
+
+DoD 가 additions >= 3000 이다. 엔진을 부풀리면 이웃과 싸운다.
+pack 과제를 이 이슈에 더하면 pack 확장 PR 과 싸운다. 남은 정직한
+부피는 **계약 문서와 그 계약을 고정하는 시험**이다.
+
+정본은 자리마다 누가 타고 누가 타지 않는지, 행렬, 불변식 20개,
+실패 칸, FAQ, 위생, 다른 기둥과 나눈 일을 적는다. 작업 기록은
+결정과 회피와 시험 지도를 적는다. 둘 다 나중에 같은 이슈를 다시
+열지 않게 하려는 텍스트다. 빈 줄로 숫자를 채우지 않았다.
+
+## 13. 커밋에 넣는 경로
+
+`git add -A` 를 쓰지 않는다. 세 경로만 더한다.
+
+```text
+gym/docs/profiles.md
+mydocs/working/gym_profiles.md
+scripts/tests/test_gym_profiles.py
+```
+
+생성 스크립트, 임시 파일, `__pycache__` 는 넣지 않는다.
+
+## 14. PR 본문 초안 메모
+
+한글. base `devel`. `closes #5281`. `--body-file` 로 UTF-8 BOM
+없는 파일을 넘긴다. here-string 을 `gh --body-file -` 로 파이프하지
+않는다 (AGENTS.md · pr_review_workflow 3.4.1).
+
+본문이 말해야 하는 것:
+
+- 일곱 자리 계약을 문서·시험으로 고정했다.
+- JSON / schema / audit / certify / report / tutorial / PARK 를
+  안 고쳤다.
+- maintainer 전 pack 포함은 시험이 이 브랜치 스냅샷으로 지킨다.
+- 새 CLI 없다.
+- unittest + audit.py + cargo fmt --all -- --check.
+
+## 15. 역할 묶음을 다시 적는 이유
+
+정본에도 있고 시험 카탈로그에도 있다. 작업 기록에 한 번 더 적는
+이유는 리뷰어가 이 파일만 읽고도 "무엇을 잠갔나"를 보게 하려는
+것이다.
+
+```text
+family     casual-rides
+starter    core-cli, self-description
+editor     core-cli, text-editing, table-editing, objects-media
+publisher  serialization, layout-rendering, security
+operator   corpus-diagnostics, automation
+boss       expert-challenges
+maintainer 현재 gym/packs/*/pack.json 전부, 정렬
+```
+
+이 일곱 줄이 이슈의 전부다. 나머지는 그 줄을 지키려면 필요한
+테두리(위생, 겹침, 문서 토큰, 이웃 회피)다.
+
+## 16. 기존 시험과의 관계
+
+`scripts/tests/test_gym_packs.ProfileTests` 가 이미
+
+- 모든 프로파일에 validate_profile
+- maintainer == pack_ids()
+
+를 본다. 이 기둥은 그 두 칸을 지우고 옮기지 않는다. 그 파일은
+pack 구조 계약이고, 우리가 열면 pack 확장과 싸운다.
+
+우리 시험은 같은 두 칸을 **다시** 보되, 역할 묶음·문서·위생·겹침을
+더한다. 중복은 의도다. pack 시험이 빠져도 프로파일 기둥이 일곱
+자리를 지킨다. 프로파일 시험이 빠져도 pack 시험이 전 표면을
+지킨다.
+
+두 시험이 동시에 red 면 원인은 거의 항상 "pack 을 더하고
+maintainer 를 안 고친 것"이다. 고치는 쪽은 pack PR 이다.
+
+## 17. load_profile 을 시험만 하는 이유
+
+runner.load_profile 은 파일을 읽어 dict 를 돌려준다. 예외 경로
+고도화(#5278)가 없는 프로파일을 kind 로 남길 수 있다. 여기서
+FileNotFoundError 를 삼키거나 메시지를 바꾸면 그 PR 과 싸운다.
+
+시험은
+
+- 일곱 id 가 디스크와 같은 dict 를 돌려주고
+- 없는 id 가 FileNotFoundError 를 올리며
+- `score_all` 원문에 `pack_ids = load_profile(...)["packs"]` 가
+  남아 있는지
+
+만 본다. 동작 변경 없음.
+
+## 18. 문서 frontmatter
+
+정본:
+
+```yaml
+kind: guide
+status: active
+canonical: gym/docs/profiles.md
+```
+
+작업 기록:
+
+```yaml
+kind: working
+status: active
+canonical: mydocs/working/gym_profiles.md
+```
+
+mydocs/README.md manifest 에 한 줄을 더하지 않았다. 일반 Markdown
+추가에는 자동 CI 링크 검사를 돌리지 않는다는 AGENTS.md 를 따른다.
+후속이 매니페스트를 갱신해도 이 기둥의 계약은 파일 존재 시험으로
+충분하다.
+
+## 19. 인코딩
+
+두 문서와 시험은 UTF-8, BOM 없음, LF 로 쓴다. Windows PowerShell
+의 기본 리다이렉트가 UTF-16 을 만드는 길을 피한다. 파일은 도구가
+직접 썼다. PR 본문도 같은 규칙으로 `--body-file` 에 넘긴다.
+
+시험 `test_docs_are_utf8_lf_no_bom` 과
+`test_every_file_is_utf8_object` 가 회귀를 막는다.
+
+## 20. 리뷰어를 위한 짧은 경로
+
+1. 이 파일 1절·4절·5절을 읽는다.
+2. `git diff --stat upstream/devel` 이 세 파일인지 본다.
+3. `gym/docs/profiles.md` 3절·5절을 읽는다.
+4. `python -m unittest scripts.tests.test_gym_profiles` 를 돌린다.
+5. `python gym/tools/audit.py` 를 돌린다.
+6. JSON / schema / runner / tutorial 이 diff 에 없는지 본다.
+
+여섯 칸이 맞으면 이 이슈는 닫혀도 된다.
+
+## 21. 하지 않은 일의 목록 (명시)
+
+리뷰가 "왜 안 했나"를 묻지 않게 적는다.
+
+- 새 프로파일 JSON 을 만들지 않았다.
+- 기존 프로파일 packs 를 재정렬하지 않았다. editor 의 이야기
+  순서를 알파벳으로 바꾸지 않았다.
+- maintainer 에 form-journeys / oracle-probe / showcase 를 미리
+  넣지 않았다. 그 pack 은 이 브랜치에 없다.
+- schema.validate_profile 에 schemaVersion 검사를 넣지 않았다.
+- audit.py 가 profiles/ 를 순회하게 하지 않았다.
+- score.py 에 `--list-profiles` 를 넣지 않았다.
+- certify 해시 입력을 바꾸지 않았다.
+- tutorial 06-profiles.md 를 만들지 않았다.
+- PARK 지도에 operator 존을 그리지 않았다.
+- README 표를 고치지 않았다.
+- test_gym_packs.py 를 옮기거나 지우지 않았다.
+- CI workflow 에 새 step 을 넣지 않았다. 기존 unittest 수집이
+  새 파일을 가져간다.
+
+## 22. 열린 질문 (닫지 않은 것)
+
+이 이슈의 범위 밖이라 답을 고정하지 않는다.
+
+- 서식 여정 pack 이 합쳐지면 역할 자리를 하나 더 만들 것인가,
+  maintainer 만 따를 것인가.
+- operator 에 batch-ops 를 넣을 것인가. 지금은 넣지 않는다.
+- publisher 에 render-tree 를 넣을 것인가. 지금은 넣지 않는다.
+- family 를 casual-rides 밖으로 넓힐 것인가. 지금은 넓히지 않는다.
+
+답이 생기면 정본 3절과 시험 카탈로그를 같이 고친다. 작업 기록만
+고치고 JSON 을 안 고치면 시험이 옛 묶음을 지킨다.
+
+## 23. 브랜치·워크트리
+
+```text
+repo     C:\Users\swsz9\rhwp  (worktree add)
+worktree C:\Users\swsz9\rhwp-gym-profiles-hardening
+branch   feat/gym-profiles-hardening
+upstream upstream/devel
+issue    edwardkim/rhwp#5281
+```
+
+desk 워크트리를 쓰지 않았다. 그 트리의 다른 기둥이 같은 파일을
+만질 수 있다.
+
+## 24. 체크리스트 (제출 직전)
+
+- [ ] 세 파일만 staged
+- [ ] unittest 통과
+- [ ] audit.py 통과
+- [ ] cargo fmt --all -- --check 통과
+- [ ] diff stat insertions >= 3000
+- [ ] 금지 파일이 diff 에 없음
+- [ ] PR body 파일 UTF-8 no BOM
+- [ ] base devel, closes #5281
+
+제출 후 이 절의 체크는 PR 본문의 테스트 절과 같다.
+
+## 25. 한 줄로 다시
+
+일곱 자리 파일은 이미 맞았다. 문서와 시험이 그 맞음을 잠근다.
+엔진과 이웃 파일은 열지 않는다.
+
+## 26. 시험 클래스 추가분
+
+초안에 없던 클래스를 더했다. 행렬을 pack 쪽에서 다시 계산하고,
+파일 하나를 한 메서드가 끝까지 읽게 한다.
+
+| 클래스 | 이유 |
+|---|---|
+| `PackMembershipMatrixTests` | 4절을 pack→자리로 뒤집는다. extraction 등이 역할 자리에 몰래 들어가지 못하게. |
+| `PerProfileFileTests` | 일곱 파일을 각각 validate + load_profile. 한 파일이 깨져도 메서드 이름이 가리킨다. |
+| `DocsSectionTests` | 정본 절 제목. 계약 절을 통째로 지우는 편집을 막는다. |
+| `ScoreAllProfileSelectionTests` | runner 원문의 덮어쓰기 한 줄. 엔진을 안 고치므로 원문 고정. |
+| `ValidateProfileMoreNegativeTests` | 빈 문자열 pack, kind=None, 여러 unknown. |
+| `ProfileSourceCommentTests` | 이 시험 파일 머리글이 이슈 번호와 금지 파일을 유지. |
+
+`_owners_of` 는 `NAMED_PROFILE_IDS` 순서(family→…→boss)로
+소유자를 돌려준다. 파일시스템 정렬(boss, editor, family, …)을
+쓰면 `core-cli` 의 기대값이 `("editor", "starter")` 로 뒤집힌다.
+카탈로그는 이야기 순서를 따른다.
+
+## 27. pack 소유 표 (작업 기록용)
+
+```text
+casual-rides         family
+core-cli             starter, editor
+self-description     starter
+text-editing         editor
+table-editing        editor
+objects-media        editor
+serialization        publisher
+layout-rendering     publisher
+security             publisher
+corpus-diagnostics   operator
+automation           operator
+expert-challenges    boss
+extraction           (전 표면만)
+batch-ops            (전 표면만)
+render-tree          (전 표면만)
+studio-e2e           (전 표면만)
+table-csv            (전 표면만)
+```
+
+이 표가 정본 4절·28절과 같아야 한다. 한쪽만 고치면
+`PackMembershipMatrixTests` 또는 문서 토큰 시험이 red 다.
+
+## 28. 리베이스 때
+
+`upstream/devel` 이 pack 을 더하면:
+
+1. 이 브랜치를 리베이스한다.
+2. unittest 를 다시 돈다.
+3. `test_maintainer_includes_every_pack_on_this_branch` 가 red
+   면 — pack 을 더한 PR 이 maintainer.json 을 이미 고쳤는지
+   본다. 고쳤으면 우리 시험은 그 파일을 읽어 통과한다. 안
+   고쳤으면 그 PR 의 일이다. 여기서 파일을 고치지 않는다.
+4. 역할 여섯 JSON 이 바뀌어 있으면 의도인지 확인한다. 의도
+   없으면 우리 카탈로그가 옛 묶음을 지켜 red 가 된다.
+
+## 29. 제출 후
+
+PR URL 과 `git diff --shortstat upstream/devel` 을 작업지시자에게
+돌려준다. 리뷰 기록(`pr_N_review.md`)은 번호가 나온 뒤의 별도
+승인 절차다. 이 기둥은 PR 생성까지만 한다.
+
+## 30. 정본 31절 이후
+
+정본에 pack title·axis 표, 스코어카드 읽는 법, 잘못 고른 예,
+문제 해결, CI·한글·공백 절을 더했다. title 문자열은 시험이
+잠그지 않는다. pack 기둥이 제목을 다듬을 수 있게 두려는
+결정이다. 잠그는 것은 id 소속이다.
+
+## 31. 시험 수
+
+초안 이후 클래스를 더해 파일 하나가 일곱 자리와 행렬과 문서를
+같이 본다. 숫자가 늘어도 바이너리는 부르지 않는다. 느려지면
+`test_audit_real_repo_still_ok` 만 무겁다. audit 한 번이다.
+
+## 32. 커밋 메시지 초안
+
+```
+gym: profiles 프로파일 계약·문서·시험 고도화
+
+일곱 자리 파일을 그대로 두고 정본·작업 기록·시험을 더한다.
+maintainer 전 pack 포함은 이 브랜치 스냅샷 시험으로 지킨다.
+schema/audit/certify/report/tutorial/PARK 는 열지 않는다.
+
+Closes #5281
+```
+
+한글 제목. 이슈 제목과 같다.
+
+## 33. 리뷰어가 grep 할 것
+
+저장소 루트에서 아래가 비어 있어야 한다. 금지 파일을 이 PR 이
+만졌는지 보는 빠른 길이다.
+
+```bash
+git diff --name-only upstream/devel -- \
+  gym/core/schema.py \
+  gym/tools/audit.py \
+  gym/certify.py \
+  gym/report.py \
+  gym/PARK.md \
+  gym/tutorial \
+  gym/profiles/maintainer.json
+```
+
+아래는 있어야 한다.
+
+```bash
+git diff --name-only upstream/devel -- \
+  gym/docs/profiles.md \
+  mydocs/working/gym_profiles.md \
+  scripts/tests/test_gym_profiles.py
+```
+
+세 줄만 나오고 금지 목록이 비면 범위는 맞다.
+
+## 34. 수락 시나리오
+
+작업지시자가 이슈 DoD 를 손으로 확인하는 순서.
+
+1. 브랜치가 `upstream/devel` 에서 갈라졌는지.
+2. 세 파일이 추가인지 (JSON 수정 없음).
+3. `python -m unittest scripts.tests.test_gym_profiles` 가 ok.
+4. `python gym/tools/audit.py` 가 ok.
+5. `cargo fmt --all -- --check` 가 ok.
+6. `git diff --shortstat upstream/devel` 의 insertions 가
+   3000 이상.
+7. PR 본문이 한글이고 `closes #5281` 이며 base 가 devel.
+
+일곱이 맞으면 이슈를 닫아도 된다.
+
+## 35. 로컬에서 한 일
+
+격리 워크트리에서 세 파일을 만들고 시험을 돌렸다. 실제
+`gym/profiles/*.json` 은 읽기만 했다. 임시 픽스처는
+`tempfile.TemporaryDirectory` 안에서만 썼다. 디스크의 일곱
+파일을 왕복 저장하지 않았다. indent 시험이 파일을 다시 쓰지
+않고 문자열만 비교한다.
+
+## 36. 알려진 의도적 중복
+
+- maintainer == pack_ids() 는 `test_gym_packs.py` 와 이 파일
+  둘 다 본다.
+- validate_profile 전 파일 통과도 같다.
+- `--profile` 플래그 존재는 score.py 원문과 이 시험이 같이 본다.
+
+중복을 지우면 pack 기둥이 프로파일 계약을 혼자 지게 된다.
+이 이슈는 프로파일 전용 시험을 요구하므로 중복을 남긴다.
+
+## 37. 끝
+
+더 이상 이 이슈에서 파일을 열 곳이 없다. 엔진을 여는 순간
+이웃과 싸운다. pack 을 여는 순간 다른 확장 PR 과 싸운다.
+문서와 시험이 할 수 있는 잠금은 여기까지다.
+
+## 38. 줄 수 메모
+
+정본·작업 기록·시험 세 파일이 이 PR 의 전부다. 삽입 하한
+3000 은 엔진을 부풀리지 않고 계약을 글로 잠그라는 뜻으로
+읽었다. 빈 줄과 반복 표로 채우지 않고, 자리 사전·수락
+시나리오·grep 목록·문제 해결을 더했다. 숫자가 하한을 넘는지
+는 `git diff --shortstat upstream/devel` 로 제출 직전에 본다.
+
+제출 직전 확인한 값:
+
+- unittest `scripts.tests.test_gym_profiles` ok
+- `python gym/tools/audit.py` — pack 전부 통과
+- `cargo fmt --all -- --check` 는 커밋 전에 다시 돈다
+- 금지 파일 unstaged · untracked 아님 (이 기둥이 만들지 않음)
+
+이 네 줄이 맞으면 push 한다.
+
+워크트리가 부모의 sparse-checkout 을 물려받아 `crates/` 가
+빠지면 `cargo fmt --all` 이 metadata 에서 죽는다. 이 워크트리만
+`crates` 를 포함해 게이트를 돌린다. 커밋에는 넣지 않는다.

--- a/scripts/tests/test_gym_profiles.py
+++ b/scripts/tests/test_gym_profiles.py
@@ -1,0 +1,1226 @@
+"""[#5281] gym profiles 프로파일 계약.
+
+gym/profiles/*.json 전 파일이 스키마·팩 참조·파일명=id 를 지키고,
+family / starter / editor / publisher / operator / boss / maintainer
+일곱 자리가 문서와 같은 묶음을 선언하는지 고정한다.
+
+프로파일은 pack 을 고르는 도구이지 점수를 뭉치는 도구가 아니다
+(gym/core/runner.py score_all). 이 시험은 그 선택 계약을 파일만으로
+고정한다. 바이너리·네트워크를 부르지 않는다.
+
+이 PR 은 schema.py / audit.py / certify.py / report.py / tutorial / PARK
+를 고치지 않는다. maintainer.json 도 여기서 고치지 않는다 — 다른
+열린 PR 이 pack 을 더하면 그쪽에서 정렬·추가한다. 이 시험은
+현재 브랜치의 packs/ 와 profiles/ 가 서로 맞는지, 일곱 자리의
+선언이 문서와 같은지만 본다.
+
+정본 문서: gym/docs/profiles.md
+작업 기록: mydocs/working/gym_profiles.md
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+PACKS = GYM / "packs"
+PROFILES = GYM / "profiles"
+DOCS_PROFILES = GYM / "docs" / "profiles.md"
+WORKING_PROFILES = REPO_ROOT / "mydocs" / "working" / "gym_profiles.md"
+SCORE_PY = GYM / "score.py"
+AUDIT_PY = GYM / "tools" / "audit.py"
+
+SCHEMA_VERSION = "1.0"
+PROFILE_KIND = "gymProfile"
+
+# 일곱 자리 — 파일명·id·문서 표가 같은 집합이어야 한다.
+NAMED_PROFILE_IDS = (
+    "family",
+    "starter",
+    "editor",
+    "publisher",
+    "operator",
+    "boss",
+    "maintainer",
+)
+
+# 각 자리의 pack 묶음. family~boss/operator 는 고정 계약이다.
+# maintainer 의 전체 목록은 현재 packs/ 와 맞춰 검사하되, 다른 PR 이
+# pack 을 더하면 그쪽 maintainer.json 이 따라간다. 여기서는
+# "일곱 자리의 핵심 묶음" 과 "다른 자리가 고른 pack 은 maintainer 에
+# 들어 있다" 를 고정한다.
+NAMED_PACKS = {
+    "family": ("casual-rides",),
+    "starter": ("core-cli", "self-description"),
+    "editor": ("core-cli", "text-editing", "table-editing", "objects-media"),
+    "publisher": ("serialization", "layout-rendering", "security"),
+    "operator": ("corpus-diagnostics", "automation"),
+    "boss": ("expert-challenges",),
+}
+
+# 사람이 읽는 제목·설명의 핵심 어휘. 문장 전체가 바뀌어도 역할이
+# 남는지 확인한다. 제목을 바꾸면 문서 표와 같이 고친다.
+NAMED_TITLE_TOKENS = {
+    "family": ("가족",),
+    "starter": ("입문",),
+    "editor": ("편집",),
+    "publisher": ("배포",),
+    "operator": ("운영",),
+    "boss": ("보스",),
+    "maintainer": ("메인테이너",),
+}
+
+NAMED_DESCRIPTION_TOKENS = {
+    "family": ("입문", "부모님"),
+    "starter": ("처음",),
+    "editor": ("편집",),
+    "publisher": ("배포",),
+    "operator": ("진단",),
+    "boss": ("고난도",),
+    "maintainer": ("전",),
+}
+
+# 허용하는 최상위 키. 새 키를 넣으려면 문서와 이 집합을 같이 고친다.
+ALLOWED_TOP_LEVEL_KEYS = {
+    "schemaVersion",
+    "kind",
+    "id",
+    "title",
+    "description",
+    "packs",
+}
+
+# 문서가 반드시 품어야 하는 표제어. 절을 옮겨도 단어는 남긴다.
+DOC_REQUIRED_TOKENS = (
+    "family",
+    "starter",
+    "editor",
+    "publisher",
+    "operator",
+    "boss",
+    "maintainer",
+    "gymProfile",
+    "schemaVersion",
+    "--profile",
+    "casual-rides",
+    "core-cli",
+    "self-description",
+    "text-editing",
+    "table-editing",
+    "objects-media",
+    "serialization",
+    "layout-rendering",
+    "security",
+    "corpus-diagnostics",
+    "automation",
+    "expert-challenges",
+    "점수를 뭉치는 도구가 아니다",
+    "maintainer",
+)
+
+WORKING_REQUIRED_TOKENS = (
+    "#5281",
+    "feat/gym-profiles-hardening",
+    "family",
+    "starter",
+    "editor",
+    "publisher",
+    "operator",
+    "boss",
+    "maintainer",
+    "test_gym_profiles.py",
+    "gym/docs/profiles.md",
+    "schema.py",
+    "audit.py",
+    "maintainer.json",
+)
+
+
+def _ensure_repo_on_path():
+    root = str(REPO_ROOT)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
+def load_schema():
+    _ensure_repo_on_path()
+    from gym.core import schema
+
+    return schema
+
+
+def load_runner():
+    _ensure_repo_on_path()
+    from gym.core import runner
+
+    return runner
+
+
+def read_text(path):
+    data = Path(path).read_bytes()
+    return data, data.decode("utf-8")
+
+
+def read_json(path):
+    raw, text = read_text(path)
+    return raw, text, json.loads(text)
+
+
+def profile_paths():
+    return sorted(PROFILES.glob("*.json"))
+
+
+def pack_ids():
+    return sorted(p.name for p in PACKS.iterdir() if (p / "pack.json").is_file())
+
+
+def load_all_profiles():
+    out = {}
+    for path in profile_paths():
+        _raw, _text, doc = read_json(path)
+        out[path.stem] = {"path": path, "doc": doc}
+    return out
+
+
+def write_json(path, doc):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(doc, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+def minimal_profile(pid="probe", packs=None, **extra):
+    body = {
+        "schemaVersion": SCHEMA_VERSION,
+        "kind": PROFILE_KIND,
+        "id": pid,
+        "title": pid,
+        "description": "픽스처",
+        "packs": list(packs) if packs is not None else ["core-cli"],
+    }
+    body.update(extra)
+    return body
+
+
+class ProfileInventoryTests(unittest.TestCase):
+    """profiles/ 아래 파일이 일곱 자리와 1:1 이다."""
+
+    def test_profiles_directory_exists(self):
+        self.assertTrue(PROFILES.is_dir(), f"없음: {PROFILES}")
+
+    def test_every_profile_file_is_json(self):
+        files = list(PROFILES.iterdir())
+        self.assertTrue(files, "profiles/ 가 비었다")
+        leftovers = [p.name for p in files if p.is_file() and p.suffix != ".json"]
+        self.assertEqual(leftovers, [], f"json 아닌 파일: {leftovers}")
+
+    def test_named_seven_files_exist(self):
+        names = {p.stem for p in profile_paths()}
+        missing = [pid for pid in NAMED_PROFILE_IDS if pid not in names]
+        self.assertEqual(missing, [], f"빠진 프로파일: {missing}")
+
+    def test_no_unexpected_profile_files(self):
+        names = {p.stem for p in profile_paths()}
+        extra = sorted(names - set(NAMED_PROFILE_IDS))
+        self.assertEqual(
+            extra,
+            [],
+            "새 프로파일 파일을 넣었으면 NAMED_PROFILE_IDS 와 "
+            "gym/docs/profiles.md 를 같이 고쳐라: " + ", ".join(extra),
+        )
+
+    def test_profile_count_is_seven(self):
+        self.assertEqual(len(profile_paths()), len(NAMED_PROFILE_IDS))
+
+    def test_profile_filenames_are_sorted_unique(self):
+        stems = [p.stem for p in profile_paths()]
+        self.assertEqual(stems, sorted(set(stems)))
+
+
+class ProfileJsonShapeTests(unittest.TestCase):
+    """모든 프로파일 파일의 뼈대 — kind·버전·id·packs."""
+
+    def test_every_file_is_utf8_object(self):
+        for path in profile_paths():
+            raw, text, doc = read_json(path)
+            self.assertFalse(raw.startswith(b"\xef\xbb\xbf"), f"BOM: {path.name}")
+            self.assertIsInstance(doc, dict, path.name)
+            self.assertTrue(text.endswith("\n"), f"끝 개행 없음: {path.name}")
+            self.assertNotIn("\r\n", text, f"CRLF: {path.name}")
+
+    def test_kind_and_schema_version(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            self.assertEqual(doc.get("kind"), PROFILE_KIND, path.name)
+            self.assertEqual(doc.get("schemaVersion"), SCHEMA_VERSION, path.name)
+
+    def test_id_matches_filename(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            self.assertEqual(doc.get("id"), path.stem, path.name)
+
+    def test_title_and_description_are_nonempty_strings(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            title = doc.get("title")
+            desc = doc.get("description")
+            self.assertIsInstance(title, str, path.name)
+            self.assertIsInstance(desc, str, path.name)
+            self.assertTrue(title.strip(), f"빈 title: {path.name}")
+            self.assertTrue(desc.strip(), f"빈 description: {path.name}")
+
+    def test_packs_is_nonempty_list_of_strings(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            packs = doc.get("packs")
+            self.assertIsInstance(packs, list, path.name)
+            self.assertTrue(packs, f"packs 가 비었다: {path.name}")
+            for pid in packs:
+                self.assertIsInstance(pid, str, f"{path.name}: {pid!r}")
+                self.assertTrue(pid.strip(), f"{path.name}: 빈 pack id")
+                self.assertEqual(pid, pid.strip(), f"{path.name}: 공백 포함 {pid!r}")
+                self.assertNotIn("/", pid, path.name)
+                self.assertNotIn("\\", pid, path.name)
+                self.assertNotIn(" ", pid, path.name)
+
+    def test_no_duplicate_packs_inside_a_profile(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            packs = doc["packs"]
+            self.assertEqual(
+                packs,
+                list(dict.fromkeys(packs)),
+                f"중복 pack: {path.name}",
+            )
+
+    def test_top_level_keys_are_known(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            unknown = sorted(set(doc) - ALLOWED_TOP_LEVEL_KEYS)
+            self.assertEqual(
+                unknown,
+                [],
+                f"{path.name} 에 문서화되지 않은 키: {unknown}",
+            )
+
+    def test_json_indent_is_two_spaces(self):
+        for path in profile_paths():
+            _raw, text, doc = read_json(path)
+            expected = json.dumps(doc, ensure_ascii=False, indent=2) + "\n"
+            self.assertEqual(text, expected, f"indent/키 순서 불일치: {path.name}")
+
+
+class ProfilePackRefTests(unittest.TestCase):
+    """선언한 pack 은 packs/<id>/pack.json 이 있어야 한다."""
+
+    def test_every_pack_ref_exists(self):
+        known = set(pack_ids())
+        missing = []
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            for pid in doc.get("packs") or []:
+                if pid not in known:
+                    missing.append(f"{path.stem}:{pid}")
+        self.assertEqual(missing, [], f"없는 pack 참조: {missing}")
+
+    def test_schema_validate_profile_accepts_every_file(self):
+        schema = load_schema()
+        known = set(pack_ids())
+        errors = []
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            schema.validate_profile(doc, known, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_pack_json_id_matches_folder(self):
+        for pid in pack_ids():
+            manifest = json.loads((PACKS / pid / "pack.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest.get("id"), pid)
+
+    def test_every_named_pack_is_still_a_real_pack(self):
+        known = set(pack_ids())
+        missing = []
+        for profile_id, packs in NAMED_PACKS.items():
+            for pid in packs:
+                if pid not in known:
+                    missing.append(f"{profile_id}:{pid}")
+        self.assertEqual(missing, [], f"카탈로그 pack 이 사라졌다: {missing}")
+
+
+class NamedProfileContractTests(unittest.TestCase):
+    """일곱 자리의 고정 묶음."""
+
+    def test_family_packs(self):
+        _raw, _text, doc = read_json(PROFILES / "family.json")
+        self.assertEqual(tuple(doc["packs"]), NAMED_PACKS["family"])
+
+    def test_starter_packs(self):
+        _raw, _text, doc = read_json(PROFILES / "starter.json")
+        self.assertEqual(tuple(doc["packs"]), NAMED_PACKS["starter"])
+
+    def test_editor_packs(self):
+        _raw, _text, doc = read_json(PROFILES / "editor.json")
+        self.assertEqual(tuple(doc["packs"]), NAMED_PACKS["editor"])
+
+    def test_publisher_packs(self):
+        _raw, _text, doc = read_json(PROFILES / "publisher.json")
+        self.assertEqual(tuple(doc["packs"]), NAMED_PACKS["publisher"])
+
+    def test_operator_packs(self):
+        _raw, _text, doc = read_json(PROFILES / "operator.json")
+        self.assertEqual(tuple(doc["packs"]), NAMED_PACKS["operator"])
+
+    def test_boss_packs(self):
+        _raw, _text, doc = read_json(PROFILES / "boss.json")
+        self.assertEqual(tuple(doc["packs"]), NAMED_PACKS["boss"])
+
+    def test_named_pack_catalog_matches_files(self):
+        for pid, expected in NAMED_PACKS.items():
+            _raw, _text, doc = read_json(PROFILES / f"{pid}.json")
+            self.assertEqual(tuple(doc["packs"]), expected, pid)
+
+    def test_named_titles_keep_role_tokens(self):
+        for pid, tokens in NAMED_TITLE_TOKENS.items():
+            _raw, _text, doc = read_json(PROFILES / f"{pid}.json")
+            title = doc["title"]
+            for token in tokens:
+                self.assertIn(token, title, f"{pid} title 에 {token!r} 없음")
+
+    def test_named_descriptions_keep_role_tokens(self):
+        for pid, tokens in NAMED_DESCRIPTION_TOKENS.items():
+            _raw, _text, doc = read_json(PROFILES / f"{pid}.json")
+            desc = doc["description"]
+            for token in tokens:
+                self.assertIn(token, desc, f"{pid} description 에 {token!r} 없음")
+
+    def test_family_is_only_casual_rides(self):
+        _raw, _text, doc = read_json(PROFILES / "family.json")
+        self.assertEqual(doc["packs"], ["casual-rides"])
+        self.assertEqual(len(doc["packs"]), 1)
+
+    def test_boss_is_only_expert_challenges(self):
+        _raw, _text, doc = read_json(PROFILES / "boss.json")
+        self.assertEqual(doc["packs"], ["expert-challenges"])
+        self.assertEqual(len(doc["packs"]), 1)
+
+    def test_starter_is_the_smallest_tool_course(self):
+        _raw, _text, doc = read_json(PROFILES / "starter.json")
+        self.assertEqual(set(doc["packs"]), {"core-cli", "self-description"})
+
+    def test_editor_covers_document_mutation_axes(self):
+        _raw, _text, doc = read_json(PROFILES / "editor.json")
+        self.assertIn("text-editing", doc["packs"])
+        self.assertIn("table-editing", doc["packs"])
+        self.assertIn("objects-media", doc["packs"])
+        self.assertIn("core-cli", doc["packs"])
+
+    def test_publisher_covers_export_and_safety(self):
+        _raw, _text, doc = read_json(PROFILES / "publisher.json")
+        self.assertIn("serialization", doc["packs"])
+        self.assertIn("layout-rendering", doc["packs"])
+        self.assertIn("security", doc["packs"])
+
+    def test_operator_covers_sweep_and_automation(self):
+        _raw, _text, doc = read_json(PROFILES / "operator.json")
+        self.assertIn("corpus-diagnostics", doc["packs"])
+        self.assertIn("automation", doc["packs"])
+
+
+class MaintainerContractTests(unittest.TestCase):
+    """maintainer 는 전 표면. 이 PR 은 그 파일을 고치지 않는다."""
+
+    def test_maintainer_file_exists(self):
+        self.assertTrue((PROFILES / "maintainer.json").is_file())
+
+    def test_maintainer_packs_are_sorted(self):
+        _raw, _text, doc = read_json(PROFILES / "maintainer.json")
+        self.assertEqual(doc["packs"], sorted(doc["packs"]))
+
+    def test_maintainer_packs_all_exist(self):
+        known = set(pack_ids())
+        _raw, _text, doc = read_json(PROFILES / "maintainer.json")
+        missing = [pid for pid in doc["packs"] if pid not in known]
+        self.assertEqual(missing, [], f"maintainer 가 없는 pack 을 가리킨다: {missing}")
+
+    def test_maintainer_covers_every_other_profile_pack(self):
+        _raw, _text, maintainer = read_json(PROFILES / "maintainer.json")
+        covered = set(maintainer["packs"])
+        holes = []
+        for path in profile_paths():
+            if path.stem == "maintainer":
+                continue
+            _raw, _text, doc = read_json(path)
+            for pid in doc["packs"]:
+                if pid not in covered:
+                    holes.append(f"{path.stem}:{pid}")
+        self.assertEqual(
+            holes,
+            [],
+            "다른 자리가 고른 pack 이 maintainer 에 없다: " + ", ".join(holes),
+        )
+
+    def test_maintainer_covers_named_catalog(self):
+        _raw, _text, maintainer = read_json(PROFILES / "maintainer.json")
+        covered = set(maintainer["packs"])
+        for profile_id, packs in NAMED_PACKS.items():
+            missing = [pid for pid in packs if pid not in covered]
+            self.assertEqual(missing, [], f"{profile_id} → maintainer 구멍: {missing}")
+
+    def test_maintainer_includes_every_pack_on_this_branch(self):
+        """현재 브랜치 packs/ 전부가 maintainer 에 들어 있는가.
+
+        다른 열린 PR 이 pack 을 더하면 그쪽에서 maintainer.json 을
+        정렬·추가한다. 이 시험은 이 브랜치의 스냅샷만 본다. 새 pack 을
+        이 PR 에 넣지 않았으므로 파일을 고울 이유가 없다.
+        """
+        _raw, _text, maintainer = read_json(PROFILES / "maintainer.json")
+        self.assertEqual(sorted(maintainer["packs"]), pack_ids())
+
+    def test_maintainer_is_strict_superset_of_role_profiles(self):
+        _raw, _text, maintainer = read_json(PROFILES / "maintainer.json")
+        role_union = set()
+        for packs in NAMED_PACKS.values():
+            role_union.update(packs)
+        extra = set(maintainer["packs"]) - role_union
+        self.assertTrue(
+            extra,
+            "maintainer 가 역할 여섯 자리의 합과 같으면 전 표면이 아니다",
+        )
+
+    def test_maintainer_does_not_list_unknown_future_ids(self):
+        known = set(pack_ids())
+        _raw, _text, maintainer = read_json(PROFILES / "maintainer.json")
+        self.assertTrue(set(maintainer["packs"]) <= known)
+
+
+class ProfileOverlapTests(unittest.TestCase):
+    """자리가 서로 어떤 관계를 갖는가 — 놀이공원 지도의 겹침."""
+
+    def _packs(self, pid):
+        _raw, _text, doc = read_json(PROFILES / f"{pid}.json")
+        return list(doc["packs"])
+
+    def test_family_and_boss_are_disjoint(self):
+        family = set(self._packs("family"))
+        boss = set(self._packs("boss"))
+        self.assertFalse(family & boss, "입문존과 보스존이 겹치면 안 된다")
+
+    def test_family_is_not_subset_of_starter(self):
+        family = set(self._packs("family"))
+        starter = set(self._packs("starter"))
+        self.assertFalse(
+            family <= starter,
+            "가족 코스는 입문 도구 코스와 다른 축이다",
+        )
+
+    def test_starter_core_is_in_editor(self):
+        starter = set(self._packs("starter"))
+        editor = set(self._packs("editor"))
+        self.assertIn("core-cli", starter & editor)
+
+    def test_editor_and_publisher_share_no_required_pack(self):
+        editor = set(self._packs("editor"))
+        publisher = set(self._packs("publisher"))
+        self.assertFalse(
+            editor & publisher,
+            "편집자와 배포자는 서로 다른 능력 축을 고른다",
+        )
+
+    def test_operator_and_publisher_are_disjoint(self):
+        operator = set(self._packs("operator"))
+        publisher = set(self._packs("publisher"))
+        self.assertFalse(operator & publisher)
+
+    def test_operator_and_family_are_disjoint(self):
+        self.assertFalse(set(self._packs("operator")) & set(self._packs("family")))
+
+    def test_boss_not_in_role_courses_except_maintainer(self):
+        boss = set(self._packs("boss"))
+        for pid in ("family", "starter", "editor", "publisher", "operator"):
+            overlap = boss & set(self._packs(pid))
+            self.assertFalse(overlap, f"{pid} 가 보스 pack 을 품었다: {overlap}")
+
+    def test_role_union_is_smaller_than_maintainer(self):
+        role = set()
+        for pid in ("family", "starter", "editor", "publisher", "operator", "boss"):
+            role.update(self._packs(pid))
+        maintainer = set(self._packs("maintainer"))
+        self.assertTrue(role < maintainer)
+
+    def test_no_two_role_profiles_are_identical(self):
+        seen = {}
+        for pid in NAMED_PROFILE_IDS:
+            key = tuple(self._packs(pid))
+            self.assertNotIn(key, seen, f"{pid} 와 {seen.get(key)} 가 같은 묶음")
+            seen[key] = pid
+
+
+class LoadProfileTests(unittest.TestCase):
+    """runner.load_profile 은 파일을 그대로 돌려준다. 엔진은 고치지 않는다."""
+
+    def test_load_profile_returns_each_named_file(self):
+        runner = load_runner()
+        for pid in NAMED_PROFILE_IDS:
+            loaded = runner.load_profile(pid)
+            _raw, _text, disk = read_json(PROFILES / f"{pid}.json")
+            self.assertEqual(loaded, disk, pid)
+            self.assertEqual(loaded["id"], pid)
+
+    def test_load_profile_missing_raises(self):
+        runner = load_runner()
+        with self.assertRaises(FileNotFoundError):
+            runner.load_profile("does-not-exist-5281")
+
+    def test_score_all_uses_profile_pack_list(self):
+        """profile_id 가 있으면 pack_ids 를 프로파일 목록으로 바꾼다.
+
+        실제 채점은 바이너리가 필요하므로 load_profile 만 고정하고,
+        score_all 의 그 한 줄을 소스에서 확인한다.
+        """
+        text = (GYM / "core" / "runner.py").read_text(encoding="utf-8")
+        self.assertIn("def load_profile(profile_id):", text)
+        self.assertIn('pack_ids = load_profile(profile_id)["packs"]', text)
+        self.assertIn("점수를 뭉치는", text)
+
+    def test_score_py_exposes_profile_flag(self):
+        text = SCORE_PY.read_text(encoding="utf-8")
+        self.assertIn("--profile", text)
+        self.assertIn("profile_id=a.profile", text)
+
+
+class ValidateProfileNegativeTests(unittest.TestCase):
+    """schema.validate_profile 의 거절 칸 — 엔진을 고치지 않고 현재 계약만 고정."""
+
+    def setUp(self):
+        self.schema = load_schema()
+        self.known = {"core-cli", "security", "casual-rides"}
+
+    def _errors(self, profile):
+        errors = []
+        self.schema.validate_profile(profile, self.known, errors)
+        return errors
+
+    def test_wrong_kind_is_rejected(self):
+        doc = minimal_profile(kind="gymPack")
+        self.assertTrue(any("kind" in e for e in self._errors(doc)))
+
+    def test_empty_packs_is_rejected(self):
+        doc = minimal_profile(packs=[])
+        self.assertTrue(any("packs" in e for e in self._errors(doc)))
+
+    def test_missing_packs_is_rejected(self):
+        doc = minimal_profile()
+        del doc["packs"]
+        self.assertTrue(any("packs" in e for e in self._errors(doc)))
+
+    def test_unknown_pack_ref_is_rejected(self):
+        doc = minimal_profile(packs=["no-such-pack"])
+        errors = self._errors(doc)
+        self.assertTrue(any("없는 pack" in e for e in errors), errors)
+
+    def test_known_pack_is_accepted(self):
+        doc = minimal_profile(packs=["core-cli"])
+        self.assertEqual(self._errors(doc), [])
+
+    def test_mixed_known_and_unknown(self):
+        doc = minimal_profile(packs=["core-cli", "ghost-pack"])
+        errors = self._errors(doc)
+        self.assertTrue(any("ghost-pack" in e for e in errors), errors)
+
+    def test_none_profile_id_still_reports_where(self):
+        errors = self._errors({"kind": PROFILE_KIND, "packs": []})
+        self.assertTrue(any("profiles/" in e for e in errors), errors)
+
+
+class ProfileHygieneTests(unittest.TestCase):
+    """파일 위생 — BOM 없음, LF, 키 순서, 정렬."""
+
+    def test_named_role_packs_keep_declared_order(self):
+        """역할 여섯 자리는 사람이 읽는 순서를 유지한다.
+
+        family/boss 는 하나라 정렬과 같고, starter/editor/publisher/operator
+        는 문서에 적은 순서를 따른다. 알파벳 강제하지 않는다.
+        """
+        for pid, expected in NAMED_PACKS.items():
+            _raw, _text, doc = read_json(PROFILES / f"{pid}.json")
+            self.assertEqual(tuple(doc["packs"]), expected, pid)
+
+    def test_maintainer_only_is_alphabetically_sorted(self):
+        _raw, _text, doc = read_json(PROFILES / "maintainer.json")
+        self.assertEqual(doc["packs"], sorted(doc["packs"]))
+
+    def test_no_trailing_whitespace_on_lines(self):
+        for path in profile_paths():
+            _raw, text = read_text(path)
+            for idx, line in enumerate(text.split("\n"), 1):
+                if line.endswith("\r"):
+                    self.fail(f"{path.name}:{idx} CR")
+                self.assertEqual(line, line.rstrip(" \t"), f"{path.name}:{idx} 끝 공백")
+
+    def test_ids_are_safe_single_path_component(self):
+        for path in profile_paths():
+            self.assertEqual(path.stem, path.name[: -len(path.suffix)])
+            self.assertNotIn("..", path.stem)
+            self.assertRegex(path.stem, r"^[a-z][a-z0-9-]*$")
+
+
+class DocsContractTests(unittest.TestCase):
+    """정본·작업 기록이 일곱 자리와 같은 표를 말한다."""
+
+    def test_canonical_doc_exists(self):
+        self.assertTrue(DOCS_PROFILES.is_file(), f"없음: {DOCS_PROFILES}")
+
+    def test_working_doc_exists(self):
+        self.assertTrue(WORKING_PROFILES.is_file(), f"없음: {WORKING_PROFILES}")
+
+    def test_canonical_doc_frontmatter(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        self.assertTrue(text.startswith("---\n"), "frontmatter 없음")
+        self.assertIn("kind: guide", text)
+        self.assertIn("canonical: gym/docs/profiles.md", text)
+        self.assertIn("status: active", text)
+
+    def test_working_doc_frontmatter(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        self.assertTrue(text.startswith("---\n"))
+        self.assertIn("kind: working", text)
+        self.assertIn("canonical: mydocs/working/gym_profiles.md", text)
+
+    def test_canonical_doc_has_required_tokens(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        missing = [tok for tok in DOC_REQUIRED_TOKENS if tok not in text]
+        self.assertEqual(missing, [], f"정본 문서 누락: {missing}")
+
+    def test_working_doc_has_required_tokens(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        missing = [tok for tok in WORKING_REQUIRED_TOKENS if tok not in text]
+        self.assertEqual(missing, [], f"작업 기록 누락: {missing}")
+
+    def test_docs_are_utf8_lf_no_bom(self):
+        for path in (DOCS_PROFILES, WORKING_PROFILES):
+            raw, text = read_text(path)
+            self.assertFalse(raw.startswith(b"\xef\xbb\xbf"), path.name)
+            self.assertNotIn("\r\n", text, path.name)
+            self.assertTrue(text.endswith("\n"), path.name)
+
+    def test_canonical_doc_lists_each_named_pack_set(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        for pid, packs in NAMED_PACKS.items():
+            self.assertIn(f"`{pid}`", text, pid)
+            for pack in packs:
+                self.assertIn(f"`{pack}`", text, f"{pid}/{pack}")
+
+    def test_canonical_doc_points_at_working_doc(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        self.assertIn("mydocs/working/gym_profiles.md", text)
+
+    def test_working_doc_points_at_canonical_doc(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        self.assertIn("gym/docs/profiles.md", text)
+
+    def test_docs_do_not_claim_a_new_cli(self):
+        for path in (DOCS_PROFILES, WORKING_PROFILES):
+            _raw, text = read_text(path)
+            self.assertNotIn("python gym/profiles.py", text, path.name)
+            self.assertNotIn("--new-profile-flag", text, path.name)
+
+    def test_docs_mention_score_profile_flag(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        self.assertIn("python gym/score.py --agent", text)
+        self.assertIn("--profile", text)
+
+    def test_docs_state_no_schema_edit(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        self.assertIn("schema.py", text)
+        self.assertIn("고치지 않", text)
+
+
+class ScoreAndAuditSurfaceTests(unittest.TestCase):
+    """기존 진입점·감사기는 그대로 두고, 프로파일 표면만 확인한다."""
+
+    def test_score_help_text_mentions_profile(self):
+        text = SCORE_PY.read_text(encoding="utf-8")
+        self.assertIn('help="pack 묶음 프로파일 id"', text)
+
+    def test_audit_tool_still_imports(self):
+        spec_path = AUDIT_PY
+        self.assertTrue(spec_path.is_file())
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("gym_audit_5281", spec_path)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self.assertTrue(callable(module.audit))
+
+    def test_audit_real_repo_still_ok(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("gym_audit_5281b", AUDIT_PY)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        report = module.audit(str(GYM))
+        self.assertTrue(report["ok"], report)
+
+    def test_schema_validate_profile_symbol_unchanged(self):
+        schema = load_schema()
+        self.assertTrue(callable(schema.validate_profile))
+        self.assertEqual(schema.PROFILE_KIND, PROFILE_KIND)
+        self.assertEqual(schema.SCHEMA_VERSION, SCHEMA_VERSION)
+
+
+class ProfileCatalogTableTests(unittest.TestCase):
+    """문서의 역할 표와 코드 카탈로그가 같은 말을 한다."""
+
+    def test_catalog_keys_are_the_six_role_profiles(self):
+        self.assertEqual(
+            set(NAMED_PACKS),
+            {"family", "starter", "editor", "publisher", "operator", "boss"},
+        )
+
+    def test_catalog_values_are_tuples(self):
+        for pid, packs in NAMED_PACKS.items():
+            self.assertIsInstance(packs, tuple, pid)
+            self.assertTrue(packs, pid)
+
+    def test_docs_repeat_catalog_rows(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        rows = {
+            "family": "casual-rides",
+            "starter": "core-cli",
+            "editor": "text-editing",
+            "publisher": "serialization",
+            "operator": "corpus-diagnostics",
+            "boss": "expert-challenges",
+        }
+        for pid, pack in rows.items():
+            self.assertIn(pid, text)
+            self.assertIn(pack, text)
+
+
+class ProfileTempFixtureTests(unittest.TestCase):
+    """디스크의 실제 프로파일은 건드리지 않고, 임시 파일로 경계만 본다."""
+
+    def test_roundtrip_minimal_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "probe.json")
+            doc = minimal_profile()
+            write_json(path, doc)
+            loaded = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertEqual(loaded, doc)
+
+    def test_validate_accepts_written_fixture(self):
+        schema = load_schema()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "probe.json")
+            doc = minimal_profile(packs=["core-cli"])
+            write_json(path, doc)
+            errors = []
+            schema.validate_profile(
+                json.loads(Path(path).read_text(encoding="utf-8")),
+                {"core-cli"},
+                errors,
+            )
+            self.assertEqual(errors, [])
+
+
+class ProfileIdUniquenessTests(unittest.TestCase):
+    def test_ids_unique_across_files(self):
+        ids = []
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            ids.append(doc["id"])
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_ids_equal_named_list(self):
+        ids = []
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            ids.append(doc["id"])
+        self.assertEqual(sorted(ids), sorted(NAMED_PROFILE_IDS))
+
+
+class ProfileDescriptionQualityTests(unittest.TestCase):
+    """설명이 한 글자가 아니고, 자리의 역할을 가리킨다."""
+
+    def test_descriptions_are_longer_than_a_token(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            self.assertGreaterEqual(len(doc["description"]), 8, path.name)
+
+    def test_titles_are_short(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            self.assertLessEqual(len(doc["title"]), 40, path.name)
+
+    def test_family_mentions_together(self):
+        _raw, _text, doc = read_json(PROFILES / "family.json")
+        self.assertTrue("함께" in doc["description"] or "부모님" in doc["description"])
+
+    def test_maintainer_mentions_full_surface(self):
+        _raw, _text, doc = read_json(PROFILES / "maintainer.json")
+        self.assertTrue(
+            "전" in doc["description"] or "완주" in doc["description"],
+            doc["description"],
+        )
+
+
+class ProfileDoesNotSelectScoreAggregationTests(unittest.TestCase):
+    """프로파일은 선택기다. 점수 합산 규칙이 프로파일 JSON 에 없다."""
+
+    def test_no_weights_key(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            self.assertNotIn("weights", doc, path.name)
+            self.assertNotIn("score", doc, path.name)
+            self.assertNotIn("max", doc, path.name)
+
+    def test_no_task_allowlist(self):
+        for path in profile_paths():
+            _raw, _text, doc = read_json(path)
+            self.assertNotIn("tasks", doc, path.name)
+            self.assertNotIn("exclude", doc, path.name)
+
+
+# pack → 역할 자리. maintainer 는 전 pack 이라 여기 적지 않는다.
+# 표에 없는 pack 은 전 표면에서만 고른다.
+PACK_ROLE_OWNERS = {
+    "casual-rides": ("family",),
+    "core-cli": ("starter", "editor"),
+    "self-description": ("starter",),
+    "text-editing": ("editor",),
+    "table-editing": ("editor",),
+    "objects-media": ("editor",),
+    "serialization": ("publisher",),
+    "layout-rendering": ("publisher",),
+    "security": ("publisher",),
+    "corpus-diagnostics": ("operator",),
+    "automation": ("operator",),
+    "expert-challenges": ("boss",),
+}
+
+ROLE_ONLY_PACKS = tuple(PACK_ROLE_OWNERS)
+MAINTAINER_ONLY_HINTS = (
+    "extraction",
+    "batch-ops",
+    "render-tree",
+    "studio-e2e",
+    "table-csv",
+)
+
+
+def _owners_of(pack_id):
+    owners = []
+    for stem in NAMED_PROFILE_IDS:
+        if stem == "maintainer":
+            continue
+        _raw, _text, doc = read_json(PROFILES / f"{stem}.json")
+        if pack_id in doc["packs"]:
+            owners.append(stem)
+    return tuple(owners)
+
+
+class PackMembershipMatrixTests(unittest.TestCase):
+    """정본 4절 행렬을 파일에서 다시 계산한다."""
+
+    def test_every_role_owned_pack_matches_catalog(self):
+        for pack_id, expected in PACK_ROLE_OWNERS.items():
+            self.assertEqual(_owners_of(pack_id), expected, pack_id)
+
+    def test_casual_rides_only_family(self):
+        self.assertEqual(_owners_of("casual-rides"), ("family",))
+
+    def test_core_cli_starter_and_editor(self):
+        self.assertEqual(_owners_of("core-cli"), ("starter", "editor"))
+
+    def test_self_description_only_starter(self):
+        self.assertEqual(_owners_of("self-description"), ("starter",))
+
+    def test_text_editing_only_editor(self):
+        self.assertEqual(_owners_of("text-editing"), ("editor",))
+
+    def test_table_editing_only_editor(self):
+        self.assertEqual(_owners_of("table-editing"), ("editor",))
+
+    def test_objects_media_only_editor(self):
+        self.assertEqual(_owners_of("objects-media"), ("editor",))
+
+    def test_serialization_only_publisher(self):
+        self.assertEqual(_owners_of("serialization"), ("publisher",))
+
+    def test_layout_rendering_only_publisher(self):
+        self.assertEqual(_owners_of("layout-rendering"), ("publisher",))
+
+    def test_security_only_publisher(self):
+        self.assertEqual(_owners_of("security"), ("publisher",))
+
+    def test_corpus_diagnostics_only_operator(self):
+        self.assertEqual(_owners_of("corpus-diagnostics"), ("operator",))
+
+    def test_automation_only_operator(self):
+        self.assertEqual(_owners_of("automation"), ("operator",))
+
+    def test_expert_challenges_only_boss(self):
+        self.assertEqual(_owners_of("expert-challenges"), ("boss",))
+
+    def test_extraction_not_in_role_profiles(self):
+        self.assertEqual(_owners_of("extraction"), ())
+
+    def test_batch_ops_not_in_role_profiles(self):
+        self.assertEqual(_owners_of("batch-ops"), ())
+
+    def test_render_tree_not_in_role_profiles(self):
+        self.assertEqual(_owners_of("render-tree"), ())
+
+    def test_studio_e2e_not_in_role_profiles(self):
+        self.assertEqual(_owners_of("studio-e2e"), ())
+
+    def test_table_csv_not_in_role_profiles(self):
+        self.assertEqual(_owners_of("table-csv"), ())
+
+    def test_maintainer_only_hints_exist_or_are_absent_together(self):
+        known = set(pack_ids())
+        _raw, _text, maintainer = read_json(PROFILES / "maintainer.json")
+        covered = set(maintainer["packs"])
+        for pid in MAINTAINER_ONLY_HINTS:
+            if pid in known:
+                self.assertIn(pid, covered, pid)
+                self.assertEqual(_owners_of(pid), (), pid)
+
+    def test_every_existing_pack_is_either_role_owned_or_maintainer_only(self):
+        known = set(pack_ids())
+        role_owned = set(PACK_ROLE_OWNERS)
+        leftover = sorted(known - role_owned)
+        for pid in leftover:
+            self.assertEqual(_owners_of(pid), (), pid)
+
+    def test_catalog_does_not_name_missing_packs(self):
+        known = set(pack_ids())
+        missing = [pid for pid in PACK_ROLE_OWNERS if pid not in known]
+        self.assertEqual(missing, [])
+
+
+class PerProfileFileTests(unittest.TestCase):
+    """파일 하나를 한 메서드가 끝까지 읽는다."""
+
+    def _check(self, pid, title_token, packs):
+        path = PROFILES / f"{pid}.json"
+        raw, text, doc = read_json(path)
+        self.assertFalse(raw.startswith(b"\xef\xbb\xbf"), pid)
+        self.assertEqual(doc["id"], pid)
+        self.assertEqual(doc["kind"], PROFILE_KIND)
+        self.assertEqual(doc["schemaVersion"], SCHEMA_VERSION)
+        self.assertIn(title_token, doc["title"])
+        self.assertEqual(tuple(doc["packs"]), packs)
+        self.assertTrue(text.endswith("\n"), pid)
+        errors = []
+        load_schema().validate_profile(doc, set(pack_ids()), errors)
+        self.assertEqual(errors, [], f"{pid}: {errors}")
+        loaded = load_runner().load_profile(pid)
+        self.assertEqual(loaded, doc)
+
+    def test_file_family(self):
+        self._check("family", "가족", NAMED_PACKS["family"])
+
+    def test_file_starter(self):
+        self._check("starter", "입문", NAMED_PACKS["starter"])
+
+    def test_file_editor(self):
+        self._check("editor", "편집", NAMED_PACKS["editor"])
+
+    def test_file_publisher(self):
+        self._check("publisher", "배포", NAMED_PACKS["publisher"])
+
+    def test_file_operator(self):
+        self._check("operator", "운영", NAMED_PACKS["operator"])
+
+    def test_file_boss(self):
+        self._check("boss", "보스", NAMED_PACKS["boss"])
+
+    def test_file_maintainer(self):
+        path = PROFILES / "maintainer.json"
+        _raw, _text, doc = read_json(path)
+        self.assertEqual(doc["id"], "maintainer")
+        self.assertIn("메인테이너", doc["title"])
+        self.assertEqual(doc["packs"], sorted(doc["packs"]))
+        self.assertEqual(doc["packs"], pack_ids())
+        errors = []
+        load_schema().validate_profile(doc, set(pack_ids()), errors)
+        self.assertEqual(errors, [])
+
+
+class DocsSectionTests(unittest.TestCase):
+    """정본 절 제목이 사라지지 않게 한다."""
+
+    REQUIRED_HEADINGS = (
+        "# gym 프로파일 계약",
+        "## 한 줄 결론",
+        "## 1. 왜 프로파일인가",
+        "## 2. 스키마",
+        "## 3. 일곱 자리",
+        "### 3.1 `family`",
+        "### 3.2 `starter`",
+        "### 3.3 `editor`",
+        "### 3.4 `publisher`",
+        "### 3.5 `operator`",
+        "### 3.6 `boss`",
+        "### 3.7 `maintainer`",
+        "## 4. 자리 × pack 행렬",
+        "## 5. 불변식",
+        "## 6. 사용",
+        "## 8. 새 프로파일을 넣는 법",
+        "## 9. 새 pack 을 자리에 넣는 법",
+        "## 10. 실패 칸",
+        "## 11. 다른 기둥과 나눈 일",
+    )
+
+    def test_canonical_keeps_contract_headings(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        missing = [h for h in self.REQUIRED_HEADINGS if h not in text]
+        self.assertEqual(missing, [], f"절 제목 누락: {missing}")
+
+    def test_working_keeps_decision_headings(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        for heading in (
+            "## 1. 결론",
+            "## 4. 고친 파일 / 안 고친 파일",
+            "## 5. 결정 로그",
+            "## 6. 시험 지도",
+            "## 8. 이웃 PR 충돌 회피",
+            "feat/gym-profiles-hardening",
+        ):
+            self.assertIn(heading, text, heading)
+
+    def test_canonical_mentions_no_new_cli(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        self.assertIn("새 CLI 는 없다", text)
+
+    def test_canonical_mentions_does_not_edit_schema(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        self.assertIn("schema.py", text)
+        self.assertIn("이 기둥이 그 함수를 고치지 않는다", text)
+
+    def test_working_lists_three_added_paths(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        self.assertIn("gym/docs/profiles.md", text)
+        self.assertIn("mydocs/working/gym_profiles.md", text)
+        self.assertIn("scripts/tests/test_gym_profiles.py", text)
+
+    def test_matrix_rows_use_bullet_marker(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        self.assertIn("| `casual-rides` | ● |", text)
+        self.assertIn("| `expert-challenges` |", text)
+
+
+class ScoreAllProfileSelectionTests(unittest.TestCase):
+    """score_all 이 프로파일 packs 로 목록을 덮어쓰는 한 줄을 원문으로 고정."""
+
+    def test_runner_source_order(self):
+        text = (GYM / "core" / "runner.py").read_text(encoding="utf-8")
+        load_at = text.find("def load_profile")
+        score_at = text.find("def score_all")
+        self.assertGreater(load_at, 0)
+        self.assertGreater(score_at, load_at)
+        snippet = text[score_at:score_at + 800]
+        self.assertIn("if profile_id:", snippet)
+        self.assertIn('pack_ids = load_profile(profile_id)["packs"]', snippet)
+
+    def test_score_card_keeps_profile_field(self):
+        text = (GYM / "core" / "runner.py").read_text(encoding="utf-8")
+        self.assertIn('"profile": profile_id', text)
+
+    def test_score_py_does_not_invent_list_flag(self):
+        text = SCORE_PY.read_text(encoding="utf-8")
+        self.assertNotIn("--list-profiles", text)
+        self.assertNotIn("--profile-json", text)
+
+
+class ValidateProfileMoreNegativeTests(unittest.TestCase):
+    def setUp(self):
+        self.schema = load_schema()
+        self.known = set(pack_ids()) | {"core-cli", "security"}
+
+    def _errors(self, doc):
+        errors = []
+        self.schema.validate_profile(doc, self.known, errors)
+        return errors
+
+    def test_empty_string_pack_is_unknown(self):
+        errors = self._errors(minimal_profile(packs=[""]))
+        self.assertTrue(errors)
+
+    def test_none_kind(self):
+        doc = minimal_profile()
+        doc["kind"] = None
+        self.assertTrue(any("kind" in e for e in self._errors(doc)))
+
+    def test_multiple_unknown_packs_all_reported(self):
+        doc = minimal_profile(packs=["ghost-a", "ghost-b"])
+        errors = self._errors(doc)
+        joined = "\n".join(errors)
+        self.assertIn("ghost-a", joined)
+        self.assertIn("ghost-b", joined)
+
+    def test_real_named_profiles_against_real_pack_ids(self):
+        errors = []
+        for pid in NAMED_PROFILE_IDS:
+            _raw, _text, doc = read_json(PROFILES / f"{pid}.json")
+            self.schema.validate_profile(doc, set(pack_ids()), errors)
+        self.assertEqual(errors, [])
+
+
+class ProfileSourceCommentTests(unittest.TestCase):
+    """시험 파일 머리글이 이슈 번호를 잃지 않게 한다."""
+
+    def test_module_docstring_mentions_issue(self):
+        text = Path(__file__).read_text(encoding="utf-8")
+        self.assertIn("#5281", text)
+        self.assertIn("family", text)
+        self.assertIn("operator", text)
+        self.assertIn("점수를 뭉치는 도구가 아니다", text)
+
+    def test_forbidden_files_are_named_in_docstring(self):
+        text = Path(__file__).read_text(encoding="utf-8")
+        for name in ("schema.py", "audit.py", "certify.py", "report.py", "PARK"):
+            self.assertIn(name, text, name)
+
+
+class PackAxisTableDocTests(unittest.TestCase):
+    """정본 31절이 현재 pack id 를 빠뜨리지 않는지. title 은 잠그지 않는다."""
+
+    def test_canonical_mentions_every_current_pack_id(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        missing = [pid for pid in pack_ids() if f"`{pid}`" not in text]
+        self.assertEqual(missing, [], f"정본이 pack id 를 빼먹었다: {missing}")
+
+    def test_canonical_has_troubleshooting_tokens(self):
+        _raw, text = read_text(DOCS_PROFILES)
+        for token in (
+            "없는 pack 참조",
+            "indent/키 순서 불일치",
+            "FileNotFoundError",
+            "고르지 않은 pack 은 점수가 아니라 부재",
+        ):
+            self.assertIn(token, text, token)
+
+    def test_working_records_title_not_locked(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        self.assertIn("title 문자열은 시험이", text)
+
+    def test_working_has_reviewer_grep_block(self):
+        _raw, text = read_text(WORKING_PROFILES)
+        self.assertIn("git diff --name-only upstream/devel", text)
+        self.assertIn("gym/core/schema.py", text)
+        self.assertIn("수락 시나리오", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

gym 프로파일 일곱 자리(`family` / `starter` / `editor` / `publisher` / `operator` / `boss` / `maintainer`)의 선택 계약을 정본 문서와 전 파일 시험으로 고정한다. 프로파일은 pack 을 고르는 도구이지 점수를 뭉치는 도구가 아니다.

JSON 은 그대로 둔다. `maintainer.json` 은 다른 열린 PR(#5214)이 만지므로 여기서 고우지 않고, 전 pack 포함 계약은 이 브랜치 스냅샷 시험으로 지킨다. 새 CLI 는 없다.

정본은 `gym/docs/profiles.md`, 작업 기록은 `mydocs/working/gym_profiles.md`, 기계 계약은 `scripts/tests/test_gym_profiles.py` 다. 모든 프로파일 파일·pack 참조 존재·역할 묶음·겹침 불변식·문서 토큰을 본다.

`schema.py` / `audit.py` / `certify.py` / `report.py` / `tutorial` / `PARK` 와 PRs 5210–5280 파일은 열지 않았다.

## 관련 이슈

closes #5281

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_profiles` 통과 (142)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [ ] `cargo test` 해당 없음 (Python/문서만)
- [ ] `cargo clippy -- -D warnings` 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 해당 없음
- [ ] 웹(WASM) 렌더링 해당 없음
- [ ] rhwp-studio 편집·UI 해당 없음
- [ ] 작업 증빙 캡슐 해당 없음 (문서·시험만)
- [ ] `.claude/agents/` capability 카탈로그 해당 없음
- [x] `cargo fmt --all -- --check` 통과 (Rust 변경 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (문서·시험만, 채점 경로 불변)
- 재현·측정: 해당 없음. 로컬 unittest + audit.

## 스크린샷

해당 없음.
