### PR TITLE
fix(serializer/hwpx): 문단 번호 paraHead의 정렬·번호너비·자동내어쓰기를 attr에서 유도해 h2x 소실 방지 (#5309)

### DIFF
--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -418,6 +418,16 @@ fn write_diag_line<W: Write>(
     )
 }
 
+// [#5309] '문단 머리 정보'(표 41) attr bits 0–1 → OWPML paraHead@align 토큰.
+// 0=왼쪽·1=가운데·2=오른쪽 (HWP5 스펙). 3은 미사용이라 LEFT 로 폴백.
+fn numbering_head_align_str(attr: u32) -> &'static str {
+    match attr & 0x03 {
+        1 => "CENTER",
+        2 => "RIGHT",
+        _ => "LEFT",
+    }
+}
+
 // [#2947] parser 측 parse_numbering_format_code() (표 43) 의 역매핑.
 fn numbering_format_str(code: u8) -> &'static str {
     match code {
@@ -999,12 +1009,21 @@ fn write_numbering<W: Write>(
         let num_format = numbering_format_str(h.number_format);
         let text_offset_s = h.text_distance.to_string();
         let char_pr_id_ref_s = h.char_shape_id.to_string();
+        // [#5309] '문단 머리 정보'(표 41) attr 저위 비트에서 정렬·번호너비·자동내어쓰기를
+        // 유도한다. 종전엔 align="LEFT"/useInstWidth="1"/autoIndent="1" 상수만 방출해,
+        // HWP5→HWPX 저장 때마다 문단 번호의 정렬·들여쓰기 설정이 기본값으로 리셋됐다.
+        // NumberingHead 모델엔 이 값의 lexical 필드가 없어 attr 비트가 유일한 원천이다.
+        // 비트↔토큰은 한컴 저작 HWPX 쌍(143E433F…)으로 직접 1:1 대응 확증. numFormat
+        // de-hardcode(#2947)와 동형.
+        let align = numbering_head_align_str(h.attr);
+        let use_inst_width = if (h.attr >> 2) & 0x01 != 0 { "1" } else { "0" };
+        let auto_indent = if (h.attr >> 3) & 0x01 != 0 { "1" } else { "0" };
         let attrs = [
             ("start", start_s.as_str()),
             ("level", level_s.as_str()),
-            ("align", "LEFT"),
-            ("useInstWidth", "1"),
-            ("autoIndent", "1"),
+            ("align", align),
+            ("useInstWidth", use_inst_width),
+            ("autoIndent", auto_indent),
             ("widthAdjust", wa.as_str()),
             ("textOffsetType", "PERCENT"),
             ("textOffset", text_offset_s.as_str()),

--- a/tests/cases/issue_numbering_parahead_from_attr.rs
+++ b/tests/cases/issue_numbering_parahead_from_attr.rs
@@ -1,0 +1,96 @@
+//! HWP5 → HWPX 저장에서 문단 번호(numbering) paraHead 의 정렬·번호너비·자동내어쓰기가
+//! 하드코딩되어 소실되던 문제(#5309).
+//!
+//! HWP5 `HWPTAG_NUMBERING` 의 각 수준 '문단 머리 정보'(표 41) `attr` 은 bits0–1=정렬,
+//! bit2=번호너비 사용(useInstWidth), bit3=자동 내어쓰기(autoIndent)를 담는다. HWPX
+//! 직렬화기는 원본 HWPX paraHead splice 가 없는 HWP5 경유 경로에서 종전에 이 셋을
+//! align="LEFT"/useInstWidth="1"/autoIndent="1" 상수로 방출해, 저장할 때마다 문단 번호
+//! 정렬·들여쓰기가 기본값으로 리셋됐다(numFormat 은 #2947 에서 이미 de-hardcode).
+//!
+//! 비트↔토큰은 한컴 저작 HWPX 쌍(samples/143E433F503322BD33.{hwp,hwpx})으로 직접 1:1
+//! 대응 확증: attr bit2→useInstWidth, bit3→autoIndent(같은 방향), bits0–1→align.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Read;
+
+use rhwp::model::document::Document;
+use rhwp::model::style::{Numbering, NumberingHead};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+fn head(attr: u32) -> NumberingHead {
+    NumberingHead {
+        attr,
+        ..Default::default()
+    }
+}
+
+/// 방출된 header.xml 에서 앞 6개 <hh:paraHead> 의 (align, useInstWidth, autoIndent) 추출.
+fn para_head_flags(hwpx: &[u8]) -> Vec<(String, String, String)> {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(hwpx)).expect("zip");
+    let mut xml = String::new();
+    zip.by_name("Contents/header.xml")
+        .expect("header.xml")
+        .read_to_string(&mut xml)
+        .expect("read");
+
+    let pick = |tag: &str, key: &str| -> String {
+        let needle = format!("{key}=\"");
+        tag.find(&needle)
+            .map(|s| {
+                let v = &tag[s + needle.len()..];
+                v[..v.find('"').expect("닫는 따옴표")].to_string()
+            })
+            .unwrap_or_default()
+    };
+
+    let mut out = Vec::new();
+    let mut rest = xml.as_str();
+    while let Some(p) = rest.find("<hh:paraHead") {
+        rest = &rest[p..];
+        let end = rest.find('>').expect("태그 끝");
+        let tag = &rest[..end + 1];
+        out.push((
+            pick(tag, "align"),
+            pick(tag, "useInstWidth"),
+            pick(tag, "autoIndent"),
+        ));
+        rest = &rest[end + 1..];
+        if out.len() == 6 {
+            break;
+        }
+    }
+    out
+}
+
+#[test]
+fn hwp5_numbering_parahead_derived_from_attr_bits() {
+    let mut doc = Document::default();
+    let mut numbering = Numbering {
+        start_number: 1,
+        ..Default::default()
+    };
+    // 수준별 attr 저위 비트를 다양하게 — 각 필드가 상수가 아니라 attr 에서 유도됨을 검증.
+    numbering.heads[0] = head(0x00); // align=LEFT,   uiw=0, ai=0
+    numbering.heads[1] = head(0x04); // bit2:         uiw=1, ai=0
+    numbering.heads[2] = head(0x08); // bit3:         uiw=0, ai=1
+    numbering.heads[3] = head(0x01); // bits0-1=1:    align=CENTER
+    numbering.heads[4] = head(0x02); // bits0-1=2:    align=RIGHT
+    numbering.heads[5] = head(0x0c); // bit2|bit3:    uiw=1, ai=1
+    doc.doc_info.numberings.push(numbering);
+
+    let hwpx = serialize_hwpx(&doc).expect("HWPX 직렬화");
+    let flags = para_head_flags(&hwpx);
+
+    assert_eq!(
+        flags,
+        vec![
+            ("LEFT".into(), "0".into(), "0".into()),
+            ("LEFT".into(), "1".into(), "0".into()),
+            ("LEFT".into(), "0".into(), "1".into()),
+            ("CENTER".into(), "0".into(), "0".into()),
+            ("RIGHT".into(), "0".into(), "0".into()),
+            ("LEFT".into(), "1".into(), "1".into()),
+        ],
+        "paraHead 의 align/useInstWidth/autoIndent 는 head.attr 저위 비트에서 유도돼야 한다"
+    );
+}


### PR DESCRIPTION
## 요약

HWP5 문서를 HWPX로 저장(export-hwpx)할 때 문단 번호(numbering) 정의의 각 수준 `<hh:paraHead>`에 정렬(`align`)·번호 너비 사용(`useInstWidth`)·자동 내어쓰기(`autoIndent`)가 **원본과 무관하게 상수**로 방출돼, 저장할 때마다 문단 번호의 정렬·들여쓰기 설정이 기본값으로 리셋되던 문제를 고칩니다. closes #5309

## 원인

`src/serializer/hwpx/header.rs`의 numbering `write_numbering` Stage 1 뼈대(원본 HWPX paraHead splice가 없는 **HWP5 경유 경로**, `raw_para_heads = None`)가 다음을 상수로 방출했습니다:

```
("align", "LEFT"), ("useInstWidth", "1"), ("autoIndent", "1"),
```

HWP5 `HWPTAG_NUMBERING`의 각 수준 '문단 머리 정보'(표 41) `attr`은
- bits 0–1 = 정렬(0=왼쪽·1=가운데·2=오른쪽)
- bit 2 = 번호 너비 사용(useInstWidth)
- bit 3 = 자동 내어쓰기(autoIndent)

를 담지만 직렬화가 이를 무시했습니다. `numFormat`은 이미 #2947에서 `h.number_format`(attr bits 5–8)로 de-hardcode됐고, 나머지 3필드가 남아 있었습니다. `NumberingHead` 모델에는 이 값을 담는 별도 lexical 필드가 없어 attr 비트가 유일한 원천이므로, HWP5→HWPX 저장에서 통째로 소실됩니다.

## 수정

Stage 1 뼈대에서 `align`/`useInstWidth`/`autoIndent`를 `h.attr` 저위 비트에서 유도합니다(`numbering_head_align_str` 헬퍼 추가). numFormat 수정(#2947)과 동형입니다.

## 정답지 대조

한컴 저작 HWPX 쌍 `samples/143E433F503322BD33.{hwp, hwpx}`로 비트↔토큰이 **직접 1:1** 대응함을 확증했습니다: attr bit2→useInstWidth, bit3→autoIndent(같은 방향), bits0–1→align. 예) HWP5 num0 head0=`0x0c`(uiw1/ai1)·head6=`0x2c`(numFmt=1=CIRCLED_DIGIT)가 한컴 HWPX paraHead 순서와 일치.

실측: 코퍼스 한컴 HWPX 다수가 비기본값(`useInstWidth="0"`·`autoIndent="0"`)을 실제 보유(samples/hwpx/143E433F503322BD33.hwpx, exam_social.hwpx 등). 종전 직렬화는 이를 전부 `"1"`로 덮었습니다.

## 검증

- 계약 테스트 `tests/cases/issue_numbering_parahead_from_attr.rs` — head.attr={0x00,0x04,0x08,0x01,0x02,0x0c} → 방출 paraHead가 `[(LEFT,0,0),(LEFT,1,0),(LEFT,0,1),(CENTER,0,0),(RIGHT,0,0),(LEFT,1,1)]`인지 검사.
- 실코퍼스 확인: attr=0x08 head를 가진 HWP5의 h2x 저장이 `useInstWidth="0" autoIndent="1"`로 방출(종전 `"1"/"1"`).
- 렌더러는 이 비트를 소비하지 않아 rhwp 렌더는 불변이며, 저장된 HWPX를 여는 한글에서 문단 번호 정렬/들여쓰기가 보존됩니다.
- x2x 경로는 `raw_para_heads=Some`으로 splice를 쓰므로 종전과 동일(무영향).
- fmt/clippy + numbering·paraHead·roundtrip·ir_field_sweep·convert_verify 게이트 통과.

## 발견 경위

10k 코퍼스 HWP5 727문서 h2x(HWP5→HWPX) 왕복 IR 발산 하니스에서 `numberings[].heads[].attr` 574문서 발산 → attr 저위 비트 하드코딩으로 규명.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
