### PR TITLE
feat(tools): oracle_public issue_draft — 임계 초과 문서 이슈 초안 생성기

### DIFF
--- a/tools/oracle_public/fixtures/report_all_pass.json
+++ b/tools/oracle_public/fixtures/report_all_pass.json
@@ -1,0 +1,26 @@
+{
+  "schema": "oracle_public.failure_report/v1",
+  "generated_at": "2026-08-18T00:05:00Z",
+  "source": "visual_sweep",
+  "rhwp_bin": "target/debug/rhwp",
+  "dpi": 96,
+  "pixel_diff_threshold": 12,
+  "threshold": {
+    "metric": "worst_pixel_match_percent",
+    "op": "<",
+    "value": 99.0
+  },
+  "documents": [
+    {
+      "id": "blank2010",
+      "hwp": "samples/blank2010.hwp",
+      "pdf": "pdf/blank2010-2022.pdf",
+      "pages": 1,
+      "metrics": {
+        "worst_pixel_match_percent": 99.98,
+        "average_pixel_match_percent": 99.98,
+        "worst_pages": [1]
+      }
+    }
+  ]
+}

--- a/tools/oracle_public/fixtures/report_diff_ratio.json
+++ b/tools/oracle_public/fixtures/report_diff_ratio.json
@@ -1,0 +1,39 @@
+{
+  "schema": "oracle_public.failure_report/v1",
+  "generated_at": "2026-08-18T00:15:00Z",
+  "source": "visual_sweep",
+  "rhwp_bin": "target/release/rhwp",
+  "dpi": 144,
+  "pixel_diff_threshold": 8,
+  "threshold": {
+    "metric": "diff_ratio",
+    "op": ">",
+    "value": 0.01
+  },
+  "documents": [
+    {
+      "id": "bunjang",
+      "hwp": "samples/21868765.hwp",
+      "pdf": "samples/21868765.pdf",
+      "pages": 2,
+      "metrics": {
+        "diff_ratio": 0.0425,
+        "diff_pixels": 8500,
+        "total_pixels": 200000,
+        "worst_pages": [2]
+      }
+    },
+    {
+      "id": "tiny_noise",
+      "hwp": "samples/blank2010.hwp",
+      "pdf": "pdf/blank2010-2022.pdf",
+      "pages": 1,
+      "metrics": {
+        "diff_ratio": 0.0004,
+        "diff_pixels": 80,
+        "total_pixels": 200000,
+        "worst_pages": [1]
+      }
+    }
+  ]
+}

--- a/tools/oracle_public/fixtures/report_explicit.json
+++ b/tools/oracle_public/fixtures/report_explicit.json
@@ -1,0 +1,42 @@
+{
+  "schema": "oracle_public.failure_report/v1",
+  "generated_at": "2026-08-18T00:10:00Z",
+  "source": "dump-pages-smoke",
+  "rhwp_bin": "target/debug/rhwp",
+  "dpi": 96,
+  "threshold": {
+    "metric": "page_count_delta",
+    "op": ">",
+    "value": 0
+  },
+  "documents": [
+    {
+      "id": "forced_flag",
+      "hwp": "samples/exam_math.hwp",
+      "pdf": "pdf/exam_math-2022.pdf",
+      "pages": 12,
+      "exceeds": true,
+      "metrics": {
+        "page_count_delta": 0,
+        "rhwp_pages": 12,
+        "pdf_pages": 12
+      },
+      "repro": {
+        "command": "rhwp dump-pages samples/exam_math.hwp --json"
+      },
+      "notes": "지표는 게이트를 넘지 않지만 검토자가 exceeds=true 로 초안을 강제했다."
+    },
+    {
+      "id": "suppressed",
+      "hwp": "samples/exam_eng.hwp",
+      "pdf": "pdf/exam_eng-2022.pdf",
+      "pages": 8,
+      "exceeds": false,
+      "metrics": {
+        "page_count_delta": 3,
+        "rhwp_pages": 11,
+        "pdf_pages": 8
+      }
+    }
+  ]
+}

--- a/tools/oracle_public/fixtures/report_invalid.json
+++ b/tools/oracle_public/fixtures/report_invalid.json
@@ -1,0 +1,15 @@
+{
+  "schema": "oracle_public.failure_report/v1",
+  "threshold": {
+    "metric": "worst_pixel_match_percent",
+    "op": "<",
+    "value": 99.0
+  },
+  "documents": [
+    {
+      "id": "",
+      "hwp": "samples/missing.hwp",
+      "metrics": {}
+    }
+  ]
+}

