### PR TITLE
docs(skills): 안전 편집 스킬을 run 계획·dry-run·verify 경로로 고도화

### DIFF
--- a/.claude/skills/rhwp-safe-edit/SKILL.md
+++ b/.claude/skills/rhwp-safe-edit/SKILL.md
@@ -15,15 +15,39 @@ description: rhwp CLI로 HWP/HWPX 문서를 원본 훼손 없이 편집하는 �
 4. **판정은 예외가 아니라 봉투** — exit 3/4 와 `notFound`·`ambiguous`·`overflow` 는
    고장이 아니라 **읽고 분기해야 하는 데이터**다.
 
+이 스킬은 **새 편집 로직을 만들지 않는다.** 이미 devel 에 있는 `edit` 하위명령과
+`run` 계획 실행기(`run_plan_engine`)를 에이전트가 원본을 깨지 않고 부르게 배선한다.
+
 권위 출처: [`mydocs/manual/cli_commands.md`](../../../mydocs/manual/cli_commands.md)
 (§edit 각 절·§run·§종료 코드 #2707)와
 [`mydocs/manual/agent_knowledge_map.md`](../../../mydocs/manual/agent_knowledge_map.md) §1-1(라).
+
+## 자식 문서 (이 스킬의 본문)
+
+SKILL.md 는 라우터다. 작업 종류에 맞는 자식을 **읽고 나서** 명령을 조립한다.
+
+| 작업 | 읽기 | 경로 |
+|------|------|------|
+| 편집 1건 (누름틀·치환·셀·그림·마스킹·메타 제거) | 1층 단건 | [references/single_edit.md](references/single_edit.md) |
+| 여러 편집을 한 번에·원자적으로 | 3층 계획서 | [references/run_plans.md](references/run_plans.md) |
+| dry-run → 저장 → --verify → 재독 | 검증 루프 | [references/verify_loops.md](references/verify_loops.md) |
+| exit 3/4 · invalid[] · notFound 를 데이터로 | 실패 봉투 | [references/failure_envelopes.md](references/failure_envelopes.md) |
+
+실측 워크스루(명령 + 기대 봉투)는 [examples/](examples/README.md) 다.
+기계가 읽는 계획서·봉투 픽스처는 [fixtures/](fixtures/catalog.json) 다.
 
 ## 실행
 
 ```bash
 cargo build --release        # 최초 1회 또는 소스 변경 후
 ./target/release/rhwp <명령> [옵션]
+```
+
+계획서 문법을 지어내지 마라. 쓰기 전에 스키마를 읽는다.
+
+```bash
+rhwp export-plan-schema --json     # 봉투 + 스키마 (MCP 리소스 rhwp://schemas/plan 과 동일)
+rhwp export-plan-schema --bare     # JSON Schema 본문만 — 검증기에 그대로 먹인다
 ```
 
 ## 요청 → 명령 매핑
@@ -41,6 +65,15 @@ cargo build --release        # 최초 1회 또는 소스 변경 후
 | "메타데이터 제거" | `edit sanitize` | `removedCount`·`removed[]` |
 | "여러 편집을 한 번에(원자)" | `run <계획.json> [--dry-run] [--json]` | `invalid[]`·`steps[]`·`verify` |
 | "서식 1 + 데이터 N명분" | `batch fill --form … --data <행.jsonl\|csv> --out-dir …` | 행별 `notFound`·`filledCount` |
+
+`run` 계획서의 action 은 넷뿐이다. **이 스킬은 다섯 번째 action 을 만들지 않는다.**
+
+- `fill_fields{data}`
+- `replace_text{find,replace[,occurrence][,caseSensitive]}`
+- `set_cell{table,row,col,text[,keepStyle]}`
+- `set_checkbox{occurrence}`
+
+그림 삽입·마스킹·메타 제거는 1층 `edit` 로 남는다. 계획서에 `insert_image` 를 지어내지 마라.
 
 ## 판단 트리 — 1층이냐 3층이냐
 
@@ -69,15 +102,12 @@ rhwp run plan.json --json               # ② 통과했을 때만 저장
 ```
 
 - 계획서 문법의 단일 출처는 `rhwp export-plan-schema --json`(MCP 리소스 `rhwp://schemas/plan`).
-- step 종류는 `fill_fields{data}` · `replace_text{find,replace[,occurrence]}` ·
-  `set_cell{table,row,col,text[,keepStyle]}` · `set_checkbox{occurrence}` 넷이다.
 - 각 step 은 선택 필드 `if` 로 조건을 달 수 있다(`fieldExists`·`fieldEquals`·`textFound`,
   #3719 §6-8). 조건이 거짓이면 그 step 만 건너뛰며 저널에 `skipped:true` 로 남는다.
-- 바인딩(`@rhwp/node`·Python `rhwp`)의 `Plan(...).check()/.run()` 이 정확히 이 두 호출이다 —
-  [`bindings/node/README.md`](../../../bindings/node/README.md) §3층,
-  [`mydocs/manual/python_binding_guide.md`](../../../mydocs/manual/python_binding_guide.md) §2.
 - **위반은 데이터다**: 선검증 실패는 `invalid[]` 에 **전부 모아** 온다(두더지잡기 방지).
-  exit 2 지만 봉투는 나온다 — 아래 함정 ⑥.
+  exit 2 지만 봉투는 나온다 — 함정 ⑥.
+
+자세한 조립은 [references/run_plans.md](references/run_plans.md).
 
 ## 원본 불변·산출 분리 원칙
 
@@ -101,11 +131,20 @@ rhwp run plan.json --json               # ② 통과했을 때만 저장
 | 0 | 성공 | 봉투의 데이터 신호(`notFound` 등)는 **여전히** 확인한다 |
 | 1 | 런타임 실패(읽기·파싱·쓰기) | 환경·입력을 본다. stdout 은 0바이트 |
 | 2 | 사용법 오류 — **호출 조립 버그** | 재시도 금지, 인자를 고친다 |
-| 3 | `--verify` IR 차이 검출 | 고장이 아니라 **판정**. 산출물은 남는다. `verify.diffCount` 를 읽고 판단 |
+| 3 | `--verify` IR 차이 검출 **또는** `run` CAS 전제 실패 | 고장이 아니라 **판정**. 1층은 산출물이 남고, `run` 단언/CAS 는 디스크 무변경 |
 | 4 | `--verify-pages` 쪽 수 불일치 | 위와 같음 (`convert`/`export-hwpx` 전용) |
 
 바인딩도 같은 규약이다 — exit 3/4 를 예외로 올리지 않고 **반환값의 판정 필드**로 준다.
 예외로 다루면 호출자가 봉투의 근거(`diffCount`·`status`)를 읽지 않게 되기 때문이다.
+
+**1층 `--verify` 와 3층 `assertions.verify` 는 같은 숫자가 아니다.**
+
+- 1층 `edit … --verify`: 산출물은 **남기고** exit 3. `verify.diffCount` 를 읽는다.
+- 3층 `run` + `assertions.verify: true`: 차이가 있으면 **저장하지 않고** exit 3.
+- `run` + `preconditions.inputSha256` 불일치: `invalid[]` 는 비어 있고
+  `preconditionFailed` + `nextCall` + **exit 3**. 사용법 오류(2)가 아니다.
+
+표와 분기는 [references/failure_envelopes.md](references/failure_envelopes.md).
 
 ## 절차 (권장 루프)
 
@@ -126,6 +165,8 @@ rhwp export-tables 작성본.hwpx --json | jq '.tables[0].cells[] | select(.row=
 rhwp edit replace-text 공문.hwp --find "2025년" --replace "2026년" -o 개정본.hwp --json
 rhwp search 개정본.hwp "2025년" --json | jq .matchCount     # → 0 이어야 함
 ```
+
+루프 전체와 `changedPages: null` 함정은 [references/verify_loops.md](references/verify_loops.md).
 
 ## 함정 (실측된 것만)
 
@@ -151,11 +192,31 @@ rhwp search 개정본.hwp "2025년" --json | jq .matchCount     # → 0 이어�
    거면 `--no-raw` 로 애초에 뺀다.
 10. **`--verify` 통과 ≠ 완전 동일.** 자기 재파싱 게이트일 뿐이며, 무손실이 계약이면
     `ir-diff <원본> <산출> --json`(차이 시 exit 3)을 별도로 돌려 `categories` 를 읽는다.
+11. **CAS 해시 불일치는 exit 3 이지 exit 2 가 아니다.** `invalid[]` 는 비어 있고
+    `preconditionFailed` + `nextCall` 이 온다. 호출 조립을 고치는 자리가 아니다.
+12. **조건절은 입력 문서 기준으로 실행 전에 한 번만 판정한다.** 앞 step 이 채운 값이
+    뒤 step 의 `if` 를 바꾸지 않는다. "채운 뒤에 치환"을 `if` 로 표현하지 마라.
+
+## 하지 않는 것
+
+- 새 `edit` 하위명령·새 `run` action 을 이 스킬에서 발명하지 않는다.
+- gym 과제·채점·pack 을 이 스킬 경로에 끌어들이지 않는다.
+- 온보딩·MCP 세션·출처 표지·문서 트리아지 스킬 본문을 이 파동에서 고치지 않는다.
+- `--in-place` 를 현황 조사 없이 기본값으로 쓰지 않는다. `redact` 에서만, 그리고
+  사용자가 원본 덮어쓰기를 **명시**했을 때만.
+- 계획서 키를 예시에서 베껴 쓰지 않고 `export-plan-schema` 를 먼저 읽는다.
 
 ## 상세 레퍼런스
 
+- 1층 단건: [references/single_edit.md](references/single_edit.md)
+- 3층 계획: [references/run_plans.md](references/run_plans.md)
+- 검증 루프: [references/verify_loops.md](references/verify_loops.md)
+- 실패 봉투: [references/failure_envelopes.md](references/failure_envelopes.md)
+- 워크스루: [examples/README.md](examples/README.md)
+- 픽스처 목록: [fixtures/catalog.json](fixtures/catalog.json)
 - 전체 명령·옵션·종료 코드: [`mydocs/manual/cli_commands.md`](../../../mydocs/manual/cli_commands.md)
 - 서식 채움 심화(반복 필드·병합 셀·치환): [`mydocs/manual/form_filling_guide.md`](../../../mydocs/manual/form_filling_guide.md)
 - `run` 실측 저널·실패 사례: [`mydocs/manual/agent_task_playbook.md`](../../../mydocs/manual/agent_task_playbook.md) §12
 - dry-run→저장→changedPages 루프 실측: [`mydocs/manual/agent_surface_playbook.md`](../../../mydocs/manual/agent_surface_playbook.md) §9
 - 봉투 필드 사전·`null` 사전: [`mydocs/manual/agent_knowledge_map.md`](../../../mydocs/manual/agent_knowledge_map.md) §2
+- 이 파동의 작업 기록: [`mydocs/working/agent_safe_edit.md`](../../../mydocs/working/agent_safe_edit.md)

--- a/.claude/skills/rhwp-safe-edit/examples/01_fill_fields_single.md
+++ b/.claude/skills/rhwp-safe-edit/examples/01_fill_fields_single.md
@@ -1,0 +1,117 @@
+# 01 — 누름틀 한 건 (`edit fill-fields`)
+
+층: 1. 목표: `samples/field-01.hwp` 의 회사명·작성자만 채운 산출물을
+원본과 다른 경로에 남긴다. 원본 바이트는 그대로다.
+
+권위: [single_edit.md](../references/single_edit.md) §3,
+[verify_loops.md](../references/verify_loops.md) §1–5.
+픽스처: [../fixtures/plans](../fixtures/catalog.json) 이 아니라 1층 봉투
+[../fixtures/envelopes/fill_ok.json](../fixtures/envelopes/fill_ok.json).
+
+## 0. 이 편에서 하지 않는 것
+
+- `--in-place` 로 원본을 덮어쓰지 않는다.
+- `fields` 없이 필드 이름을 지어내지 않는다.
+- `filledCount` 만 보고 완료라고 하지 않는다.
+- 다음 치환을 같은 산출물에 이어 붙이지 않는다. 이어야 하면 07 편(`run`)으로 간다.
+
+## 1. 발견
+
+```bash
+rhwp fields samples/field-01.hwp --json
+```
+
+기대 키: `schemaVersion`, `fields[].name`, `fields[].value`.
+이 샘플은 테스트가 11개 누름틀(회사명/작성자/부서명/전화번호/이메일/제목/목차1×5)로
+소개한다. 에이전트는 그 숫자를 외우지 않고 이 호출의 배열을 읽는다.
+
+동명이 있으면 배열 순서가 순번이다. `목차1` 이 다섯 번이면
+`목차1[0]` … `목차1[4]` 만 지목할 수 있다.
+
+## 2. 선확인
+
+```bash
+rhwp edit fill-fields samples/field-01.hwp \
+  --data '{"회사명":"페타플로","작성자":"홍길동"}' \
+  --dry-run --json
+```
+
+읽는 필드:
+
+| 키 | 기대 |
+|----|------|
+| `dryRun` | `true` |
+| `filledCount` | 2 |
+| `filled[].name` | 회사명, 작성자 |
+| `notFound` | `[]` |
+| `ambiguous` | `[]` |
+| `output` | **부재** |
+| `changedPages` | `null` |
+
+`out/field-filled.hwp` 를 아직 만들지 않았다. `-o` 를 붙였더라도 dry-run 은 touch 하지 않는다.
+
+`notFound` 가 비지 않으면 data 키를 고치고 이 절을 반복한다.
+`ambiguous` 가 비지 않으면 `이름[N]` 으로 고친다. 12 편.
+
+## 3. 실행
+
+```bash
+rhwp edit fill-fields samples/field-01.hwp \
+  --data '{"회사명":"페타플로","작성자":"홍길동"}' \
+  -o out/field-filled.hwp --verify --json
+```
+
+기대 봉투 골격은 `fixtures/envelopes/fill_ok.json` 과 같다.
+
+- exit 0 이고 `verify.identical == true` 이거나
+- exit 3 이고 `verify.identical == false` — 산출물은 **있다**. 10 편.
+
+`verify` 가 `null` 이면 `--verify` 를 빼먹은 것이다. 통과가 아니다.
+
+## 4. 재독
+
+```bash
+rhwp fields out/field-filled.hwp --json \
+  | jq -c '[.fields[]|select(.name=="회사명" or .name=="작성자")|{name,value}]'
+```
+
+기대: `[{"name":"작성자","value":"홍길동"},{"name":"회사명","value":"페타플로"}]`
+(순서는 문서 순). 다른 필드 `value` 는 입력과 같다.
+
+## 5. 눈검증
+
+`changedPages` 가 배열이면 그 쪽만:
+
+```bash
+rhwp export-svg out/field-filled.hwp -o out/svg -p 0 --json
+```
+
+`null` 이면 이 절을 건너뛴다. dry-run 잔재를 렌더하지 않는다.
+
+## 6. 원본 대조
+
+```bash
+# POSIX
+cmp samples/field-01.hwp samples/field-01.hwp
+# 실행 전에 떠 둔 해시와 비교하는 것이 15 편.
+```
+
+원본 경로에 `-o` 를 두지 않았으므로 원본은 그대로여야 한다.
+
+## 7. 실패를 이 편에서 보면
+
+| 관찰 | 편/문서 |
+|------|---------|
+| `notFound` 비지 않음, exit 0 | [failure_envelopes.md](../references/failure_envelopes.md) §3.1 |
+| `ambiguous` | 12 편 |
+| `--data @row.json` 이 CP949 | exit 1, UTF-8 로 저장 |
+| 다음 편집이 남음 | 07 편 |
+
+## 8. 명령 체크리스트
+
+- [ ] `rhwp fields` 를 먼저 돌렸다
+- [ ] `--dry-run --json` 과 실행이 같은 data / 같은 입력이다
+- [ ] `-o` 가 `samples/field-01.hwp` 가 아니다
+- [ ] `--verify` 를 붙였거나, 안 붙였으면 `verify: null` 을 통과로 말하지 않는다
+- [ ] `notFound == []` 그리고 `ambiguous == []`
+- [ ] `rhwp fields` 재독이 data 와 같다

--- a/.claude/skills/rhwp-safe-edit/examples/02_replace_text_single.md
+++ b/.claude/skills/rhwp-safe-edit/examples/02_replace_text_single.md
@@ -1,0 +1,85 @@
+# 02 — 문구 일괄 치환 (`edit replace-text`)
+
+층: 1. 목표: 문서의 `2025년` 을 `2026년` 으로 바꾸고, 산출물에서
+`2025년` 의 `matchCount` 가 0 인지 재독한다.
+
+권위: [single_edit.md](../references/single_edit.md) §4.
+코어는 `replace_all` (역순, 오프셋 안전). 새 치환 엔진이 없다.
+
+## 0. 하지 않는 것
+
+- `--find ""` (exit 2, 문서 전체).
+- 0건인 줄 알고 1층에서 "성공"으로 보고하기. 산출 파일이 없다.
+- 같은 파일을 여러 번 치환해 반쪽 이력을 남기기. 여러 치환은 `run`.
+
+## 1. 발견
+
+```bash
+rhwp search 공문.hwp "2025년" --json | jq '{matchCount, pages: [.matches[].page]}'
+```
+
+`matchCount == 0` 이면 이 편을 끝낸다. 3층으로 같은 찾기를 넣으면
+`'2025년' 일치 0건` 으로 선검증이 거부한다. 층이 다르면 판정이 다르다.
+
+## 2. 선확인
+
+```bash
+rhwp edit replace-text 공문.hwp --find "2025년" --replace "2026년" --dry-run --json
+```
+
+기대: `dryRun: true`, `replacedCount` == 발견의 `matchCount`, `output` 부재.
+
+`--occurrence 3` 을 쓸 거면 dry-run 에서도 같은 플래그를 붙인다.
+전건 dry-run 을 보고 occurrence 실행을 하면 선확인이 아니다.
+
+## 3. 실행
+
+```bash
+rhwp edit replace-text 공문.hwp --find "2025년" --replace "2026년" \
+  -o 개정본.hwp --verify --json
+```
+
+`replacedCount: 0` 이면 `output` 키가 없고 개정본.hwp 가 생기지 않는다.
+무변경 산출물 금지.
+
+체크박스 한 칸만 켤 때:
+
+```bash
+rhwp edit replace-text 신청서.hwp --find "□" --replace "☑" --occurrence 0 -o 체크.hwp --json
+```
+
+여러 칸 + 다른 편집이면 `run` 의 `set_checkbox`.
+
+## 4. 재독
+
+```bash
+rhwp search 개정본.hwp "2025년" --json | jq .matchCount     # → 0
+rhwp search 개정본.hwp "2026년" --json | jq .matchCount     # → 원래 건수
+```
+
+`--occurrence k` 였으면 첫 호출이 `원본 matchCount - 1`.
+
+## 5. 눈검증
+
+실측 (`hwp3-sample.hwp`, playbook §9-3):
+
+- 전건 `의`→`의`: `changedPages` 0..14 (15쪽)
+- `--occurrence 3` 으로 `의`→`★`: `changedPages: [0]` 만
+
+```bash
+rhwp export-svg 개정본.hwp -o out/svg -p 0 --json
+```
+
+배열에 있는 쪽만 렌더한다.
+
+## 6. `--ignore-case`
+
+CLI 기본은 구별. `--ignore-case` 는 1층 플래그.
+3층으로 옮기면 `caseSensitive: false` 다. `ignoreCase` 키가 아니다.
+
+## 7. 체크리스트
+
+- [ ] `rhwp search` 로 건수를 먼저 봤다
+- [ ] dry-run 의 `replacedCount` 가 그 건수와 같다
+- [ ] 실행 후 `search` 재독
+- [ ] `changedPages` 가 배열일 때만 눈검증

--- a/.claude/skills/rhwp-safe-edit/examples/03_set_cell_single.md
+++ b/.claude/skills/rhwp-safe-edit/examples/03_set_cell_single.md
@@ -1,0 +1,80 @@
+# 03 — 표 한 칸 (`edit set-cell`)
+
+층: 1. 목표: `export-tables` 가 준 `index/row/col` 에 값을 쓰고
+같은 좌표로 다시 읽는다.
+
+권위: [single_edit.md](../references/single_edit.md) §5,
+playbook §14, `tests/edit_set_cell_contract.rs`.
+
+## 0. 하지 않는 것
+
+- 배열 순번을 `--table` 에 넣기. `tables[].index` 다. 0부터가 아닐 수 있다.
+- 병합으로 덮인 칸에 쓰기. 앵커를 안내받으며 exit 2, stdout 0바이트.
+- 중첩 표 (`cells[].nested`). v1 범위 밖.
+- `--text` 에 줄바꿈·탭.
+- `overflow` 를 무시하고 제출본 만들기.
+
+## 1. 발견
+
+```bash
+rhwp export-tables 양식.hwpx --json | jq '.tables[] | {index, rows, cols, cellCount}'
+rhwp export-tables 양식.hwpx --json \
+  | jq '.tables[] | select(.index==12) | .cells[:6] | .[] | {row,col,text}'
+```
+
+공개 샘플 `samples/table-001.hwp` 는 테스트가 좌표를 하드코딩하지 않고
+최상위 표의 첫 셀을 다시 고른다 (`edit_verify_contract.rs`). 에이전트도 같다.
+
+## 2. 선확인
+
+```bash
+rhwp edit set-cell 양식.hwpx --table 12 --row 1 --col 1 --text "1,234" --dry-run --json
+```
+
+기대 키: `oldText`, `newText`, `overflow`, `dryRun: true`, `keepStyle: false`.
+`overflow` 가 비지 않으면 값을 줄이거나 사용자에게 알린다. 11 편.
+
+기본은 검정·비이탤릭·비진하게 (#3391). 안내문 파란 글자를 유지하려면
+dry-run 에도 `--keep-style` 을 같이 붙인다.
+
+## 3. 실행
+
+```bash
+rhwp edit set-cell 양식.hwpx --table 12 --row 1 --col 1 --text "1,234" \
+  -o 작성본.hwpx --verify --json
+```
+
+실측 골격:
+
+```json
+{"changedPages":[6,7],"col":1,"newText":"1,234","oldText":"",
+ "outputFormat":"hwpx","overflow":[],"row":1,"table":12}
+```
+
+HWPX 입력은 HWPX 산출 (#3383). `outputFormat` 을 `info --json` 의 `format` 과 대조한다.
+
+## 4. 재독
+
+```bash
+rhwp export-tables 작성본.hwpx --json \
+  | jq -r '.tables[]|select(.index==12)|.cells[]|select(.row==1 and .col==1).text'
+```
+
+기대 `1,234`. 이웃 칸은 그대로.
+
+## 5. 병합 칸을 치면
+
+```
+(0,2) 는 병합으로 덮인 칸입니다 — 앵커 (0,1) 를 지정하세요.
+exit=2  stdout_bytes=0
+```
+
+같은 좌표로 재시도하지 않는다. 앵커 `(0,1)` 로 dry-run 부터.
+
+## 6. 체크리스트
+
+- [ ] `index` 를 `--table` 에 넣었다
+- [ ] dry-run 에서 `overflow` 를 읽었다
+- [ ] 재독 좌표가 쓰기 좌표와 같다
+- [ ] 여러 칸이면 03 을 반복하지 않고 07 (`run` `set_cell` 여러 step) 또는
+      13 (`csv-to-table`) 으로 간다

--- a/.claude/skills/rhwp-safe-edit/examples/04_insert_image_single.md
+++ b/.claude/skills/rhwp-safe-edit/examples/04_insert_image_single.md
@@ -1,0 +1,56 @@
+# 04 — 도장·서명 (`edit insert-image`)
+
+층: 1 **만**. `run` 계획서에 `insert_image` action 은 없다.
+지어내면 `알 수 없는 action` + exit 2.
+
+권위: [single_edit.md](../references/single_edit.md) §6, #3719 §6-5.
+
+## 0. 단위
+
+`--x --y --width --height` 는 픽셀이 아니다. HWPUNIT (1/7200 inch).
+A4 세로 ≈ 59528 × 84188. 쪽 왼쪽 위가 (0,0). `--page` 는 0 기준.
+
+```bash
+rhwp info 신청서_filled.hwp --json | jq '{pageCount, format}'
+```
+
+쪽 번호가 `pageCount` 이상이면 exit 2. 문서를 읽기 전에 끊길 수 있다.
+
+## 1. 그림 형식
+
+허용: png jpg jpeg bmp tif tiff. 확장자와 내용을 둘 다 본다.
+그 밖은 문서를 열기 전에 exit 2.
+
+## 2. 선확인
+
+```bash
+rhwp edit insert-image 신청서_filled.hwp --image samples/images/moogung.jpg \
+  --page 0 --x 50000 --y 70000 --width 5000 --height 5000 --dry-run --json
+```
+
+`binDataId` 는 저장 전에 없다. `overflow` 는 dry-run 에서도 온다.
+쪽 밖으로 나가도 자르지 않고 신호만 낸다.
+
+## 3. 실행
+
+```bash
+rhwp edit insert-image 신청서_filled.hwp --image samples/images/moogung.jpg \
+  --page 0 --x 50000 --y 70000 --width 5000 --height 5000 \
+  -o 제출본.hwp --verify --json | jq '{output, overflow, binDataId, verify}'
+```
+
+`overflow` 가 비지 않으면 좌표·크기를 줄여 02 절로 돌아간다.
+잘린 도장을 제출본으로 넘기지 않는다.
+
+## 4. 계획서에 넣지 않는 이유
+
+`run` 의 action 4종은 fill_fields / replace_text / set_cell / set_checkbox.
+도장은 1층으로 분리한다. 사용자가 "한 계획에 도장까지"를 요구하면
+"엔진이 받지 않는다. 원자 편집 후 1층으로 얹는다"고 말하고
+원자 부분만 `run` 한다.
+
+## 5. 체크리스트
+
+- [ ] 단위가 HWPUNIT 이다
+- [ ] `run` steps 에 그림을 넣지 않았다
+- [ ] `overflow` 를 읽었다

--- a/.claude/skills/rhwp-safe-edit/examples/05_redact_single.md
+++ b/.claude/skills/rhwp-safe-edit/examples/05_redact_single.md
@@ -1,0 +1,80 @@
+# 05 — 개인정보 마스킹 (`edit redact`)
+
+층: 1. 되돌릴 수 없다. 기본 산출 이름도 만들지 않는다.
+
+권위: [single_edit.md](../references/single_edit.md) §7.
+
+## 0. 하지 않는 것
+
+- `-o` 와 `--in-place` 없이 실행 (exit 2).
+- `-o` 가 원본 자신 (exit 2).
+- `--dry-run` 없이 바로 저장.
+- `findings[].raw` 를 이슈·로그·채팅에 붙이기.
+- `run` steps 에 `redact` 를 넣기 (없는 action).
+
+## 1. 선확인 (필수)
+
+```bash
+rhwp edit redact 계약서.hwp --dry-run --json | jq '.findings[] | {kind, page, masked}'
+```
+
+이 호출의 `raw` 는 원문 개인정보다. 터미널에만 두고 복사하지 않는다.
+
+첨부 가능한 사본:
+
+```bash
+rhwp edit redact 계약서.hwp --dry-run --no-raw --json > 검토용.json
+```
+
+`raw` 키가 빠진다 (`null` 이 아님). `kind`/`masked`/`page`/`charOffset` 은 남는다.
+
+## 2. 경로 거부 표본
+
+```
+$ rhwp edit redact samples/복학원서.hwp --json
+오류: 마스킹은 되돌릴 수 없습니다. 산출 경로를 -o <출력> 으로 지정하거나,
+      원본을 덮어쓸 의도라면 --in-place 를 명시하세요
+      (먼저 --dry-run 으로 무엇이 지워질지 확인하기를 권합니다).
+exit=2
+```
+
+픽스처 [../fixtures/envelopes/redact_missing_output.json](../fixtures/envelopes/redact_missing_output.json)
+은 이 stderr 요지와 exit 2 를 기록한다. stdout 은 0바이트라 JSON 봉투가 아니다.
+
+## 3. 실행
+
+```bash
+rhwp edit redact 계약서.hwp -o 공개본.hwp --verify --no-raw --json \
+  | jq '{redactedCount, findingCount, changedPages, noRaw}'
+```
+
+탐지 0건이면 출력 파일을 만들지 않는다.
+
+`--kind ssn,card` 로 좁힐 수 있다. dry-run 과 실행의 kind 가 같아야 선확인이다.
+
+## 4. 재독
+
+```bash
+rhwp edit redact 공개본.hwp --dry-run --no-raw --json | jq .findingCount
+```
+
+같은 kind 로 0. 원문 재스윕에 `--no-raw` 없이 돌리지 마라.
+
+## 5. `--in-place`
+
+사용자가 "원본을 덮어써" 라고 **명시**했을 때만.
+쓰기는 원자적이라 도중 실패해도 원본이 잘리지 않는다.
+에이전트 기본은 그래도 `-o`.
+
+## 6. 탐지 범위 (v1)
+
+ssn / card / phone(하이픈 필수, 02 또는 01x) / email.
+02 외 지역번호, 여권, 계좌, 13·14·19자리 카드는 범위 밖.
+형태가 맞아도 체크섬·생년월일 검증을 통과하지 못하면 탐지하지 않는다.
+
+## 7. 체크리스트
+
+- [ ] dry-run 을 먼저 했다
+- [ ] `-o` 가 원본과 다르다
+- [ ] 남길 봉투는 `--no-raw`
+- [ ] 재독도 `--no-raw`

--- a/.claude/skills/rhwp-safe-edit/examples/06_sanitize_single.md
+++ b/.claude/skills/rhwp-safe-edit/examples/06_sanitize_single.md
@@ -1,0 +1,45 @@
+# 06 — 메타데이터 제거 (`edit sanitize`)
+
+층: 1. 본문은 건드리지 않는다. `--dry-run`/`--verify` 플래그가 없다.
+빠진 것이 아니라 재실행 `removedCount: 0` 과 `export-text` 전후 동일로 증명한다.
+
+권위: [single_edit.md](../references/single_edit.md) §8.
+
+## 1. 실행
+
+```bash
+rhwp edit sanitize 보고서.hwp -o 배포본.hwp --json | jq '.removed[] | "\(.field): \(.before)"'
+```
+
+`removed[]` 는 거짓 보고를 하지 않는다. 실제로 지운 필드만 온다.
+
+## 2. 재실행 = 증거
+
+```bash
+rhwp edit sanitize 배포본.hwp -o /tmp/재확인.hwp --json | jq .removedCount
+```
+
+기대 0. 0 이 아니면 첫 실행이 덜 지운 것이다 — 이 스킬이 새 로직을 넣는 자리가 아니고
+구현 회귀이므로 이슈로 남긴다.
+
+## 3. 본문 불변
+
+```bash
+rhwp export-text 보고서.hwp
+rhwp export-text 배포본.hwp
+```
+
+두 결과가 같아야 한다. 메타만 지운다는 계약의 재독이다.
+
+## 4. `--keep-preview`
+
+미리보기 **이미지**를 남긴다. 미리보기 텍스트는 언제나 대상.
+HWP5 직렬화기는 빈 PrvText 를 본문 앞부분으로 다시 채우므로,
+텍스트는 지금 본문과 다를 때만 지우고 보고한다.
+
+## 5. 체크리스트
+
+- [ ] `-o` 분리
+- [ ] `removedCount` 재실행 0
+- [ ] `export-text` 전후 동일
+- [ ] `run` 에 sanitize 를 넣지 않았다

--- a/.claude/skills/rhwp-safe-edit/examples/07_run_atomic_fill_replace.md
+++ b/.claude/skills/rhwp-safe-edit/examples/07_run_atomic_fill_replace.md
@@ -1,0 +1,120 @@
+# 07 — 원자 편집 (`rhwp run` fill + replace)
+
+층: 3. 목표: 누름틀 채움과 연도 치환을 **전부 되거나 전혀 안 되게** 한다.
+1층 `edit` 를 두 번 이어 붙이지 않는다.
+
+권위: [run_plans.md](../references/run_plans.md),
+playbook §12, `tests/plan_schema_contract.rs`.
+
+## 0. 하지 않는 것
+
+- `source`/`op` 키. `input`/`steps[].action` 이다.
+- action 카멜 (`fillFields`). 스네이크 네 이름만.
+- `insert_image` 를 steps 에 추가.
+- dry-run 없이 바로 저장.
+- `planVersion` 생략.
+
+## 1. 스키마
+
+```bash
+rhwp export-plan-schema --json | jq '{planSchemaVersion, definitionCount, dialect}'
+```
+
+기대: `planSchemaVersion` `"1.1"`, `definitionCount` 11,
+`dialect` `https://json-schema.org/draft/2020-12/schema`.
+
+계획을 쓰기 전에 `--bare` 로 `FillFieldsStep` / `ReplaceTextStep` 필수 키를 확인한다.
+
+```bash
+rhwp export-plan-schema --bare | jq '.["$defs"].FillFieldsStep.required'
+```
+
+## 2. 계획서
+
+픽스처 [../fixtures/plans/valid_multi_step.json](../fixtures/plans/valid_multi_step.json)
+과 같은 골격:
+
+```json
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {"action": "fill_fields", "data": {"회사명": "페타플로", "작성자": "홍길동"}},
+    {"action": "fill_fields", "data": {"목차1[0]": "개요"}}
+  ],
+  "assertions": {"notFoundEmpty": true, "verify": true}
+}
+```
+
+`목차1` 을 순번 없이 쓰면 `ambiguous` 가 저널에 남고 첫 칸만 찬다.
+선검증은 통과한다 (칸은 존재하므로). 완료 조건에 `ambiguous == []` 를 넣는다.
+
+## 3. 선검증
+
+```bash
+rhwp run out/plan.json --dry-run --json
+```
+
+기대 골격: [../fixtures/envelopes/run_dry_run_preview.json](../fixtures/envelopes/run_dry_run_preview.json).
+
+- `dryRun: true`
+- `invalid: []`
+- `preview[]` 길이 = steps 길이
+- `out/plan_result.hwp` 가 생기지 않음
+
+사람 모드면 `검사 통과: N step 실행 가능 (디스크 무변경, 산출 예정 …)`.
+
+`invalid` 가 비지 않으면 09 편. 디스크는 그대로다.
+
+## 4. 실행
+
+```bash
+rhwp run out/plan.json --json
+```
+
+실측 저널 골격 (playbook §9-2):
+
+```json
+{
+  "assertions": {"notFoundEmpty": true, "verify": true},
+  "changedPages": [0, 1],
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "outputFormat": "hwp5",
+  "planVersion": "1.0",
+  "steps": [
+    {"action": "fill_fields", "ambiguous": [], "confusable": [],
+     "filledCount": 2, "notFound": [], "step": 0}
+  ],
+  "verify": {"diffCount": 0, "identical": true}
+}
+```
+
+`verify.identical == false` 면 exit 3 이고 **파일이 없다**. 10 편.
+
+## 5. 재독
+
+```bash
+rhwp fields out/plan_result.hwp --json \
+  | jq -c '[.fields[]|select(.value!="")|{name,value}]'
+```
+
+각 step 의 `filled[]` 와 대조한다.
+
+## 6. 왜 1층 체인이 아닌가
+
+```
+edit fill-fields -o a.hwp
+edit replace-text a.hwp -o b.hwp    # replace 가 실패하면 a.hwp 가 반쪽
+```
+
+`run` 은 a.hwp 를 만들지 않는다. 실패 시 원본만 남는다. 15 편.
+
+## 7. 체크리스트
+
+- [ ] `export-plan-schema` 를 읽었다
+- [ ] `--dry-run` 후 `invalid[]` 가 비었다
+- [ ] `assertions.verify: true`
+- [ ] `output` 이 `input` 과 다르다
+- [ ] 재독이 저널과 같다

--- a/.claude/skills/rhwp-safe-edit/examples/08_run_conditional.md
+++ b/.claude/skills/rhwp-safe-edit/examples/08_run_conditional.md
@@ -1,0 +1,90 @@
+# 08 — 조건부 step (`if`)
+
+층: 3. 목표: 입력 문서에 필드/문구가 있을 때만 그 step 을 적용하고,
+건너뛴 step 을 저널에서 숨기지 않는다.
+
+권위: [run_plans.md](../references/run_plans.md) §5, #3719 §6-8.
+
+## 0. 하지 않는 것
+
+- `if` 에 조건 두 개 (and/or 가 계획서에 없음 → invalid).
+- 앞 step 이 쓴 값을 뒤 step `if` 로 읽기. 판정은 **입력 문서 기준 1회**.
+- 빈 `if: {}`.
+
+선확인은 다른 계획과 같다.
+
+```bash
+rhwp run plan.json --dry-run --json
+```
+
+`preview[]` 에서 `skipped: true` 인 항목의 `step` 인덱스가 계획서와 같은지 본다.
+
+## 1. 세 종류 (정확히 하나)
+
+픽스처:
+
+- [valid_conditional_field_exists.json](../fixtures/plans/valid_conditional_field_exists.json)
+- [valid_conditional_field_equals.json](../fixtures/plans/valid_conditional_field_equals.json)
+- [valid_conditional_text_found.json](../fixtures/plans/valid_conditional_text_found.json)
+- [invalid_two_conditions.json](../fixtures/plans/invalid_two_conditions.json)
+
+```json
+{"action": "replace_text", "find": "임시", "replace": "확정",
+ "if": {"fieldExists": "결재란"}}
+```
+
+```json
+{"action": "fill_fields", "data": {"비고": "해당없음"},
+ "if": {"fieldEquals": {"name": "해당여부", "value": "N"}}}
+```
+
+```json
+{"action": "set_checkbox", "occurrence": 0,
+ "if": {"textFound": "개인정보 수집에 동의"}}
+```
+
+## 2. 건너뜀은 자리 유지
+
+dry-run preview:
+
+```json
+{"step": 1, "action": "replace_text", "skipped": true,
+ "reason": "fieldExists '결재란' 이 문서에 없습니다"}
+```
+
+(reason 문장은 실행기 구현의 문자열. 테스트는 `skipped: true` 키를 고정한다.)
+
+실행 저널에도 같은 인덱스로 남는다. 사람 모드:
+
+```
+완료: 1 step 적용 · 1 step 건너뜀, 산출 …
+  - step 1 건너뜀: …
+```
+
+건너뛴 step 은 "실행 가능" 개수에 넣지 않는다. dry-run 예고와 실행 적용 수가 같다.
+
+## 3. 선검증 면제
+
+조건이 거짓이면 그 step 의 대상이 없어도 invalid 가 아니다.
+없는 필드를 채우는 step 에 `if.fieldExists` 를 달면, 필드가 없을 때
+그 step 만 건너뛰고 나머지는 적용된다.
+
+조건이 참인데 대상이 없으면 (모순) 선검증이 거부한다.
+`fieldExists` 가 참인데 같은 이름의 data 키가 범위 밖인 경우 등.
+
+## 4. 입력 기준의 함정
+
+```json
+{"action": "fill_fields", "data": {"상태": "완료"}},
+{"action": "replace_text", "find": "미완료", "replace": "완료",
+ "if": {"fieldEquals": {"name": "상태", "value": "완료"}}}
+```
+
+두 번째 `if` 는 입력 문서의 `상태` 다. 첫 step 이 방금 쓴 값이 아니다.
+"채운 뒤에 치환"은 조건이 아니라 **순서** 로 쓴다. 둘 다 조건 없이 나열한다.
+
+## 5. 체크리스트
+
+- [ ] `if` 키가 정확히 하나
+- [ ] 앞 step 결과에 의존하지 않는다
+- [ ] preview/journal 에서 skipped step 의 인덱스가 계획서와 같다

--- a/.claude/skills/rhwp-safe-edit/examples/09_run_invalid_collected.md
+++ b/.claude/skills/rhwp-safe-edit/examples/09_run_invalid_collected.md
@@ -1,0 +1,76 @@
+# 09 — 선검증 위반을 한 번에 (`invalid[]`)
+
+층: 3. 목표: 잘못된 계획을 실행하지 않고, 위반을 전부 모아 고친다.
+하나 고치고 다시 돌려 다음 위반을 만나는 두더지잡기를 하지 않는다.
+
+권위: [run_plans.md](../references/run_plans.md) §10,
+[failure_envelopes.md](../references/failure_envelopes.md) §6.3.
+
+## 1. 표본
+
+픽스처 [../fixtures/envelopes/run_invalid_collected.json](../fixtures/envelopes/run_invalid_collected.json),
+[../fixtures/envelopes/run_invalid_replace_zero.json](../fixtures/envelopes/run_invalid_replace_zero.json).
+
+실측 (playbook §9-2):
+
+```
+$ rhwp run out/plan.json --dry-run --json
+{"input":"samples/field-01.hwp",
+ "invalid":[{"action":"replace_text","reason":"'여기에 입력' 일치 0건 — 치환할 곳이 없습니다","step":1}],
+ "output":"out/plan_result.hwp","planVersion":"1.0","schemaVersion":"1.0"}
+exit=2
+```
+
+`output` 키는 예정 경로일 뿐 파일이 생겼다는 뜻이 아니다.
+이 경로를 `test -e` 하면 없어야 한다 (이전 잔재를 미리 지운다).
+
+## 2. 여러 위반
+
+엔진은 전 step 을 훑어 `invalid` 에 push 한다. 첫 위반에서 멈추지 않는다.
+
+```json
+"invalid": [
+  {"step": 0, "action": "fill_fields",
+   "reason": "필드 '없는필드' 이(가) 없거나 순번이 범위 밖입니다 (동명 0개)"},
+  {"step": 1, "action": "replace_text",
+   "reason": "'여기에 입력' 일치 0건 — 치환할 곳이 없습니다"},
+  {"step": 2, "action": "insert_image",
+   "reason": "알 수 없는 action: insert_image (fill_fields·replace_text·set_cell·set_checkbox)"}
+]
+```
+
+세 줄을 한 번에 고친다. 첫 줄만 고치고 재실행하지 않는다.
+
+## 3. 문법 오류는 `error`
+
+`planVersion` 누락은 `invalid[]` 가 아니라:
+
+```
+{"error":"planVersion \"1.0\" 이 필요합니다","schemaVersion":"1.0"}
+exit=2
+```
+
+픽스처 [../fixtures/envelopes/run_error_plan_version.json](../fixtures/envelopes/run_error_plan_version.json).
+분기: FixPlanKeys. `steps` 를 보기 전에 끊긴다.
+
+## 4. 에이전트 루프
+
+```
+run --dry-run --json
+if exit 2 and invalid:
+    for item in invalid: fix plan[item.step]
+    repeat dry-run
+if exit 2 and error:
+    fix keys (planVersion/input/output/steps)
+    repeat dry-run
+if exit 0 and dryRun:
+    run without --dry-run
+```
+
+같은 계획 바이트를 재시도하지 않는다.
+
+## 5. 체크리스트
+
+- [ ] stdout 을 exit 2 에서도 파싱했다
+- [ ] invalid 전 원소를 고쳤다
+- [ ] 산출 경로에 파일이 생기지 않았음을 확인했다

--- a/.claude/skills/rhwp-safe-edit/examples/10_verify_exit3.md
+++ b/.claude/skills/rhwp-safe-edit/examples/10_verify_exit3.md
@@ -1,0 +1,63 @@
+# 10 — exit 3 두 갈래
+
+같은 숫자, 다른 디스크. 예외로 throw 하지 않고 봉투를 읽는다.
+
+권위: [verify_loops.md](../references/verify_loops.md) §3.3,
+[failure_envelopes.md](../references/failure_envelopes.md) §4,
+`tests/edit_verify_contract.rs`.
+
+## 1. 1층 — 산출물이 남는다
+
+```bash
+rhwp edit fill-fields samples/field-01.hwp \
+  --data '{"회사명":"검증사"}' -o /tmp/fill.hwp --verify --json
+```
+
+계약:
+
+- `verify.identical == true` ⇒ exit 0
+- `verify.identical == false` ⇒ exit 3
+- 어느 쪽이든 `/tmp/fill.hwp` 가 **존재**한다
+
+픽스처 [../fixtures/envelopes/edit_verify_diff.json](../fixtures/envelopes/edit_verify_diff.json),
+[../fixtures/envelopes/edit_verify_ok.json](../fixtures/envelopes/edit_verify_ok.json).
+
+다음: 산출물을 지우기 전에 `fields` 재독. 값이 맞으면 사용자에게
+"자기검증이 차이를 봤지만 값은 반영됐다"고 보고한다.
+`--verify` 는 원본↔산출 비교가 아니다.
+
+## 2. 3층 단언 — 산출물이 없다
+
+```json
+"assertions": {"verify": true}
+```
+
+차이가 있으면 exit 3, `output` 경로에 이번 실행의 파일이 없다.
+픽스처 [../fixtures/envelopes/run_verify_fail_no_output.json](../fixtures/envelopes/run_verify_fail_no_output.json).
+
+다음: 원본은 그대로. 재계획. "깨진 파일을 복구"하지 않는다.
+
+## 3. `--verify` 를 안 붙인 1층
+
+```json
+"verify": null
+```
+
+exit 0. 통과가 아니다. 픽스처 [../fixtures/envelopes/verify_null.json](../fixtures/envelopes/verify_null.json).
+
+## 4. `ir-diff` 는 세 번째 갈래
+
+```bash
+rhwp ir-diff 원본.hwp 산출.hwp --json
+```
+
+차이 시 exit 3, `categories`. 서식 채우기 전후는 차이가 정상이다.
+무손실 변환 계약에만 `diffCount == 0` 을 건다.
+`--json` 없이 돌리면 차이가 있어도 exit 0 일 수 있다.
+
+## 5. 체크리스트
+
+- [ ] exit 3 을 파싱했다
+- [ ] 1층이면 산출물 존재를 확인했다
+- [ ] 3층이면 산출물 부재를 확인했다
+- [ ] `verify: null` 을 통과로 말하지 않았다

--- a/.claude/skills/rhwp-safe-edit/examples/11_overflow_data.md
+++ b/.claude/skills/rhwp-safe-edit/examples/11_overflow_data.md
@@ -1,0 +1,55 @@
+# 11 — `overflow` 는 성공 안의 경고
+
+층: 1. `set-cell` / `insert-image` 는 넘쳐도 채운다. exit 0.
+신호를 무시하면 표·쪽 밖으로 나간 제출본이 나온다.
+
+권위: [single_edit.md](../references/single_edit.md) §5.3, #3480.
+
+## 1. 표본
+
+픽스처 [../fixtures/envelopes/set_cell_overflow.json](../fixtures/envelopes/set_cell_overflow.json).
+
+```json
+"overflow": [{
+  "target": "table0[1,1]",
+  "text": "아주아주긴값",
+  "cellWidthPx": 20.71,
+  "textWidthPx": 48.0,
+  "lines": 3
+}]
+```
+
+실측 형태는 playbook §14. 칸 폭은 근사다. 정밀 조판이 아니다.
+
+```bash
+rhwp edit set-cell 양식.hwpx --table 0 --row 1 --col 1 --text "아주아주긴값" --dry-run --json
+```
+
+## 2. dry-run 에서도 온다
+
+파일을 만들기 전에 알 수 있다. 선확인에서 잡고 값을 줄인다.
+
+여러 줄이 정상인 칸(주소·사유)은 overflow 가 떠도 사용자가 승인하면 진행한다.
+에이전트가 혼자 승인하지 않는다.
+
+## 3. insert-image
+
+```json
+"overflow": [{
+  "page": 0,
+  "paperWidthHu": 59528,
+  "paperHeightHu": 84188,
+  "rightHu": 62000,
+  "bottomHu": 76000,
+  "overflowXHu": 2472,
+  "overflowYHu": 0
+}]
+```
+
+자르지 않는다. 좌표를 줄여 다시 dry-run.
+
+## 4. 체크리스트
+
+- [ ] dry-run 에서 overflow 를 읽었다
+- [ ] 비어 있지 않으면 사용자에게 알렸다
+- [ ] exit 0 을 완료로 바꾸지 않았다

--- a/.claude/skills/rhwp-safe-edit/examples/12_ambiguous_not_complete.md
+++ b/.claude/skills/rhwp-safe-edit/examples/12_ambiguous_not_complete.md
@@ -1,0 +1,62 @@
+# 12 — `filledCount` 성공 ≠ 완료
+
+층: 1. 순번 없는 동명 키는 첫 칸만 채우고 `ambiguous` 를 남긴다. exit 0.
+
+권위: [failure_envelopes.md](../references/failure_envelopes.md) §3.2,
+form_filling_guide, #3476.
+
+## 1. 표본
+
+`samples/field-01.hwp` 의 `목차1` ×5.
+
+```bash
+rhwp edit fill-fields samples/field-01.hwp --data '{"목차1":"개요"}' --dry-run --json
+```
+
+기대 골격 [../fixtures/envelopes/fill_ambiguous_exit0.json](../fixtures/envelopes/fill_ambiguous_exit0.json):
+
+```json
+{
+  "filledCount": 1,
+  "filled": [{"name": "목차1", "occurrence": 0, "value": "개요"}],
+  "notFound": [],
+  "ambiguous": [{"name": "목차1", "matched": 1, "total": 5}]
+}
+```
+
+5칸 중 1칸. 이것을 완성본으로 넘기지 않는다.
+
+## 2. 고치는 법
+
+```bash
+rhwp fields samples/field-01.hwp --json | jq -r '.fields[] | select(.name=="목차1") | .name'
+# 다섯 줄 → 순번 0..4
+```
+
+```json
+{"목차1[0]":"개요","목차1[1]":"범위","목차1[2]":"일정","목차1[3]":"예산","목차1[4]":"기타"}
+```
+
+다시 dry-run. `ambiguous` 가 비고 `filledCount` 가 5 인지 본다.
+
+## 3. `notFound` 도 같은 함정
+
+```json
+{"filledCount": 1, "notFound": ["없는필드"], "ambiguous": []}
+```
+
+exit 0. 픽스처 [../fixtures/envelopes/fill_notfound_exit0.json](../fixtures/envelopes/fill_notfound_exit0.json).
+
+3층은 이 키를 선검증에서 거부한다. 1층이 더 관대하므로 봉투를 더 엄격히 읽는다.
+
+## 4. 완료 식
+
+```
+exit ∈ {0,3} AND notFound == [] AND ambiguous == [] AND filledCount == 지목한 키 수
+```
+
+## 5. 체크리스트
+
+- [ ] `fields` 로 동명 개수를 셌다
+- [ ] 동명이면 `이름[N]`
+- [ ] dry-run 의 ambiguous/notFound 를 읽었다

--- a/.claude/skills/rhwp-safe-edit/examples/13_csv_to_table_gate.md
+++ b/.claude/skills/rhwp-safe-edit/examples/13_csv_to_table_gate.md
@@ -1,0 +1,46 @@
+# 13 — CSV 되돌리기 게이트 (`csv-to-table`)
+
+층: 1 인접. 표 전체를 덮어쓰되 치수가 다르면 **한 칸도 쓰지 않는다**.
+
+권위: [single_edit.md](../references/single_edit.md) §9, playbook §13.
+
+표 왕복의 전체 스킬은 rhwp-table-exchange 다. 이 편은 안전 편집 관점의
+`invalid[]` + dry-run 만 고정한다.
+
+## 1. 올바른 순서
+
+```bash
+rhwp table-to-csv 양식.hwpx --table 12 -o t12.csv --json
+# 값만 수정. 행·열·병합 빈 칸을 유지
+rhwp csv-to-table 양식.hwpx --csv t12.csv --table 12 --dry-run --json
+rhwp csv-to-table 양식.hwpx --csv t12.csv --table 12 -o 완성.hwpx --verify --json
+rhwp table-to-csv 완성.hwpx --table 12
+```
+
+손으로 CSV 를 만들지 않는다. 병합 자리를 사람이 비우기는 어렵다.
+
+## 2. 거부 표본
+
+픽스처 [../fixtures/envelopes/csv_to_table_invalid.json](../fixtures/envelopes/csv_to_table_invalid.json).
+
+```
+$ rhwp csv-to-table samples/table-001.hwp --csv out/bad.csv --table 0 --dry-run --json
+{"changed":[],"changedCount":0,"colCount":9,"rowCount":19,
+ "invalid":[
+   {"actual":2,"expected":19,"reason":"rowCountMismatch",
+    "message":"CSV 행 수 2 가 표 0 의 행 수 19 와 다릅니다 — 표 크기는 바꾸지 않습니다."},
+   {"actual":2,"expected":9,"reason":"colCountMismatch","row":0},
+   {"actual":2,"expected":9,"reason":"colCountMismatch","row":1}
+ ]}
+exit=2
+```
+
+`coveredCellNotEmpty` 는 덮인 칸에 값이 있을 때. 앵커에 두고 그 칸은 비운다.
+
+exit 2 여도 봉투가 있다. 단건 `edit` 와 다른 점이다.
+
+## 3. 체크리스트
+
+- [ ] `table-to-csv` 산출을 고쳤다
+- [ ] dry-run 의 `invalid[]` 가 비었다
+- [ ] `--table` 이 `index` 다

--- a/.claude/skills/rhwp-safe-edit/examples/14_batch_fill_row_judgment.md
+++ b/.claude/skills/rhwp-safe-edit/examples/14_batch_fill_row_judgment.md
@@ -1,0 +1,60 @@
+# 14 — 메일머지 행 판정 (`batch fill`)
+
+층: 배치. 원자 `run` 이 아니다. 서식 1 + 데이터 N행.
+행별 `notFound` 가 있어도 **최종 exit 0** 일 수 있다.
+
+권위: [single_edit.md](../references/single_edit.md) §10,
+playbook §9-4.
+
+## 1. 전행 dry-run
+
+```bash
+rhwp batch fill --form samples/field-01.hwp --data out/rows.jsonl \
+  --out-dir out/merge --name-field 회사명 --dry-run --json
+```
+
+실측 세 줄 (playbook):
+
+```
+{"dryRun":true,"filledCount":3,"notFound":[],"row":0, …}
+{"dryRun":true,"filledCount":3,"notFound":[],"row":1, …}
+{"dryRun":true,"filledCount":2,"notFound":["없는필드"],"row":2, …}
+batch fill: 3행 중 3 성공, 0 실패
+exit=0
+```
+
+row 2 는 실행 성공이 아니라 레코드 판정 실패다. 데이터를 고치기 전에
+`--dry-run` 을 떼지 않는다.
+
+픽스처 [../fixtures/envelopes/batch_row_notfound.json](../fixtures/envelopes/batch_row_notfound.json)
+은 그 세 번째 줄의 골격이다.
+
+## 2. 완료 식 (행 단위)
+
+```
+각 레코드: error 없음 AND notFound == [] AND (동명이면 ambiguous 없음)
+전행이 위 식을 만족한 뒤에만 실행
+```
+
+최종 exit 0 을 전행 완료로 읽지 않는다.
+
+## 3. 실행 후
+
+같은 NDJSON 을 다시 훑는다. 표본 한 행만 `fields` 재독.
+실패 행은 `source`/`output`/`row` 로 격리해 단건 `edit fill-fields` 또는
+데이터 수정 후 그 행만 다시 `batch fill` 하지 말고 — 배치 도구가 행 재시도
+입구를 따로 열지 않으면 — 단건으로 처리한다.
+
+## 4. `run` 과의 경계
+
+- N명분 독립 산출 → `batch fill`
+- 한 문서에 여러 종류의 편집 → `run`
+- 한 문서에 칸 하나 → 1층 `edit`
+
+`run` 을 N번 돌리지 않는다. `batch` 를 원자 다단계 대신 쓰지 않는다.
+
+## 5. 체크리스트
+
+- [ ] 전행 dry-run
+- [ ] 행마다 notFound 를 봤다
+- [ ] 최종 exit 0 만 믿지 않았다

--- a/.claude/skills/rhwp-safe-edit/examples/15_original_untouched.md
+++ b/.claude/skills/rhwp-safe-edit/examples/15_original_untouched.md
@@ -1,0 +1,44 @@
+# 15 — 원본이 그대로인지 증명하기
+
+모든 층의 공통 사후 조건. 주장이 아니라 해시/바이트 대조.
+
+권위: [verify_loops.md](../references/verify_loops.md) §9,
+`tests/edit_fill_fields_contract.rs` (dry-run 은 파일을 만들지 않는다).
+
+## 1. 실행 전
+
+```bash
+sha256sum samples/field-01.hwp > /tmp/orig.sha
+# PowerShell
+Get-FileHash samples/field-01.hwp -Algorithm SHA256 | Select-Object Hash
+```
+
+산출 경로가 남아 있으면 지운다. 이전 잔재를 이번 실패의 산출물로 오인하지 않기 위함.
+
+## 2. 수행
+
+02 선확인 + 03 실행 (01 편 또는 07 편). 실패 표본(09)도 좋다.
+
+## 3. 실행 후
+
+```bash
+sha256sum -c /tmp/orig.sha
+cmp samples/field-01.hwp samples/field-01.hwp
+```
+
+원본 경로의 해시가 같아야 한다.
+
+`-o` 가 원본과 같았다면 이 대조는 의미가 없다 — 그 호출 자체가 규약 위반이다.
+`redact --in-place` 는 사용자가 명시한 덮어쓰기이므로 이 편의 대상이 아니다.
+
+## 4. `run` 실패 후
+
+선검증 실패·단언 실패·CAS 실패는 산출 경로를 만들지 않는다.
+`test ! -e out/plan_result.hwp` (잔재를 지운 뒤).
+
+## 5. 체크리스트
+
+- [ ] 실행 전 해시를 떠 두었다
+- [ ] `-o` ≠ input
+- [ ] 실행 후 원본 해시가 같다
+- [ ] 실패 표본에서도 같다

--- a/.claude/skills/rhwp-safe-edit/examples/16_precondition_cas.md
+++ b/.claude/skills/rhwp-safe-edit/examples/16_precondition_cas.md
@@ -1,0 +1,58 @@
+# 16 — CAS 전제 (`preconditions.inputSha256`)
+
+층: 3. 계획이 세워진 뒤 입력이 바뀌면 실행 0·저장 0·exit 3.
+사용법 오류(2)가 아니다. `invalid[]` 는 비어 있다.
+
+권위: [run_plans.md](../references/run_plans.md) §7, #4378 R22, #3905.
+
+## 1. 지문을 얻는 법
+
+실행기가 쓰는 함수는 파일 전체 SHA-256 소문자 64자.
+`Get-FileHash` / `sha256sum` 과 같다.
+
+```bash
+sha256sum samples/field-01.hwp
+```
+
+계획서:
+
+```json
+"preconditions": {
+  "inputSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+```
+
+픽스처 [../fixtures/plans/valid_preconditions.json](../fixtures/plans/valid_preconditions.json)
+은 자리만 맞춘 표본이다. 실제 해시는 실행 시 다시 계산한다.
+
+## 2. 불일치 봉투
+
+픽스처 [../fixtures/envelopes/run_precondition_failed.json](../fixtures/envelopes/run_precondition_failed.json).
+
+- exit **3**
+- `invalid: []`
+- `preconditionFailed.kind == "inputSha256"`
+- `expected` / `actual`
+- `nextCall.name == "run"`
+- `nextCall.arguments` 에 `--plan-json` (actual 해시로 교체된 계획), `--dry-run`, `--json`
+
+## 3. 다음 호출
+
+`nextCall` 을 그대로 실행한다. dry-run 이라 디스크를 안 건드린다.
+
+- 통과: `--dry-run` 만 빼고 같은 계획을 실행
+- `invalid[]` 가 나옴: 문서가 바뀌어 step 이 성립하지 않음. 발견부터 재계획
+
+인자를 고쳐 exit 2 를 없애려 하지 마라. 문법이 틀린 것이 아니다.
+
+## 4. 문법 오류와의 구분
+
+빈 `preconditions: {}` 는 exit 2 (`inputSha256` 하나 필요).
+64자가 아닌 문자열도 exit 2.
+이것은 4.2 갈래 (FixPlanKeys) 이지 CAS 판정이 아니다.
+
+## 5. 체크리스트
+
+- [ ] 불일치를 exit 2 로 분류하지 않았다
+- [ ] `invalid[]` 가 비어 있음을 확인했다
+- [ ] `nextCall` 을 dry-run 으로 실행했다

--- a/.claude/skills/rhwp-safe-edit/examples/README.md
+++ b/.claude/skills/rhwp-safe-edit/examples/README.md
@@ -1,0 +1,45 @@
+# rhwp-safe-edit 워크스루
+
+이 폴더는 스킬이 안내하는 경로를 **한 편씩** 끝까지 적어 둔 표본이다.
+새 편집 명령을 만들지 않는다. 각 편은 이미 있는 CLI 와 이미 있는 봉투 키만 사용한다.
+
+레퍼런스:
+
+- 1층: [../references/single_edit.md](../references/single_edit.md)
+- 3층: [../references/run_plans.md](../references/run_plans.md)
+- 루프: [../references/verify_loops.md](../references/verify_loops.md)
+- 봉투: [../references/failure_envelopes.md](../references/failure_envelopes.md)
+
+픽스처 JSON 은 [../fixtures/catalog.json](../fixtures/catalog.json) 이 목록이다.
+워크스루의 "기대 봉투" 블록은 그 픽스처와 같은 키를 쓴다.
+
+## 목록
+
+| # | 파일 | 층 | 보여주는 것 |
+|---|------|----|-------------|
+| 01 | [01_fill_fields_single.md](01_fill_fields_single.md) | 1 | 발견 → dry-run → `-o --verify` → fields 재독 |
+| 02 | [02_replace_text_single.md](02_replace_text_single.md) | 1 | search → 치환 → matchCount 0 |
+| 03 | [03_set_cell_single.md](03_set_cell_single.md) | 1 | export-tables 좌표 → set-cell → 재독 |
+| 04 | [04_insert_image_single.md](04_insert_image_single.md) | 1 | HWPUNIT · overflow · run 에 넣지 않음 |
+| 05 | [05_redact_single.md](05_redact_single.md) | 1 | `-o` 필수 · `--no-raw` · dry-run 먼저 |
+| 06 | [06_sanitize_single.md](06_sanitize_single.md) | 1 | removedCount 재실행 0 · 본문 불변 |
+| 07 | [07_run_atomic_fill_replace.md](07_run_atomic_fill_replace.md) | 3 | 스키마 → dry-run → 원자 저장 |
+| 08 | [08_run_conditional.md](08_run_conditional.md) | 3 | if 한 종류 · 입력 기준 1회 판정 |
+| 09 | [09_run_invalid_collected.md](09_run_invalid_collected.md) | 3 | invalid[] 전부 수집 · 디스크 무변경 |
+| 10 | [10_verify_exit3.md](10_verify_exit3.md) | 1/3 | exit 3 두 갈래 (산출 남김 vs 안 남김) |
+| 11 | [11_overflow_data.md](11_overflow_data.md) | 1 | overflow 는 성공 코드 안의 경고 |
+| 12 | [12_ambiguous_not_complete.md](12_ambiguous_not_complete.md) | 1 | filledCount ≠ 완료 |
+| 13 | [13_csv_to_table_gate.md](13_csv_to_table_gate.md) | 1 | invalid[] + 한 칸도 안 씀 |
+| 14 | [14_batch_fill_row_judgment.md](14_batch_fill_row_judgment.md) | 배치 | 행별 notFound · 최종 exit 0 |
+| 15 | [15_original_untouched.md](15_original_untouched.md) | 공통 | 원본 해시 대조 |
+| 16 | [16_precondition_cas.md](16_precondition_cas.md) | 3 | CAS exit 3 · nextCall |
+
+## 공통 규칙
+
+1. 입력은 저장소 공개 샘플 (`samples/field-01.hwp`, `samples/table-001.hwp` 등) 또는
+   워크스루가 밝히는 가명 경로다. 새 바이너리 픽스처를 이 폴더에 두지 않는다.
+2. 명령은 `rhwp ` 로 시작하는 실재 토큰만 쓴다 (`tests/skills_contract.rs` 가 SKILL.md 를,
+   `scripts/tests/test_agent_safe_edit.py` 가 레퍼런스·예제를 검사).
+3. "하지 않는 호출" 절이 각 편에 있다. 무계획 `--in-place` 와 `edit` 체인은 여기 표본에 없다.
+4. 기대 봉투는 키 집합이 계약이다. 수치(`filledCount: 2`)는 샘플이 바뀌면 변할 수 있어
+   테스트는 키·exit·분기 이름을 고정하고 숫자는 표본으로만 둔다.

--- a/.claude/skills/rhwp-safe-edit/fixtures/catalog.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/catalog.json
@@ -1,0 +1,92 @@
+{
+  "catalogVersion": "1.0",
+  "skill": "rhwp-safe-edit",
+  "issue": 5294,
+  "note": "새 편집 로직이 아니라 기존 edit/run 계약을 표본으로 고정한다.",
+  "actions": [
+    "fill_fields",
+    "replace_text",
+    "set_cell",
+    "set_checkbox"
+  ],
+  "plans": {
+    "valid": [
+      "valid_fill_fields.json",
+      "valid_replace_text.json",
+      "valid_set_cell.json",
+      "valid_set_checkbox.json",
+      "valid_multi_step.json",
+      "valid_conditional_field_exists.json",
+      "valid_conditional_field_equals.json",
+      "valid_conditional_text_found.json",
+      "valid_assertions_verify.json",
+      "valid_preconditions.json",
+      "valid_dry_run_flag.json",
+      "valid_replace_occurrence.json"
+    ],
+    "invalid": [
+      "invalid_missing_plan_version.json",
+      "invalid_wrong_keys_source_op.json",
+      "invalid_empty_steps.json",
+      "invalid_unknown_action.json",
+      "invalid_camel_action.json",
+      "invalid_replace_empty_find.json",
+      "invalid_set_cell_newline.json",
+      "invalid_two_conditions.json",
+      "invalid_numeric_plan_version.json"
+    ]
+  },
+  "envelopes": [
+    "fill_ok.json",
+    "fill_notfound_exit0.json",
+    "fill_ambiguous_exit0.json",
+    "verify_null.json",
+    "edit_verify_ok.json",
+    "edit_verify_diff.json",
+    "replace_zero.json",
+    "set_cell_overflow.json",
+    "redact_missing_output.json",
+    "run_dry_run_preview.json",
+    "run_invalid_replace_zero.json",
+    "run_invalid_collected.json",
+    "run_error_plan_version.json",
+    "run_precondition_failed.json",
+    "run_verify_fail_no_output.json",
+    "csv_to_table_invalid.json",
+    "batch_row_notfound.json",
+    "insert_image_overflow.json",
+    "sanitize_second_run_zero.json"
+  ],
+  "loops": [
+    "layer1_fill.json",
+    "layer1_replace.json",
+    "layer1_set_cell.json",
+    "layer3_run.json",
+    "verify_null_vs_object.json",
+    "changed_pages_null.json"
+  ],
+  "examples": [
+    "01_fill_fields_single.md",
+    "02_replace_text_single.md",
+    "03_set_cell_single.md",
+    "04_insert_image_single.md",
+    "05_redact_single.md",
+    "06_sanitize_single.md",
+    "07_run_atomic_fill_replace.md",
+    "08_run_conditional.md",
+    "09_run_invalid_collected.md",
+    "10_verify_exit3.md",
+    "11_overflow_data.md",
+    "12_ambiguous_not_complete.md",
+    "13_csv_to_table_gate.md",
+    "14_batch_fill_row_judgment.md",
+    "15_original_untouched.md",
+    "16_precondition_cas.md"
+  ],
+  "references": [
+    "single_edit.md",
+    "run_plans.md",
+    "verify_loops.md",
+    "failure_envelopes.md"
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/batch_row_notfound.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/batch_row_notfound.json
@@ -1,0 +1,17 @@
+{
+  "dryRun": true,
+  "filledCount": 2,
+  "notFound": [
+    "없는필드"
+  ],
+  "output": "out/merge/라마바.hwp",
+  "row": 2,
+  "source": "samples/field-01.hwp",
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "row-incomplete",
+    "layer": "batch-fill",
+    "complete": false
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/csv_to_table_invalid.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/csv_to_table_invalid.json
@@ -1,0 +1,33 @@
+{
+  "changed": [],
+  "changedCount": 0,
+  "colCount": 9,
+  "rowCount": 19,
+  "invalid": [
+    {
+      "actual": 2,
+      "expected": 19,
+      "reason": "rowCountMismatch",
+      "message": "CSV 행 수 2 가 표 0 의 행 수 19 와 다릅니다 — 표 크기는 바꾸지 않습니다."
+    },
+    {
+      "actual": 2,
+      "expected": 9,
+      "reason": "colCountMismatch",
+      "row": 0
+    },
+    {
+      "actual": 2,
+      "expected": 9,
+      "reason": "colCountMismatch",
+      "row": 1
+    }
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 2,
+    "branch": "FixPlan",
+    "outputKept": false,
+    "layer": "csv-to-table"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/edit_verify_diff.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/edit_verify_diff.json
@@ -1,0 +1,18 @@
+{
+  "source": "samples/field-01.hwp",
+  "output": "out/field-filled.hwp",
+  "outputFormat": "hwp5",
+  "verify": {
+    "identical": false,
+    "diffCount": 2
+  },
+  "filledCount": 1,
+  "notFound": [],
+  "ambiguous": [],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 3,
+    "branch": "InspectKeptOutput",
+    "outputKept": true
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/edit_verify_ok.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/edit_verify_ok.json
@@ -1,0 +1,18 @@
+{
+  "source": "samples/field-01.hwp",
+  "output": "out/field-filled.hwp",
+  "outputFormat": "hwp5",
+  "verify": {
+    "identical": true,
+    "diffCount": 0
+  },
+  "filledCount": 1,
+  "notFound": [],
+  "ambiguous": [],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "verify-ok",
+    "outputKept": true
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/fill_ambiguous_exit0.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/fill_ambiguous_exit0.json
@@ -1,0 +1,27 @@
+{
+  "source": "samples/field-01.hwp",
+  "dryRun": true,
+  "filledCount": 1,
+  "filled": [
+    {
+      "name": "목차1",
+      "occurrence": 0,
+      "value": "개요"
+    }
+  ],
+  "notFound": [],
+  "ambiguous": [
+    {
+      "name": "목차1",
+      "matched": 1,
+      "total": 5
+    }
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "incomplete-ambiguous",
+    "layer": "edit-fill-fields",
+    "complete": false
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/fill_notfound_exit0.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/fill_notfound_exit0.json
@@ -1,0 +1,26 @@
+{
+  "source": "samples/field-01.hwp",
+  "dryRun": false,
+  "filledCount": 1,
+  "filled": [
+    {
+      "name": "회사명",
+      "occurrence": 0,
+      "value": "페타플로"
+    }
+  ],
+  "notFound": [
+    "없는필드"
+  ],
+  "ambiguous": [],
+  "output": "out/field-filled.hwp",
+  "outputFormat": "hwp5",
+  "verify": null,
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "incomplete-notFound",
+    "layer": "edit-fill-fields",
+    "complete": false
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/fill_ok.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/fill_ok.json
@@ -1,0 +1,34 @@
+{
+  "source": "samples/field-01.hwp",
+  "dryRun": false,
+  "filledCount": 2,
+  "filled": [
+    {
+      "name": "회사명",
+      "occurrence": 0,
+      "value": "페타플로"
+    },
+    {
+      "name": "작성자",
+      "occurrence": 0,
+      "value": "홍길동"
+    }
+  ],
+  "notFound": [],
+  "ambiguous": [],
+  "output": "out/field-filled.hwp",
+  "outputFormat": "hwp5",
+  "verify": {
+    "identical": true,
+    "diffCount": 0
+  },
+  "changedPages": [
+    0
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "ok",
+    "layer": "edit-fill-fields"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/insert_image_overflow.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/insert_image_overflow.json
@@ -1,0 +1,28 @@
+{
+  "source": "신청서_filled.hwp",
+  "image": "samples/images/moogung.jpg",
+  "page": 0,
+  "x": 50000,
+  "y": 70000,
+  "width": 5000,
+  "height": 5000,
+  "dryRun": true,
+  "overflow": [
+    {
+      "page": 0,
+      "paperWidthHu": 59528,
+      "paperHeightHu": 84188,
+      "rightHu": 62000,
+      "bottomHu": 76000,
+      "overflowXHu": 2472,
+      "overflowYHu": 0
+    }
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "WarnOverflow",
+    "layer": "edit-insert-image",
+    "complete": false
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/redact_missing_output.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/redact_missing_output.json
@@ -1,0 +1,13 @@
+{
+  "_skillMeta": {
+    "exit": 2,
+    "branch": "FixArgv",
+    "stdoutBytes": 0,
+    "layer": "edit-redact"
+  },
+  "stderrContains": "마스킹은 되돌릴 수 없습니다",
+  "requires": [
+    "-o",
+    "--in-place"
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/replace_zero.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/replace_zero.json
@@ -1,0 +1,15 @@
+{
+  "source": "공문.hwp",
+  "find": "없는문자열XYZ",
+  "replace": "X",
+  "caseSensitive": true,
+  "dryRun": false,
+  "replacedCount": 0,
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "no-output",
+    "outputKept": false,
+    "layer": "edit-replace-text"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_dry_run_preview.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_dry_run_preview.json
@@ -1,0 +1,39 @@
+{
+  "planVersion": "1.0",
+  "dryRun": true,
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "preview": [
+    {
+      "step": 0,
+      "action": "fill_fields",
+      "targets": [
+        {
+          "name": "회사명",
+          "occurrence": 0,
+          "sameNameCount": 1,
+          "value": "페타플로"
+        }
+      ]
+    },
+    {
+      "step": 1,
+      "action": "replace_text",
+      "find": "2025년",
+      "matches": 7,
+      "willReplace": 7
+    }
+  ],
+  "invalid": [],
+  "assertions": {
+    "notFoundEmpty": true,
+    "verify": true
+  },
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "preview",
+    "outputKept": false,
+    "layer": "run"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_error_plan_version.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_error_plan_version.json
@@ -1,0 +1,9 @@
+{
+  "error": "planVersion \"1.0\" 이 필요합니다",
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 2,
+    "branch": "FixPlanKeys",
+    "layer": "run"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_invalid_collected.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_invalid_collected.json
@@ -1,0 +1,30 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "invalid": [
+    {
+      "step": 0,
+      "action": "fill_fields",
+      "reason": "필드 '없는필드' 이(가) 없거나 순번이 범위 밖입니다 (동명 0개)"
+    },
+    {
+      "step": 1,
+      "action": "replace_text",
+      "reason": "'여기에 입력' 일치 0건 — 치환할 곳이 없습니다"
+    },
+    {
+      "step": 2,
+      "action": "insert_image",
+      "reason": "알 수 없는 action: insert_image (fill_fields·replace_text·set_cell·set_checkbox)"
+    }
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 2,
+    "branch": "FixPlan",
+    "outputKept": false,
+    "layer": "run",
+    "collected": true
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_invalid_replace_zero.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_invalid_replace_zero.json
@@ -1,0 +1,19 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "invalid": [
+    {
+      "step": 1,
+      "action": "replace_text",
+      "reason": "'여기에 입력' 일치 0건 — 치환할 곳이 없습니다"
+    }
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 2,
+    "branch": "FixPlan",
+    "outputKept": false,
+    "layer": "run"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_precondition_failed.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_precondition_failed.json
@@ -1,0 +1,29 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "invalid": [],
+  "preconditionFailed": {
+    "kind": "inputSha256",
+    "expected": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "actual": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "nextCall": {
+    "name": "run",
+    "arguments": [
+      "--plan-json",
+      "{}",
+      "--dry-run",
+      "--json"
+    ],
+    "why": "계획 수립 후 입력 문서가 바뀌었습니다. 같은 의도를 새 지문으로 다시 선검증하세요 — 통과하면 --dry-run 만 빼고 그대로 실행하고, invalid 가 나오면 문서를 다시 읽고 재계획하세요."
+  },
+  "error": "입력 문서가 계획의 기대 해시와 다릅니다 — 계획 수립 후 문서가 바뀌었습니다. 실행 0·저장 0. nextCall 로 재계획하세요 (#3905 CAS).",
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 3,
+    "branch": "Call-nextCall",
+    "outputKept": false,
+    "layer": "run"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_verify_fail_no_output.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/run_verify_fail_no_output.json
@@ -1,0 +1,37 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "step": 0,
+      "action": "fill_fields",
+      "filledCount": 1,
+      "filled": [
+        {
+          "name": "회사명",
+          "occurrence": 0,
+          "value": "X"
+        }
+      ],
+      "notFound": [],
+      "ambiguous": [],
+      "confusable": []
+    }
+  ],
+  "assertions": {
+    "notFoundEmpty": true,
+    "verify": true
+  },
+  "verify": {
+    "identical": false,
+    "diffCount": 1
+  },
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 3,
+    "branch": "ReplanNoOutput",
+    "outputKept": false,
+    "layer": "run"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/sanitize_second_run_zero.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/sanitize_second_run_zero.json
@@ -1,0 +1,14 @@
+{
+  "source": "배포본.hwp",
+  "keepPreview": false,
+  "removedCount": 0,
+  "removed": [],
+  "output": "/tmp/재확인.hwp",
+  "outputFormat": "hwp5",
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "already-clean",
+    "layer": "edit-sanitize"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/set_cell_overflow.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/set_cell_overflow.json
@@ -1,0 +1,26 @@
+{
+  "source": "양식.hwpx",
+  "table": 0,
+  "row": 1,
+  "col": 1,
+  "oldText": "",
+  "newText": "아주아주긴값",
+  "dryRun": true,
+  "keepStyle": false,
+  "overflow": [
+    {
+      "target": "table0[1,1]",
+      "text": "아주아주긴값",
+      "cellWidthPx": 20.71,
+      "textWidthPx": 48.0,
+      "lines": 3
+    }
+  ],
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "WarnOverflow",
+    "complete": false,
+    "layer": "edit-set-cell"
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/envelopes/verify_null.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/envelopes/verify_null.json
@@ -1,0 +1,29 @@
+{
+  "source": "samples/field-01.hwp",
+  "dryRun": false,
+  "filledCount": 2,
+  "filled": [
+    {
+      "name": "회사명",
+      "occurrence": 0,
+      "value": "페타플로"
+    },
+    {
+      "name": "작성자",
+      "occurrence": 0,
+      "value": "홍길동"
+    }
+  ],
+  "notFound": [],
+  "ambiguous": [],
+  "output": "out/field-filled.hwp",
+  "outputFormat": "hwp5",
+  "verify": null,
+  "schemaVersion": "1.0",
+  "_skillMeta": {
+    "exit": 0,
+    "branch": "verify-not-requested",
+    "layer": "edit-fill-fields",
+    "verified": false
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/loops/changed_pages_null.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/loops/changed_pages_null.json
@@ -1,0 +1,22 @@
+{
+  "id": "changed_pages_null",
+  "layer": "any",
+  "goal": "changedPages null ≠ 빈 배열",
+  "invariants": [
+    {
+      "value": null,
+      "meaning": "확정 불가. dry-run 또는 조판 전. 눈검증 금지"
+    },
+    {
+      "value": [],
+      "meaning": "바뀐 쪽 없음. 렌더 불필요"
+    },
+    {
+      "value": [
+        0,
+        1
+      ],
+      "meaning": "그 쪽만 export-svg -p"
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/loops/layer1_fill.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/loops/layer1_fill.json
@@ -1,0 +1,83 @@
+{
+  "id": "layer1_fill",
+  "layer": 1,
+  "goal": "누름틀 채움 루프",
+  "sample": "samples/field-01.hwp",
+  "steps": [
+    {
+      "id": "discover",
+      "command": [
+        "rhwp",
+        "fields",
+        "samples/field-01.hwp",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "fields"
+      ]
+    },
+    {
+      "id": "dry-run",
+      "command": [
+        "rhwp",
+        "edit",
+        "fill-fields",
+        "samples/field-01.hwp",
+        "--data",
+        "{\"회사명\":\"페타플로\"}",
+        "--dry-run",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "dryRun",
+        "notFound",
+        "ambiguous",
+        "filledCount"
+      ],
+      "forbidFieldsPresent": [
+        "output"
+      ],
+      "mustNotCreate": "out/field-filled.hwp"
+    },
+    {
+      "id": "execute",
+      "command": [
+        "rhwp",
+        "edit",
+        "fill-fields",
+        "samples/field-01.hwp",
+        "--data",
+        "{\"회사명\":\"페타플로\"}",
+        "-o",
+        "out/field-filled.hwp",
+        "--verify",
+        "--json"
+      ],
+      "expectExit": [
+        0,
+        3
+      ],
+      "readFields": [
+        "output",
+        "verify",
+        "notFound",
+        "ambiguous"
+      ]
+    },
+    {
+      "id": "reread",
+      "command": [
+        "rhwp",
+        "fields",
+        "out/field-filled.hwp",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "fields"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/loops/layer1_replace.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/loops/layer1_replace.json
@@ -1,0 +1,80 @@
+{
+  "id": "layer1_replace",
+  "layer": 1,
+  "goal": "치환 후 search matchCount",
+  "steps": [
+    {
+      "id": "discover",
+      "command": [
+        "rhwp",
+        "search",
+        "공문.hwp",
+        "2025년",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "matchCount"
+      ]
+    },
+    {
+      "id": "dry-run",
+      "command": [
+        "rhwp",
+        "edit",
+        "replace-text",
+        "공문.hwp",
+        "--find",
+        "2025년",
+        "--replace",
+        "2026년",
+        "--dry-run",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "replacedCount",
+        "dryRun"
+      ]
+    },
+    {
+      "id": "execute",
+      "command": [
+        "rhwp",
+        "edit",
+        "replace-text",
+        "공문.hwp",
+        "--find",
+        "2025년",
+        "--replace",
+        "2026년",
+        "-o",
+        "개정본.hwp",
+        "--json"
+      ],
+      "expectExit": [
+        0,
+        3
+      ],
+      "readFields": [
+        "replacedCount",
+        "changedPages"
+      ]
+    },
+    {
+      "id": "reread",
+      "command": [
+        "rhwp",
+        "search",
+        "개정본.hwp",
+        "2025년",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "matchCount"
+      ],
+      "expectMatchCount": 0
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/loops/layer1_set_cell.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/loops/layer1_set_cell.json
@@ -1,0 +1,87 @@
+{
+  "id": "layer1_set_cell",
+  "layer": 1,
+  "goal": "export-tables 왕복",
+  "steps": [
+    {
+      "id": "discover",
+      "command": [
+        "rhwp",
+        "export-tables",
+        "양식.hwpx",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "tables"
+      ]
+    },
+    {
+      "id": "dry-run",
+      "command": [
+        "rhwp",
+        "edit",
+        "set-cell",
+        "양식.hwpx",
+        "--table",
+        "12",
+        "--row",
+        "1",
+        "--col",
+        "1",
+        "--text",
+        "1,234",
+        "--dry-run",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "oldText",
+        "newText",
+        "overflow"
+      ]
+    },
+    {
+      "id": "execute",
+      "command": [
+        "rhwp",
+        "edit",
+        "set-cell",
+        "양식.hwpx",
+        "--table",
+        "12",
+        "--row",
+        "1",
+        "--col",
+        "1",
+        "--text",
+        "1,234",
+        "-o",
+        "작성본.hwpx",
+        "--json"
+      ],
+      "expectExit": [
+        0,
+        3
+      ],
+      "readFields": [
+        "newText",
+        "changedPages",
+        "outputFormat"
+      ]
+    },
+    {
+      "id": "reread",
+      "command": [
+        "rhwp",
+        "export-tables",
+        "작성본.hwpx",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "tables"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/loops/layer3_run.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/loops/layer3_run.json
@@ -1,0 +1,72 @@
+{
+  "id": "layer3_run",
+  "layer": 3,
+  "goal": "스키마 → dry-run → 원자 실행",
+  "steps": [
+    {
+      "id": "schema",
+      "command": [
+        "rhwp",
+        "export-plan-schema",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "planSchemaVersion",
+        "definitionCount",
+        "schema"
+      ]
+    },
+    {
+      "id": "dry-run",
+      "command": [
+        "rhwp",
+        "run",
+        "out/plan.json",
+        "--dry-run",
+        "--json"
+      ],
+      "expectExit": [
+        0,
+        2
+      ],
+      "readFields": [
+        "invalid",
+        "preview",
+        "dryRun"
+      ],
+      "mustNotCreate": "out/plan_result.hwp"
+    },
+    {
+      "id": "execute",
+      "command": [
+        "rhwp",
+        "run",
+        "out/plan.json",
+        "--json"
+      ],
+      "expectExit": [
+        0,
+        3
+      ],
+      "readFields": [
+        "steps",
+        "verify",
+        "changedPages"
+      ]
+    },
+    {
+      "id": "reread",
+      "command": [
+        "rhwp",
+        "fields",
+        "out/plan_result.hwp",
+        "--json"
+      ],
+      "expectExit": 0,
+      "readFields": [
+        "fields"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/loops/verify_null_vs_object.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/loops/verify_null_vs_object.json
@@ -1,0 +1,23 @@
+{
+  "id": "verify_null_vs_object",
+  "layer": 1,
+  "goal": "verify null 은 통과가 아니다",
+  "invariants": [
+    {
+      "when": "verify_requested == false",
+      "field": "verify",
+      "equals": null,
+      "notMeaning": "passed"
+    },
+    {
+      "when": "verify.identical == true",
+      "expectExit": 0
+    },
+    {
+      "when": "verify.identical == false",
+      "expectExit": 3,
+      "outputKeptIfLayer": 1,
+      "outputKeptIfLayer3": false
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_camel_action.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_camel_action.json
@@ -1,0 +1,13 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fillFields",
+      "data": {
+        "회사명": "X"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_empty_steps.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_empty_steps.json
@@ -1,0 +1,6 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": []
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_missing_plan_version.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_missing_plan_version.json
@@ -1,0 +1,12 @@
+{
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "X"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_numeric_plan_version.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_numeric_plan_version.json
@@ -1,0 +1,13 @@
+{
+  "planVersion": 1.0,
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "X"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_replace_empty_find.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_replace_empty_find.json
@@ -1,0 +1,12 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "replace_text",
+      "find": "",
+      "replace": "X"
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_set_cell_newline.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_set_cell_newline.json
@@ -1,0 +1,14 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "set_cell",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "text": "a\\nb"
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_two_conditions.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_two_conditions.json
@@ -1,0 +1,16 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "replace_text",
+      "find": "A",
+      "replace": "B",
+      "if": {
+        "fieldExists": "회사명",
+        "textFound": "회사"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_unknown_action.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_unknown_action.json
@@ -1,0 +1,11 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "insert_image",
+      "image": "stamp.png"
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_wrong_keys_source_op.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/invalid_wrong_keys_source_op.json
@@ -1,0 +1,12 @@
+{
+  "source": "samples/field-01.hwp",
+  "out": "out/plan_result.hwp",
+  "ops": [
+    {
+      "op": "fill",
+      "fields": {
+        "회사명": "X"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_assertions_verify.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_assertions_verify.json
@@ -1,0 +1,17 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "페타플로"
+      }
+    }
+  ],
+  "assertions": {
+    "notFoundEmpty": true,
+    "verify": true
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_conditional_field_equals.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_conditional_field_equals.json
@@ -1,0 +1,19 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "비고": "해당없음"
+      },
+      "if": {
+        "fieldEquals": {
+          "name": "회사명",
+          "value": ""
+        }
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_conditional_field_exists.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_conditional_field_exists.json
@@ -1,0 +1,15 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "replace_text",
+      "find": "임시",
+      "replace": "확정",
+      "if": {
+        "fieldExists": "회사명"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_conditional_text_found.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_conditional_text_found.json
@@ -1,0 +1,14 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "set_checkbox",
+      "occurrence": 0,
+      "if": {
+        "textFound": "회사"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_dry_run_flag.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_dry_run_flag.json
@@ -1,0 +1,14 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "페타플로"
+      }
+    }
+  ],
+  "dryRun": true
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_fill_fields.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_fill_fields.json
@@ -1,0 +1,14 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "페타플로",
+        "작성자": "홍길동"
+      }
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_multi_step.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_multi_step.json
@@ -1,0 +1,24 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "페타플로",
+        "작성자": "홍길동"
+      }
+    },
+    {
+      "action": "fill_fields",
+      "data": {
+        "목차1[0]": "개요"
+      }
+    }
+  ],
+  "assertions": {
+    "notFoundEmpty": true,
+    "verify": true
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_preconditions.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_preconditions.json
@@ -1,0 +1,19 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "fill_fields",
+      "data": {
+        "회사명": "페타플로"
+      }
+    }
+  ],
+  "preconditions": {
+    "inputSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "assertions": {
+    "verify": true
+  }
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_replace_occurrence.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_replace_occurrence.json
@@ -1,0 +1,13 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "replace_text",
+      "find": "목차",
+      "replace": "차례",
+      "occurrence": 0
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_replace_text.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_replace_text.json
@@ -1,0 +1,13 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "replace_text",
+      "find": "회사명",
+      "replace": "상호",
+      "caseSensitive": true
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_set_cell.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_set_cell.json
@@ -1,0 +1,15 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "set_cell",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "text": "1,234",
+      "keepStyle": false
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_set_checkbox.json
+++ b/.claude/skills/rhwp-safe-edit/fixtures/plans/valid_set_checkbox.json
@@ -1,0 +1,11 @@
+{
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "steps": [
+    {
+      "action": "set_checkbox",
+      "occurrence": 0
+    }
+  ]
+}

--- a/.claude/skills/rhwp-safe-edit/references/failure_envelopes.md
+++ b/.claude/skills/rhwp-safe-edit/references/failure_envelopes.md
@@ -1,0 +1,492 @@
+# 실패 봉투 — exit 3/4 와 판정 필드
+
+이 문서는 rhwp-safe-edit 가 **실패를 예외가 아니라 데이터로** 읽는 규약이다.
+새 종료 코드를 만들지 않는다. #2707 계약과 `run_plan_engine` 이 이미 내는
+저널 모양만 사전으로 옮긴다.
+
+권위: [`mydocs/manual/cli_commands.md`](../../../../mydocs/manual/cli_commands.md) §종료 코드,
+[`mydocs/manual/agent_knowledge_map.md`](../../../../mydocs/manual/agent_knowledge_map.md) §2,
+[`mydocs/manual/agent_troubleshooting_guide.md`](../../../../mydocs/manual/agent_troubleshooting_guide.md),
+`tests/cli_exit_codes.rs`, `tests/edit_verify_contract.rs`, `tests/plan_schema_contract.rs`.
+
+1층은 [single_edit.md](single_edit.md). 3층은 [run_plans.md](run_plans.md).
+루프는 [verify_loops.md](verify_loops.md).
+
+---
+
+## 0. 한 줄
+
+```
+종료 코드를 먼저 본다 → stdout 가 있으면 파싱한다 → 판정 필드로 분기한다.
+exit 3/4 는 고장이 아니다. notFound 는 성공 코드 안의 미완료다.
+```
+
+바인딩이 3/4 를 예외로 올리면 호출자가 `diffCount` 를 읽지 못하게 된다.
+그 바인딩은 이 스킬의 계약과 어긋난다.
+
+---
+
+## 1. 종료 코드 표 (#2707)
+
+| exit | 이름 | 이 스킬에서 만나는 때 | stdout | 디스크 |
+|-----:|------|----------------------|--------|--------|
+| 0 | 성공 | 명령이 수행됨. 데이터 신호는 **별도 확인** | 봉투 (`--json`) | 1층은 변경 있으면 `-o` 에 기록. 0건이면 안 만듦 |
+| 1 | 런타임 | 파일 없음, 파싱 실패, 쓰기 실패, 암호 | **0바이트** (단건) | 원본 불변. 산출 안 씀 |
+| 2 | 사용법 | 인자 오조립, 계획서 문법, 선검증 위반, redact 경로 거부, 병합 칸 | 단건 edit = 0바이트. **`run`/`csv-to-table` = invalid[] 봉투** | 원본 불변 |
+| 3 | 판정 | `--verify` IR 차이, `run` assertions.verify 실패, `run` CAS 불일치, `ir-diff --json` 차이 | 봉투 | 1층·convert 는 산출 **남김**. `run` 단언/CAS 는 **안 남김** |
+| 4 | 쪽 수 판정 | `convert`/`export-hwpx --verify-pages` | 봉투 | 산출 남김. 이 스킬의 기본 `edit`/`run` 경로는 4 를 내지 않음 |
+
+알 수 없는 명령·옵션은 경고 후 진행하지 않고 즉시 2. 안내는 stderr.
+정형 수복 줄(#4220 T4)이 있으면 stderr 마지막 줄이 `수복: {nextCall…}` 이다.
+소비자는 그 한 줄만 파싱하면 된다. 런타임 실패(1)에는 이 줄이 없다.
+
+---
+
+## 2. stdout 이 비었을 때 / 있을 때
+
+### 2.1 단건 `edit` 6종
+
+exit 1 또는 2 → stdout 0바이트. JSON 파서를 돌리지 마라.
+stderr 사람용 메시지를 읽고 인자를 고친다.
+
+exit 0·3 → stdout 봉투. 3 이어도 파싱한다. 그것이 이 문서의 핵심이다.
+
+### 2.2 `run`
+
+모든 실패가 봉투를 낼 수 있다.
+
+| 상황 | exit | 봉투 키 |
+|------|-----:|---------|
+| `planVersion` 누락/오값 | 2 | `error` |
+| `input`/`output`/`steps` 누락 | 2 | `error` |
+| 계획 JSON 파싱 실패 | 2 | (사람용 stderr, 파일 입구) |
+| 계획 파일 없음 | 1 | (사람용 stderr) |
+| 입력 문서 읽기/파싱 실패 | 1 | `error` |
+| 선검증 위반 | 2 | `invalid[]` (1개 이상) |
+| CAS 불일치 | 3 | `invalid: []`, `preconditionFailed`, `nextCall` |
+| assertions.verify 실패 | 3 | `verify.identical: false`, 저장 없음 |
+| 성공 | 0 | `steps[]` 또는 dry-run 이면 `preview[]` |
+
+규칙: **exit 2 라고 stdout 을 버리지 마라.** 비어 있지 않으면 읽는다.
+
+### 2.3 `csv-to-table`
+
+exit 2 + `invalid[]`. 한 칸도 쓰지 않았다는 증거가 봉투에 있다.
+
+### 2.4 `batch`
+
+한 건이라도 런타임 실패면 최종 exit 1 이지만 **스트림은 끝까지** 흐른다.
+레코드에 `error` 가 있는 줄만 격리한다. 집계:
+
+- `error` 있으면 1
+- 없고 `verifyPages` 불일치면 4
+- `verify` 차이만 있으면 3
+- 전부 통과면 0
+
+`source` 가 어느 줄이 어느 파일인지 잇는 유일한 키다.
+
+---
+
+## 3. 성공 코드 안의 미완료 — 가장 위험한 갈래
+
+exit 0 인데 작업이 끝나지 않은 신호들이다. 예외가 안 나므로 에이전트가 가장 잘 놓친다.
+
+### 3.1 `notFound[]`
+
+`edit fill-fields` 가 문서에 없는 이름, 또는 범위 밖 `이름[N]` 을 여기에 싣는다.
+exit 는 0. `filledCount` 는 찾은 칸만 센다.
+
+```json
+{"filledCount": 1, "notFound": ["없는필드", "목차1[99]"], "ambiguous": []}
+```
+
+완료 조건에 `notFound == []` 를 넣지 않으면 덜 채운 산출물이 완성본이 된다.
+
+3층 `run` 은 이 경우를 선검증에서 거부한다 (`invalid[]` + exit 2).
+1층과 3층의 엄격함이 다르다. 1층을 쓸 때 더 조심한다.
+
+### 3.2 `ambiguous[]`
+
+순번 없는 이름이 여러 칸에 해당할 때.
+
+```json
+{"name": "목차1", "matched": 1, "total": 5}
+```
+
+첫 칸만 채웠다. 나머지 4칸은 그대로다. `filledCount: 1` 은 거짓말이 아니다 —
+다만 완료가 아니다. `이름[0]`…`이름[4]` 로 다시 지목한다.
+
+### 3.3 `confusable[]`
+
+화면상 구별되지 않는 필드 이름(유니코드 혼동자). 채우기는 수행한다.
+경고다. 채운 칸이 의도한 칸인지 재독한다. 사람 모드 `run` 은 stderr 로도 한 줄 낸다.
+
+### 3.4 `overflow[]`
+
+`set-cell` / `insert-image`. 채우기·삽입은 수행한다. 값이 칸/쪽 밖으로 넘친다.
+`--dry-run` 에서도 온다. 무시하면 제출본이 잘린다.
+
+워크스루: [../examples/11_overflow_data.md](../examples/11_overflow_data.md).
+
+### 3.5 `batch fill` 행 단위 `notFound`
+
+최종 exit 0. 레코드마다 확인하지 않으면 N부가 조용히 덜 찬다.
+
+### 3.6 `replacedCount: 0` / `findingCount: 0` / `removedCount: 0`
+
+exit 0, 산출 파일 없음 (`output` 키 부재) 또는 sanitize 재실행의 정상 증거.
+문맥 없이 "성공"이라고 하지 마라.
+
+- 치환 0건: 찾을 문자열이 없었다. 1층은 허용, 3층은 거부.
+- 탐지 0건: 마스킹할 PII 가 없었다. 산출 없음.
+- 제거 0건: 이미 깨끗한 문서, 또는 두 번째 sanitize.
+
+### 3.7 `verify: null`
+
+검증을 요청하지 않았다. 통과가 아니다.
+
+픽스처: [../fixtures/envelopes/fill_notfound_exit0.json](../fixtures/envelopes/fill_notfound_exit0.json),
+[../fixtures/envelopes/fill_ambiguous_exit0.json](../fixtures/envelopes/fill_ambiguous_exit0.json),
+[../fixtures/envelopes/verify_null.json](../fixtures/envelopes/verify_null.json).
+
+워크스루: [../examples/12_ambiguous_not_complete.md](../examples/12_ambiguous_not_complete.md).
+
+---
+
+## 4. exit 3 — 판정 세 갈래
+
+같은 숫자, 다른 디스크, 다른 다음 행동.
+
+### 4.1 1층 `edit … --verify`
+
+```json
+{"output": "out.hwp", "verify": {"identical": false, "diffCount": 2}}
+```
+
+산출물은 **있다**. `tests/edit_verify_contract.rs` 가
+`identical=false ⇒ exit 3` 그리고 `out.exists()` 를 지킨다.
+
+다음: `diffCount` 를 읽고, 재독(⑤)이 맞으면 사용자에게
+"자기검증이 차이를 봤지만 값은 반영됐다"고 보고한다.
+값이 틀리면 산출물을 버리고 원본에서 다시.
+
+### 4.2 3층 `assertions.verify`
+
+차이가 있으면 저장하지 않는다. 산출 경로에 이번 실행의 파일이 없다.
+저널의 `verify.identical` 이 false.
+
+다음: 원본은 그대로다. 계획·입력을 조사하고 재실행한다.
+"파일이 깨졌으니 복구"가 아니다 — 쓰여지지 않았다.
+
+### 4.3 3층 CAS `preconditionFailed`
+
+```json
+{
+  "schemaVersion": "1.0",
+  "planVersion": "1.0",
+  "input": "서식.hwp",
+  "output": "완성본.hwp",
+  "invalid": [],
+  "preconditionFailed": {
+    "kind": "inputSha256",
+    "expected": "aaa…",
+    "actual": "bbb…"
+  },
+  "nextCall": {
+    "name": "run",
+    "arguments": ["--plan-json", "{…actual 해시로 교체…}", "--dry-run", "--json"],
+    "why": "계획 수립 후 입력 문서가 바뀌었습니다. …"
+  },
+  "error": "입력 문서가 계획의 기대 해시와 다릅니다 — 계획 수립 후 문서가 바뀌었습니다. 실행 0·저장 0. nextCall 로 재계획하세요 (#3905 CAS)."
+}
+```
+
+CAS 해시 불일치는 exit 3 이지 exit 2 가 아니다.
+`invalid[]` 가 비어 있으므로 "exit 2 선검증 실패" 분기에 넣지 마라.
+`nextCall` 을 실행한다 (`--dry-run`). 통과하면 `--dry-run` 만 빼고,
+`invalid` 가 나오면 문서를 다시 읽고 계획을 다시 짠다.
+
+픽스처: [../fixtures/envelopes/run_precondition_failed.json](../fixtures/envelopes/run_precondition_failed.json),
+[../fixtures/envelopes/edit_verify_diff.json](../fixtures/envelopes/edit_verify_diff.json).
+
+### 4.4 `ir-diff --json`
+
+두 파일 비교. 차이 시 exit 3, `categories` + `diffCount`.
+서식 채우기 전후는 차이가 나는 것이 정상이다. 무손실 변환 계약에만
+"diffCount == 0" 을 완료 조건으로 건다.
+
+---
+
+## 5. exit 4 — 이 스킬의 변두리
+
+`--verify-pages` 는 `convert` / `export-hwpx` 전용이다.
+저장 전 쪽 수와 저장 후 재로딩 쪽 수가 다르면 산출물은 남기고 exit 4.
+
+`edit` 6종과 `run` 은 이 코드를 내지 않는다.
+에이전트가 `edit` 호출에서 4 를 보면 다른 명령이 섞인 것이다 — 호출 조립을 의심한다.
+
+---
+
+## 6. exit 2 사전 — 호출 조립 버그
+
+같은 명령줄을 재시도하지 않는다. 인자를 고친다.
+
+### 6.1 1층 (stdout 0바이트)
+
+| stderr 요지 | 고칠 것 |
+|-------------|---------|
+| `사용법: rhwp edit fill-fields …` | `--data` 누락 |
+| `사용법: rhwp edit replace-text …` | `--find`/`--replace` 누락, 빈 find |
+| `사용법: rhwp edit set-cell …` | 좌표/`--text` 누락 |
+| 병합으로 덮인 칸 — 앵커 (r,c) | `--row/--col` 을 앵커로 |
+| 본문 최상위 표 N 번이 없습니다 | `export-tables` 의 `index` 재확인 |
+| 줄바꿈·탭은 넣을 수 없습니다 | 한 줄 값 |
+| 마스킹은 되돌릴 수 없습니다. `-o` 또는 `--in-place` | 경로 명시 |
+| `-o` 가 원본 자신 | 다른 경로 |
+| 지원하지 않는 그림 형식 | png/jpg/jpeg/bmp/tif/tiff |
+| `--mask` 가 영숫자 또는 두 글자 | 한 글자 기호 |
+| `--page` 범위 밖 | `info.pageCount` |
+| `--width`/`--height` 0 | 1 이상 |
+
+### 6.2 `run` (`error` 한 줄)
+
+| `error` | 고칠 것 |
+|---------|---------|
+| `planVersion "1.0" 이 필요합니다` | 키 추가, 문자열 `"1.0"` |
+| `input (원본 문서 경로)이 필요합니다` | `source` 를 `input` 으로 |
+| `output (산출 경로)이 필요합니다` | `out` 을 `output` 으로 |
+| `steps 는 비어 있지 않은 배열이어야 합니다` | step 한 개 이상 |
+| `preconditions 객체에는 inputSha256 하나가 반드시 필요합니다` | 빈 객체 금지 |
+| `preconditions 에는 inputSha256 외 속성을 둘 수 없습니다` | 키 하나만 |
+| `preconditions.inputSha256 은 64자리 16진이어야 합니다` | 길이·문자 |
+| `preconditions.inputSha256 은 문자열이어야 합니다` | 숫자가 아님 |
+| `preconditions 는 객체여야 합니다` | 문자열/배열 금지 |
+
+### 6.3 `run` (`invalid[]`)
+
+원소: `{step, action?, reason}`.
+
+| `reason` 패턴 | 고칠 것 |
+|---------------|---------|
+| `data 는 {"필드이름":"값"} 객체여야 합니다` | data 타입 |
+| `필드 'X' 이(가) 없거나 순번이 범위 밖입니다 (동명 N개)` | 이름·순번. `fields` 재독 |
+| `find (비어 있지 않은 문자열)가 필요합니다` | find |
+| `replace (문자열)가 필요합니다` | replace 타입 |
+| `occurrence N 이(가) 범위 밖입니다 ('…' 일치 M건)` | 순번 또는 find |
+| `'…' 일치 0건 — 치환할 곳이 없습니다` | find 문자열. search 로 확인 |
+| `occurrence (0 기준 순번)가 필요합니다` | set_checkbox |
+| `occurrence N 이(가) 범위 밖입니다 (빈 체크박스 □ M건)` | 순번 |
+| `table·row·col (정수)과 text (문자열)가 필요합니다` | 키·타입 |
+| `text 에 줄바꿈·탭은 넣을 수 없습니다` | 한 줄 |
+| `table/row/col … 범위를 벗어났습니다` | 정수 범위 |
+| `resolve_table_cell` 안내 (병합·없는 표) | export-tables |
+| `action 이 필요합니다` | action 키 |
+| `알 수 없는 action: X (fill_fields·replace_text·set_cell·set_checkbox)` | 스네이크 4종 |
+| 조건절 문법 오류 | if 키 하나, 닫힌 객체 |
+
+여러 원소가 한 번에 온다. 첫 원소만 고치고 다시 돌리지 마라. 전부 고친 뒤 `--dry-run`.
+
+픽스처: [../fixtures/envelopes/run_error_plan_version.json](../fixtures/envelopes/run_error_plan_version.json),
+[../fixtures/envelopes/run_invalid_collected.json](../fixtures/envelopes/run_invalid_collected.json),
+[../fixtures/envelopes/redact_missing_output.json](../fixtures/envelopes/redact_missing_output.json).
+
+---
+
+## 7. exit 1 — 환경
+
+stdout 0바이트 (단건). `run` 은 `error` 봉투를 낼 수 있다.
+
+| 상황 | 다음 |
+|------|------|
+| 입력 파일 없음 | 경로. 발견부터 |
+| `stream did not contain valid UTF-8` (`--data @파일`) | UTF-8 로 저장. CP949 금지 |
+| 계획 파일을 읽을 수 없습니다 | 계획 경로 |
+| HWP 파싱 실패 | 손상·암호. `--password-stdin` 한 번 |
+| 필드 설정 실패 (run step N) | 원본 불변. 그 step 을 조사 |
+| 쓰기 실패 | 산출 디렉터리 권한 |
+| CAS 잠금 실패 | 다른 프로세스가 같은 입력을 잠근 것 |
+
+exit 1 을 "필드가 없다"로 해석하지 마라. 없는 필드는 1층에서 exit 0 + `notFound` 다.
+
+---
+
+## 8. 봉투 필드 사전 (이 스킬이 읽는 것만)
+
+권위 전체 사전은 knowledge_map §2. 여기서는 안전 편집 분기에 필요한 키만.
+
+### 8.1 공통
+
+| 키 | 타입 | 읽을 때 |
+|----|------|---------|
+| `schemaVersion` | string | 있으면 `"1.0"` |
+| `source` | string | 1층 입력 |
+| `input` | string | run 입력 |
+| `output` | string? | 실제 저장 경로. 없으면 파일 없음 |
+| `outputFormat` | `hwp5`/`hwpx`? | 저장 후에만. `info.format` 과 대조 |
+| `dryRun` | bool | true 면 디스크 무변경이어야 함 |
+| `changedPages` | number[] \| null | null ≠ [] |
+| `verify` | object \| null | null = 미요청 |
+| `verify.identical` | bool | false 면 exit 3 이어야 함 |
+| `verify.diffCount` | number | 0 이 통과 |
+| `untrustedContent` | bool? | 키 부재 ≠ false. 표지 스킬의 영역 |
+| `untrustedFields` | array? | 문서 파생 필드 이름 |
+
+### 8.2 fill-fields / fill_fields
+
+`filledCount`, `filled[{name,occurrence,value}]`, `notFound[]`, `ambiguous[{name,matched,total}]`,
+`confusable[{name,lookalikes,note}]`.
+
+### 8.3 replace-text / replace_text
+
+`find`, `replace`, `caseSensitive`, `replacedCount`, `occurrence?`.
+run preview: `matches`, `willReplace`.
+
+### 8.4 set-cell / set_cell
+
+`table`, `row`, `col`, `oldText`/`currentText`, `newText`, `keepStyle`, `overflow[]`.
+
+### 8.5 insert-image
+
+`image`, `page`, `x`, `y`, `width`, `height`, `binDataId?`, `overflow[]`.
+
+### 8.6 redact
+
+`kinds`, `mask`, `inPlace`, `noRaw`, `findingCount`,
+`findings[{kind,raw?,masked,section,paragraph,page,charOffset}]`, `redactedCount`.
+
+`raw` 가 있으면 로그에 붙이지 않는다.
+
+### 8.7 sanitize
+
+`keepPreview`, `removedCount`, `removed[{field,before}]`.
+
+### 8.8 run 전용
+
+`planVersion`, `steps[]`, `preview[]`, `invalid[]`, `assertions`,
+`preconditionFailed`, `nextCall`, `inputSha256`, `error`.
+
+### 8.9 csv-to-table
+
+`changedCount`, `changed[{row,col,oldText,newText}]`, `invalid[]`,
+`rowCount`, `colCount`.
+
+---
+
+## 9. 분기 의사코드 (에이전트용)
+
+```
+fn handle(exit, stdout, cmd):
+    if exit == 1:
+        return RetryEnv(stderr)
+    if exit == 2:
+        if stdout nonempty and json.invalid:
+            return FixPlan(json.invalid)          # run / csv-to-table
+        if stdout nonempty and json.error:
+            return FixPlanKeys(json.error)        # run 문법
+        return FixArgv(stderr)                    # 단건 edit
+    if exit == 4:
+        return ReadVerifyPages(json)              # convert 계열만
+    if exit == 3:
+        j = parse(stdout)
+        if j.preconditionFailed:
+            return Call(j.nextCall)               # CAS
+        if j.verify and j.verify.identical == false:
+            if cmd starts with "run":
+                return ReplanNoOutput(j)          # 저장 안 됨
+            else:
+                return InspectKeptOutput(j)       # 1층, 파일 있음
+        if cmd contains "ir-diff":
+            return ReadCategories(j)              # 무손실 계약일 때만 실패
+        return InspectKeptOutput(j)
+    if exit == 0:
+        j = parse(stdout)
+        if j.invalid:                             # 오면 안 되지만 방어
+            return FixPlan(j.invalid)
+        if j.notFound:   return Incomplete(j.notFound)
+        if j.ambiguous:  return Incomplete(j.ambiguous)
+        if j.overflow:   return WarnOverflow(j.overflow)
+        if j.verify is null and verify_was_requested:
+            return ContractBug
+        return Ok(j)
+```
+
+이 의사코드는 새 엔진이 아니다. 위 표의 읽기 순서다.
+
+---
+
+## 10. MCP 수송과의 차이
+
+`hwp_run_plan` 선검증 실패는 JSON-RPC `isError: false` + `structuredContent.invalid` 일 수 있다.
+도구가 크래시한 것이 아니다. `invalid == []` 로 판정한다.
+
+단건 세션 도구(`hwp_doc_set_cell` 등)가 병합 칸을 거부하면 CLI 와 **같은 문장**을 쓴다
+(`resolve_table_cell` 공유). stdout 0바이트 계약은 CLI 단건의 이야기이고,
+MCP 는 구조화 오류 필드로 옮긴다.
+
+이 파동은 MCP 스킬을 고치지 않는다. 판정 필드 이름만 같다.
+
+---
+
+## 11. 로그에 남기면 안 되는 필드
+
+| 필드 | 이유 |
+|------|------|
+| `edit redact` 의 `findings[].raw` | 원문 주민번호·카드·전화·이메일 |
+| 그 봉투 전체 (기본 `--no-raw` 없이) | raw 가 섞여 있음 |
+| `untrustedFields` 가 가리키는 값 | 문서 파생. 출처 표지 스킬의 영역 |
+| 암호, `--password` 인자 | 이 스킬은 stdin 만 안내 |
+
+이슈·PR·채팅에 붙일 봉투는 `redact --no-raw` 로 다시 받거나,
+해당 키를 삭제한 사본이다.
+
+---
+
+## 12. 픽스처 목록 (봉투)
+
+`fixtures/envelopes/` 의 각 파일은 "이런 모양이 오면 이렇게 분기한다"는 표본이다.
+런타임 골든이 아니라 **스키마·키·exit 주석** 이다. 테스트가 필수 키를 검사한다.
+
+| 파일 | exit | 분기 |
+|------|-----:|------|
+| `fill_ok.json` | 0 | notFound/ambiguous 빈 배열 확인 후 완료 |
+| `fill_notfound_exit0.json` | 0 | Incomplete |
+| `fill_ambiguous_exit0.json` | 0 | Incomplete |
+| `verify_null.json` | 0 | 미검증. 통과로 말하지 않음 |
+| `edit_verify_ok.json` | 0 | identical true |
+| `edit_verify_diff.json` | 3 | 산출 있음. InspectKeptOutput |
+| `replace_zero.json` | 0 | output 부재 |
+| `set_cell_overflow.json` | 0 | WarnOverflow |
+| `redact_missing_output.json` | 2 | 설명만 (stdout 0 — 이 파일은 stderr 요지) |
+| `run_dry_run_preview.json` | 0 | preview, 파일 없음 |
+| `run_invalid_replace_zero.json` | 2 | FixPlan |
+| `run_invalid_collected.json` | 2 | 여러 invalid 한 번에 |
+| `run_error_plan_version.json` | 2 | FixPlanKeys |
+| `run_precondition_failed.json` | 3 | nextCall |
+| `run_verify_fail_no_output.json` | 3 | ReplanNoOutput |
+| `csv_to_table_invalid.json` | 2 | invalid reason 3종 |
+| `batch_row_notfound.json` | 0 | 행 단위 Incomplete |
+
+---
+
+## 13. 테스트가 고정하는 불변식
+
+`scripts/tests/test_agent_safe_edit.py` 가 이 문서와 픽스처에 대해 확인한다.
+
+1. 스킬·레퍼런스가 `exit 3` 을 "고장"이 아니라 "판정"으로 부른다.
+2. 1층 verify 실패는 산출물이 남는다고 적혀 있다.
+3. run 단언/CAS 실패는 디스크 무변경이라고 적혀 있다.
+4. CAS 는 exit 3 이고 `invalid[]` 가 비어 있다고 적혀 있다.
+5. `notFound`/`ambiguous` 는 exit 0 가능이라고 적혀 있다.
+6. 계획 action 은 네 이름뿐이다. `insert_image` 를 유효 action 으로 안내하지 않는다.
+7. 픽스처 JSON 이 파싱되고 catalog 와 짝이 맞는다.
+8. `rhwp <명령>` 참조가 실재 명령이다 (SKILL.md + references/*.md).
+
+구현을 바꾸지 않는다. 문서와 픽스처가 구현이 이미 내는 말을 따라가는지를 본다.
+
+---
+
+## 14. 다음
+
+- 워크스루: [../examples/README.md](../examples/README.md)
+- 픽스처 카탈로그: [../fixtures/catalog.json](../fixtures/catalog.json)
+- 작업 기록: [`mydocs/working/agent_safe_edit.md`](../../../../mydocs/working/agent_safe_edit.md)

--- a/.claude/skills/rhwp-safe-edit/references/run_plans.md
+++ b/.claude/skills/rhwp-safe-edit/references/run_plans.md
@@ -1,0 +1,591 @@
+# 3층 계획서 — `rhwp run`
+
+이 문서는 rhwp-safe-edit 의 **여러 편집을 원자적으로** 적용하는 경로다.
+새 action 을 발명하지 않는다. `run_plan_engine`(CLI `run` 과 MCP `hwp_run_plan` 이
+공유하는 본체)이 이미 받는 계획서만 조립한다.
+
+권위:
+
+- 스키마 단일 출처: `rhwp export-plan-schema --json` (`planSchemaVersion` 1.1)
+- 구현: `src/plan_schema.rs`, `src/main.rs` `run_plan_engine`
+- 실측: [`mydocs/manual/agent_task_playbook.md`](../../../../mydocs/manual/agent_task_playbook.md) §12
+- 계약 테스트: `tests/plan_schema_contract.rs`
+
+1층 단건은 [single_edit.md](single_edit.md). 검증 루프는 [verify_loops.md](verify_loops.md).
+실패 봉투는 [failure_envelopes.md](failure_envelopes.md).
+
+---
+
+## 0. 왜 3층인가
+
+`edit` 를 이어 붙이면:
+
+```
+원본 ──fill──► a.hwp ──replace──► b.hwp
+                 ▲
+                 └ fill 은 성공, replace 가 실패하면 a.hwp 가 반쪽 산출물
+```
+
+`run` 은 그 중간 상태를 만들지 않는다.
+
+```
+원본 ──(메모리에서 fill+replace)──► 단언 통과 시에만 output 한 번
+실패(선검증·실행·단언) ──► 디스크 무변경, 원본 그대로
+```
+
+세 층:
+
+1. **선검증 (check)** — 전 step 의 실행 가능성을 입력 문서 기준으로 판정.
+   위반은 `invalid[]` 에 **전부** 모은다. 실행 0, 저장 0, exit 2.
+2. **원자 실행** — 전 step 을 인메모리 IR 에만 적용. 디스크는 아직 그대로.
+3. **저널 + 저장** — `assertions.verify` 가 참이면 산출 바이트를 재파싱해
+   인메모리 IR 과 대조. 통과할 때만 `output` 에 **한 번** 쓴다.
+
+`--dry-run` / 계획서 `dryRun: true` 는 1층만 수행하고 `preview[]` 를 낸다.
+
+---
+
+## 1. 계획서를 쓰기 전에 스키마를 읽는다
+
+필드명을 지어내면 `invalid[]` 왕복이 생긴다. 스키마가 정답지다.
+
+```bash
+rhwp export-plan-schema --json      # 봉투: schemaVersion, planSchemaVersion, dialect, definitionCount, schema
+rhwp export-plan-schema --bare      # JSON Schema 본문만 ($ref: #/$defs/Plan)
+rhwp export-plan-schema -o plan.schema.json --json
+```
+
+봉투 계약 (`tests/plan_schema_contract.rs`):
+
+- `schemaVersion`: `"1.0"` (봉투 판)
+- `planSchemaVersion`: `"1.1"` (#4378 — `preconditions.inputSha256` 추가)
+- `dialect`: `https://json-schema.org/draft/2020-12/schema`
+- `definitionCount` == `$defs` 키 수 (11: Plan, Preconditions, Assertions, Step,
+  FillFieldsStep, ReplaceTextStep, SetCellStep, SetCheckboxStep, StepCondition,
+  FieldEqualsCondition, PreviewStep)
+- `untrustedContent`: false — 문서를 열지 않는 명령
+
+`--bare` 는 봉투 키와 출처 표지를 싣지 않는다. 검증기에 그대로 먹이는 본문이다.
+
+계획서 본체·step 은 `additionalProperties: true` (추가-전용 진화).
+**조건절은 닫혀 있다** (`additionalProperties: false`, minProperties=1, maxProperties=1).
+스키마가 실행기보다 관대하면 "검증은 통과하는데 실행은 거부"가 생긴다.
+
+---
+
+## 2. 계획서 봉투 — 필수 키 넷
+
+```json
+{
+  "planVersion": "1.0",
+  "input": "서식.hwp",
+  "output": "완성본.hwp",
+  "steps": [ { "action": "fill_fields", "data": { "기관명": "한국수자원공사" } } ]
+}
+```
+
+| 키 | 필수 | 값 | 오타로 자주 쓰는 것 |
+|----|:----:|----|---------------------|
+| `planVersion` | 예 | 문자열 `"1.0"` 만 | 누락, `1.0` 숫자, `"2.0"` |
+| `input` | 예 | 원본 경로. 실행기는 읽기만 | `source`, `file`, `path` |
+| `output` | 예 | 산출 경로. 단언 통과 후 한 번 씀 | `out`, `dest`, `-o` |
+| `steps` | 예 | 비어 있지 않은 배열 | `ops`, `actions`, `[]` |
+| `assertions` | 아니오 | `notFoundEmpty`·`verify` | |
+| `preconditions` | 아니오 | `{ "inputSha256": "<64 hex>" }` | 빈 객체, 다른 키 |
+| `dryRun` | 아니오 | bool. CLI `--dry-run` 이 덮어씀 | |
+
+`planVersion` 이 `"1.0"` 이 아니면:
+
+```json
+{"error":"planVersion \"1.0\" 이 필요합니다","schemaVersion":"1.0"}
+```
+
+exit 2. 실행 0.
+
+`steps` 가 없거나 빈 배열이면 `"steps 는 비어 있지 않은 배열이어야 합니다"`.
+아무것도 하지 않는 계획은 의도가 아니라 실수다.
+
+픽스처: [../fixtures/plans/valid_fill_fields.json](../fixtures/plans/valid_fill_fields.json),
+[../fixtures/plans/invalid_missing_plan_version.json](../fixtures/plans/invalid_missing_plan_version.json),
+[../fixtures/plans/invalid_wrong_keys_source_op.json](../fixtures/plans/invalid_wrong_keys_source_op.json),
+[../fixtures/plans/invalid_empty_steps.json](../fixtures/plans/invalid_empty_steps.json).
+
+---
+
+## 3. CLI 입구
+
+```
+rhwp run <계획.json> [--json] [--dry-run]
+rhwp run --plan-json '<JSON>' [--json] [--dry-run]
+```
+
+- 파일 경로와 `--plan-json` 인라인 둘 다 받는다. 인라인이 있으면 파일을 무시한다.
+- `--dry-run` 은 계획서에 `dryRun: true` 를 **덮어쓴다**. 계획서가 `false` 여도
+  플래그가 이긴다. 의도의 단일 출처는 계획서이고 CLI 는 편의 입구다.
+- 알 수 없는 옵션은 exit 2, 계획 파일을 읽기 전에 끊는다.
+- 계획 파일 읽기 실패는 exit 1 (`오류: 계획 파일을 읽을 수 없습니다`).
+- JSON 파싱 실패는 exit 2 (`오류: 계획 JSON 파싱 실패`).
+
+`--json` 이면 저널이 stdout. 사람 모드에서 성공이면 한 줄 요약 + step 미리보기,
+실패면 저널을 **stderr** 로 남긴다 (판정 근거를 버리 지 않기 위함).
+에이전트는 항상 `--json` 을 붙인다.
+
+---
+
+## 4. action 4종 — 이 스킬이 배선하는 전부
+
+`steps[].action` 은 스네이크다. 카멜(`fillFields`)·케밥(`fill-fields`)·
+1층 CLI 이름(`fill-fields`)을 그대로 넣으면 `알 수 없는 action` 이다.
+
+### 4.1 `fill_fields`
+
+필수: `data` 객체. 값 타입은 string / number / boolean.
+문자열이 아니면 JSON 표기 그대로 문자열화한다.
+
+```json
+{"action": "fill_fields", "data": {"회사명": "페타플로", "목차1[0]": "개요"}}
+```
+
+선검증:
+
+- `data` 가 객체가 아니면 invalid.
+- 각 키를 `이름` 또는 `이름[순번]` 으로 분해.
+- 그 이름의 동명 개수가 0 이거나 순번 ≥ 개수 이면
+  `필드 '…' 이(가) 없거나 순번이 범위 밖입니다 (동명 N개)`.
+
+미리보기 `preview[]` 원소:
+
+```json
+{"step": 0, "action": "fill_fields", "targets": [
+  {"name": "회사명", "occurrence": 0, "sameNameCount": 1, "value": "페타플로"}
+]}
+```
+
+실행 저널:
+
+```json
+{
+  "step": 0,
+  "action": "fill_fields",
+  "filledCount": 2,
+  "filled": [{"name": "회사명", "occurrence": 0, "value": "페타플로"}],
+  "notFound": [],
+  "ambiguous": [],
+  "confusable": []
+}
+```
+
+선검증이 없는 필드를 이미 걸렀으므로 저널의 `notFound` 는 항상 `[]` 이다.
+`assertions.notFoundEmpty` 기본 true 가 이 구조적 보장을 계약 표기로 남긴다.
+
+순번 없이 동명 키를 주면 첫 칸을 채우고 `ambiguous: [{name, matched:1, total:N}]`.
+화면상 구별되지 않는 이름(유니코드 혼동)은 `confusable` 로 경고한다.
+사람 모드면 stderr 에 한 줄 경고가 나간다. 채우기는 막지 않는다.
+
+### 4.2 `replace_text`
+
+필수: `find`(비어 있지 않은 문자열), `replace`(문자열, 빈 문자열 = 삭제).
+선택: `caseSensitive`(기본 true), `occurrence`(0 기준 한 건).
+
+선검증:
+
+- `find` 없거나 빈 문자열 → `find (비어 있지 않은 문자열)가 필요합니다`
+- `replace` 가 문자열 아님 → `replace (문자열)가 필요합니다`
+- `occurrence` 가 일치 건수 이상 → `occurrence N 이(가) 범위 밖입니다 ('…' 일치 M건)`
+- occurrence 없이 일치 0건 → `'…' 일치 0건 — 치환할 곳이 없습니다`
+
+1층 `edit replace-text` 는 0건을 exit 0 + 산출 없음으로 보고한다.
+3층은 0건을 **계획 오류** 로 거부한다. 조용히 0건 성공을 만들지 않는다.
+
+미리보기:
+
+```json
+{"step": 1, "action": "replace_text", "find": "2025년", "matches": 7, "willReplace": 7}
+```
+
+`occurrence` 가 있으면 `willReplace` 는 1.
+
+### 4.3 `set_cell`
+
+필수: `table`·`row`·`col`(0 이상 정수), `text`(한 줄 문자열).
+선택: `keepStyle`(기본 false — 검정으로 기록).
+
+선검증:
+
+- 네 키 중 하나라도 빠지거나 타입 불일치 →
+  `table·row·col (정수)과 text (문자열)가 필요합니다`
+- `text` 에 `\r` `\n` `\t` → `text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록)`
+- `row`/`col` 이 65535 초과 → `0..65535 범위를 벗어났습니다` (HWP 격자 주소는 u16)
+- 병합으로 덮인 칸·없는 표·중첩 표 → `resolve_table_cell` 의 안내 문장 그대로
+
+미리보기:
+
+```json
+{"step": 2, "action": "set_cell", "table": 0, "row": 2, "col": 1,
+ "currentText": "", "newText": "1,234"}
+```
+
+좌표는 **실행 시점**에 다시 해석한다. 앞 step 이 표를 밀어도 격자 주소는 같다.
+그래도 조건절은 입력 문서 기준이므로, "앞 step 이 만든 칸"을 `if` 로 가리키지 마라.
+
+### 4.4 `set_checkbox`
+
+필수: `occurrence`(0 기준 빈 체크박스 □ 순번).
+
+선검증:
+
+- 키 없음 → `occurrence (0 기준 순번)가 필요합니다`
+- `n >= grep("□")` → `occurrence N 이(가) 범위 밖입니다 (빈 체크박스 □ M건)`
+
+미리보기:
+
+```json
+{"step": 3, "action": "set_checkbox", "occurrence": 0, "available": 4}
+```
+
+실행은 그 □ 를 ☑ 로 바꾼다. 1층 `replace-text --find □ --replace ☑ --occurrence k` 와
+같은 코어다. 계획서에만 별칭이 있다.
+
+### 4.5 없는 action
+
+```json
+{"step": 0, "action": "insert_image",
+ "reason": "알 수 없는 action: insert_image (fill_fields·replace_text·set_cell·set_checkbox)"}
+```
+
+`fillFields`, `replace`, `setCell`, `op`, `edit` 도 전부 이 갈래다.
+이 스킬은 다섯 번째 action 을 문서에 추가하지 않는다.
+
+픽스처: [../fixtures/plans/invalid_unknown_action.json](../fixtures/plans/invalid_unknown_action.json),
+[../fixtures/plans/invalid_camel_action.json](../fixtures/plans/invalid_camel_action.json).
+
+---
+
+## 5. 조건절 `if` (#3719 §6-8)
+
+모든 action 이 선택 필드 `if` 를 받는다. 조건이 거짓이면 그 step 만 건너뛰고
+저널/미리보기에 `skipped: true` + `reason` 을 남긴다.
+
+### 5.1 정확히 한 종류
+
+허용 키 셋, **한 객체에 하나**:
+
+| 키 | 피연산자 | 참인 때 |
+|----|----------|---------|
+| `fieldExists` | 비어 있지 않은 문자열 | 그 이름(또는 `이름[N]`)의 누름틀이 있다 |
+| `fieldEquals` | `{name, value}` | 그 누름틀의 **현재 값**이 value 와 완전 일치 |
+| `textFound` | 비어 있지 않은 문자열 | 본문에 그 문자열이 한 건이라도 있다 (대소문자 구별) |
+
+둘 이상 주면 and/or 가 계획서에 없으므로 거부한다.
+빈 객체도 거부 (`minProperties: 1`).
+모르는 키도 거부 (조건절은 닫힌 객체).
+
+### 5.2 판정 시점
+
+조건은 **입력 문서 기준으로 실행 전에 한 번** 판정한다.
+앞 step 의 채움·치환이 뒤 step 의 `if` 를 바꾸지 않는다.
+
+이유: 선검증과 실행이 같은 판정을 보게 하기 위함이다.
+실행 중에 다시 보면 "선검증은 통과시켰는데 실행에서 조건을 잃는" 상태가 생긴다.
+
+따라서 이런 계획은 의도와 다르게 움직인다:
+
+```json
+{"action": "fill_fields", "data": {"상태": "완료"}},
+{"action": "replace_text", "find": "미완료", "replace": "완료",
+ "if": {"fieldEquals": {"name": "상태", "value": "완료"}}}
+```
+
+두 번째 `if` 는 입력 문서의 `상태` 를 본다. 첫 step 이 방금 쓴 값이 아니다.
+
+"채운 뒤에 치환"은 조건이 아니라 **step 순서** 로 표현한다. 둘 다 조건 없이 나열하면
+선검증이 둘 다 실행 가능하다고 판정한 뒤 메모리에서 순서대로 적용한다.
+
+### 5.3 건너뛴 step 은 선검증 면제
+
+조건이 거짓인 step 은 실행 가능성 검사를 하지 않는다.
+없는 필드를 채우는 step 이라도 `if` 가 거짓이면 위반이 아니다.
+
+이것이 없으면 조건절은 "쓸 수는 있으나 쓰면 계획이 통과하지 않는" 장식이 된다.
+
+건너뛴 step 도 `preview[]`/`steps[]` 에서 **자리를 지킨다**.
+인덱스로 계획서 항목과 짝지을 수 있다. 조용히 사라지면 "왜 그 칸이 안 바뀌었는지"
+저널만 봐서는 재구성되지 않는다.
+
+픽스처: [../fixtures/plans/valid_conditional_field_exists.json](../fixtures/plans/valid_conditional_field_exists.json),
+[../fixtures/plans/valid_conditional_field_equals.json](../fixtures/plans/valid_conditional_field_equals.json),
+[../fixtures/plans/valid_conditional_text_found.json](../fixtures/plans/valid_conditional_text_found.json),
+[../fixtures/plans/invalid_two_conditions.json](../fixtures/plans/invalid_two_conditions.json).
+
+---
+
+## 6. assertions
+
+```json
+"assertions": { "notFoundEmpty": true, "verify": true }
+```
+
+| 키 | 기본 | 뜻 |
+|----|------|-----|
+| `notFoundEmpty` | **true** | 지목한 대상이 하나도 빠지지 않았음. 선검증이 구조적으로 보장. 저널에 계약 표기 |
+| `verify` | **false** | 저장 직전 산출 바이트를 재파싱해 인메모리 IR 과 대조 |
+
+`verify: true` 이고 차이가 있으면 **exit 3, 디스크 무변경**.
+1층 `edit --verify` 가 산출물을 남기는 것과 **반대**다.
+
+단언 실패는 계획이 스스로 검증 조건을 들고 다녀서
+"성공했다고 보고했는데 산출물이 깨진" 상태를 구조적으로 없앤다.
+
+생략하면 기본값으로 판정한다. `assertions` 키 자체가 없어도 된다.
+
+픽스처: [../fixtures/plans/valid_assertions_verify.json](../fixtures/plans/valid_assertions_verify.json).
+
+---
+
+## 7. preconditions.inputSha256 (#4378 R22)
+
+```json
+"preconditions": { "inputSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" }
+```
+
+계획이 세워진 시점의 입력 바이트를 고정한다. 실행 시점 해시가 다르면
+다른 에이전트/사람이 그 사이에 문서를 바꾼 것이다.
+
+계약:
+
+- `preconditions` 를 쓰면 `inputSha256` **하나만** 있어야 한다.
+- 값은 64자리 16진 (대소문자 무관, 내부는 소문자로 정규화).
+- 빈 객체, 다른 키, 비문자열, 길이 오류는 exit 2 (사용법).
+- 해시는 `rhwp` 가 파일을 읽은 직후 `sha256_hex_of` 로 계산한 값과 대조한다.
+
+**불일치 판정은 exit 3 이지 exit 2 가 아니다.**
+
+- 계획서 문법도 의미도 옳다. 틀린 것은 세상 쪽이다.
+- `invalid[]` 는 **빈 배열**이다. "invalid 가 비어 있지 않으면 exit 2" 불변식을
+  CAS 가 흔들지 않게 하기 위함이다.
+- 봉투에 `preconditionFailed: {kind:"inputSha256", expected, actual}` 와
+  `nextCall` 이 실린다.
+
+`nextCall` 은 같은 의도를 **새 지문**으로 다시 선검증하는 실행 가능한 호출이다.
+
+```json
+{
+  "name": "run",
+  "arguments": ["--plan-json", "<기대 해시를 실제로 갈아 끼운 계획>", "--dry-run", "--json"],
+  "why": "계획 수립 후 입력 문서가 바뀌었습니다. …"
+}
+```
+
+`--dry-run` 이라 디스크를 건드리지 않는다. 통과하면 `--dry-run` 만 빼고 다시 부르고,
+`invalid[]` 가 나오면 문서를 다시 읽고 재계획한다.
+
+픽스처: [../fixtures/plans/valid_preconditions.json](../fixtures/plans/valid_preconditions.json),
+[../fixtures/envelopes/run_precondition_failed.json](../fixtures/envelopes/run_precondition_failed.json).
+
+---
+
+## 8. dry-run 미리보기
+
+```bash
+rhwp run plan.json --dry-run --json
+```
+
+성공 봉투:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "planVersion": "1.0",
+  "dryRun": true,
+  "input": "서식.hwp",
+  "output": "완성본.hwp",
+  "preview": [ {"step": 0, "action": "fill_fields", "targets": […]} ],
+  "invalid": [],
+  "assertions": {"notFoundEmpty": true, "verify": true}
+}
+```
+
+사람 모드:
+
+```
+검사 통과: 2 step 실행 가능 · 1 step 건너뜀 예정 (디스크 무변경, 산출 예정 완성본.hwp)
+  - step 0: 누름틀 1칸 채움
+  - step 1 건너뜀 예정: …
+  - step 2: '2025년' 7건 중 7건 치환
+```
+
+건너뛸 step 은 "실행 가능" 개수에 넣지 않는다.
+dry-run 이 예고하는 실행 개수와 실제 `run` 이 보고할 적용 개수가 같아야 한다.
+
+dry-run 은 산출 경로를 touch 하지 않는다. `output` 키는 "예정 경로"일 뿐
+파일이 생겼다는 뜻이 아니다.
+
+워크스루: [../examples/07_run_atomic_fill_replace.md](../examples/07_run_atomic_fill_replace.md),
+[../examples/08_run_conditional.md](../examples/08_run_conditional.md).
+
+---
+
+## 9. 실행 저널 (저장 성공)
+
+```json
+{
+  "schemaVersion": "1.0",
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "outputFormat": "hwp5",
+  "changedPages": [0, 1],
+  "steps": [
+    {
+      "step": 0, "action": "fill_fields",
+      "filledCount": 2,
+      "filled": [
+        {"name": "작성자", "occurrence": 0, "value": "홍길동"},
+        {"name": "회사명", "occurrence": 0, "value": "페타플로"}
+      ],
+      "notFound": [], "ambiguous": [], "confusable": []
+    },
+    {
+      "step": 1, "action": "fill_fields",
+      "filledCount": 1,
+      "filled": [{"name": "목차1", "occurrence": 0, "value": "개요"}],
+      "notFound": [], "ambiguous": [], "confusable": []
+    }
+  ],
+  "assertions": {"notFoundEmpty": true, "verify": true},
+  "verify": {"diffCount": 0, "identical": true}
+}
+```
+
+`changedPages` 는 재조판 후 0 기준 쪽 번호. 눈검증은 이 쪽만 렌더한다.
+dry-run 저널에는 이 키가 없거나 확정할 수 없다 — 저장 전에 조판하지 않는다.
+
+CAS 를 켠 성공 저널은 `inputSha256` 을 싣는다. 계획서의 기대 해시와
+실행기가 읽은 해시가 같은 함수(`sha256_hex_of`)를 쓴다.
+
+---
+
+## 10. 선검증 실패 저널
+
+위반을 **한 번에** 모은다. 하나 고치면 다음이 나오는 두더지잡기를 피한다.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "planVersion": "1.0",
+  "input": "samples/field-01.hwp",
+  "output": "out/plan_result.hwp",
+  "invalid": [
+    {"step": 1, "action": "replace_text",
+     "reason": "'여기에 입력' 일치 0건 — 치환할 곳이 없습니다"}
+  ]
+}
+```
+
+exit 2. 산출 파일이 생기지 않는다. 원본 불변.
+
+`invalid[]` 원소는 최소 `step` + `reason`. `action` 은 있을 때 싣는다
+(`action` 자체가 빠진 step 은 `action` 키가 없을 수 있다).
+
+에이전트 분기:
+
+```
+stdout 가 비어 있지 않고 invalid 가 비어 있지 않으면
+  → 호출 조립을 고친다. 같은 계획을 재시도하지 않는다.
+  → step 인덱스로 계획서를 고치고 다시 --dry-run.
+```
+
+워크스루: [../examples/09_run_invalid_collected.md](../examples/09_run_invalid_collected.md).
+봉투 픽스처: [../fixtures/envelopes/run_invalid_replace_zero.json](../fixtures/envelopes/run_invalid_replace_zero.json).
+
+---
+
+## 11. MCP `hwp_run_plan` 주의
+
+같은 `run_plan_engine` 이다. 그러나 MCP 경로에서 선검증 실패는
+JSON-RPC `isError: false` 일 수 있다. 도구 실행이 실패한 것이 아니라
+**판정 봉투**를 돌려준 것이기 때문이다.
+
+판정:
+
+```
+structuredContent.invalid == []  이고  preconditionFailed 가 없다
+```
+
+`isError` 만 보고 성공으로 오독하지 마라. MCP 세션 스킬의 본문을 이 파동에서
+고치지 않는다. 여기서는 "같은 엔진, 같은 저널, 다른 수송" 만 적는다.
+
+`hwp_export_plan_schema` 가 `export-plan-schema --json` 과 같다.
+문서를 입력으로 받지 않는다.
+
+---
+
+## 12. 바인딩
+
+Node `@rhwp/node` 와 Python `rhwp` 의 `Plan(...).check()` / `.run()` 이
+있으면 그것은 각각 `run --dry-run` 과 `run` 이다. 새 판정 로직이 아니다.
+
+이 devel 스냅샷에 바인딩 README 가 없을 수 있다. 없어도 CLI 두 호출이 정본이다.
+바인딩이 exit 3/4 를 예외로 올리면 계약 위반이다 — 판정 필드로 돌려야 한다.
+
+---
+
+## 13. 1층과의 대응표
+
+| 1층 CLI | 계획 action | 0건 처리 | 비고 |
+|---------|-------------|----------|------|
+| `edit fill-fields --data` | `fill_fields.data` | 1층은 notFound+exit 0, 3층은 선검증 거부 | 3층이 더 엄격 |
+| `edit replace-text --find/--replace` | `replace_text` | 1층 0건=산출 없음, 3층 0건=invalid | 3층이 더 엄격 |
+| `edit replace-text --occurrence` | `replace_text.occurrence` | 범위 밖은 둘 다 실패 | |
+| `edit replace-text --ignore-case` | `caseSensitive: false` | 기본이 반대 이름 | 기본은 구별 |
+| `edit set-cell --keep-style` | `keepStyle: true` | | |
+| `edit replace-text □→☑ --occurrence` | `set_checkbox` | | 별칭 |
+| `edit insert-image` | **없음** | | 1층만 |
+| `edit redact` | **없음** | | 1층만 |
+| `edit sanitize` | **없음** | | 1층만 |
+| `csv-to-table` | **없음** | | 1층만 |
+| `batch fill` | **없음** | | 메일머지 |
+
+`caseSensitive` 기본 true = CLI 기본(구별). `--ignore-case` 를 쓰려면
+계획서에 `caseSensitive: false` 를 적는다. 키 이름을 지어내 `ignoreCase` 로 쓰지 마라.
+
+---
+
+## 14. 권장 작성 순서
+
+1. `rhwp export-plan-schema --bare` 를 읽어 action 필수 키를 확인한다.
+2. `fields` / `export-tables` / `search` 로 주소를 얻는다.
+3. 계획서를 쓴다. `input` 은 원본, `output` 은 새 경로.
+4. 원본이 경합에 노출되면 `preconditions.inputSha256` 을 넣는다.
+5. `rhwp run plan.json --dry-run --json` → `invalid[]` 가 비고 `preview[]` 가 맞는지.
+6. `assertions.verify: true` 를 켜고 `rhwp run plan.json --json`.
+7. 저널의 `steps[]` 와 `changedPages` 를 읽고 재독·눈검증은
+   [verify_loops.md](verify_loops.md) 로 간다.
+
+---
+
+## 15. 계획서 작성 함정 (실측)
+
+1. `source`/`op`/`ops`/`file` — 실행기가 모르는 키는 본문에선 무시되거나
+   (`additionalProperties: true`) 필수 키 누락으로 떨어진다. 필수 키를 대체하지 못한다.
+2. `planVersion` 숫자 `1.0` — 문자열만 받는다.
+3. action 카멜/케밥.
+4. `fill_fields` 의 data 를 배열로 쓰기.
+5. `set_cell.text` 에 여러 줄.
+6. `if` 에 조건 두 개.
+7. `if` 로 "앞 step 의 결과"를 읽으려 하기.
+8. `insert_image` 를 steps 에 넣기.
+9. 빈 `steps: []`.
+10. `output` 을 원본과 같은 경로로 두기 — 엔진이 원본을 읽기만 한다고 해도,
+    성공 시 그 경로에 쓴다. 에이전트는 원본과 다른 `-o` 와 같은 이유로 분리한다.
+11. dry-run 없이 바로 실행. 선검증이 디스크를 안 건드린다는 것을 알고도
+    preview 를 안 보면 `ambiguous`/`confusable` 을 놓친다.
+12. CAS 불일치를 exit 2 로 분류해 인자를 고치려 하기.
+
+---
+
+## 16. 다음 문서
+
+- 저장 후 `--verify` · 재독 · `changedPages` → [verify_loops.md](verify_loops.md)
+- exit 코드와 봉투 사전 → [failure_envelopes.md](failure_envelopes.md)
+- 원자 워크스루 → [../examples/07_run_atomic_fill_replace.md](../examples/07_run_atomic_fill_replace.md)

--- a/.claude/skills/rhwp-safe-edit/references/single_edit.md
+++ b/.claude/skills/rhwp-safe-edit/references/single_edit.md
@@ -1,0 +1,689 @@
+# 1층 단건 편집 — `edit` 하위명령
+
+이 문서는 rhwp-safe-edit 의 **편집 1건** 경로다. 새 편집 로직을 설명하지 않는다.
+이미 devel 에 있는 `edit` 6종과 인접 쓰기 명령(`csv-to-table`)을 에이전트가
+원본을 깨지 않고 부르기 위한 조립 규약만 적는다.
+
+권위: [`mydocs/manual/cli_commands.md`](../../../../mydocs/manual/cli_commands.md) §edit.
+실측 루프: [`mydocs/manual/agent_surface_playbook.md`](../../../../mydocs/manual/agent_surface_playbook.md) §9.
+회귀 테스트: `tests/edit_fill_fields_contract.rs`, `tests/edit_replace_text_contract.rs`,
+`tests/edit_set_cell_contract.rs`, `tests/insert_image_contract.rs`,
+`tests/edit_verify_contract.rs`, `tests/edit_format_preserve_contract.rs`,
+`tests/edit_fit_check_contract.rs`, `tests/edit_field_occurrence_contract.rs`.
+
+여러 편집을 한 파일에 원자적으로 적용해야 하면 이 문서를 닫고
+[run_plans.md](run_plans.md) 로 간다. `edit` 를 이어 붙이지 않는다.
+
+---
+
+## 0. 1층을 고르는 조건
+
+다음을 **모두** 만족할 때만 1층이다.
+
+1. 바꿀 대상이 한 종류다 (누름틀이거나, 문자열이거나, 칸이거나, 그림이거나, PII 이거나, 메타다).
+2. 중간 실패 시 반쯤 채워진 `-o` 산출물이 남아도 다음 명령으로 이을 필요가 없다.
+3. 사용자가 "한 번에 / 원자적으로 / 여러 칸과 문구를 같이" 라고 하지 않았다.
+
+하나라도 아니면 3층 `run` 이다.
+
+`batch fill` 은 1층도 3층도 아니다. 서식 1 + 데이터 N행의 **메일머지** 다.
+행마다 독립 산출물을 내고, 행별 `notFound` 가 있어도 최종 exit 0 일 수 있다.
+N명분 발급이면 `batch fill` 이지 `run` 을 N번 돌리는 것이 아니다.
+
+---
+
+## 1. 공통 계약 — 여섯 명령이 같은 말
+
+`edit` 6종은 아래를 공유한다. 명령마다 예외가 있으면 그 절에서만 덮어쓴다.
+
+### 1.1 원본은 읽기만
+
+실행기는 입력 경로를 열어 읽고, 변경은 메모리 IR 에서 끝낸 뒤 **다른 경로**에 쓴다.
+입력 파일을 truncate 하지 않는다. 직렬화·쓰기 실패 시 산출 경로에도 부분 파일을
+남기지 않는다(원자 쓰기). 원본 바이트는 실패 전후 동일하다.
+
+### 1.2 산출 분리 (`-o`)
+
+| 명령 | `-o` 생략 시 기본 이름 | `-o` 필수? |
+|------|------------------------|:----------:|
+| `edit fill-fields` | `<입력>_filled.<확장자>` | 아니오 |
+| `edit replace-text` | `<입력>_replaced.<확장자>` | 아니오 |
+| `edit set-cell` | `<입력>_cell.<확장자>` | 아니오 |
+| `edit insert-image` | `<입력>_image.<확장자>` | 아니오 |
+| `edit sanitize` | `<입력>_sanitized.<확장자>` | 아니오 |
+| `edit redact` | **기본 이름 없음** | **예** (`-o` 또는 `--in-place`) |
+
+에이전트 기본은 **항상 `-o` 를 명시**한다. 기본 이름이 생겨도 작업 디렉터리에
+예기치 않은 `*_filled.hwp` 가 쌓이는 것을 막기 위함이다.
+
+`edit redact` 는 `-o` 와 `--in-place` 둘 다 없으면 exit 2 로 **실행 자체를 거부**한다.
+`-o` 가 입력 경로와 같아도 거부한다. 되돌릴 수 없는 마스킹을 기본 이름으로
+조용히 만들지 않기 위한 보호다.
+
+`--in-place` 는 `redact` 전용이다. 다른 `edit` 에 `--in-place` 를 붙이지 마라.
+사용자가 "원본을 덮어써" 라고 **명시**하지 않으면 `--in-place` 를 제안하지 않는다.
+
+### 1.3 `--dry-run` — 같은 명령줄에서 플래그 하나
+
+선확인은 실행과 **같은 인자**에 `--dry-run` 만 더한 것이어야 한다.
+dry-run 에서 본 `notFound`·`overflow`·`findingCount` 를 실행에서 다시 해석하지 않는다.
+
+dry-run 계약:
+
+- 산출 파일을 만들지 않는다. `-o` 가 가리키는 경로를 touch 하지 않는다.
+- 봉투에 `dryRun: true` 가 실린다.
+- `output` / `outputFormat` / `verify` / `binDataId` 는 실제 저장 때만 실린다.
+- `changedPages` 는 항상 `null` 이다 (확정 불가 — 저장 전 재조판을 하지 않음).
+
+### 1.4 `--json` — stdout 은 봉투만
+
+`--json` 이면 stdout 은 JSON 한 덩어리다. 진행·경고·사람용 요약은 stderr 다.
+stdout+stderr 를 한 버퍼에 붙잡아 파싱하지 마라.
+
+단건 `edit` 가 exit 1 또는 2 로 끝나면 stdout 은 **0바이트**다 (부분 매니페스트 금지).
+종료 코드를 먼저 보고 0/3/4 일 때만 파싱한다.
+
+예외는 이 스킬 범위 안에서 `run` 과 `csv-to-table` 뿐이다 — 그 둘은 exit 2 에서도
+`invalid[]` 봉투를 낸다. 1층 `edit` 6종은 그 예외가 아니다.
+
+### 1.5 `--verify` — 자기 재파싱 게이트
+
+저장 직후 산출 바이트를 다시 읽어 인메모리 IR 과 대조한다.
+
+- 요청하지 않으면 봉투의 `verify` 는 **`null`** 이다. 통과가 아니라 **안 한 것**.
+- `identical: true` · `diffCount: 0` 이면 exit 0.
+- `identical: false` 이면 봉투를 출력한 뒤 **exit 3**. 산출 파일은 **남는다**.
+- 이것은 `ir-diff <원본> <산출>` 이 아니다. 원본과 산출을 비교하지 않는다.
+  저장본이 방금 직렬화한 IR 과 같은지를 본다.
+
+무손실이 계약이면 별도로 `rhwp ir-diff <원본> <산출> --json` 을 돌린다.
+차이 시 exit 3, `categories` 를 읽는다.
+
+### 1.6 입력 형식 보존 (#3383)
+
+| 입력 | 기본 산출 | 직렬화 |
+|------|-----------|--------|
+| `.hwpx` | `.hwpx` (`export_hwpx_native`) | HWPX 네이티브 |
+| `.hwp` (HWP5/HWP3) | `.hwp` (HWP5) | 어댑터 경유 `export_hwp_with_adapter` |
+
+봉투 `outputFormat` 은 `info --json` 의 `format` 과 같은 어휘다 (`hwp5` / `hwpx`).
+두 봉투를 그대로 대조할 수 있다.
+
+예외 하나: HWPX 입력에 `-o ….hwp` 를 **명시**하면 경로를 존중해 HWP5 로 저장하고
+stderr 로 형식 변경·이미지·차트 유실 가능성을 경고한다. 형식 변환의 정식 통로는
+`export-hwpx` 이지 `edit -o` 가 아니다.
+
+반대로 HWP 입력에 `-o ….hwpx` 를 줘도 형식은 바뀌지 않는다 (경고만). 변환은
+`export-hwpx` 가 담당한다.
+
+### 1.7 무변경 산출물 금지
+
+치환 0건(`replacedCount: 0`), 마스킹 탐지 0건(`findingCount: 0`)이면 출력 파일을
+만들지 않고 봉투에 `output` 키 자체가 없다. "빈 산출물을 만들어 두었다"고 보고하지 마라.
+
+`fill-fields` 는 지목한 키가 모두 `notFound` 여도 exit 0 일 수 있다. 이 경우에도
+실제로 채운 칸이 0 이면 산출물을 완성본으로 다루지 않는다.
+
+### 1.8 공통 플래그 표
+
+| 플래그 | fill-fields | replace-text | set-cell | insert-image | redact | sanitize |
+|--------|:-----------:|:------------:|:--------:|:------------:|:------:|:--------:|
+| `-o/--output` | ○ | ○ | ○ | ○ | 필수* | ○ |
+| `--dry-run` | ○ | ○ | ○ | ○ | ○ | — |
+| `--json` | ○ | ○ | ○ | ○ | ○ | ○ |
+| `--verify` | ○ | ○ | ○ | ○ | ○ | — |
+| `--in-place` | — | — | — | — | ○ | — |
+| `--keep-style` | — | — | ○ | — | — | — |
+| `--ignore-case` | — | ○ | — | — | — | — |
+| `--occurrence` | data 키 | ○ | — | — | — | — |
+| `--no-raw` | — | — | — | — | ○ | — |
+| `--keep-preview` | — | — | — | — | — | ○ |
+
+`*` redact 는 `-o` 또는 `--in-place` 중 하나.
+
+sanitize 에 `--dry-run`/`--verify` 가 없는 것은 이 스킬이 빼먹은 것이 아니다.
+메타 제거는 본문을 건드리지 않으며, 재실행 `removedCount: 0` 이 적용 증거다.
+
+---
+
+## 2. 발견 — 쓰기 전에 주소를 얻는다
+
+주소를 추측하지 않는다. 쓰기는 발견이 준 좌표만 받는다.
+
+### 2.1 누름틀 — `fields --json`
+
+```bash
+rhwp fields 신청서.hwp --json
+```
+
+읽는 키:
+
+- `fields[].name` — 채울 때 `--data` 키. 동명이면 선언 순서가 순번이다.
+- `fields[].value` — 현재 값. 비어 있으면 미작성.
+- `fields[].guide` (있으면) — 안내문. 실값과 섞지 않는다.
+
+같은 이름이 N번 나오면 `--data '{"이름[0]":"…","이름[N-1]":"…"}'` (0 기준, #3476).
+순번 없는 키는 **첫 매치만** 채우고 `ambiguous` 로 보고한다.
+
+실측 샘플 `samples/field-01.hwp` 는 누름틀 11개다
+(회사명/작성자/부서명/전화번호/이메일/제목/목차1×5). 테스트가 이 목록을
+하드코딩하지 않고 `fields --json` 으로 다시 읽는다. 에이전트도 그렇게 한다.
+
+### 2.2 표 격자 — `export-tables --json`
+
+```bash
+rhwp export-tables 양식.hwpx --json | jq '.tables[] | {index, rows, cols, cellCount}'
+```
+
+읽는 키:
+
+- `tables[].index` — `--table` 에 넣는 값. **배열 순번이 아니다.** 0부터가 아닐 수 있다.
+- `tables[].cells[].row` / `col` — `--row` / `--col`.
+- 병합 앵커 — 덮인 칸은 값이 없다. 앵커 좌표만 쓸 수 있다.
+- `cells[].nested` — 중첩 표. **v1 `set-cell` 범위 밖**.
+
+표 전체를 스프레드시트에서 고칠 거면 `table-to-csv` → 외부 편집 → `csv-to-table` 이다.
+그 왕복은 rhwp-table-exchange 스킬의 책임이다. 이 스킬은 칸 하나(`set-cell`)와
+원자 계획서(`run` 의 `set_cell`)만 다룬다.
+
+### 2.3 문자열 — `search --json`
+
+```bash
+rhwp search 공문.hwp "2025년" --json | jq '{matchCount, matches: [.matches[]|{page,section,paragraph}]}'
+```
+
+`matchCount` 가 0 이면 `replace-text` 를 돌리지 않는다. 1층은 0건 치환을 성공(exit 0,
+산출 없음)으로 보고하고, 3층 `run` 은 0건을 **선검증 위반**(invalid + exit 2)으로 거부한다.
+같은 찾기라도 층이 다르면 판정이 다르다.
+
+### 2.4 그림 자리 — 쪽 좌표는 HWPUNIT
+
+`insert-image` 의 `--x/--y/--width/--height` 는 픽셀이 아니다. 1 HWPUNIT = 1/7200 inch.
+A4 세로 ≈ 59528 × 84188. 쪽 왼쪽 위가 (0, 0) 이다.
+
+쪽 번호는 0 기준. `info --json` 의 `pageCount` 로 범위를 확인하고, 밖이면 실행기가
+exit 2 로 거부한다.
+
+---
+
+## 3. `edit fill-fields` — 누름틀 채우기 (#3329)
+
+검증된 코어 `set_field_value_by_name` 을 재사용한다. 필드 값만 바꾸므로
+레이아웃·구조는 불변이다. 새 편집 로직이 없다.
+
+### 3.1 사용법
+
+```
+rhwp edit fill-fields <파일.hwp|파일.hwpx> --data <JSON|@파일> [-o <출력>] [--dry-run] [--verify] [--json]
+```
+
+- `--data` — `{"필드이름":"값"}`. `@경로` 면 파일에서 읽는다. **UTF-8**.
+  CP949 저장본은 `stream did not contain valid UTF-8` + exit 1.
+- 값이 문자열이 아니면 JSON 표현을 문자열로 넣는다.
+- 반복 항목: `이름[N]` (0 기준). 범위 밖 순번은 `notFound` 에 실린다.
+
+### 3.2 봉투
+
+```json
+{
+  "schemaVersion": "1.0",
+  "source": "신청서.hwp",
+  "dryRun": false,
+  "filledCount": 2,
+  "filled": [
+    {"name": "회사명", "occurrence": 0, "value": "페타플로"},
+    {"name": "작성자", "occurrence": 0, "value": "홍길동"}
+  ],
+  "notFound": [],
+  "ambiguous": [],
+  "output": "out/filled.hwp",
+  "outputFormat": "hwp5",
+  "verify": null
+}
+```
+
+| 필드 | 뜻 | 완료 조건 |
+|------|-----|-----------|
+| `filledCount` | 실제로 쓴 칸 수 | 성공 판정이 **아님** |
+| `filled[]` | 이름·순번·값 | 재독 대조의 기대값 |
+| `notFound[]` | 없는 이름 또는 범위 밖 순번 | **반드시 빈 배열**이어야 완료 |
+| `ambiguous[]` | `{name,matched,total}` 순번 없는 동명 | **반드시 빈 배열**이어야 완료 |
+| `output` | 저장된 경로 | dry-run / 무변경 시 부재 |
+| `verify` | 자기검증 또는 `null` | `--verify` 를 붙였는가 |
+
+완료 식:
+
+```
+exit ∈ {0,3}  AND  notFound == []  AND  ambiguous == []  AND  filledCount == 지목한 키 수
+```
+
+`filledCount == 2` 이고 `ambiguous: [{name:"목차1", matched:1, total:5}]` 이면
+5칸 중 1칸만 채운 것이다. 이것을 완성본으로 사용자에게 넘기지 마라.
+
+### 3.3 권장 호출
+
+```bash
+rhwp fields samples/field-01.hwp --json | jq -r '.fields[].name'
+rhwp edit fill-fields samples/field-01.hwp \
+  --data '{"회사명":"페타플로","작성자":"홍길동"}' \
+  --dry-run --json
+rhwp edit fill-fields samples/field-01.hwp \
+  --data '{"회사명":"페타플로","작성자":"홍길동"}' \
+  -o out/field-filled.hwp --verify --json
+rhwp fields out/field-filled.hwp --json \
+  | jq -c '[.fields[]|select(.value!="")|{name,value}]'
+```
+
+워크스루: [../examples/01_fill_fields_single.md](../examples/01_fill_fields_single.md).
+
+### 3.4 실패
+
+- 입력 없음·파싱 실패·쓰기 실패 → exit 1, stdout 0바이트, 원본 불변.
+- `--data` 누락·JSON 파싱 실패 → exit 2, stdout 0바이트.
+- 필드 설정 중 하나라도 실패 → 산출 파일을 쓰지 않고 exit 1.
+
+`notFound` 는 실패가 아니다. exit 0 이다. 봉투를 읽지 않으면 놓친다.
+
+---
+
+## 4. `edit replace-text` — 일괄 치환 (#3373)
+
+검증된 코어 `replace_all` (역순 치환, 오프셋 안전)을 재사용한다. 새 편집 로직이 없다.
+본문과 표 셀을 함께 본다.
+
+### 4.1 사용법
+
+```
+rhwp edit replace-text <파일> --find <문자열> --replace <문자열> [-o] [--ignore-case] [--occurrence N] [--dry-run] [--verify] [--json]
+```
+
+- `--find` 빈 문자열은 exit 2 (문서 전체를 뜻하게 되므로).
+- `--replace ""` 는 삭제다.
+- `--ignore-case` 기본은 구별한다.
+- `--occurrence k` (0 기준) 이면 그 한 건만. 체크박스 □→☑ 도 이 경로다.
+
+### 4.2 봉투
+
+```json
+{
+  "schemaVersion": "1.0",
+  "source": "공문.hwp",
+  "find": "2025년",
+  "replace": "2026년",
+  "caseSensitive": true,
+  "dryRun": false,
+  "replacedCount": 7,
+  "changedPages": [0, 2, 3],
+  "output": "개정본.hwp",
+  "outputFormat": "hwp5",
+  "verify": {"identical": true, "diffCount": 0}
+}
+```
+
+`replacedCount: 0` 이면 `output` 키가 없고 파일을 만들지 않는다.
+
+전건 치환은 여러 쪽에 걸친다. `--occurrence 3` 은 보통 한쪽이다.
+눈검증은 `changedPages` 만 `export-svg -p N` 한다.
+
+### 4.3 권장 호출
+
+```bash
+rhwp search 공문.hwp "2025년" --json | jq .matchCount
+rhwp edit replace-text 공문.hwp --find "2025년" --replace "2026년" --dry-run --json
+rhwp edit replace-text 공문.hwp --find "2025년" --replace "2026년" -o 개정본.hwp --verify --json
+rhwp search 개정본.hwp "2025년" --json | jq .matchCount     # → 0
+```
+
+체크박스 한 칸:
+
+```bash
+rhwp edit replace-text 신청서.hwp --find "□" --replace "☑" --occurrence 0 -o 체크.hwp --json
+```
+
+여러 칸을 켜고 다른 편집과 같이 가야 하면 `run` 의 `set_checkbox` 다.
+1층에서 `--occurrence` 를 여러 번 이어 붙이지 마라.
+
+워크스루: [../examples/02_replace_text_single.md](../examples/02_replace_text_single.md).
+
+---
+
+## 5. `edit set-cell` — 표 한 칸 (#3381)
+
+`export-tables` 와 같은 좌표계(`index`/`row`/`col`). 누름틀 없는 표 양식의
+발견 → 기록 → 재독 을 한 주소로 닫는다. v1 범위는 본문 최상위 표와 셀 첫 문단.
+
+### 5.1 사용법
+
+```
+rhwp edit set-cell <파일> --table <N> --row <R> --col <C> --text <값> [-o] [--keep-style] [--dry-run] [--verify] [--json]
+```
+
+- 좌표는 0 기준. `--table` 은 `export-tables` 의 `index`.
+- 빈 `--text` 는 비우기다. 줄바꿈·탭은 v1 에서 거부 (exit 2).
+- `--keep-style` 없으면 검정·비이탤릭·비진하게 (#3391). 파란 안내문 스타일을
+  실값이 상속하지 않게 한다. 안내문 모양을 유지할 때만 `--keep-style`.
+
+### 5.2 봉투
+
+```json
+{
+  "schemaVersion": "1.0",
+  "source": "양식.hwpx",
+  "table": 12,
+  "row": 1,
+  "col": 1,
+  "oldText": "",
+  "newText": "1,234",
+  "dryRun": false,
+  "keepStyle": false,
+  "overflow": [],
+  "changedPages": [6, 7],
+  "output": "작성본.hwpx",
+  "outputFormat": "hwpx"
+}
+```
+
+`oldText` 가 변경 이력이다. 로그에 그대로 남길 수 있다.
+
+### 5.3 `overflow` (#3480)
+
+넣은 값이 칸 폭을 넘치면 원소가 실린다.
+
+```json
+[{
+  "target": "table0[2,3]",
+  "text": "…",
+  "cellWidthPx": 214.63,
+  "textWidthPx": 440.0,
+  "lines": 3
+}]
+```
+
+- 채우기를 **막지 않는다**. 여러 줄이 정상인 칸(주소·사유)이 있다. 판단은 소비자 몫.
+- `--dry-run` 에서도 검사된다. 파일을 만들기 전에 알 수 있다.
+- 칸 폭은 `Cell.width` − 안여백, 글자 폭은 첫 문단 `CharShape.base_size` 기준
+  한글 전각·ASCII 반각 **근사**다. 정밀 조판이 아니다.
+- 조판 엔진이 있어야 한다. 에이전트는 렌더를 보지 않으므로 이 신호가 없으면
+  표 밖으로 넘친 문서를 완성본으로 오판한다.
+
+`overflow` 가 비지 않으면 사용자에게 알리고, 짧은 값으로 다시 dry-run 할지 묻는다.
+무시하고 제출본으로 넘기지 마라.
+
+### 5.4 병합·범위
+
+병합으로 덮인 칸은 앵커 좌표를 안내하며 exit 2, stdout 0바이트.
+
+```
+(0,2) 는 병합으로 덮인 칸입니다 — 앵커 (0,1) 를 지정하세요.
+```
+
+격자 밖 좌표도 exit 2. 중첩 표는
+
+```
+본문 최상위 표 0 번이 없습니다 (최상위 표 0개; 중첩 표는 v1 범위 밖)
+```
+
+`--table 999` 처럼 없는 번호는 배열 길이로 추측하지 말고 `export-tables` 를 다시 읽는다.
+
+### 5.5 권장 호출
+
+```bash
+rhwp export-tables 양식.hwpx --json | jq '.tables[] | select(.index==12) | {rows,cols}'
+rhwp edit set-cell 양식.hwpx --table 12 --row 1 --col 1 --text "1,234" --dry-run --json
+rhwp edit set-cell 양식.hwpx --table 12 --row 1 --col 1 --text "1,234" -o 작성본.hwpx --json
+rhwp export-tables 작성본.hwpx --json \
+  | jq -r '.tables[]|select(.index==12)|.cells[]|select(.row==1 and .col==1).text'
+```
+
+워크스루: [../examples/03_set_cell_single.md](../examples/03_set_cell_single.md).
+
+---
+
+## 6. `edit insert-image` — 도장·서명 (#3719 §6-5)
+
+채워 넣은 서식에 직인을 얹는 제출의 마지막 조각. 인자 파싱·저장·봉투·`--verify`·
+`changedPages` 형태는 `set-cell` 과 같다.
+
+### 6.1 사용법
+
+```
+rhwp edit insert-image <파일> --image <그림> [--page N] [--x N --y N] [--width N --height N] [-o] [--dry-run] [--verify] [--json]
+```
+
+- `--image` 필수. 허용 확장자 **그리고** 내용: `png` `jpg` `jpeg` `bmp` `tif` `tiff`.
+  그 밖은 문서를 읽기 전에 exit 2.
+- 단위는 전부 HWPUNIT. `--page` 생략 = 0. 범위 밖이면 exit 2.
+- `--width`/`--height` 둘 다 생략이면 원본 픽셀을 96dpi 로 환산.
+  한쪽만 주면 원본 비율로 다른 쪽을 계산. `0` 은 exit 2.
+- 쪽 밖으로 나가도 **자르지 않는다.** `overflow` 로만 알린다.
+- 대체 텍스트는 삽입한 파일명을 그대로 쓴다.
+
+### 6.2 봉투 요지
+
+- `binDataId` — 실제 저장 때만. 방금 삽입한 BinData 참조.
+- `overflow[]` — 넘칠 때만 원소 1개, 아니면 `[]`.
+  `{page, paperWidthHu, paperHeightHu, rightHu, bottomHu, overflowXHu, overflowYHu}`.
+- `changedPages` — 저장 후 쪽 번호(0 기준). dry-run 은 `null`.
+
+```bash
+rhwp edit insert-image 신청서_filled.hwp --image samples/images/moogung.jpg \
+  --page 0 --x 50000 --y 70000 --width 5000 --height 5000 \
+  -o 제출본.hwp --json | jq '{output, overflow, binDataId}'
+```
+
+워크스루: [../examples/04_insert_image_single.md](../examples/04_insert_image_single.md).
+
+이 action 은 `run` 계획서에 없다. 도장까지 한 계획에 넣지 마라.
+1층으로 산출을 만든 뒤 그 산출을 다음 1층 입력으로 쓰거나, 사용자가
+원자성을 요구하면 "도장은 계획 밖 1층" 이라고 명시한다.
+
+---
+
+## 7. `edit redact` — 개인정보 마스킹 (#3719 §6-11)
+
+탐지는 읽기 전용 코어 `document_core::queries::pii_scan`.
+변경은 검증된 치환 경로 `replace_all_native`. 새 편집 로직이 없다.
+
+### 7.1 사용법
+
+```
+rhwp edit redact <파일> [--kind ssn|phone|email|card|all] [--mask <문자>] [--dry-run] [--no-raw] [--verify] [-o <출력>|--in-place] [--json]
+```
+
+- `--kind` 기본 `all`. 쉼표 나열.
+- `--mask` 한 글자. 영숫자는 거부. 두 글자 이상은 자르지 않고 exit 2.
+- `--dry-run` 이 **권장 첫 단계**. `findings[]` 만 보고 파일을 만들지 않는다.
+- `--no-raw` 는 `findings[].raw` 를 필드 자체에서 뺀다 (`null` 아님).
+  로그·이슈에 봉투를 붙일 거면 처음부터 `--no-raw`.
+- `-o` 또는 `--in-place` **필수**. 둘 다 없으면 exit 2. `-o` == 원본도 거부.
+
+### 7.2 탐지 규칙 (보수적)
+
+오탐은 본문을 훼손하고 되돌릴 수 없다. 형태가 맞아도 검증을 통과하지 못하면 탐지하지 않는다.
+
+| 종류 | 형태 | 추가 검증 |
+|------|------|-----------|
+| `ssn` | `######-#######` | 생년월일 실재(윤년) + 성별/세기 1~8 + mod 11 |
+| `card` | `4-4-4-4` / Amex `4-6-5` / 연속 15·16자리 | Luhn |
+| `phone` | `01[016789]-3~4-4`, `02-3~4-4` | 하이픈 필수 |
+| `email` | `지역부@라벨(.라벨)+` | 라벨 2개 이상 + TLD 영문 2자 이상 |
+
+앞뒤가 숫자면 더 긴 토큰의 일부로 보고 버린다.
+**02 외 지역번호, 13·14·19자리 카드, 여권·계좌는 v1 범위 밖.**
+
+### 7.3 봉투 요지
+
+```
+findingCount, findings[{kind, raw?, masked, section, paragraph, page, charOffset}],
+redactedCount, changedPages, dryRun, inPlace, noRaw, kinds, mask,
+output?, outputFormat?, verify?
+```
+
+탐지 0건이면 출력 파일을 만들지 않는다.
+`findings[].raw` 는 원문 개인정보다. 기본은 포함. 전송하지 마라.
+
+### 7.4 권장 호출
+
+```bash
+rhwp edit redact 계약서.hwp --dry-run --json | jq '.findings[] | {kind, page, masked}'
+rhwp edit redact 계약서.hwp --dry-run --no-raw --json > 검토용.json
+rhwp edit redact 계약서.hwp -o 공개본.hwp --verify --no-raw --json \
+  | jq '{redactedCount, changedPages, findingCount}'
+```
+
+워크스루: [../examples/05_redact_single.md](../examples/05_redact_single.md).
+
+`run` 계획서에 `redact` action 은 없다. 공개 전 정리는 1층으로 분리한다.
+
+---
+
+## 8. `edit sanitize` — 메타데이터 제거 (#3719 §6-11)
+
+본문 내용은 건드리지 않는다. `export-text` 결과가 전후 동일하다.
+
+### 8.1 사용법
+
+```
+rhwp edit sanitize <파일> [--keep-preview] [-o <출력>] [--json]
+```
+
+- `--keep-preview` — 미리보기 **이미지**를 남긴다. 미리보기 텍스트는 언제나 대상.
+- 기본 산출 이름: `<입력>_sanitized.<확장자>`.
+
+지우는 대상 셋:
+
+1. OLE 요약 정보 (`\x05HwpSummaryInformation`) — title/subject/author/keywords/
+   comments/lastSavedBy/revisionNumber/dateString 과 FILETIME 시각들.
+   바이트 길이를 바꾸지 않고 비운다.
+2. HWPX 저작자 메타 (`Contents/content.hpf` 의 `<opf:metadata>`) — 중립 블록으로 교체.
+3. 미리보기 (PrvText·PrvImage).
+
+`removed[]` 는 거짓 보고를 하지 않는다. HWP5 직렬화기는 PrvText 가 비면 본문 앞부분으로
+다시 채우므로, 미리보기 텍스트는 **지금 본문과 다를 때만** 지우고 보고한다.
+
+**두 번째 실행은 `removedCount: 0`** 이다. 이것이 첫 실행이 실제로 지웠다는 증거다.
+
+```bash
+rhwp edit sanitize 보고서.hwp -o 배포본.hwp --json | jq '.removed[] | "\(.field): \(.before)"'
+rhwp edit sanitize 배포본.hwp -o /tmp/재확인.hwp --json | jq .removedCount   # → 0
+rhwp export-text 보고서.hwp > /tmp/a.txt
+rhwp export-text 배포본.hwp > /tmp/b.txt
+# 본문 동일해야 한다
+```
+
+워크스루: [../examples/06_sanitize_single.md](../examples/06_sanitize_single.md).
+
+---
+
+## 9. 인접 1층 — `csv-to-table` (#3719 §7)
+
+표 전체를 CSV 로 덮어쓴다. `edit` 우산 아래는 아니지만 같은 안전 장치
+(`--dry-run` · `-o` · `--verify` · `invalid[]`)를 쓴다.
+
+```
+rhwp csv-to-table <파일> --csv <경로.csv> --table <N> [-o] [--dry-run] [--verify] [--json]
+```
+
+치수 계약. 행·열이 다르거나 덮인 칸에 값이 있으면 **한 칸도 쓰지 않고**
+`invalid[]` + exit 2. 이 점은 단건 `edit` 와 달리 실패해도 봉투가 나온다.
+
+| `invalid[].reason` | 뜻 |
+|--------------------|-----|
+| `rowCountMismatch` | CSV 행 수 ≠ 표 행 수 |
+| `colCountMismatch` | 해당 행의 열 수 ≠ 표 열 수 |
+| `coveredCellNotEmpty` | 병합으로 덮인 칸에 값이 있음 |
+
+처방: 손으로 CSV 를 만들지 말고 `table-to-csv` 가 뽑은 것을 값만 고친다.
+
+워크스루: [../examples/13_csv_to_table_gate.md](../examples/13_csv_to_table_gate.md).
+
+---
+
+## 10. `batch fill` — 서식 1 + 데이터 N (#3238 계열)
+
+```
+rhwp batch fill --form <서식> --data <행.jsonl|csv> --out-dir <디렉터리> [--name-field <필드>] [--dry-run] [--json]
+```
+
+- 행마다 독립 산출물. 한 행의 `notFound` 가 다른 행을 막지 않는다.
+- **행별 `notFound` 가 있어도 최종 exit 0** 일 수 있다.
+- 완료 조건은 행 단위: 각 NDJSON 레코드의 `notFound == []` 그리고 `filledCount`.
+- 먼저 `--dry-run` 으로 전행을 흘려 `notFound` 가 있는 행을 고친 뒤 실행한다.
+
+원자적 다단계 편집이 아니다. N명분 메일머지다.
+워크스루: [../examples/14_batch_fill_row_judgment.md](../examples/14_batch_fill_row_judgment.md).
+
+---
+
+## 11. 1층에서 금지하는 조립
+
+1. `edit fill-fields -o a.hwp` 다음에 `edit replace-text a.hwp -o b.hwp` 를
+   "한 작업"으로 묶지 마라. 중간 `a.hwp` 가 반쪽이다. `run` 으로 간다.
+2. `--in-place` 를 fill/replace/set-cell/insert-image/sanitize 에 붙이지 마라.
+3. HWPX 를 `-o out.hwp` 로 받아 형식을 바꾸지 마라. 바꾸려면 `export-hwpx` 가 아니다 —
+   그 방향은 `convert` / 어댑터 경로이고, 편집의 일이 아니다.
+4. `fields` 를 건너뛰고 필드 이름을 지어내지 마라.
+5. `export-tables` 의 배열 순번을 `--table` 에 넣지 마라. `index` 다.
+6. `overflow` 를 무시하고 제출본을 만들지 마라.
+7. `filledCount` 만 보고 완료라고 하지 마라.
+8. dry-run 의 `changedPages: null` 을 "바뀐 쪽 없음"으로 읽지 마라.
+9. `--verify` 없이 저장한 뒤 `verify: null` 을 통과로 읽지 마라.
+10. 새 하위명령(`edit ungroup-shape` 등)이 이 스킬 범위에 들어왔다고 가정하지 마라.
+    이 스킬이 배선하는 1층은 위 6종 + `csv-to-table` + `batch fill` 이다.
+
+---
+
+## 12. 1층 호출 체크리스트
+
+저장 버튼을 치기 전에 이 목록을 채운다.
+
+- [ ] 발견 명령을 돌렸다 (`fields` / `export-tables` / `search` / `info`).
+- [ ] 같은 명령줄에 `--dry-run --json` 을 붙여 봉투를 읽었다.
+- [ ] `notFound`·`ambiguous`·`overflow`·`findingCount` 를 완료 조건에 넣었다.
+- [ ] `-o` 가 입력과 다른 경로다. `redact` 면 `-o` 또는 명시적 `--in-place`.
+- [ ] `--verify` 를 붙일지 결정했고, 안 붙이면 `verify: null` 을 통과로 말하지 않는다.
+- [ ] 저장 후 재독 명령이 준비돼 있다 (`fields` / `export-tables` / `search` / 재 sanitize).
+- [ ] 눈검증은 `changedPages` 가 배열일 때만, 그 쪽만 `export-svg -p N`.
+- [ ] 다음 편집이 남아 있으면 1층을 닫고 [run_plans.md](run_plans.md) 로 간다.
+
+---
+
+## 13. 명령 ↔ 재독 대조표
+
+| 쓰기 | 재독 | 기대 |
+|------|------|------|
+| `edit fill-fields` | `fields --json` | 채운 이름의 `value` 가 data 와 같다 |
+| `edit replace-text` | `search --json` | `find` 의 `matchCount` 가 0 (전건) 또는 1 감소 (occurrence) |
+| `edit set-cell` | `export-tables --json` | 해당 `index/row/col` 의 `text` 가 `newText` |
+| `edit insert-image` | `info` / 쪽 `export-svg` | `overflow` 가 비었고 해당 쪽에 그림 |
+| `edit redact` | `edit redact --dry-run` (산출에) | `findingCount: 0` (같은 kind) |
+| `edit sanitize` | `edit sanitize` 재실행 | `removedCount: 0` |
+| `csv-to-table` | `table-to-csv` | CSV 왕복이 같음 |
+| `batch fill` | 행별 `fields` 또는 레코드 `notFound` | 모든 행 `notFound == []` |
+
+재독이 기대와 다르면 산출물을 사용자에게 넘기지 않고, 원본은 그대로이므로
+같은 명령줄을 고쳐 다시 돌린다.
+
+---
+
+## 14. 샘플 파일 (이 저장소)
+
+테스트와 예제가 쓰는 공개 샘플이다. 경로를 지어내지 마라.
+
+| 샘플 | 1층에서 쓰는 이유 |
+|------|-------------------|
+| `samples/field-01.hwp` | 누름틀 11개. fill-fields·run fill_fields 의 기본 입력 |
+| `samples/form-01.hwp` | 서식. visual-regression 과 공유하는 공개 양식 |
+| `samples/table-001.hwp` | 표 격자. set-cell / csv-to-table |
+| `samples/hwp3-sample.hwp` | 다쪽 치환. `changedPages` 실측 |
+
+새 HWP 픽스처를 이 스킬 폴더에 넣지 않는다. 기존 공개 샘플만 가리킨다.
+
+---
+
+## 15. 다음 문서
+
+- 여러 편집 → [run_plans.md](run_plans.md)
+- 저장 후 판정 루프 → [verify_loops.md](verify_loops.md)
+- exit 3/4 와 `invalid[]` → [failure_envelopes.md](failure_envelopes.md)
+- 단건 워크스루 → [../examples/README.md](../examples/README.md)

--- a/.claude/skills/rhwp-safe-edit/references/verify_loops.md
+++ b/.claude/skills/rhwp-safe-edit/references/verify_loops.md
@@ -1,0 +1,456 @@
+# 검증 루프 — dry-run · `-o` · `--verify` · 재독
+
+이 문서는 rhwp-safe-edit 가 **한 편집을 끝냈다고 말하기 전에** 돌리는 루프다.
+새 검증 엔진을 만들지 않는다. 이미 있는 `--dry-run`, `-o`, `--verify`,
+`ir-diff`, `search`, `fields`, `export-tables`, `export-svg` 를 순서대로 배선한다.
+
+권위: [`mydocs/manual/agent_surface_playbook.md`](../../../../mydocs/manual/agent_surface_playbook.md) §9,
+[`mydocs/manual/cli_commands.md`](../../../../mydocs/manual/cli_commands.md) §종료 코드,
+`tests/edit_verify_contract.rs`, `tests/changed_pages_contract.rs`.
+
+1층 조립은 [single_edit.md](single_edit.md). 3층 계획서는 [run_plans.md](run_plans.md).
+exit 3/4 를 데이터로 읽는 법은 [failure_envelopes.md](failure_envelopes.md).
+
+---
+
+## 0. 루프 한 장
+
+```
+① 발견        fields / export-tables / search / info
+② 선확인      같은 명령줄 + --dry-run --json     → 디스크 무변경
+③ 실행        --dry-run 을 떼고 -o · --verify     → 원본과 다른 경로
+④ 판정        종료 코드 + 봉투 필드               → 예외로 throw 하지 않음
+⑤ 재독        쓰기와 쌍인 읽기 명령               → 값이 맞는지
+⑥ 눈검증      changedPages 쪽만 export-svg        → null 이면 아직 하지 않음
+⑦ (선택)      ir-diff 원본 vs 산출                → 무손실 계약일 때만
+```
+
+어느 단계에서든 실패하면 원본은 그대로다. 산출 경로만 버리거나 덮어쓴다.
+
+"실행과 같은 명령줄에서 `--dry-run` 하나만 빼면 되는 것"이 선확인의 정의다.
+dry-run 과 실행의 인자가 갈라지면 선확인이 아니다.
+
+---
+
+## 1. ① 발견 — 주소를 쓰기 전에 읽는다
+
+쓰기는 발견이 준 좌표만 받는다. 이름을 기억해서 넣지 않는다.
+
+| 목표 | 발견 명령 | 쓰는 필드 |
+|------|-----------|-----------|
+| 누름틀 채우기 | `rhwp fields <파일> --json` | `fields[].name`, 동명 개수 = 순번 범위 |
+| 표 칸 | `rhwp export-tables <파일> --json` | `tables[].index`, `cells[].row/col` |
+| 문구 치환 | `rhwp search <파일> <검색어> --json` | `matchCount`, 쪽·문단 |
+| 쪽 범위 | `rhwp info <파일> --json` | `pageCount`, `format` |
+| 체크박스 | `rhwp search <파일> □ --json` | `matchCount` = `set_checkbox` 범위 |
+
+발견 결과를 프롬프트에 통째로 붙여 다음 도구 이름을 바꾸지 않는다.
+이름·좌표·건수만 골라 명령 인자를 만든다.
+
+암호 문서는 `--password-stdin`. 발견이 exit 1 이면 쓰기를 시작하지 않는다.
+
+---
+
+## 2. ② 선확인 — `--dry-run --json`
+
+### 2.1 1층
+
+```bash
+rhwp edit fill-fields 서식.hwp --data @row.json --dry-run --json
+rhwp edit replace-text 공문.hwp --find "2025년" --replace "2026년" --dry-run --json
+rhwp edit set-cell 양식.hwpx --table 12 --row 1 --col 1 --text "1,234" --dry-run --json
+rhwp edit insert-image 서식.hwp --image 도장.png --page 0 --x 50000 --y 70000 --dry-run --json
+rhwp edit redact 계약서.hwp --dry-run --no-raw --json
+```
+
+읽는 것:
+
+- `dryRun` 이 true 인가. 아니면 실행해 버린 것이다 — 중단.
+- `notFound` / `ambiguous` / `overflow` / `findingCount` / `replacedCount`.
+- `output` 키가 **없어야** 한다. 있으면 dry-run 이 아니다.
+- 산출 경로를 `test -e` 로 확인한다. 파일이 생겼으면 계약 위반이다. 사용자에게 알린다.
+
+`edit sanitize` 에는 `--dry-run` 이 없다. 선확인 대신 복사본에 적용하고
+`removed[]` 를 읽은 뒤, 본문 `export-text` 전후가 같은지 본다.
+
+### 2.2 3층
+
+```bash
+rhwp run plan.json --dry-run --json
+```
+
+읽는 것:
+
+- `invalid[]` 가 비었는가. 아니면 계획을 고치고 ② 로 돌아간다.
+- `preview[]` 의 step 수 = 계획서 steps 수 (건너뛴 step 포함).
+- `skipped: true` 인 step 이 의도한 것인가.
+- `preview[].targets[].sameNameCount` > 1 이면 순번을 붙일지 결정한다.
+- `willReplace` / `matches` 가 기대와 같은가.
+- 산출 경로에 파일이 생기지 않았는가.
+
+dry-run 의 exit 는 성공이면 0, 선검증 실패면 2. exit 2 여도 stdout 에 봉투가 있다.
+
+### 2.3 `changedPages: null`
+
+dry-run 은 재조판을 하지 않으므로 `changedPages` 는 항상 `null` 이다.
+`null` 은 "바뀐 쪽 없음"이 아니다. 빈 배열 `[]` 이 "바뀐 쪽 없음"이다.
+
+눈검증(⑥)을 dry-run 직후에 하지 마라. 저장 후 배열이 온 다음에 한다.
+
+---
+
+## 3. ③ 실행 — `-o` 와 `--verify`
+
+### 3.1 산출 분리
+
+```bash
+rhwp edit fill-fields 서식.hwp --data @row.json -o 완성본.hwp --verify --json
+rhwp run plan.json --json
+```
+
+`-o` / 계획서 `output` 은 입력과 **다른 경로**다.
+작업 디렉터리 루트에 `*_filled.hwp` 기본 이름을 만들지 않으려면 항상 명시한다.
+
+`redact` 는 `-o` 또는 `--in-place`. 에이전트 기본은 `-o`.
+
+### 3.2 `--verify` 를 붙이는 때
+
+에이전트 기본은 붙인다. 빠지면 봉투의 `verify` 가 `null` 이고,
+그것은 통과가 아니라 **검증을 안 한 것**이다.
+
+```
+$ rhwp edit fill-fields samples/field-01.hwp \
+    --data '{"회사명":"페타플로","작성자":"홍길동"}' -o out/field-filled.hwp --json
+{ … "output":"out/field-filled.hwp","outputFormat":"hwp5","verify":null}
+```
+
+붙이면:
+
+```
+"verify": {"diffCount": 0, "identical": true}
+```
+
+`run` 은 계획서 `assertions.verify: true` 가 같은 스위치다.
+CLI 플래그 `--verify` 가 `run` 에 있는 것이 아니다. 계획서에 적는다.
+
+### 3.3 1층 verify 와 3층 verify 의 디스크
+
+| 경로 | 차이 시 산출물 | exit |
+|------|----------------|-----:|
+| `edit … --verify` | **남는다** | 3 |
+| `run` + `assertions.verify` | **남기지 않는다** | 3 |
+| `convert` / `export-hwpx --verify` | 남는다 | 3 |
+| `convert` / `export-hwpx --verify-pages` | 남는다 | 4 |
+
+1층에서 exit 3 이 나왔어도 산출물은 있다. 버리기 전에 `verify.diffCount` 와
+재독(⑤)을 보고 판단한다. "exit 3 = 실패 = 파일 없음" 으로 지우지 마라.
+
+3층에서 exit 3 이면 산출 경로를 열지 마라. 파일이 없거나 이전 잔재다.
+
+워크스루: [../examples/10_verify_exit3.md](../examples/10_verify_exit3.md).
+
+---
+
+## 4. ④ 판정 — 종료 코드를 먼저
+
+```
+code = process.exitCode
+if code == 1:
+    stdout 는 0바이트. 환경·경로·암호를 본다. 재시도는 원인을 고친 뒤.
+elif code == 2:
+    단건 edit 는 stdout 0바이트. run / csv-to-table 은 invalid[] 를 읽는다.
+    같은 명령줄을 재시도하지 않는다.
+elif code in (0, 3, 4):
+    stdout JSON 을 파싱한다. 아래 완료 식을 평가한다.
+```
+
+완료 식은 명령마다 다르다. 공통으로:
+
+- `schemaVersion` 이 있다.
+- 1층이면 `dryRun` 이 false (실행했는데 true 면 잘못 붙인 것).
+- `notFound` / `ambiguous` / `invalid` 가 있으면 비었는지 본다.
+- `verify` 가 객체면 `identical` 과 `diffCount` 를 읽는다.
+  `identical == false` 인데 code == 0 이면 계약 위반이다 (`tests/edit_verify_contract.rs`).
+
+`filledCount > 0` 만으로 완료하지 않는다.
+
+---
+
+## 5. ⑤ 재독 — 쓰기와 쌍
+
+저장이 끝난 산출물에 대해 **같은 주소로** 다시 읽는다.
+
+### 5.1 fill-fields
+
+```bash
+rhwp fields 완성본.hwp --json \
+  | jq -c '[.fields[]|select(.name=="회사명" or .name=="작성자")|{name,value}]'
+```
+
+기대: data 에 넣은 값이 `value` 에 있다. 동명 필드는 `이름[N]` 으로 지목한
+순번만 바뀌고 나머지는 입력과 같다.
+
+### 5.2 replace-text
+
+```bash
+rhwp search 개정본.hwp "2025년" --json | jq .matchCount
+```
+
+전건 치환이면 0. `--occurrence k` 이면 원본 `matchCount - 1`.
+`replacedCount` 와 `matchCount` 감소가 맞아야 한다.
+
+### 5.3 set-cell
+
+```bash
+rhwp export-tables 작성본.hwpx --json \
+  | jq -r '.tables[]|select(.index==12)|.cells[]|select(.row==1 and .col==1).text'
+```
+
+기대: 봉투의 `newText`. 이웃 칸은 `old` 그대로.
+
+### 5.4 insert-image
+
+```bash
+rhwp info 제출본.hwp --json | jq '{pageCount, format}'
+rhwp export-svg 제출본.hwp -o /tmp/svg -p 0 --json
+```
+
+`overflow` 가 비었는지, 해당 쪽 SVG 가 생겼는지. 픽셀 대조는 이 스킬의 일이 아니다.
+시각 회귀는 rhwp-visual-regression 스킬로 넘긴다.
+
+### 5.5 redact
+
+```bash
+rhwp edit redact 공개본.hwp --dry-run --no-raw --json | jq .findingCount
+```
+
+같은 `--kind` 로 0 이어야 한다. 원문에 `--no-raw` 없이 재스윕하지 마라.
+
+### 5.6 sanitize
+
+```bash
+rhwp edit sanitize 배포본.hwp -o /tmp/재확인.hwp --json | jq .removedCount
+```
+
+기대 0. 본문은
+
+```bash
+rhwp export-text 원본.hwp
+rhwp export-text 배포본.hwp
+```
+
+두 결과가 같아야 한다.
+
+### 5.7 run 다단계
+
+저널 `steps[]` 를 순회하며 각 action 에 위 재독을 적용한다.
+`skipped: true` 인 step 의 대상은 원본과 같아야 한다.
+
+한 step 의 재독이 실패하면 산출물을 완성본으로 넘기지 않는다.
+원본은 살아 있으므로 계획서를 고치고 ② 부터.
+
+---
+
+## 6. ⑥ 눈검증 — `changedPages` 만
+
+편집 봉투는 재조판 후 **0 기준 쪽 번호**를 준다.
+
+실측 (`agent_surface_playbook` §9-3):
+
+```
+$ rhwp edit replace-text samples/hwp3-sample.hwp --find 의 --replace 의 -o out/rep1.hwp --json
+{"changedPages":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"replacedCount":276, …}
+
+$ rhwp edit replace-text samples/hwp3-sample.hwp --find 의 --replace ★ --occurrence 3 -o out/rep2.hwp --json
+{"changedPages":[0],"occurrence":3,"replacedCount":1, …}
+```
+
+전건은 15쪽, occurrence 3 은 0쪽 하나. **그 쪽만** 렌더한다.
+
+```bash
+rhwp export-svg out/rep2.hwp -o out/svg -p 0 --json
+```
+
+규칙:
+
+- `changedPages` 가 배열이면 그 원소만 `-p`.
+- `[]` 이면 바뀐 쪽이 없다. 렌더할 필요가 없다. 재독(⑤)만 확인한다.
+- `null` 이면 확정 불가. dry-run 이거나 조판을 못 한 것. 전체를 보지 말고
+  먼저 왜 null 인지 본다. 저장 전 null 이면 저장 후에 다시 받는다.
+- 쪽 번호는 0 기준이다. `export-svg -p` 도 0 기준이다. 사용자에게 말할 때
+  "1쪽"으로 바꾸려면 +1 하고, 명령에는 0 을 유지한다.
+
+세션 도구 `hwp_doc_render_page` 는 같은 루프를 상수 비용으로 닫는다.
+이 파동은 MCP 스킬을 고치지 않는다. CLI `export-svg -p` 가 동등한 1층이다.
+
+---
+
+## 7. ⑦ `ir-diff` — 무손실이 계약일 때만
+
+`--verify` 통과가 "원본과 완전 동일"이 아니다. 자기 재파싱 게이트다.
+
+실측:
+
+```
+$ rhwp export-hwpx samples/추진일정.hwp out/추진일정.hwpx --verify --json
+{"verify":{"diffCount":0,"identical":true}, …}
+exit=0
+
+$ rhwp ir-diff samples/추진일정.hwp out/추진일정.hwpx --json
+{"categories":{"cc":1,"char_offsets[0]: A=32 vs B=16":1},"diffCount":2,"identical":false, …}
+exit=3
+```
+
+두 판정은 같은 대상을 보지 않는다.
+
+- `--verify`: 저장 직후 산출물을 재파싱해 **자기 자신**과 대조.
+- `ir-diff`: 두 파일을 직접 비교.
+
+무손실이 계약이면 **둘 다** 돌리고 `categories` 를 읽어 판단한다.
+일반 서식 채우기는 원본과 산출이 달라야 한다 (`ir-diff` 차이 존재 = 정상).
+이 경우 `ir-diff` 를 "실패"로 보고하지 마라.
+
+`ir-diff` 는 `--json` 없이 차이가 있어도 exit 0 일 수 있다.
+자동화에서는 반드시 `--json` 을 붙인다.
+
+---
+
+## 8. `batch fill` 루프
+
+대량은 전행 dry-run 이 선확인이다.
+
+```
+$ rhwp batch fill --form samples/field-01.hwp --data out/rows.jsonl \
+    --out-dir out/merge --name-field 회사명 --dry-run --json
+{"dryRun":true,"filledCount":3,"notFound":[],"output":"out/merge\\페타플로.hwp","row":0, …}
+{"dryRun":true,"filledCount":3,"notFound":[],"output":"out/merge\\가나다.hwp","row":1, …}
+{"dryRun":true,"filledCount":2,"notFound":["없는필드"],"output":"out/merge\\라마바.hwp","row":2, …}
+batch fill: 3행 중 3 성공, 0 실패 (…, dry-run)
+exit=0
+```
+
+세 번째 행에 `notFound` 가 있는데 **exit 0**. 데이터 품질 문제는 실행 실패가 아니다.
+행 단위로 `notFound` 를 확인하지 않으면 조용히 덜 채운 산출물 N개가 나온다.
+
+루프:
+
+1. `--dry-run --json` 으로 NDJSON 을 받는다.
+2. `notFound` 가 있는 `row` 를 고친다 (데이터 또는 매핑).
+3. 전행이 깨끗해진 뒤에 `--dry-run` 을 떼고 실행한다.
+4. 실행 NDJSON 을 다시 훑어 같은 완료 식을 적용한다.
+5. 표본 한 행만 `fields` 재독 + `changedPages` 눈검증.
+
+워크스루: [../examples/14_batch_fill_row_judgment.md](../examples/14_batch_fill_row_judgment.md).
+
+---
+
+## 9. 원본 불변을 루프에서 증명하기
+
+에이전트가 "원본을 안 건드렸다"고 말하려면 주장이 아니라 대조가 있어야 한다.
+
+```bash
+# 실행 전
+cp 서식.hwp /tmp/orig.hwp
+# 또는
+sha256sum 서식.hwp > /tmp/orig.sha
+
+# ② ③ 수행
+
+# 실행 후
+cmp 서식.hwp /tmp/orig.hwp          # 바이트 동일
+# 또는
+sha256sum -c /tmp/orig.sha
+```
+
+Windows 에서는 `Get-FileHash` 로 같은 대조를 한다.
+테스트는 이 불변식을 이미 지킨다 (`edit_fill_fields_contract.rs` —
+dry-run 은 산출 경로를 만들지 않고, 실패 시 출력 파일을 쓰지 않는다).
+
+`run` 선검증 실패·단언 실패·CAS 실패는 산출 경로를 만들지 않는다.
+이전 실행의 잔재가 그 경로에 있으면 이번 실패의 산출물이 아니다.
+돌리기 전에 산출 경로를 지운다.
+
+워크스루: [../examples/15_original_untouched.md](../examples/15_original_untouched.md).
+
+---
+
+## 10. 세션 루프 (참고, 이 스킬은 CLI 가 정본)
+
+```
+hwp_open → hwp_doc_fill_fields / hwp_doc_replace_text / …
+         → changedPages 를 읽어 hwp_doc_render_page
+         → hwp_doc_save {verify:true}
+         → hwp_close
+```
+
+`hwp_doc_save` 전에는 디스크가 바뀌지 않는다.
+저장 후에도 핸들은 열려 있어 이어서 편집·재저장할 수 있다.
+세션 안의 연속 편집은 메모리에서 이어지므로 1층을 이어 붙이는 반쪽 파일 문제가
+디스크에는 없다. 그러나 저장 한 번에 단언을 걸려면 결국 `hwp_run_plan` 또는
+`hwp_doc_save --verify` 다.
+
+이 파동은 MCP 스킬 본문을 수정하지 않는다. 위 줄은 CLI 루프와 동형이라는
+표지일 뿐이다.
+
+---
+
+## 11. 루프 픽스처
+
+기계가 읽는 루프 정의는 [../fixtures/loops/](../fixtures/loops/) 다.
+
+| 파일 | 뜻 |
+|------|-----|
+| `layer1_fill.json` | 발견→dry-run→실행→재독 (fill-fields) |
+| `layer1_replace.json` | 치환 + search 재독 |
+| `layer1_set_cell.json` | export-tables 왕복 |
+| `layer3_run.json` | export-plan-schema→dry-run→run→재독 |
+| `verify_null_vs_object.json` | verify null ≠ 통과 |
+| `changed_pages_null.json` | null ≠ [] |
+
+각 파일은 단계 배열과 각 단계의 `command`·`expectExit`·`readFields` 를 담는다.
+테스트가 이 스키마를 고정한다. 런타임에 rhwp 를 반드시 띄우지는 않는다 —
+문서와 픽스처가 같은 단어를 쓰는지가 이 파동의 시험이다.
+
+---
+
+## 12. 에이전트가 루프를 건너뛰는 징후
+
+다음이 보이면 루프를 되감는다.
+
+1. 첫 도구 호출이 `edit` 또는 `run` 이고 그 앞에 `fields`/`export-tables`/`search` 가 없다.
+2. `--dry-run` 없이 `-o` 로 바로 저장했다.
+3. 저장 후 `fields`/`search`/`export-tables` 재독이 없다.
+4. `verify: null` 을 "검증 통과" 로 사용자에게 말했다.
+5. `changedPages: null` 인 채로 `export-svg` 전 페이지를 돌렸다.
+6. exit 3 을 예외로 삼켜 봉투를 읽지 않았다.
+7. `filledCount` 만 보고 완료라고 했다.
+8. 원본 경로에 썼다 (`-o` 가 입력과 같거나 `--in-place` 를 묻지 않고 사용).
+
+이 징후가 0건인 것이 K8 DoD 의 "무계획 실행 0" 이다.
+스킬 판단 트리가 구조적으로 배제하고, 예제·픽스처·시험이 그 배제를 표본으로 남긴다.
+
+---
+
+## 13. 단계별 중단 표
+
+| 단계에서 본 것 | 다음 |
+|----------------|------|
+| 발견 exit 1 (파일 없음·암호) | 쓰기 금지. 암호는 stdin 재시도 한 번 |
+| dry-run `notFound` 비지 않음 | data/키 수정 후 ② |
+| dry-run `ambiguous` 비지 않음 | `이름[N]` 으로 고친 후 ② |
+| dry-run `overflow` 비지 않음 | 더 짧은 값 또는 사용자에게 알림 |
+| dry-run `invalid[]` 비지 않음 | 계획서 수정 후 ②. 재시도 금지 |
+| 실행 exit 1 | 원본 확인. 산출 경로 잔재 삭제 |
+| 실행 exit 2 (1층) | 인자 수정. 같은 줄 재시도 금지 |
+| 실행 exit 3 (1층 verify) | 산출물은 있음. diffCount 읽고 ⑤ |
+| 실행 exit 3 (run verify/CAS) | 산출물 없음. 저널 읽고 재계획 |
+| 실행 exit 4 | convert/export-hwpx 전용. 이 스킬 기본 경로 아님 |
+| 재독 불일치 | 산출물 폐기. 원본에서 다시 |
+| `changedPages` 쪽 렌더 실패 | 시각 스킬로 인계. 편집 자체는 재독이 맞으면 유지 |
+
+---
+
+## 14. 다음 문서
+
+- 종료 코드·봉투 필드 사전 → [failure_envelopes.md](failure_envelopes.md)
+- 루프 워크스루 모음 → [../examples/README.md](../examples/README.md)

--- a/mydocs/working/agent_safe_edit.md
+++ b/mydocs/working/agent_safe_edit.md
@@ -1,0 +1,284 @@
+---
+kind: working
+status: active
+issue: 5294
+---
+
+# 에이전트 안전 편집 스킬 고도화 (#5294)
+
+작업 브랜치: `feat/agent-safe-edit`
+대상 스킬: `.claude/skills/rhwp-safe-edit/`
+이슈: [agent: 안전 편집(run 계획·dry-run·verify) 스킬 고도화](https://github.com/edwardkim/rhwp/issues/5294)
+
+## 1. 한 줄
+
+실사용 에이전트가 HWP/HWPX 를 고칠 때 원본을 깨지 않도록, 이미 devel 에 있는
+`edit` 과 `run` 을 문서·픽스처·시험으로 배선한다. 새 편집 로직 발명 금지. gym 금지.
+
+## 2. 이슈가 요구한 것 / 하지 말라는 것
+
+요구:
+
+- 원본 훼손 없이 편집하는 실사용 경로를 키운다.
+- 기존 edit + run 계획 (dry-run, `-o`, `--verify`, exit 3/4 를 데이터로)을 문서화·배선.
+- `.claude/skills/rhwp-safe-edit/` 확장 — SKILL.md + `references/`
+  (single edit, run plans, verify loops, failure envelopes).
+- 워크스루를 마크다운/JSON 픽스처 + 테스트로 남긴다.
+- `mydocs/working/agent_safe_edit.md` (이 파일).
+- additions 5000–10000, 최소 5000.
+- PR 전 `cargo fmt --all -- --check`.
+- isolation worktree, 브랜치 `feat/agent-safe-edit` from `upstream/devel`.
+- 한국어 PR, base `devel`, `closes #5294`, `--body-file`.
+- `git add -A` 금지.
+
+금지:
+
+- 새 edit 로직 발명.
+- gym/ 를 열지 않는다. gym 을 만지지 않는다 (gym 금지).
+- 다른 네 에이전트 스킬을 이 파동에서 고치지 않는다
+  (`rhwp-onboarding`, `rhwp-mcp-session`, `rhwp-provenance`, `rhwp-doc-triage`).
+
+## 3. 왜 스킬만 키우나
+
+K8 안전 편집 스킬은 이미 있다 (원 PR #4215, #4253 통합, 커밋 1ac20c359).
+SKILL.md 한 장이 판단 트리와 함정 10개조를 담고, exit 3 을 판정 데이터로 읽으라고 적는다.
+
+트랙 K 기록 (`mydocs/tech/agent_roadmap/track_k_skills.md` K8 DoD)이 남긴 구멍은
+"임의 편집 요청 표본에서 무계획 실행 0"을 **실행 로그·표본 테스트로** 확인하지
+않았다는 점이다. 판단 트리가 구조적으로 그 경로를 배제한다는 설계상 주장만 있었다.
+
+이 파동은 그 구멍을 메운다.
+
+- 1층/3층/루프/봉투를 자식 문서로 쪼개 에이전트가 한 장을 다 읽지 않고도
+  해당 갈래를 끝까지 따라가게 한다.
+- 16편 워크스루가 "발견 없이 `--in-place`" 경로를 표본에서 빼 둔다.
+- JSON 픽스처가 유효/무효 계획과 실패 봉투의 키를 기계가 읽게 한다.
+- Python·Rust 시험이 문서와 픽스처가 같은 단어를 쓰는지 고정한다.
+
+구현(`run_plan_engine`, `edit fill-fields` 등)은 그대로다. 테스트가 기존 계약
+테스트(`edit_*_contract.rs`, `plan_schema_contract.rs`, `skills_contract.rs`)를
+대체하지 않는다. 스킬 팩이 그 계약을 인용하는지만 본다.
+
+## 4. 범위
+
+만진 것:
+
+| 경로 | 역할 |
+|------|------|
+| `.claude/skills/rhwp-safe-edit/SKILL.md` | 라우터. 자식 문서 표, 하지 않는 것, CAS·조건절 함정 추가 |
+| `references/single_edit.md` | 1층 6종 + csv-to-table + batch fill |
+| `references/run_plans.md` | 계획서 스키마 1.1, action 4, if, assertions, CAS |
+| `references/verify_loops.md` | 발견→dry-run→-o/--verify→재독→눈검증→ir-diff |
+| `references/failure_envelopes.md` | exit 0/1/2/3/4, 성공 안 미완료, 분기 의사코드 |
+| `examples/01`–`16` + README | 워크스루 |
+| `fixtures/plans/*.json` | 유효 12 · 무효 9 |
+| `fixtures/envelopes/*.json` | 분기 표본 19 |
+| `fixtures/loops/*.json` | 루프 정의 6 |
+| `fixtures/catalog.json` | 목록의 단일 출처 |
+| `scripts/tests/test_agent_safe_edit.py` | 파일 계약 (바이너리 없음). `tests/` 신규 integration 은 suite-policy 상 `tests/cases/` 만 허용이라 이 파동은 Python 시험을 정본으로 둔다 |
+| `mydocs/working/agent_safe_edit.md` | 이 기록 |
+
+만지지 않은 것:
+
+- `src/` 편집 엔진, `run_plan_engine`, 새 CLI 플래그
+- `gym/` 전부
+- `.claude/skills/rhwp-onboarding/`
+- `.claude/skills/rhwp-mcp-session/`
+- `.claude/skills/rhwp-provenance/`
+- `.claude/skills/rhwp-doc-triage/`
+- 다른 스킬 SKILL.md
+- 공개 샘플 HWP 바이너리 (새 픽스처를 스킬 폴더에 넣지 않음)
+
+## 5. 기존 계약의 지도 (발명하지 않은 것)
+
+문서가 가리키는 구현·매뉴얼의 위치다. 스킬이 이 표를 복제하지 않고 인용한다.
+
+| 계약 | 출처 |
+|------|------|
+| 종료 코드 0/1/2/3/4 | cli_commands.md §종료 코드, #2707 |
+| fill-fields 봉투 · 반복 필드 | cli_commands.md, #3329, #3476 |
+| replace-text 0건 무산출 | cli_commands.md, #3373 |
+| set-cell overflow · keep-style | #3381, #3391, #3480 |
+| insert-image HWPUNIT · overflow | #3719 §6-5 |
+| redact `-o` 필수 · `--no-raw` | #3719 §6-11 |
+| sanitize 재실행 0 | #3719 §6-11 |
+| 입력 형식 보존 | #3383 |
+| run 선검증→원자→저널 | #3703, main.rs `run_plan_engine` |
+| 조건절 if 1회 입력 기준 | #3719 §6-8 |
+| 계획 스키마 1.1 · CAS | #4378, plan_schema.rs, PLAN_SCHEMA_VERSION |
+| `--verify` 봉투-exit | #3702, edit_verify_contract.rs |
+| 스킬 실재 명령 가드 | #4508, skills_contract.rs |
+| dry-run / changedPages 실측 | agent_surface_playbook.md §9 |
+| run 실측 저널 | agent_task_playbook.md §12 |
+
+action 4종은 스키마 `$defs` 와 실행기 `match action` 이 같다.
+다섯 번째를 스킬이 만들어 넣지 않는다. `insert_image` 를 유효 계획에 넣은
+픽스처는 `invalid_unknown_action.json` 뿐이다.
+
+## 6. 1층과 3층의 엄격함 차이 (문서가 특히 붙든 곳)
+
+같은 찾기라도 층이 다르면 판정이 다르다. 에이전트가 여기를 섞으면
+"1층에서 성공한 계획을 3층에 넣었더니 exit 2" 가 된다.
+
+| 상황 | 1층 `edit` | 3층 `run` |
+|------|------------|-----------|
+| 없는 필드 | `notFound` + exit 0 | 선검증 `invalid` + exit 2 |
+| 치환 0건 | `replacedCount: 0`, 산출 없음, exit 0 | `일치 0건` invalid + exit 2 |
+| `--verify` 차이 | 산출 **남김**, exit 3 | `assertions.verify` 면 산출 **안 남김**, exit 3 |
+| 동명 순번 생략 | `ambiguous` + 첫 칸, exit 0 | 동일 (칸은 존재하므로 선검증 통과) |
+| 그림/마스킹/메타 | CLI 있음 | action 없음 |
+
+스킬은 이 표를 세 문서(single_edit, run_plans, failure_envelopes)에 반복한다.
+시험이 "1층 verify 는 outputKept, 3층은 아님" 픽스처를 고정한다.
+
+## 7. exit 3 세 갈래
+
+이슈가 "exit 3/4 를 데이터로" 라고 한 이유다. 같은 숫자가 세 가지 다음 행동을 뜻한다.
+
+1. 1층 `--verify` — 파일 있음. `InspectKeptOutput`.
+2. 3층 `assertions.verify` — 파일 없음. `ReplanNoOutput`.
+3. 3층 CAS `preconditionFailed` — 파일 없음, `invalid[]` 비어 있음, `nextCall`.
+   사용법(2)이 아니다.
+
+exit 4 는 `convert`/`export-hwpx --verify-pages` 전용. `edit`/`run` 기본 경로는 내지 않는다.
+
+성공 코드(0) 안의 미완료 (`notFound`, `ambiguous`, `overflow`, `batch` 행 `notFound`,
+`verify: null`)가 더 위험하다. 예외가 안 나므로 에이전트가 완성본으로 넘긴다.
+failure_envelopes.md §3 과 12·11·14 편이 이 갈래의 표본이다.
+
+## 8. 디렉터리 규약
+
+```
+.claude/skills/rhwp-safe-edit/
+  SKILL.md                 라우터 (frontmatter name == 폴더명)
+  references/
+    single_edit.md
+    run_plans.md
+    verify_loops.md
+    failure_envelopes.md
+  examples/
+    README.md
+    01_… 16_….md
+  fixtures/
+    catalog.json
+    plans/{valid_*,invalid_*}.json
+    envelopes/*.json
+    loops/*.json
+```
+
+`catalog.json` 이 목록의 단일 출처다.  stray JSON 이 생기면 시험이 실패한다.
+워크스루가 가리키는 픽스처 파일명도 catalog 와 같아야 한다.
+
+상대 링크는 스킬 폴더 안에서 해석되고, `mydocs/manual/…` 로 나가는 링크는
+저장소 루트 기준으로 존재해야 한다. Python 시험이 깨진 링크를 모은다.
+
+## 9. 시험
+
+### 9.1 파일 계약 (바이너리 없음)
+
+```
+python -m unittest scripts.tests.test_agent_safe_edit
+```
+
+확인하는 것:
+
+- 레이아웃, frontmatter, 자식 문서 네 장
+- 레퍼런스별 계약 토큰
+- catalog ↔ 디스크 파일 1:1
+- 유효 계획은 `planVersion`/`input`/`output`/`steps` + action ∈ 4
+- 무효 계획은 알려진 규칙 하나를 깬다
+- 봉투마다 `_skillMeta.exit` ∈ {0,1,2,3,4} 와 `branch`
+- CAS 봉투는 exit 3 + 빈 `invalid` + `nextCall`
+- 루프 단계가 `rhwp` 로 시작하고 `--dry-run` 을 포함한다
+- `rhwp <머리>` 가 알려진 집합에 속한다
+- 상대 링크가 존재한다
+- gym/packs 등을 편집하라고 하지 않는다
+- 형제 스킬 경로가 사라지지 않았다 (본문은 요구하지 않음)
+
+### 9.2 기존 구현 시험 (이 파동이 돌리지 않아도 되는 이유)
+
+`edit_fill_fields_contract.rs`, `edit_replace_text_contract.rs`,
+`edit_set_cell_contract.rs`, `edit_verify_contract.rs`,
+`plan_schema_contract.rs` 가 엔진을 이미 지킨다. 이 파동은 엔진을 바꾸지
+않았으므로 그 시험들을 재실행하는 것이 게이트는 아니다.
+로컬에서 의심되면 그 테스트 이름만 골라 돌린다.
+
+### 9.4 fmt 게이트
+
+```
+cargo fmt --all -- --check
+```
+
+이슈 DoD 의 하드 게이트. Rust 파일을 넣었으므로 PR 생성 전에 통과해야 한다.
+`newline_style = Unix`. Python·Markdown 은 rustfmt 대상이 아니다.
+
+## 10. 에이전트가 이 스킬을 소비하는 순서
+
+1. SKILL.md 판단 트리 — 1건이면 1층, 여러 건이면 3층.
+2. 해당 레퍼런스 한 장.
+3. 같은 번호의 examples/ 편.
+4. 명령을 조립할 때 fixtures/plans 또는 envelopes 의 키를 베낀다.
+5. 종료 코드 → failure_envelopes 의사코드.
+6. 완료 식을 만족할 때만 산출물을 사용자에게 넘긴다.
+
+무계획 실행(발견 없이 `--in-place`, dry-run 없이 `-o`, `filledCount` 만 보고 완료)은
+위 순서에 칸이 없다. 워크스루의 "하지 않는 것" 절이 그 칸을 비워 둔다.
+
+## 11. 의도적으로 복제하지 않은 것
+
+- MCP 도구 스키마. `capabilities --mcp` 가 단일 출처. 세션 루프는 verify_loops 에
+  참고 한 절만 있고, rhwp-mcp-session 스킬 본문은 그대로다.
+- 출처 표지 소비. `untrustedContent` 키 부재 ≠ false 는 한 줄로만 가리키고
+  rhwp-provenance 에 맡긴다.
+- 문서 트리아지 순서 (`info`→`explain`→…). 발견은 fields/export-tables/search 만.
+- 온보딩 닥터. 바이너리 위치는 SKILL 의 `cargo build --release` 한 줄.
+- gym pack · 채점 · admission. 문장에 gym 이 나오면 "만지지 않는다"는 표지다.
+
+## 12. 검증 실측 (이 작업)
+
+로컬에서 수행한 것:
+
+```
+python -m unittest scripts.tests.test_agent_safe_edit
+cargo fmt --all -- --check
+```
+
+(실행 시각·통과 수는 PR 본문의 테스트 체크리스트에 적는다.)
+
+수행하지 않은 것:
+
+- 전체 `cargo test` (엔진 변경 없음)
+- clippy (Rust 는 테스트만, 경고 0을 이 파동의 엔진 변경으로 요구하지 않음)
+- 시각 SVG 전후 (레이아웃 변경 없음)
+- WASM
+- gym audit / certify
+
+## 13. PR 메모
+
+- base: `devel`
+- head: `kevin9327:feat/agent-safe-edit` (origin 이 fork)
+- 제목 한국어, 본문 `--body-file` UTF-8 without BOM
+- `closes #5294`
+- `git add -A` 를 쓰지 않고 경로를 지정해 add
+- 생성 후 `gh pr view --json body` 로 한글·BOM·`??` 확인
+
+## 14. 남은 일 (이 PR 밖)
+
+- K8 원 DoD 의 "임의 편집 요청 표본을 실제 에이전트 세션으로 돌려 무계획 실행 0"은
+  이 문서·픽스처가 표본을 제공할 뿐, 라이브 에이전트 세션 로그는 여기 없다.
+- 바인딩 `Plan.check/run` README 는 이 devel 스냅샷에 파일이 없을 수 있다.
+  CLI 두 호출이 정본이라고 적었다.
+- capability 카탈로그에 `rhwp-safe-edit` 행이 원래 없었다. 이 파동은 스킬을
+  새로 만들지 않고 확장만 하므로 카탈로그 행을 추가하지 않았다.
+  등록이 필요하면 별도 이슈에서 `CAP-5294` 를 논의한다.
+- skills_contract.rs 를 레퍼런스 md 까지 재귀 스캔하도록 넓히는 것은
+  다른 스킬에 영향을 줄 수 있어 이 파동에서 하지 않았다.
+
+## 15. 파일 점검표 (작성 시점)
+
+레퍼런스 4, 예제 16+README, 계획 21, 봉투 19, 루프 6, catalog 1,
+Python 시험 1, 작업 기록 1, SKILL 1.
+
+합계 줄 수는 `git diff --shortstat upstream/devel` 이 정본이다.
+이슈 창 5000–10000 을 벗어나면 예제·픽스처를 더하거나 줄인다.
+패딩용 난문은 넣지 않는다 — 각 줄은 기존 계약의 키·분기·함정이다.

--- a/scripts/tests/test_agent_safe_edit.py
+++ b/scripts/tests/test_agent_safe_edit.py
@@ -1,0 +1,700 @@
+"""[#5294] rhwp-safe-edit 스킬 고도화 계약.
+
+에이전트가 원본을 훼손하지 않고 기존 edit / run 경로를 부르도록
+문서·픽스처·워크스루가 같은 단어를 쓰는지 파일만으로 고정한다.
+
+새 편집 로직을 시험하지 않는다. gym/ 을 열지 않는다.
+다른 네 에이전트 스킬(onboarding / mcp-session / provenance / doc-triage)의
+본문을 요구하거나 바꾸지 않는다. 바이너리·네트워크를 부르지 않는다.
+
+정본: .claude/skills/rhwp-safe-edit/
+작업 기록: mydocs/working/agent_safe_edit.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / ".claude" / "skills" / "rhwp-safe-edit"
+SKILL_MD = SKILL / "SKILL.md"
+REFS = SKILL / "references"
+EXAMPLES = SKILL / "examples"
+FIXTURES = SKILL / "fixtures"
+PLANS = FIXTURES / "plans"
+ENVS = FIXTURES / "envelopes"
+LOOPS = FIXTURES / "loops"
+CATALOG = FIXTURES / "catalog.json"
+WORKING = REPO / "mydocs" / "working" / "agent_safe_edit.md"
+
+REFERENCE_NAMES = (
+    "single_edit.md",
+    "run_plans.md",
+    "verify_loops.md",
+    "failure_envelopes.md",
+)
+
+RUN_ACTIONS = (
+    "fill_fields",
+    "replace_text",
+    "set_cell",
+    "set_checkbox",
+)
+
+# 이 파동이 만지지 않는 형제 스킬. 존재만 확인하고 내용을 요구하지 않는다.
+SIBLING_SKILLS = (
+    "rhwp-onboarding",
+    "rhwp-mcp-session",
+    "rhwp-provenance",
+    "rhwp-doc-triage",
+)
+
+# 1층 CLI 하위명령 — 스킬이 배선하는 기존 표면.
+EDIT_SUBS = (
+    "fill-fields",
+    "replace-text",
+    "set-cell",
+    "insert-image",
+    "redact",
+    "sanitize",
+)
+
+# 문서에 반드시 남아야 하는 토큰. 문장이 바뀌어도 계약 단어는 남는다.
+REF_TOKENS = {
+    "single_edit.md": (
+        "edit fill-fields",
+        "edit replace-text",
+        "edit set-cell",
+        "edit insert-image",
+        "edit redact",
+        "edit sanitize",
+        "--dry-run",
+        "-o",
+        "--verify",
+        "outputFormat",
+        "notFound",
+        "ambiguous",
+        "overflow",
+        "원본",
+        "csv-to-table",
+        "batch fill",
+    ),
+    "run_plans.md": (
+        "planVersion",
+        "export-plan-schema",
+        "fill_fields",
+        "replace_text",
+        "set_cell",
+        "set_checkbox",
+        "invalid[]",
+        "preview",
+        "assertions",
+        "preconditions",
+        "inputSha256",
+        "fieldExists",
+        "fieldEquals",
+        "textFound",
+        "dry-run",
+        "nextCall",
+    ),
+    "verify_loops.md": (
+        "--dry-run",
+        "--verify",
+        "changedPages",
+        "fields",
+        "export-tables",
+        "search",
+        "export-svg",
+        "ir-diff",
+        "verify: null",
+        "재독",
+    ),
+    "failure_envelopes.md": (
+        "exit 3",
+        "exit 4",
+        "판정",
+        "notFound",
+        "ambiguous",
+        "invalid[]",
+        "preconditionFailed",
+        "stdout",
+        "InspectKeptOutput",
+        "ReplanNoOutput",
+    ),
+}
+
+SKILL_TOKENS = (
+    "원본 불변",
+    "산출 분리",
+    "선확인",
+    "판정은 예외가 아니라 봉투",
+    "edit fill-fields",
+    "rhwp run",
+    "export-plan-schema",
+    "exit 3",
+    "references/single_edit.md",
+    "references/run_plans.md",
+    "references/verify_loops.md",
+    "references/failure_envelopes.md",
+    "fixtures/catalog.json",
+)
+
+WORKING_TOKENS = (
+    "#5294",
+    "rhwp-safe-edit",
+    "edit",
+    "run",
+    "dry-run",
+    "--verify",
+    "exit 3",
+    "gym",
+    "5000",
+)
+
+INVENTED_ACTIONS = (
+    "insert_image",
+    "insert-image",
+    "redact",
+    "sanitize",
+    "fillFields",
+    "replaceText",
+    "setCell",
+    "setCheckbox",
+    "op",
+    "fill",
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def load_json(path: Path):
+    return json.loads(read(path))
+
+
+def md_files(root: Path):
+    return sorted(p for p in root.rglob("*.md") if p.is_file())
+
+
+def json_files(root: Path):
+    return sorted(p for p in root.rglob("*.json") if p.is_file())
+
+
+class SkillLayoutTests(unittest.TestCase):
+    def test_skill_root_exists(self):
+        self.assertTrue(SKILL.is_dir(), SKILL)
+        self.assertTrue(SKILL_MD.is_file(), SKILL_MD)
+        self.assertTrue(REFS.is_dir(), REFS)
+        self.assertTrue(EXAMPLES.is_dir(), EXAMPLES)
+        self.assertTrue(FIXTURES.is_dir(), FIXTURES)
+        self.assertTrue(CATALOG.is_file(), CATALOG)
+        self.assertTrue(WORKING.is_file(), WORKING)
+
+    def test_four_references_present(self):
+        names = sorted(p.name for p in REFS.glob("*.md"))
+        self.assertEqual(sorted(REFERENCE_NAMES), names)
+
+    def test_sibling_skills_exist_untouched_by_this_suite(self):
+        # 존재만 확인한다. 본문 토큰을 요구하면 이 파동이 형제 스킬에 결합된다.
+        for name in SIBLING_SKILLS:
+            path = REPO / ".claude" / "skills" / name / "SKILL.md"
+            self.assertTrue(path.is_file(), path)
+
+    def test_does_not_live_under_gym(self):
+        self.assertNotIn("gym", SKILL.parts)
+        self.assertFalse((REPO / "gym" / "docs" / "agent_safe_edit.md").exists())
+
+
+class FrontmatterTests(unittest.TestCase):
+    def test_skill_frontmatter(self):
+        body = read(SKILL_MD)
+        self.assertTrue(body.startswith("---\n"), "frontmatter 시작")
+        end = body.find("\n---\n", 4)
+        self.assertGreater(end, 0, "frontmatter 종료")
+        fm = body[4:end]
+        self.assertIn("name: rhwp-safe-edit", fm)
+        self.assertIn("description:", fm)
+        desc = ""
+        for line in fm.splitlines():
+            if line.startswith("description:"):
+                desc = line.split(":", 1)[1].strip()
+        self.assertGreaterEqual(len(desc), 20)
+
+    def test_skill_is_router_not_only_prose(self):
+        body = read(SKILL_MD)
+        self.assertIn("rhwp ", body)
+        self.assertIn("```bash", body)
+        for tok in SKILL_TOKENS:
+            self.assertIn(tok, body, tok)
+
+
+class ReferenceTokenTests(unittest.TestCase):
+    def test_each_reference_has_contract_tokens(self):
+        for name, tokens in REF_TOKENS.items():
+            body = read(REFS / name)
+            for tok in tokens:
+                self.assertIn(tok, body, f"{name} 에 {tok!r} 없음")
+
+    def test_single_edit_lists_six_commands(self):
+        body = read(REFS / "single_edit.md")
+        for sub in EDIT_SUBS:
+            self.assertIn(f"edit {sub}", body, sub)
+
+    def test_run_plans_does_not_invent_fifth_action(self):
+        body = read(REFS / "run_plans.md")
+        # 금지 안내로 insert_image 가 *등장*할 수는 있다. 유효 action 목록에 넣으면 안 된다.
+        self.assertIn("알 수 없는 action", body)
+        self.assertIn("fill_fields·replace_text·set_cell·set_checkbox", body)
+        self.assertNotRegex(body, r"action 5종|valid action.*insert_image")
+        self.assertRegex(body, r"다섯 번째 action 을 (문서에 )?추가하지 않는다")
+
+    def test_verify_loop_distinguishes_null_and_empty_pages(self):
+        body = read(REFS / "verify_loops.md")
+        self.assertIn("changedPages: null", body)
+        self.assertIn("빈 배열", body)
+        self.assertIn("확정 불가", body)
+
+    def test_failure_envelopes_treat_exit3_as_data(self):
+        body = read(REFS / "failure_envelopes.md")
+        self.assertIn("고장이 아니다", body)
+        self.assertIn("1층", body)
+        self.assertIn("산출물은 **있다**", body)
+        self.assertIn("디스크 무변경", body)
+        self.assertIn("CAS", body)
+        self.assertRegex(body, r"exit 3.{0,20}exit 2")
+
+    def test_layer1_verify_keeps_output_layer3_does_not(self):
+        fail = read(REFS / "failure_envelopes.md")
+        verify = read(REFS / "verify_loops.md")
+        joined = fail + "\n" + verify
+        self.assertIn("남는다", joined)
+        self.assertIn("남기지 않는다", joined)
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self):
+        self.cat = load_json(CATALOG)
+
+    def test_catalog_header(self):
+        self.assertEqual(self.cat["catalogVersion"], "1.0")
+        self.assertEqual(self.cat["skill"], "rhwp-safe-edit")
+        self.assertEqual(self.cat["issue"], 5294)
+        self.assertEqual(tuple(self.cat["actions"]), RUN_ACTIONS)
+
+    def test_catalog_lists_match_files(self):
+        for rel in self.cat["plans"]["valid"]:
+            self.assertTrue((PLANS / rel).is_file(), rel)
+        for rel in self.cat["plans"]["invalid"]:
+            self.assertTrue((PLANS / rel).is_file(), rel)
+        for rel in self.cat["envelopes"]:
+            self.assertTrue((ENVS / rel).is_file(), rel)
+        for rel in self.cat["loops"]:
+            self.assertTrue((LOOPS / rel).is_file(), rel)
+        for rel in self.cat["examples"]:
+            self.assertTrue((EXAMPLES / rel).is_file(), rel)
+        for rel in self.cat["references"]:
+            self.assertTrue((REFS / rel).is_file(), rel)
+
+    def test_no_stray_plan_files(self):
+        listed = set(self.cat["plans"]["valid"]) | set(self.cat["plans"]["invalid"])
+        actual = {p.name for p in PLANS.glob("*.json")}
+        self.assertEqual(listed, actual)
+
+    def test_no_stray_envelope_files(self):
+        listed = set(self.cat["envelopes"])
+        actual = {p.name for p in ENVS.glob("*.json")}
+        self.assertEqual(listed, actual)
+
+    def test_no_stray_loop_files(self):
+        listed = set(self.cat["loops"])
+        actual = {p.name for p in LOOPS.glob("*.json")}
+        self.assertEqual(listed, actual)
+
+    def test_example_readme_lists_same_files(self):
+        readme = read(EXAMPLES / "README.md")
+        for rel in self.cat["examples"]:
+            self.assertIn(rel, readme, rel)
+
+
+class PlanFixtureTests(unittest.TestCase):
+    def setUp(self):
+        self.cat = load_json(CATALOG)
+
+    def test_valid_plans_have_required_keys(self):
+        for name in self.cat["plans"]["valid"]:
+            plan = load_json(PLANS / name)
+            self.assertEqual(plan.get("planVersion"), "1.0", name)
+            self.assertIsInstance(plan.get("input"), str, name)
+            self.assertIsInstance(plan.get("output"), str, name)
+            steps = plan.get("steps")
+            self.assertIsInstance(steps, list, name)
+            self.assertGreaterEqual(len(steps), 1, name)
+            for step in steps:
+                self.assertIn(step.get("action"), RUN_ACTIONS, f"{name}: {step}")
+
+    def test_valid_plans_do_not_use_wrong_top_keys_instead_of_required(self):
+        for name in self.cat["plans"]["valid"]:
+            plan = load_json(PLANS / name)
+            self.assertNotIn("source", plan, name)
+            self.assertNotIn("ops", plan, name)
+            self.assertNotIn("op", plan, name)
+
+    def test_invalid_plans_are_json_but_break_a_known_rule(self):
+        checks = {
+            "invalid_missing_plan_version.json": lambda p: "planVersion" not in p,
+            "invalid_wrong_keys_source_op.json": lambda p: "input" not in p and "source" in p,
+            "invalid_empty_steps.json": lambda p: p.get("steps") == [],
+            "invalid_unknown_action.json": lambda p: p["steps"][0]["action"]
+            not in RUN_ACTIONS,
+            "invalid_camel_action.json": lambda p: p["steps"][0]["action"] == "fillFields",
+            "invalid_replace_empty_find.json": lambda p: p["steps"][0].get("find") == "",
+            "invalid_set_cell_newline.json": lambda p: True,
+            "invalid_two_conditions.json": lambda p: len(p["steps"][0].get("if", {})) > 1,
+            "invalid_numeric_plan_version.json": lambda p: not isinstance(
+                p.get("planVersion"), str
+            ),
+        }
+        listed = set(self.cat["plans"]["invalid"])
+        self.assertEqual(listed, set(checks))
+        for name, pred in checks.items():
+            plan = load_json(PLANS / name)
+            self.assertTrue(pred(plan), name)
+
+    def test_no_valid_plan_uses_invented_action(self):
+        for name in self.cat["plans"]["valid"]:
+            plan = load_json(PLANS / name)
+            for step in plan["steps"]:
+                self.assertNotIn(step["action"], INVENTED_ACTIONS, name)
+
+    def test_fill_fields_data_is_object(self):
+        for path in PLANS.glob("valid_*.json"):
+            plan = load_json(path)
+            for step in plan.get("steps") or []:
+                if step.get("action") == "fill_fields":
+                    self.assertIsInstance(step.get("data"), dict, path.name)
+
+    def test_set_cell_has_grid_keys(self):
+        plan = load_json(PLANS / "valid_set_cell.json")
+        step = plan["steps"][0]
+        for key in ("table", "row", "col", "text"):
+            self.assertIn(key, step, key)
+
+    def test_checkbox_has_occurrence(self):
+        plan = load_json(PLANS / "valid_set_checkbox.json")
+        self.assertIn("occurrence", plan["steps"][0])
+
+    def test_preconditions_shape(self):
+        plan = load_json(PLANS / "valid_preconditions.json")
+        pre = plan["preconditions"]
+        self.assertEqual(set(pre), {"inputSha256"})
+        hexes = pre["inputSha256"]
+        self.assertEqual(len(hexes), 64)
+        self.assertRegex(hexes, r"^[0-9a-f]+$")
+
+    def test_conditional_if_is_single_key(self):
+        for name in (
+            "valid_conditional_field_exists.json",
+            "valid_conditional_field_equals.json",
+            "valid_conditional_text_found.json",
+        ):
+            step = load_json(PLANS / name)["steps"][0]
+            self.assertEqual(len(step["if"]), 1, name)
+            key = next(iter(step["if"]))
+            self.assertIn(key, ("fieldExists", "fieldEquals", "textFound"))
+
+    def test_assertions_verify_plan(self):
+        plan = load_json(PLANS / "valid_assertions_verify.json")
+        self.assertTrue(plan["assertions"]["verify"])
+        self.assertTrue(plan["assertions"]["notFoundEmpty"])
+
+
+class EnvelopeFixtureTests(unittest.TestCase):
+    def test_every_envelope_declares_exit_meta(self):
+        for path in ENVS.glob("*.json"):
+            data = load_json(path)
+            meta = data.get("_skillMeta")
+            self.assertIsInstance(meta, dict, path.name)
+            self.assertIn("exit", meta, path.name)
+            self.assertIn(meta["exit"], (0, 1, 2, 3, 4), path.name)
+            self.assertIn("branch", meta, path.name)
+
+    def test_exit0_incomplete_signals(self):
+        nf = load_json(ENVS / "fill_notfound_exit0.json")
+        self.assertEqual(nf["_skillMeta"]["exit"], 0)
+        self.assertTrue(nf["notFound"])
+        self.assertFalse(nf["_skillMeta"].get("complete", True))
+
+        amb = load_json(ENVS / "fill_ambiguous_exit0.json")
+        self.assertEqual(amb["_skillMeta"]["exit"], 0)
+        self.assertTrue(amb["ambiguous"])
+        self.assertEqual(amb["ambiguous"][0]["total"], 5)
+
+    def test_verify_null_is_not_pass(self):
+        data = load_json(ENVS / "verify_null.json")
+        self.assertIsNone(data["verify"])
+        self.assertFalse(data["_skillMeta"]["verified"])
+
+    def test_layer1_verify_diff_keeps_output(self):
+        data = load_json(ENVS / "edit_verify_diff.json")
+        self.assertEqual(data["_skillMeta"]["exit"], 3)
+        self.assertTrue(data["_skillMeta"]["outputKept"])
+        self.assertFalse(data["verify"]["identical"])
+        self.assertIn("output", data)
+
+    def test_run_verify_fail_does_not_keep_output(self):
+        data = load_json(ENVS / "run_verify_fail_no_output.json")
+        self.assertEqual(data["_skillMeta"]["exit"], 3)
+        self.assertFalse(data["_skillMeta"]["outputKept"])
+        self.assertFalse(data["verify"]["identical"])
+
+    def test_cas_is_exit3_with_empty_invalid(self):
+        data = load_json(ENVS / "run_precondition_failed.json")
+        self.assertEqual(data["_skillMeta"]["exit"], 3)
+        self.assertEqual(data["invalid"], [])
+        self.assertEqual(data["preconditionFailed"]["kind"], "inputSha256")
+        self.assertEqual(data["nextCall"]["name"], "run")
+        self.assertIn("--dry-run", data["nextCall"]["arguments"])
+
+    def test_run_invalid_collects_multiple(self):
+        data = load_json(ENVS / "run_invalid_collected.json")
+        self.assertEqual(data["_skillMeta"]["exit"], 2)
+        self.assertGreaterEqual(len(data["invalid"]), 3)
+        actions = [item["action"] for item in data["invalid"]]
+        self.assertIn("insert_image", actions)
+
+    def test_replace_zero_has_no_output_key(self):
+        data = load_json(ENVS / "replace_zero.json")
+        self.assertEqual(data["replacedCount"], 0)
+        self.assertNotIn("output", data)
+        self.assertFalse(data["_skillMeta"]["outputKept"])
+
+    def test_redact_missing_output_is_stderr_only(self):
+        data = load_json(ENVS / "redact_missing_output.json")
+        self.assertEqual(data["_skillMeta"]["stdoutBytes"], 0)
+        self.assertEqual(data["_skillMeta"]["exit"], 2)
+        self.assertIn("마스킹은 되돌릴 수 없습니다", data["stderrContains"])
+
+    def test_overflow_does_not_block_fill(self):
+        data = load_json(ENVS / "set_cell_overflow.json")
+        self.assertEqual(data["_skillMeta"]["exit"], 0)
+        self.assertTrue(data["overflow"])
+        self.assertFalse(data["_skillMeta"]["complete"])
+
+    def test_csv_invalid_reasons(self):
+        data = load_json(ENVS / "csv_to_table_invalid.json")
+        reasons = {item["reason"] for item in data["invalid"]}
+        self.assertIn("rowCountMismatch", reasons)
+        self.assertIn("colCountMismatch", reasons)
+        self.assertEqual(data["changedCount"], 0)
+
+    def test_batch_row_notfound_still_exit0(self):
+        data = load_json(ENVS / "batch_row_notfound.json")
+        self.assertEqual(data["_skillMeta"]["exit"], 0)
+        self.assertTrue(data["notFound"])
+        self.assertEqual(data["row"], 2)
+
+    def test_dry_run_preview_has_no_disk(self):
+        data = load_json(ENVS / "run_dry_run_preview.json")
+        self.assertTrue(data["dryRun"])
+        self.assertEqual(data["invalid"], [])
+        self.assertTrue(data["preview"])
+        self.assertFalse(data["_skillMeta"]["outputKept"])
+
+
+class LoopFixtureTests(unittest.TestCase):
+    def test_command_loops_have_steps(self):
+        for name in (
+            "layer1_fill.json",
+            "layer1_replace.json",
+            "layer1_set_cell.json",
+            "layer3_run.json",
+        ):
+            data = load_json(LOOPS / name)
+            self.assertGreaterEqual(len(data["steps"]), 3, name)
+            ids = [s["id"] for s in data["steps"]]
+            self.assertIn("dry-run", ids, name)
+            for step in data["steps"]:
+                self.assertIsInstance(step["command"], list, name)
+                self.assertEqual(step["command"][0], "rhwp", name)
+                self.assertIn("expectExit", step, name)
+                self.assertIn("readFields", step, name)
+
+    def test_layer1_fill_forbids_output_on_dry_run(self):
+        data = load_json(LOOPS / "layer1_fill.json")
+        dry = next(s for s in data["steps"] if s["id"] == "dry-run")
+        self.assertIn("output", dry["forbidFieldsPresent"])
+        self.assertIn("--dry-run", dry["command"])
+
+    def test_layer3_starts_with_schema(self):
+        data = load_json(LOOPS / "layer3_run.json")
+        self.assertEqual(data["steps"][0]["id"], "schema")
+        self.assertEqual(data["steps"][0]["command"][1], "export-plan-schema")
+
+    def test_replace_reread_expects_zero_matches(self):
+        data = load_json(LOOPS / "layer1_replace.json")
+        reread = next(s for s in data["steps"] if s["id"] == "reread")
+        self.assertEqual(reread["expectMatchCount"], 0)
+
+    def test_invariants_loops(self):
+        vn = load_json(LOOPS / "verify_null_vs_object.json")
+        self.assertEqual(vn["invariants"][0]["equals"], None)
+        self.assertEqual(vn["invariants"][0]["notMeaning"], "passed")
+        cp = load_json(LOOPS / "changed_pages_null.json")
+        meanings = {item["meaning"] for item in cp["invariants"]}
+        self.assertTrue(any("확정 불가" in m for m in meanings))
+        self.assertTrue(any("바뀐 쪽 없음" in m for m in meanings))
+
+
+class CommandReferenceTests(unittest.TestCase):
+    """스킬 폴더의 rhwp 토큰이 알려진 머리 명령 집합에 속하는지.
+
+    실재 집합의 정본은 바이너리 자기서술(tests/skills_contract.rs)이다.
+    여기서는 이 파동이 지어낸 머리 토큰이 없는지만 본다.
+    """
+
+    KNOWN_HEADS = {
+        "edit",
+        "run",
+        "fields",
+        "search",
+        "info",
+        "export-tables",
+        "export-svg",
+        "export-text",
+        "export-plan-schema",
+        "export-hwpx",
+        "ir-diff",
+        "table-to-csv",
+        "csv-to-table",
+        "batch",
+        "convert",
+        "capabilities",
+    }
+
+    TOKEN_RE = re.compile(r"rhwp ([a-z][a-z0-9-]*)")
+
+    def test_heads_are_known(self):
+        unknown = []
+        for path in md_files(SKILL):
+            for match in self.TOKEN_RE.finditer(read(path)):
+                head = match.group(1)
+                if head not in self.KNOWN_HEADS:
+                    unknown.append(f"{path.name}: rhwp {head}")
+        self.assertEqual(unknown, [], "스킬이 모르는 머리 명령을 안내한다")
+
+    def test_edit_subs_are_known(self):
+        sub_re = re.compile(r"rhwp edit ([a-z][a-z0-9-]*)")
+        unknown = []
+        for path in md_files(SKILL):
+            for match in sub_re.finditer(read(path)):
+                sub = match.group(1)
+                if sub not in EDIT_SUBS:
+                    unknown.append(f"{path.name}: rhwp edit {sub}")
+        self.assertEqual(unknown, [])
+
+    def test_examples_contain_run_or_edit(self):
+        for path in EXAMPLES.glob("*.md"):
+            if path.name == "README.md":
+                continue
+            body = read(path)
+            self.assertTrue(
+                "rhwp edit" in body or "rhwp run" in body or "rhwp batch" in body
+                or "rhwp csv-to-table" in body or "sha256" in body,
+                path.name,
+            )
+
+
+class CrossLinkTests(unittest.TestCase):
+    LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+    def test_relative_links_inside_skill_resolve(self):
+        missing = []
+        for path in md_files(SKILL):
+            for _label, href in self.LINK_RE.findall(read(path)):
+                if href.startswith(("http://", "https://", "mailto:")):
+                    continue
+                if href.startswith("#"):
+                    continue
+                target = href.split("#", 1)[0]
+                if not target:
+                    continue
+                dest = (path.parent / target).resolve()
+                # 스킬 밖으로 나가는 링크(mydocs/…)는 저장소 루트 기준으로 존재해야 한다.
+                if not dest.exists():
+                    missing.append(f"{path.name} -> {href}")
+        self.assertEqual(missing, [])
+
+    def test_skill_points_at_working_doc(self):
+        self.assertIn("mydocs/working/agent_safe_edit.md", read(SKILL_MD))
+
+
+class WorkingDocTests(unittest.TestCase):
+    def test_working_doc_tokens(self):
+        body = read(WORKING)
+        for tok in WORKING_TOKENS:
+            self.assertIn(tok, body, tok)
+
+    def test_working_doc_states_no_new_edit_logic(self):
+        body = read(WORKING)
+        self.assertRegex(body, r"새 편집 로직|발명 금지|기존 edit")
+
+    def test_working_doc_states_not_gym(self):
+        body = read(WORKING)
+        self.assertRegex(body, r"gym 금지|gym/ 를 열지|gym 을 만지지")
+
+
+class InvariantProseTests(unittest.TestCase):
+    """문서 여러 곳이 같은 불변식을 말하는지 — 한 파일만 고치면 깨진다."""
+
+    def _all_prose(self) -> str:
+        parts = [read(SKILL_MD), read(WORKING)]
+        parts.extend(read(p) for p in REFS.glob("*.md"))
+        parts.extend(read(p) for p in EXAMPLES.glob("*.md"))
+        return "\n".join(parts)
+
+    def test_original_invariance_mentioned(self):
+        text = self._all_prose()
+        self.assertIn("원본", text)
+        self.assertRegex(text, r"원본 불변|원본은 그대로|원본 바이트")
+
+    def test_no_in_place_as_default(self):
+        skill = read(SKILL_MD)
+        self.assertIn("--in-place", skill)
+        self.assertRegex(skill, r"명시|redact")
+
+    def test_four_actions_listed_together(self):
+        text = read(REFS / "run_plans.md") + read(SKILL_MD)
+        for action in RUN_ACTIONS:
+            self.assertIn(action, text)
+
+    def test_exit_table_has_01234(self):
+        body = read(REFS / "failure_envelopes.md")
+        for code in ("| 0 ", "| 1 ", "| 2 ", "| 3 ", "| 4 "):
+            self.assertIn(code, body, code)
+
+
+class GymIsolationTests(unittest.TestCase):
+    def test_skill_markdown_does_not_instruct_editing_gym(self):
+        for path in md_files(SKILL):
+            body = read(path)
+            self.assertNotRegex(body, r"gym/packs|gym/tools|certify\.py|score\.py")
+
+    def test_fixtures_are_not_under_gym(self):
+        for path in json_files(SKILL):
+            self.assertNotIn("gym", path.parts)
+
+
+class CatalogActionLockTests(unittest.TestCase):
+    def test_catalog_actions_exactly_four(self):
+        cat = load_json(CATALOG)
+        self.assertEqual(len(cat["actions"]), 4)
+        self.assertEqual(cat["actions"], list(RUN_ACTIONS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

실사용 에이전트가 HWP/HWPX 를 원본 훼손 없이 편집하도록, 이미 devel 에 있는 `edit` 과 `run` 을 스킬·픽스처·시험으로 배선한다. 새 편집 로직은 없다. gym 은 만지지 않았다.

`.claude/skills/rhwp-safe-edit/` 를 라우터(SKILL.md)와 자식 네 장으로 나눈다.

- `references/single_edit.md` — 1층 `edit` 6종 + `csv-to-table` + `batch fill` (`-o` · `--dry-run` · `--verify`)
- `references/run_plans.md` — 3층 계획서 (`export-plan-schema` 1.1, action 4종, `if`, assertions, CAS)
- `references/verify_loops.md` — 발견 → dry-run → 저장 → 재독 → `changedPages` 눈검증
- `references/failure_envelopes.md` — exit 3/4 를 판정 데이터로 읽는 분기 (1층은 산출 유지, `run` 단언/CAS 는 디스크 무변경)

워크스루 16편과 JSON 픽스처(유효 계획 12 · 무효 9 · 봉투 19 · 루프 6)를 남긴다. `scripts/tests/test_agent_safe_edit.py` 가 문서·픽스처가 같은 단어를 쓰는지 파일만으로 고정한다.

형제 스킬(onboarding / mcp-session / provenance / doc-triage)과 gym/ 은 열지 않았다.

## 관련 이슈

closes #5294

## 테스트

- [x] `python -m unittest scripts.tests.test_agent_safe_edit` 통과 (61)
- [x] `cargo fmt --all -- --check` 통과 (Rust 변경 없음)
- [ ] `cargo test` 해당 없음 (문서·픽스처·Python 시험만. `tests/` 신규 integration 은 suite-policy 상 `tests/cases/` 만 허용)
- [ ] `cargo clippy -- -D warnings` 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 해당 없음
- [ ] 웹(WASM) 렌더링 해당 없음
- [ ] rhwp-studio 편집·UI 해당 없음
- [ ] 작업 증빙 캡슐 해당 없음 (문서·시험만)
- [ ] `.claude/agents/` capability 카탈로그 해당 없음 (기존 스킬 확장, 신규 capability 아님)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (문서·픽스처·시험만, 편집 엔진 불변)
- 재현·측정: 해당 없음. 로컬 unittest + fmt check.

## 스크린샷

해당 없음.