### PR TITLE
fix(serializer/hwpx): 라틴 줄나눔(breakLatinWord)을 attr1 bits5-6 에서 역매핑해 h2x 소실 방지 (#5297)

### DIFF
--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -1166,8 +1166,16 @@ fn write_para_pr<W: Write>(
     } else {
         "BREAK_WORD"
     };
-    // [#1986] breakLatinWord 는 IR 원문 보존값(없으면 KEEP_WORD 기본).
-    let break_latin = ps.break_latin_word.as_deref().unwrap_or("KEEP_WORD");
+    // [#1986] breakLatinWord 는 HWPX 원문 보존값(HWPX 소스). HWP5 소스는 파서가 이 렉시컬
+    // 필드를 attr1 비트로만 두고 채우지 않아(doc_info.rs) 종전엔 무조건 "KEEP_WORD" 로
+    // 강등했다 — 라틴 줄나눔 설정(하이픈·글자 단위)이 h2x 저장에서 통째로 사라졌다
+    // (10k 코퍼스 실측: 500 문서 중 222 문서가 비-KEEP 설정, para_shape 2,810개).
+    // breakNonLatinWord(bit7)와 같은 축으로 HWP5 attr1 bits5-6 에서 역매핑한다. 렉시컬
+    // 값이 있으면(HWPX 소스) 그것을 우선하므로 x2x 는 종전과 동일하다.
+    let break_latin = ps
+        .break_latin_word
+        .as_deref()
+        .unwrap_or_else(|| latin_break_from_attr1((ps.attr1 >> 5) & 0x03));
     let widow_orphan = ((ps.attr1 >> 16) & 1).to_string();
     let keep_with_next = ((ps.attr1 >> 17) & 1).to_string();
     let keep_lines = ((ps.attr1 >> 18) & 1).to_string();
@@ -1349,6 +1357,18 @@ fn vertical_alignment_str(bits: u32) -> &'static str {
         2 => "CENTER",
         3 => "BOTTOM",
         _ => "BASELINE",
+    }
+}
+
+/// HWP5 para_shape attr1 bits5-6 → HWPX `breakLatinWord` 토큰(라틴 문자의 줄나눔 단위).
+/// `breakNonLatinWord`(bit7) 역매핑과 같은 축이다. HWPX 소스는 렉시컬 값을 우선하므로
+/// 이 함수는 HWP5 소스(렉시컬 None)에서만 쓰인다. 0(=KEEP_WORD)은 코퍼스 지배값이자
+/// 종전 기본과 같아, 값이 다른 문서만 실제로 바뀐다.
+fn latin_break_from_attr1(bits: u32) -> &'static str {
+    match bits {
+        1 => "HYPHENATION",
+        2 => "BREAK_WORD",
+        _ => "KEEP_WORD",
     }
 }
 