--- a/tools/oracle_public/fixtures/report_mixed.json
+++ b/tools/oracle_public/fixtures/report_mixed.json
@@ -1,0 +1,65 @@
+{
+  "schema": "oracle_public.failure_report/v1",
+  "generated_at": "2026-08-18T00:00:00Z",
+  "source": "visual_sweep",
+  "rhwp_bin": "target/debug/rhwp",
+  "dpi": 96,
+  "pixel_diff_threshold": 12,
+  "threshold": {
+    "metric": "worst_pixel_match_percent",
+    "op": "<",
+    "value": 99.0
+  },
+  "documents": [
+    {
+      "id": "exam_math",
+      "hwp": "samples/exam_math.hwp",
+      "pdf": "pdf/exam_math-2022.pdf",
+      "pages": 12,
+      "metrics": {
+        "worst_pixel_match_percent": 87.5,
+        "average_pixel_match_percent": 94.12,
+        "worst_ink_match_percent": 91.2,
+        "diff_pixels": 12345,
+        "total_pixels": 1000000,
+        "worst_pages": [3, 7]
+      },
+      "repro": {
+        "command": "python scripts/visual_sweep.py --hwp samples/exam_math.hwp --pdf pdf/exam_math-2022.pdf --key exam_math --dpi 96 --pixel-diff-threshold 12",
+        "cwd": "."
+      },
+      "notes": "3·7쪽 수식 줄간격이 한컴 PDF 와 어긋난다."
+    },
+    {
+      "id": "exam_eng",
+      "hwp": "samples/exam_eng.hwp",
+      "pdf": "pdf/exam_eng-2022.pdf",
+      "pages": 8,
+      "metrics": {
+        "worst_pixel_match_percent": 99.41,
+        "average_pixel_match_percent": 99.72,
+        "worst_ink_match_percent": 99.55,
+        "diff_pixels": 210,
+        "total_pixels": 800000,
+        "worst_pages": [2]
+      }
+    },
+    {
+      "id": "plan_2022",
+      "hwp": "samples/2022 plan.hwp",
+      "pdf": "pdf/2022 plan-2022.pdf",
+      "pages": 4,
+      "metrics": {
+        "worst_pixel_match_percent": 72.05,
+        "average_pixel_match_percent": 81.3,
+        "worst_ink_match_percent": 68.4,
+        "diff_pixels": 88001,
+        "total_pixels": 400000,
+        "worst_pages": [1, 2, 4]
+      },
+      "repro": {
+        "command": "python scripts/visual_sweep.py --file-target plan_2022 \"samples/2022 plan.hwp\" \"pdf/2022 plan-2022.pdf\" --dpi 96 --pixel-diff-threshold 12"
+      }
+    }
+  ]
+}

