### PR TITLE
fix(serializer/hwp5): 라틴 줄나눔(breakLatinWord)을 attr1 bits5-6 에 인코딩해 x2h 소실 방지 (#5327)

### DIFF
--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -770,6 +770,19 @@ pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8> {
     // 7 이상일 때 8→0, 9→1 로 엉뚱한 수준을 박는다.
     attr1 &= !(0x07 << 25);
     attr1 |= (ps.para_level.min(6) as u32) << 25;
+    // [#5327] bits 5-6: breakLatinWord(라틴 줄나눔 단위). HWPX 파서는 이 값을 lexical
+    // 필드 break_latin_word 로만 읽고 attr1 에는 싣지 않으므로(짝 breakNonLatinWord bit7 은
+    // attr1 에 인코딩하는 것과 비대칭), 여기서 lexical 값을 attr1 bits5-6 으로 재인코딩하지
+    // 않으면 HWPX→HWP5 저장에서 라틴 줄나눔 설정이 통째로 사라진다. #5298(HWP5→HWPX)의
+    // latin_break_from_attr1 역함수. None(HWP5 원본)이면 원본 attr1 비트를 보존한다.
+    if let Some(blw) = ps.break_latin_word.as_deref() {
+        let code = match blw {
+            "HYPHENATION" => 1u32,
+            "BREAK_WORD" => 2,
+            _ => 0, // KEEP_WORD
+        };
+        attr1 = (attr1 & !(0x03 << 5)) | (code << 5);
+    }
     w.write_u32(attr1).unwrap();
     w.write_i32(ps.margin_left).unwrap();
     w.write_i32(ps.margin_right).unwrap();

--- a/tests/cases/issue_hwp5_break_latin_word_encode.rs
+++ b/tests/cases/issue_hwp5_break_latin_word_encode.rs
@@ -1,0 +1,41 @@
+//! HWPX → HWP5 저장에서 라틴 줄나눔(breakLatinWord)이 소실되던 문제(#5327).
+//!
+//! HWP5 는 breakLatinWord 를 para_shape attr1 bits5-6 에 저장한다(0=KEEP_WORD·
+//! 1=HYPHENATION·2=BREAK_WORD). HWPX 파서는 이를 lexical 필드 break_latin_word 로만
+//! 읽고 attr1 에는 싣지 않으므로(짝 breakNonLatinWord 는 attr1 bit7 에 인코딩하는 것과
+//! 비대칭), HWP5 직렬화기가 lexical 값을 attr1 bits5-6 으로 재인코딩하지 않으면
+//! HWPX→HWP5 저장에서 라틴 줄나눔 설정이 통째로 사라진다. #5298(HWP5→HWPX)의 거울.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::style::ParaShape;
+use rhwp::serializer::doc_info::serialize_para_shape;
+
+/// 직렬화된 para_shape 레코드의 attr1(선두 u32 LE) bits5-6 을 뽑는다.
+fn attr1_latin_bits(ps: &ParaShape) -> u32 {
+    let bytes = serialize_para_shape(ps);
+    let attr1 = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    (attr1 >> 5) & 0x03
+}
+
+fn ps_lexical(token: &str) -> ParaShape {
+    ParaShape {
+        break_latin_word: Some(token.to_string()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn hwp5_break_latin_word_encoded_into_attr1_bits() {
+    // HWPX 소스(lexical Some): attr1 bits5-6 으로 인코딩돼야 한다.
+    assert_eq!(attr1_latin_bits(&ps_lexical("KEEP_WORD")), 0);
+    assert_eq!(attr1_latin_bits(&ps_lexical("HYPHENATION")), 1);
+    assert_eq!(attr1_latin_bits(&ps_lexical("BREAK_WORD")), 2);
+
+    // HWP5 원본(lexical None): 원본 attr1 비트를 보존해야 한다(clobber 금지).
+    let ps_none = ParaShape {
+        attr1: 2 << 5, // BREAK_WORD 를 담은 원본 비트
+        break_latin_word: None,
+        ..Default::default()
+    };
+    assert_eq!(attr1_latin_bits(&ps_none), 2);
+}


### PR DESCRIPTION
## 요약

HWPX 문서를 HWP5로 저장할 때 문단모양의 라틴 문자 줄나눔 단위(breakLatinWord: 단어/하이픈/글자)가 소실되어, 저장된 `.hwp`를 한글에서 열면 전부 KEEP_WORD(단어 유지)로 되돌아가던 문제를 고칩니다. closes #5327

#5298(HWP5→HWPX 방향)의 **거울 방향** 결함입니다.

## 원인

HWP5는 breakLatinWord를 para_shape `attr1` bits5-6에 저장합니다(0=KEEP_WORD·1=HYPHENATION·2=BREAK_WORD). 그런데 경로가 두 곳에서 끊깁니다:

1. HWPX 파서(`src/parser/hwpx/header.rs`)는 `breakLatinWord`를 lexical 필드 `ps.break_latin_word`로만 읽고 `attr1` bits5-6은 건드리지 않습니다 — 짝 필드 `breakNonLatinWord`가 `attr1` bit7에 인코딩되는 것과 비대칭입니다.
2. HWP5 직렬화기 `serialize_para_shape`(`src/serializer/doc_info.rs`)는 `attr1`을 line_spacing·alignment·head_type·para_level만 재인코딩하고 breakLatinWord(bits5-6)는 원본 `ps.attr1`(=0) 그대로 방출합니다.

결과적으로 HWPX 소스의 breakLatinWord는 `attr1` 어디에도 실리지 않아 HWP5 저장에서 통째로 사라집니다.

## 수정

`serialize_para_shape`에서 `ps.break_latin_word`가 `Some`이면 `attr1` bits5-6으로 재인코딩합니다(#5298 `latin_break_from_attr1`의 역함수: KEEP_WORD=0·HYPHENATION=1·BREAK_WORD=2). `None`(HWP5 원본)이면 원본 `attr1` 비트를 보존하므로 h2h는 불변입니다. HWPX 직렬화(x2x)는 이 경로를 타지 않아 무영향입니다.

## 검증

- 계약 테스트 `tests/cases/issue_hwp5_break_latin_word_encode.rs` — 토큰 3종(KEEP_WORD/HYPHENATION/BREAK_WORD) → `attr1` bits5-6 = {0,1,2}, `None` + 원본 비트 → 보존 검증.
- 실경로 확인: 실제 HWPX→HWP5 export(`document.rs`의 save-as)는 `convert_if_hwpx_source` 변환기 후 `serialize_hwp`를 부르는데, 이 변환기는 break_latin_word/attr1을 건드리지 않으므로 `serialize_para_shape`가 유일한 인코딩 지점입니다.
- fmt/clippy + ir_field_sweep + convert_verify + hwp5_roundtrip 게이트 통과.

## 발견 경위

10k 코퍼스 + samples HWPX 737문서 x2h(HWPX→HWP5) 왕복 IR 발산 하니스(변환기 적용)에서 `break_latin_word` BREAK_WORD→소실 372경로로 규명. 실 HWPX 토큰 분포도 BREAK_WORD·HYPHENATION 실재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