--- a/tests/cases/issue_break_latin_word_from_attr1.rs
+++ b/tests/cases/issue_break_latin_word_from_attr1.rs
@@ -1,0 +1,63 @@
+//! HWP5 → HWPX 저장에서 라틴 문자 줄나눔 단위(breakLatinWord)가 통째로 사라지던 문제.
+//!
+//! HWP5 para_shape 는 breakLatinWord(단어/하이픈/글자)를 attr1 bits5-6 에 담는다. 파서는 이
+//! 렉시컬 필드(`break_latin_word`)를 채우지 않고 attr1 로만 보존하는데, HWPX 직렬화기는
+//! 종전에 그 렉시컬 값이 없으면 무조건 "KEEP_WORD" 로 강등했다 — h2x 저장에서 하이픈·글자
+//! 단위 줄나눔이 통째로 사라졌다(10k 코퍼스 실측: 500 문서 중 222 문서가 비-KEEP 설정).
+//!
+//! 수정: breakNonLatinWord(bit7)와 같은 축으로 attr1 bits5-6 에서 역매핑한다
+//! (0=KEEP_WORD·1=HYPHENATION·2=BREAK_WORD). 렉시컬 값이 있으면(HWPX 소스) 그것을 우선한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Read;
+
+use rhwp::model::document::Document;
+use rhwp::model::style::ParaShape;
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+fn break_latin_words(hwpx: &[u8]) -> Vec<String> {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(hwpx)).expect("zip");
+    let mut xml = String::new();
+    zip.by_name("Contents/header.xml")
+        .expect("header.xml")
+        .read_to_string(&mut xml)
+        .expect("read");
+    let needle = "breakLatinWord=\"";
+    let mut out = Vec::new();
+    let mut rest = xml.as_str();
+    while let Some(i) = rest.find(needle) {
+        rest = &rest[i + needle.len()..];
+        let end = rest.find('"').expect("닫는 따옴표");
+        out.push(rest[..end].to_string());
+        rest = &rest[end..];
+    }
+    out
+}
+
+fn ps(attr1: u32, lexical: Option<&str>) -> ParaShape {
+    ParaShape {
+        attr1,
+        break_latin_word: lexical.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn hwp5_break_latin_word_derived_from_attr1_bits() {
+    let mut doc = Document::default();
+    // HWP5 소스(렉시컬 None): attr1 bits5-6 이 설정을 담는다.
+    doc.doc_info.para_shapes.push(ps(2 << 5, None)); // BREAK_WORD
+    doc.doc_info.para_shapes.push(ps(1 << 5, None)); // HYPHENATION
+    doc.doc_info.para_shapes.push(ps(0, None)); // KEEP_WORD
+    // HWPX 소스(렉시컬 Some): attr1 을 무시하고 렉시컬 값을 그대로 쓴다.
+    doc.doc_info.para_shapes.push(ps(2 << 5, Some("KEEP_WORD")));
+
+    let hwpx = serialize_hwpx(&doc).expect("HWPX 직렬화");
+    let vals = break_latin_words(&hwpx);
+
+    assert_eq!(
+        vals,
+        vec!["BREAK_WORD", "HYPHENATION", "KEEP_WORD", "KEEP_WORD"],
+        "attr1 bits5-6 역매핑(2→BREAK_WORD·1→HYPHENATION·0→KEEP_WORD) + 렉시컬 우선이 지켜져야 한다"
+    );
+}


### PR DESCRIPTION
## 무엇을 · 왜

`closes #5297`

HWP5 를 HWPX 로 저장(h2x)하면 **라틴 문자 줄나눔 단위(breakLatinWord)가 통째로 사라진다** —
하이픈·글자 단위 설정이 모두 단어(KEEP_WORD) 단위로 강등된다.

- HWP5 파서는 `breakLatinWord` 를 para_shape `attr1` bits5-6 에 두고 렉시컬 필드는 `None` 으로
  둔다. HWPX 직렬화기는 렉시컬 값이 없으면 무조건 `"KEEP_WORD"` 로 써 왔다
  (`serializer/hwpx/header.rs`). 짝 필드 `breakNonLatinWord`(bit7)는 이미 attr1 에서
  역매핑하는데(#1986) breakLatinWord 만 누락돼 있었다.

**10k 코퍼스 HWP5 500 문서 실측**: attr1 bits5-6 이 0=22,400 / 1=285 / 2=2,525 para_shape 로
분포하며, **222 문서**가 비-KEEP 설정을 가진다. 종전 h2x 는 이를 전부 KEEP_WORD 로 잃었다.

## 수정

`serializer/hwpx/header.rs` 에서 `break_latin_word` 렉시컬 값이 없을 때(HWP5 소스) attr1
bits5-6 에서 역매핑한다(`latin_break_from_attr1`: 0=KEEP_WORD·1=HYPHENATION·2=BREAK_WORD).
렉시컬 값이 있으면(HWPX 소스) 그것을 우선하므로 **x2x 는 종전과 동일**하다.

## 검증 (로컬)

- 실측 코퍼스 파일(attr1 bits5-6=2 보유) h2x: `breakLatinWord` 분포가 종전 전부 KEEP_WORD →
  `{KEEP_WORD, BREAK_WORD}` 로 설정 복원. 지배값(0)은 KEEP_WORD 그대로라 다수 문서 불변.
- 계약 테스트 `tests/cases/issue_break_latin_word_from_attr1.rs`: attr1 bits5-6={2,1,0} + 렉시컬
  Some 을 섞어 `[BREAK_WORD, HYPHENATION, KEEP_WORD, KEEP_WORD]` 를 검사. **음성 대조**: 역매핑
  제거 시 전부 KEEP_WORD 로 FAIL.
- hwpx 직렬화기 lib **425/425** · `hwpx_roundtrip_baseline` · `hwpx_roundtrip_integration` 통과.
  변경이 h2x 경로라 `ir_field_sweep`(h2h/x2x)·`convert_verify` 무영향.
- `rustfmt --check` · `cargo clippy --lib` 무경고.

## 사정거리

h2x 전반(비-KEEP breakLatinWord 문단)에 적용. 지배값(KEEP_WORD)은 불변이라 회귀 위험 낮음.
발견 경위: 10k 코퍼스 h2x 왕복 IR 발산 하니스에서 semantic 최다 발산으로 수확.

관련: #1986(breakNonLatinWord 역매핑, 같은 축).