--- a/tools/oracle_public/issue_draft.py
+++ b/tools/oracle_public/issue_draft.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""임계 초과 문서 → GitHub 이슈 **초안** markdown 생성기.
+
+입력은 `schema/failure_report.v1.json` 계약의 실패 리포트 JSON 이다. 게이트
+(`threshold.metric op threshold.value`)를 넘는 문서마다 재현 커맨드와 수치를
+넣은 markdown 을 `--out` 디렉터리에 쓴다. 제출은 수동 — 이 도구는 `gh` 를
+호출하지 않으며 `--submit` / `--create-issue` 를 거부한다.
+
+    python tools/oracle_public/issue_draft.py \
+        --report tools/oracle_public/fixtures/report_mixed.json \
+        --out /tmp/oracle-issue-drafts
+
+종료 코드: 0 = 초안(0건 포함) 기록 성공, 2 = 입력·스키마 오류,
+3 = 제출 옵션 거부.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import operator
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_ID = "oracle_public.failure_report/v1"
+MANIFEST_SCHEMA = "oracle_public.issue_drafts/v1"
+HERE = Path(__file__).resolve().parent
+DEFAULT_TEMPLATE = HERE / "templates" / "issue.md"
+DEFAULT_SCHEMA = HERE / "schema" / "failure_report.v1.json"
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_SUBMIT_FORBIDDEN = 3
+
+OPS = {
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+}
+
+PLACEHOLDER_RE = re.compile(r"\{\{\s*([A-Za-z0-9_]+)\s*\}\}")
+SLUG_RE = re.compile(r"[^\w가-힣.-]+", re.UNICODE)
+SUBMIT_FLAGS = ("--submit", "--create-issue", "--create-issues", "--gh")
+
+FORBIDDEN_HELP = (
+    "이슈 제출은 수동입니다. 이 도구는 초안 markdown 만 디스크에 씁니다. "
+    "`gh issue create` 를 호출하지 않으며 --submit/--create-issue/--gh 를 받지 않습니다."
+)
+
+
+class ReportError(ValueError):
+    """스키마·값 계약 위반."""
+
+
+@dataclass(frozen=True)
+class Threshold:
+    metric: str
+    op: str
+    value: float
+
+    def failed(self, measured: float) -> bool:
+        return bool(OPS[self.op](measured, self.value))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"metric": self.metric, "op": self.op, "value": self.value}
+
+
+@dataclass
+class Document:
+    id: str
+    hwp: str
+    metrics: dict[str, Any]
+    pdf: str = ""
+    pages: int | None = None
+    exceeds: bool | None = None
+    repro_command: str = ""
+    repro_cwd: str = "."
+    notes: str = ""
+
+    def measured(self, metric: str) -> float | None:
+        raw = self.metrics.get(metric)
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return None
+        return float(raw)
+
+
+@dataclass
+class Report:
+    threshold: Threshold
+    documents: list[Document]
+    generated_at: str = ""
+    source: str = ""
+    rhwp_bin: str = ""
+    dpi: int | None = None
+    pixel_diff_threshold: int | None = None
+
+
+@dataclass
+class Draft:
+    document: Document
+    path: Path
+    reason: str
+    measured: float | None
+
+
+@dataclass
+class DraftBatch:
+    drafts: list[Draft] = field(default_factory=list)
+    skipped: list[dict[str, Any]] = field(default_factory=list)
+
+
+def slugify(value: str) -> str:
+    cleaned = SLUG_RE.sub("-", value.strip())
+    cleaned = re.sub(r"-{2,}", "-", cleaned).strip(".-")
+    return cleaned or "untitled"
+
+
+def format_number(value: Any) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, int) or (isinstance(value, float) and value.is_integer()):
+        return str(int(value))
+    text = f"{float(value):.8f}".rstrip("0").rstrip(".")
+    return text
+
+
+def format_worst_pages(metrics: dict[str, Any]) -> str:
+    raw = metrics.get("worst_pages")
+    if isinstance(raw, list) and raw:
+        pages = [str(item) for item in raw if isinstance(item, (int, float))]
+        if pages:
+            return ", ".join(pages)
+    return "(없음)"
+
+
+def metrics_table(metrics: dict[str, Any]) -> str:
+    if not metrics:
+        return "(지표 없음)"
+    lines = ["| 지표 | 값 |", "| --- | --- |"]
+    for key, value in metrics.items():
+        if isinstance(value, list):
+            rendered = ", ".join(str(item) for item in value)
+        else:
+            rendered = format_number(value) if isinstance(value, (int, float)) else str(value)
+        lines.append(f"| `{key}` | {rendered} |")
+    return "\n".join(lines)
+
+
+def render_template(template: str, context: dict[str, str]) -> str:
+    return PLACEHOLDER_RE.sub(lambda match: context.get(match.group(1), ""), template)
+
+
+def _require_dict(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReportError(f"{path} 는 객체여야 합니다.")
+    return value
+
+
+def _require_str(value: Any, path: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ReportError(f"{path} 는 문자열이어야 합니다.")
+    if not allow_empty and not value.strip():
+        raise ReportError(f"{path} 가 비어 있습니다.")
+    return value
+
+
+def parse_threshold(raw: Any) -> Threshold:
+    data = _require_dict(raw, "threshold")
+    metric = _require_str(data.get("metric"), "threshold.metric")
+    op = _require_str(data.get("op"), "threshold.op")
+    if op not in OPS:
+        raise ReportError(f"threshold.op 는 {sorted(OPS)} 중 하나여야 합니다: {op!r}")
+    value = data.get("value")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ReportError("threshold.value 는 숫자여야 합니다.")
+    return Threshold(metric=metric, op=op, value=float(value))
+
+
+def parse_document(raw: Any, index: int) -> Document:
+    path = f"documents[{index}]"
+    data = _require_dict(raw, path)
+    metrics = data.get("metrics")
+    if not isinstance(metrics, dict):
+        raise ReportError(f"{path}.metrics 는 객체여야 합니다.")
+    pages = data.get("pages")
+    if pages is not None and (isinstance(pages, bool) or not isinstance(pages, int) or pages < 0):
+        raise ReportError(f"{path}.pages 는 0 이상 정수여야 합니다.")
+    exceeds = data.get("exceeds")
+    if exceeds is not None and not isinstance(exceeds, bool):
+        raise ReportError(f"{path}.exceeds 는 boolean 이어야 합니다.")
+    repro = data.get("repro") or {}
+    if repro and not isinstance(repro, dict):
+        raise ReportError(f"{path}.repro 는 객체여야 합니다.")
+    command = repro.get("command", "") if isinstance(repro, dict) else ""
+    if command and not isinstance(command, str):
+        raise ReportError(f"{path}.repro.command 는 문자열이어야 합니다.")
+    cwd = repro.get("cwd", ".") if isinstance(repro, dict) else "."
+    if cwd is not None and not isinstance(cwd, str):
+        raise ReportError(f"{path}.repro.cwd 는 문자열이어야 합니다.")
+    notes = data.get("notes", "")
+    if notes and not isinstance(notes, str):
+        raise ReportError(f"{path}.notes 는 문자열이어야 합니다.")
+    pdf = data.get("pdf", "")
+    if pdf and not isinstance(pdf, str):
+        raise ReportError(f"{path}.pdf 는 문자열이어야 합니다.")
+    return Document(
+        id=_require_str(data.get("id"), f"{path}.id"),
+        hwp=_require_str(data.get("hwp"), f"{path}.hwp"),
+        metrics=metrics,
+        pdf=pdf or "",
+        pages=pages,
+        exceeds=exceeds,
+        repro_command=command or "",
+        repro_cwd=cwd or ".",
+        notes=notes or "",
+    )
+
+
+def parse_report(raw: Any) -> Report:
+    data = _require_dict(raw, "$")
+    schema = data.get("schema")
+    if schema != SCHEMA_ID:
+        raise ReportError(f"schema 는 {SCHEMA_ID!r} 여야 합니다: {schema!r}")
+    documents_raw = data.get("documents")
+    if not isinstance(documents_raw, list):
+        raise ReportError("documents 는 배열이어야 합니다.")
+    dpi = data.get("dpi")
+    if dpi is not None and (isinstance(dpi, bool) or not isinstance(dpi, int) or dpi < 1):
+        raise ReportError("dpi 는 1 이상 정수여야 합니다.")
+    pixel = data.get("pixel_diff_threshold")
+    if pixel is not None and (
+        isinstance(pixel, bool) or not isinstance(pixel, int) or not 0 <= pixel <= 255
+    ):
+        raise ReportError("pixel_diff_threshold 는 0 이상 255 이하 정수여야 합니다.")
+    source = data.get("source", "")
+    generated_at = data.get("generated_at", "")
+    rhwp_bin = data.get("rhwp_bin", "")
+    for label, value in (
+        ("source", source),
+        ("generated_at", generated_at),
+        ("rhwp_bin", rhwp_bin),
+    ):
+        if value and not isinstance(value, str):
+            raise ReportError(f"{label} 는 문자열이어야 합니다.")
+    return Report(
+        threshold=parse_threshold(data.get("threshold")),
+        documents=[parse_document(item, index) for index, item in enumerate(documents_raw)],
+        generated_at=generated_at or "",
+        source=source or "",
+        rhwp_bin=rhwp_bin or "",
+        dpi=dpi,
+        pixel_diff_threshold=pixel,
+    )
+
+
+def load_report(path: Path) -> Report:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ReportError(f"리포트를 읽을 수 없습니다: {path}: {exc}") from exc
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ReportError(f"리포트 JSON 이 깨졌습니다: {path}: {exc}") from exc
+    return parse_report(raw)
+
+
+def synthesize_repro(document: Document, report: Report) -> str:
+    if document.repro_command.strip():
+        return document.repro_command.strip()
+    parts = ["python scripts/visual_sweep.py", "--hwp", document.hwp]
+    if document.pdf:
+        parts += ["--pdf", document.pdf]
+    parts += ["--key", document.id]
+    if report.dpi is not None:
+        parts += ["--dpi", str(report.dpi)]
+    if report.pixel_diff_threshold is not None:
+        parts += ["--pixel-diff-threshold", str(report.pixel_diff_threshold)]
+    return " ".join(parts)
+
+
+def classify_document(document: Document, threshold: Threshold) -> tuple[bool, str, float | None]:
+    if document.exceeds is True:
+        return True, "exceeds=true", document.measured(threshold.metric)
+    if document.exceeds is False:
+        return False, "exceeds=false", document.measured(threshold.metric)
+    measured = document.measured(threshold.metric)
+    if measured is None:
+        return False, f"지표 없음:{threshold.metric}", None
+    if threshold.failed(measured):
+        return (
+            True,
+            f"{threshold.metric}={format_number(measured)} {threshold.op} {format_number(threshold.value)}",
+            measured,
+        )
+    return (
+        False,
+        f"{threshold.metric}={format_number(measured)} 게이트 통과",
+        measured,
+    )
+
+
+def draft_title(document: Document, threshold: Threshold, measured: float | None) -> str:
+    value = format_number(measured) if measured is not None else "?"
+    return (
+        f"[오라클] {document.id}: {threshold.metric} {value} "
+        f"({threshold.op} {format_number(threshold.value)})"
+    )
+
+
+def draft_context(document: Document, report: Report, measured: float | None) -> dict[str, str]:
+    notes = document.notes.strip()
+    return {
+        "title": draft_title(document, report.threshold, measured),
+        "id": document.id,
+        "hwp": document.hwp,
+        "pdf": document.pdf or "(없음)",
+        "pages": str(document.pages) if document.pages is not None else "(미기재)",
+        "metric": report.threshold.metric,
+        "metric_value": format_number(measured) if measured is not None else "(없음)",
+        "threshold_op": report.threshold.op,
+        "threshold_value": format_number(report.threshold.value),
+        "repro_command": synthesize_repro(document, report),
+        "repro_cwd": document.repro_cwd or ".",
+        "source": report.source or "(미기재)",
+        "rhwp_bin": report.rhwp_bin or "(미기재)",
+        "dpi": str(report.dpi) if report.dpi is not None else "(미기재)",
+        "pixel_diff_threshold": (
+            str(report.pixel_diff_threshold)
+            if report.pixel_diff_threshold is not None
+            else "(미기재)"
+        ),
+        "worst_pages": format_worst_pages(document.metrics),
+        "notes_block": f"{notes}\n" if notes else "",
+        "metrics_table": metrics_table(document.metrics),
+        "generated_at": report.generated_at or "(미기재)",
+    }
+
+
+def unique_draft_path(out_dir: Path, document_id: str, used: set[str]) -> Path:
+    base = slugify(document_id)
+    name = f"{base}.md"
+    index = 2
+    while name in used:
+        name = f"{base}-{index}.md"
+        index += 1
+    used.add(name)
+    return out_dir / name
+
+
+def select_drafts(report: Report) -> DraftBatch:
+    batch = DraftBatch()
+    for document in report.documents:
+        failed, reason, measured = classify_document(document, report.threshold)
+        if failed:
+            batch.drafts.append(
+                Draft(document=document, path=Path(), reason=reason, measured=measured)
+            )
+        else:
+            batch.skipped.append({"id": document.id, "reason": reason})
+    return batch
+
+
+def write_drafts(
+    report: Report,
+    out_dir: Path,
+    template: str,
+    *,
+    force: bool,
+    dry_run: bool,
+    report_path: Path,
+) -> dict[str, Any]:
+    batch = select_drafts(report)
+    used: set[str] = set()
+    written: list[dict[str, Any]] = []
+    if not dry_run:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    for draft in batch.drafts:
+        path = unique_draft_path(out_dir, draft.document.id, used)
+        if path.exists() and not force and not dry_run:
+            raise ReportError(f"이미 초안이 있습니다(덮으려면 --force): {path}")
+        body = render_template(template, draft_context(draft.document, report, draft.measured))
+        if not dry_run:
+            path.write_bytes(body.encode("utf-8"))
+        written.append(
+            {
+                "id": draft.document.id,
+                "path": str(path),
+                "reason": draft.reason,
+                "metric": report.threshold.metric,
+                "value": draft.measured,
+                "repro": synthesize_repro(draft.document, report),
+            }
+        )
+    manifest = {
+        "schema": MANIFEST_SCHEMA,
+        "source_report": str(report_path),
+        "threshold": report.threshold.as_dict(),
+        "drafted": len(written),
+        "skipped": len(batch.skipped),
+        "submitted": False,
+        "submit": "manual",
+        "drafts": written,
+        "skipped_documents": batch.skipped,
+    }
+    if not dry_run:
+        (out_dir / "manifest.json").write_bytes(
+            (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+        )
+    return manifest
+
+
+def reject_submit_flags(argv: list[str]) -> None:
+    hit = [flag for flag in SUBMIT_FLAGS if flag in argv]
+    if hit:
+        raise SystemExit(f"{FORBIDDEN_HELP} 거부된 옵션: {' '.join(hit)}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="임계 초과 문서의 GitHub 이슈 초안을 디스크에만 씁니다.",
+        epilog=FORBIDDEN_HELP,
+    )
+    parser.add_argument("--report", required=True, type=Path, help="failure_report v1 JSON 경로")
+    parser.add_argument("--out", required=True, type=Path, help="초안 markdown 출력 디렉터리")
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE,
+        help=f"markdown 템플릿 (기본: {DEFAULT_TEMPLATE})",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="파일을 쓰지 않고 대상만 출력")
+    parser.add_argument("--force", action="store_true", help="기존 초안 파일을 덮어쓴다")
+    parser.add_argument("--json", action="store_true", help="매니페스트를 stdout 에 JSON 으로 출력")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8")
+    args_list = list(sys.argv[1:] if argv is None else argv)
+    try:
+        reject_submit_flags(args_list)
+    except SystemExit as exc:
+        print(exc, file=sys.stderr)
+        return EXIT_SUBMIT_FORBIDDEN
+    parser = build_parser()
+    try:
+        args = parser.parse_args(args_list)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else EXIT_USAGE
+        return code if code != 0 else EXIT_OK
+    try:
+        report = load_report(args.report)
+        template = args.template.read_text(encoding="utf-8")
+        manifest = write_drafts(
+            report,
+            args.out,
+            template,
+            force=args.force,
+            dry_run=args.dry_run,
+            report_path=args.report,
+        )
+    except (OSError, ReportError) as exc:
+        print(f"오류: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    if args.json:
+        print(json.dumps(manifest, ensure_ascii=False, indent=2))
+    else:
+        print(
+            f"초안 {manifest['drafted']}건, 건너뜀 {manifest['skipped']}건"
+            + (" (dry-run)" if args.dry_run else f" → {args.out}")
+        )
+        for item in manifest["drafts"]:
+            print(f"  - {item['id']}: {item['path']}")
+        print("제출하지 않음 (수동).")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/oracle_public/schema/failure_report.v1.json
+++ b/tools/oracle_public/schema/failure_report.v1.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "oracle_public.failure_report/v1",
+  "title": "oracle_public failure report v1",
+  "description": "임계 게이트를 넘긴 문서 목록. issue_draft.py 가 이슈 초안 markdown 을 만들 때 쓰는 작은 입력 스키마. visual_sweep.py 를 수정하지 않고, 그 산출(또는 동등한 수치)을 이 형태로 옮긴다.",
+  "type": "object",
+  "required": ["schema", "threshold", "documents"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "oracle_public.failure_report/v1",
+      "description": "스키마 식별자. 다른 값은 거부한다."
+    },
+    "generated_at": {
+      "type": "string",
+      "description": "리포트 생성 시각(ISO-8601). 초안 본문에만 인용한다."
+    },
+    "source": {
+      "type": "string",
+      "description": "수치 출처 도구 이름. 예: visual_sweep, dump-pages-smoke."
+    },
+    "rhwp_bin": {
+      "type": "string",
+      "description": "재현에 쓴 rhwp 바이너리 경로."
+    },
+    "dpi": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "래스터 DPI. 재현 커맨드 합성에 쓴다."
+    },
+    "pixel_diff_threshold": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255,
+      "description": "visual_sweep --pixel-diff-threshold 와 같은 RGB 채널 임계."
+    },
+    "threshold": {
+      "type": "object",
+      "required": ["metric", "op", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "metric": {
+          "type": "string",
+          "minLength": 1,
+          "description": "documents[].metrics 에서 읽을 지표 이름."
+        },
+        "op": {
+          "enum": ["<", "<=", ">", ">="],
+          "description": "실패 조건. metric op value 가 참이면 초안을 만든다."
+        },
+        "value": {
+          "type": "number",
+          "description": "게이트 임계값."
+        }
+      }
+    },
+    "documents": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Document" }
+    }
+  },
+  "definitions": {
+    "Document": {
+      "type": "object",
+      "required": ["id", "hwp", "metrics"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "문서 키. 초안 파일명과 제목에 쓴다."
+        },
+        "hwp": {
+          "type": "string",
+          "minLength": 1,
+          "description": "HWP/HWPX 경로."
+        },
+        "pdf": {
+          "type": "string",
+          "description": "한컴 기준 PDF 경로."
+        },
+        "pages": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "exceeds": {
+          "type": "boolean",
+          "description": "true 면 지표와 무관하게 초안을 만들고, false 면 건너뛴다."
+        },
+        "metrics": {
+          "type": "object",
+          "description": "지표 이름 → 숫자(또는 worst_pages 같은 정수 배열).",
+          "additionalProperties": {
+            "type": ["number", "integer", "string", "array", "null"]
+          }
+        },
+        "repro": {
+          "type": "object",
+          "properties": {
+            "command": { "type": "string", "minLength": 1 },
+            "cwd": { "type": "string" }
+          }
+        },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tools/oracle_public/templates/issue.md
+++ b/tools/oracle_public/templates/issue.md
@@ -1,0 +1,55 @@
+---
+title: "{{title}}"
+labels: bug
+draft: true
+submit: never
+---
+
+# {{title}}
+
+> **초안 — 제출하지 않음.** 이 파일은 디스크에만 남긴다. `gh issue create` 로
+> 올리지 말고, 사람이 수치·재현 커맨드를 확인한 뒤 수동으로 등록한다.
+
+## 현상
+
+문서 `{{hwp}}` 가 한컴 기준 대비 임계 게이트를 넘었습니다.
+
+- 지표: `{{metric}}` = **{{metric_value}}**
+- 게이트: `{{metric}} {{threshold_op}} {{threshold_value}}` 이면 실패
+- 쪽수: {{pages}}
+- 최악 페이지: {{worst_pages}}
+
+{{notes_block}}
+
+## 재현 방법
+
+작업 디렉터리: `{{repro_cwd}}`
+
+```
+{{repro_command}}
+```
+
+위 명령을 그대로 다시 돌리면 같은 수치가 나와야 합니다. `scripts/visual_sweep.py`
+자체를 수정하지 않습니다.
+
+## 기대 결과
+
+한컴 기준 PDF `{{pdf}}` 와 같은 쪽수·레이아웃이어야 합니다.
+`{{metric}}` 이 게이트(`{{threshold_op}} {{threshold_value}}`)에 걸리지 않아야 합니다.
+
+## 실제 결과
+
+{{metrics_table}}
+
+## 환경
+
+- 리포트 출처: `{{source}}`
+- 리포트 시각: {{generated_at}}
+- rhwp 바이너리: `{{rhwp_bin}}`
+- DPI: {{dpi}}
+- pixel_diff_threshold: {{pixel_diff_threshold}}
+- 문서 id: `{{id}}`
+
+## 제출
+
+제출은 **수동**입니다. 이 생성기는 GitHub 이슈를 만들지 않습니다.

--- a/tools/oracle_public/test_issue_draft.py
+++ b/tools/oracle_public/test_issue_draft.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""issue_draft.py 계약 테스트 — 바이너리·네트워크 불요.
+
+실행:
+    python -m unittest tools/oracle_public/test_issue_draft.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import issue_draft as draft  # noqa: E402
+
+FIXTURES = HERE / "fixtures"
+SCRIPT = HERE / "issue_draft.py"
+FORBIDDEN_HELP_SNIPPET = "이 도구는 초안 markdown 만 디스크에 씁니다."
+
+
+def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        **kwargs,
+    )
+
+
+class SchemaTests(unittest.TestCase):
+    def test_mixed_fixture_parses(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        self.assertEqual(report.threshold.metric, "worst_pixel_match_percent")
+        self.assertEqual(len(report.documents), 3)
+
+    def test_schema_file_exists_and_names_contract(self) -> None:
+        schema = json.loads((HERE / "schema" / "failure_report.v1.json").read_text(encoding="utf-8"))
+        self.assertEqual(schema["$id"], draft.SCHEMA_ID)
+        self.assertIn("schema", schema["required"])
+        self.assertIn("threshold", schema["required"])
+        self.assertIn("documents", schema["required"])
+
+    def test_wrong_schema_id_rejected(self) -> None:
+        with self.assertRaises(draft.ReportError):
+            draft.parse_report({"schema": "nope", "threshold": {}, "documents": []})
+
+    def test_invalid_fixture_rejected(self) -> None:
+        with self.assertRaises(draft.ReportError):
+            draft.load_report(FIXTURES / "report_invalid.json")
+
+    def test_missing_metrics_rejected(self) -> None:
+        with self.assertRaises(draft.ReportError):
+            draft.parse_document({"id": "x", "hwp": "a.hwp"}, 0)
+
+    def test_bad_threshold_op_rejected(self) -> None:
+        with self.assertRaises(draft.ReportError):
+            draft.parse_threshold({"metric": "x", "op": "==", "value": 1})
+
+    def test_broken_json_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.json"
+            path.write_text("{", encoding="utf-8")
+            with self.assertRaises(draft.ReportError):
+                draft.load_report(path)
+
+
+class GateTests(unittest.TestCase):
+    def test_mixed_fixture_selects_two(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        batch = draft.select_drafts(report)
+        ids = [item.document.id for item in batch.drafts]
+        self.assertEqual(ids, ["exam_math", "plan_2022"])
+        self.assertEqual([item["id"] for item in batch.skipped], ["exam_eng"])
+
+    def test_all_pass_writes_zero_drafts(self) -> None:
+        report = draft.load_report(FIXTURES / "report_all_pass.json")
+        self.assertEqual(draft.select_drafts(report).drafts, [])
+
+    def test_explicit_exceeds_overrides_metric(self) -> None:
+        report = draft.load_report(FIXTURES / "report_explicit.json")
+        batch = draft.select_drafts(report)
+        self.assertEqual([item.document.id for item in batch.drafts], ["forced_flag"])
+        self.assertEqual(batch.skipped[0]["id"], "suppressed")
+
+    def test_diff_ratio_greater_than(self) -> None:
+        report = draft.load_report(FIXTURES / "report_diff_ratio.json")
+        batch = draft.select_drafts(report)
+        self.assertEqual([item.document.id for item in batch.drafts], ["bunjang"])
+
+    def test_missing_metric_is_skipped(self) -> None:
+        report = draft.parse_report(
+            {
+                "schema": draft.SCHEMA_ID,
+                "threshold": {"metric": "missing", "op": "<", "value": 1},
+                "documents": [{"id": "a", "hwp": "a.hwp", "metrics": {"other": 0}}],
+            }
+        )
+        batch = draft.select_drafts(report)
+        self.assertEqual(batch.drafts, [])
+        self.assertIn("지표 없음", batch.skipped[0]["reason"])
+
+
+class RenderTests(unittest.TestCase):
+    def test_draft_contains_repro_and_numbers(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        document = report.documents[0]
+        body = draft.render_template(
+            (HERE / "templates" / "issue.md").read_text(encoding="utf-8"),
+            draft.draft_context(document, report, 87.5),
+        )
+        self.assertIn("python scripts/visual_sweep.py --hwp samples/exam_math.hwp", body)
+        self.assertIn("87.5", body)
+        self.assertIn("worst_pixel_match_percent", body)
+        self.assertIn("3, 7", body)
+        self.assertIn("submit: never", body)
+        self.assertIn("초안 — 제출하지 않음", body)
+        self.assertIn("수식 줄간격", body)
+
+    def test_repro_is_synthesized_when_missing(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        command = draft.synthesize_repro(report.documents[1], report)
+        self.assertEqual(
+            command,
+            "python scripts/visual_sweep.py --hwp samples/exam_eng.hwp "
+            "--pdf pdf/exam_eng-2022.pdf --key exam_eng --dpi 96 "
+            "--pixel-diff-threshold 12",
+        )
+
+    def test_slug_collision_gets_suffix(self) -> None:
+        used: set[str] = set()
+        first = draft.unique_draft_path(Path("out"), "exam_math", used)
+        second = draft.unique_draft_path(Path("out"), "exam_math", used)
+        self.assertEqual(first.name, "exam_math.md")
+        self.assertEqual(second.name, "exam_math-2.md")
+
+    def test_slugify_strips_unsafe(self) -> None:
+        self.assertEqual(draft.slugify("2022 plan.hwp"), "2022-plan.hwp")
+        self.assertEqual(draft.slugify("???"), "untitled")
+
+
+class WriteTests(unittest.TestCase):
+    def test_writes_markdown_and_manifest(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        template = (HERE / "templates" / "issue.md").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as directory:
+            out = Path(directory)
+            manifest = draft.write_drafts(
+                report,
+                out,
+                template,
+                force=False,
+                dry_run=False,
+                report_path=FIXTURES / "report_mixed.json",
+            )
+            self.assertEqual(manifest["drafted"], 2)
+            self.assertEqual(manifest["skipped"], 1)
+            self.assertFalse(manifest["submitted"])
+            self.assertEqual(manifest["submit"], "manual")
+            math = out / "exam_math.md"
+            plan = out / "plan_2022.md"
+            self.assertTrue(math.is_file())
+            self.assertTrue(plan.is_file())
+            self.assertFalse((out / "exam_eng.md").exists())
+            text = math.read_text(encoding="utf-8")
+            self.assertIn("87.5", text)
+            self.assertIn("--pixel-diff-threshold 12", text)
+            saved = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(saved["drafted"], 2)
+
+    def test_dry_run_writes_nothing(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        template = (HERE / "templates" / "issue.md").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as directory:
+            out = Path(directory) / "nested"
+            manifest = draft.write_drafts(
+                report,
+                out,
+                template,
+                force=False,
+                dry_run=True,
+                report_path=FIXTURES / "report_mixed.json",
+            )
+            self.assertEqual(manifest["drafted"], 2)
+            self.assertFalse(out.exists())
+
+    def test_refuse_overwrite_without_force(self) -> None:
+        report = draft.load_report(FIXTURES / "report_mixed.json")
+        template = (HERE / "templates" / "issue.md").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as directory:
+            out = Path(directory)
+            (out / "exam_math.md").write_text("keep", encoding="utf-8")
+            with self.assertRaises(draft.ReportError):
+                draft.write_drafts(
+                    report,
+                    out,
+                    template,
+                    force=False,
+                    dry_run=False,
+                    report_path=FIXTURES / "report_mixed.json",
+                )
+            self.assertEqual((out / "exam_math.md").read_text(encoding="utf-8"), "keep")
+
+
+class CliTests(unittest.TestCase):
+    def test_cli_mixed_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = _run(
+                [
+                    "--report",
+                    str(FIXTURES / "report_mixed.json"),
+                    "--out",
+                    directory,
+                    "--json",
+                ]
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["drafted"], 2)
+        self.assertFalse(payload["submitted"])
+        self.assertEqual(payload["submit"], "manual")
+
+    def test_cli_all_pass_exit_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = _run(
+                [
+                    "--report",
+                    str(FIXTURES / "report_all_pass.json"),
+                    "--out",
+                    directory,
+                    "--json",
+                ]
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["drafted"], 0)
+
+    def test_cli_invalid_exit_two(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = _run(
+                [
+                    "--report",
+                    str(FIXTURES / "report_invalid.json"),
+                    "--out",
+                    directory,
+                ]
+            )
+        self.assertEqual(result.returncode, draft.EXIT_USAGE)
+        self.assertIn("오류", result.stderr)
+
+    def test_submit_flag_rejected(self) -> None:
+        result = _run(
+            [
+                "--submit",
+                "--report",
+                str(FIXTURES / "report_mixed.json"),
+                "--out",
+                "unused",
+            ]
+        )
+        self.assertEqual(result.returncode, draft.EXIT_SUBMIT_FORBIDDEN)
+        self.assertIn("수동", result.stderr)
+
+    def test_create_issue_flag_rejected(self) -> None:
+        result = _run(["--create-issue"])
+        self.assertEqual(result.returncode, draft.EXIT_SUBMIT_FORBIDDEN)
+
+    def test_module_never_invokes_github(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn("import subprocess", source)
+        self.assertNotIn("os.system", source)
+        self.assertNotIn("shutil.which", source)
+        self.assertIn(FORBIDDEN_HELP_SNIPPET, source)
+
+
+class SourceIsolationTests(unittest.TestCase):
+    def test_only_new_oracle_public_tree(self) -> None:
+        self.assertTrue((HERE / "issue_draft.py").is_file())
+        self.assertTrue((HERE / "templates" / "issue.md").is_file())
+        self.assertTrue((HERE / "fixtures" / "report_mixed.json").is_file())
+        sweep = HERE.parents[1] / "scripts" / "visual_sweep.py"
+        self.assertTrue(sweep.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

M01-6 (#5346): 임계 게이트를 넘긴 문서 실패 리포트 JSON을 **GitHub 이슈 초안 markdown**으로 바꿉니다. 산출은 디스크에만 남기고, 제출은 사람이 검토한 뒤 수동으로 합니다. `gh issue create`는 호출하지 않으며 `--submit` / `--create-issue` / `--gh`는 거부합니다.

전부 `tools/oracle_public/` 신규 파일입니다. `scripts/visual_sweep.py`는 수정하지 않았습니다.

- `issue_draft.py` — `failure_report/v1` 리포트를 읽어 게이트(`metric op value`, 또는 `exceeds` 강제)에 걸린 문서마다 재현 커맨드·수치 표를 넣은 초안을 씁니다
- `schema/failure_report.v1.json` — 작은 입력 스키마
- `templates/issue.md` — 저장소 버그 리포트 절(현상/재현/기대/실제/환경)에 맞춘 초안 템플릿
- `fixtures/` — 혼합 실패·전원 통과·강제 exceeds·diff_ratio·스키마 오류 예제
- `test_issue_draft.py` — 스키마·게이트·렌더·CLI·제출 거부 26건 (바이너리·네트워크 불요)

```
python tools/oracle_public/issue_draft.py \
  --report tools/oracle_public/fixtures/report_mixed.json \
  --out /tmp/oracle-issue-drafts
```

혼합 픽스처는 `exam_math`·`plan_2022` 2건만 초안이 되고, 게이트를 통과한 `exam_eng`는 건너뜁니다. `manifest.json`의 `submitted`는 항상 `false`입니다.

## 관련 이슈

closes #5346

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `python -m unittest tools/oracle_public/test_issue_draft.py` 26건 통과
- [ ] `cargo test` / `cargo clippy` — 해당 없음 (Rust 소스 미변경, Python 도구만 추가)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (문서 편집 없음)
- [ ] capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (독립 실행 Python 도구, 기존 코드 미변경)
- 재현·측정: `python -m unittest tools/oracle_public/test_issue_draft.py` (약 1초)

## 스크린샷

해당 없음.
