### PR TITLE
feat(oracle): pdf-2020·pdf-large 편입과 다중버전 쪽수 불일치 목록

### DIFF
--- a/tools/oracle_public/fixtures/lfs_pointer.pdf
+++ b/tools/oracle_public/fixtures/lfs_pointer.pdf
@@ -1,0 +1,4 @@
+version https://git-lfs.github.com/spec/v1
+fixture: not a real git-lfs object
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+size 99

--- a/tools/oracle_public/multiver_index.py
+++ b/tools/oracle_public/multiver_index.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""pdf/ · pdf-2020/ · pdf-large/ 한컴 오라클 편입 + 다중버전 쪽수 불일치 목록.
+
+M01-5 (#5345). 전부 신규 파일. scripts/visual_sweep.py 는 건드리지 않는다.
+
+무엇을 하는가
+-------------
+세 오라클 트리를 순회해 stem(원본 문서 이름) × 한글 버전(2010/2018/2020/2022/2024)으로
+묶고, 같은 stem 에 버전이 둘 이상이면 pypdf 로 쪽수를 잰다. 쪽수가 갈리면 불일치
+목록에 넣고, 갈리지 않으면 일치로 남긴다. 픽셀 차이는 이 클레임 범위 밖이라
+측정하지 않고 보고서에도 적지 않는다.
+
+쪽수를 못 잰 파일(LFS 포인터, %PDF 아님, pypdf 실패)은 page_count=null 로 두고
+이유를 적는다. 추측 쪽수를 넣지 않는다.
+
+버전 토큰
+---------
+파일명 끝에서 `-2010`/`-2018`/`-2020`/`-2022`/`-2024` 와 변이
+(`kopub`/`no-ttf`/`hwp`/`hwpx`/`hancom`)를 벗긴 나머지가 stem 이다.
+`hwp3-sample16-hwp5-2018-2020.pdf` 처럼 연도가 두 개면 **마지막**만 오라클
+버전이고 앞 연도는 stem 에 남긴다(변환에 쓴 한글 버전).
+접미가 없으면 디렉터리 기본값만 쓴다: pdf/=2022, pdf-2020/=2020.
+pdf-large/ 는 기본값이 없다.
+
+종료 코드: 0 성공 / 2 사용법·경로 오류.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1.0"
+CLAIM_ID = "M01-5"
+METRIC = "pypdf_page_count"
+PIXEL_DIFF_SCOPE = "out_of_scope"
+
+HANGUL_YEARS = frozenset({"2010", "2018", "2020", "2022", "2024"})
+VARIANT_TOKENS = frozenset({"kopub", "no-ttf", "hwp", "hwpx", "hancom"})
+DEFAULT_TREES = ("pdf", "pdf-2020", "pdf-large")
+DIR_DEFAULT_VERSION = {
+    "pdf": "2022",
+    "pdf-2020": "2020",
+    "pdf-2010": "2010",
+    "pdf-large": None,
+}
+LFS_PREFIX = b"version https://git-lfs.github.com"
+REPORT_DIRNAME = "reports"
+
+
+def repo_root_from_here() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def parse_oracle_name(stem: str) -> tuple[str, str | None, list[str]]:
+    """파일 stem 에서 (문서stem, 한글버전|None, 변이목록)을 벗긴다."""
+    tokens = stem.split("-")
+    version: str | None = None
+    variants: list[str] = []
+    changed = True
+    while tokens and changed:
+        changed = False
+        last = tokens[-1]
+        if version is None and last in HANGUL_YEARS:
+            version = last
+            tokens.pop()
+            changed = True
+            continue
+        if last.lower() in VARIANT_TOKENS:
+            variants.append(last.lower())
+            tokens.pop()
+            changed = True
+            continue
+    variants.reverse()
+    return "-".join(tokens), version, variants
+
+
+def tree_of(rel_posix: str) -> str:
+    return rel_posix.split("/", 1)[0]
+
+
+def classify_bytes(head: bytes) -> str | None:
+    """측정 불가면 이유 코드를, 측정 가능하면 None."""
+    if head.startswith(LFS_PREFIX):
+        return "lfs_pointer"
+    if not head.startswith(b"%PDF"):
+        return "not_pdf"
+    return None
+
+
+def measure_page_count(path: Path) -> tuple[int | None, str]:
+    """쪽수 또는 (None, 이유). 추측하지 않는다."""
+    try:
+        head = path.read_bytes()[:80]
+    except OSError as exc:
+        return None, f"io_error:{type(exc).__name__}"
+    blocked = classify_bytes(head)
+    if blocked is not None:
+        return None, blocked
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        return None, "pypdf_missing"
+    try:
+        import logging
+
+        logging.getLogger("pypdf").setLevel(logging.ERROR)
+        reader = PdfReader(str(path), strict=False)
+        return len(reader.pages), "pypdf"
+    except Exception as exc:  # noqa: BLE001 — 측정 실패는 이유만 남긴다
+        return None, f"pypdf_error:{type(exc).__name__}"
+
+
+def discover_pdfs(root: Path, trees: tuple[str, ...] | list[str]) -> list[Path]:
+    found: list[Path] = []
+    for tree in trees:
+        base = root / tree
+        if not base.is_dir():
+            continue
+        found.extend(p for p in base.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf")
+    found.sort(key=lambda p: p.as_posix().lower())
+    return found
+
+
+def describe_file(root: Path, path: Path, *, measure: bool) -> dict[str, Any]:
+    rel = path.relative_to(root).as_posix()
+    tree = tree_of(rel)
+    stem, explicit, variants = parse_oracle_name(path.stem)
+    inferred = False
+    version = explicit
+    version_source = "explicit" if explicit is not None else "unknown"
+    if explicit is None:
+        default = DIR_DEFAULT_VERSION.get(tree)
+        if default is not None:
+            version = default
+            inferred = True
+            version_source = "inferred_dir"
+    rec: dict[str, Any] = {
+        "path": rel,
+        "tree": tree,
+        "filename": path.name,
+        "stem": stem,
+        "hangul_version": version,
+        "version_source": version_source,
+        "version_inferred": inferred,
+        "variants": variants,
+        "size_bytes": path.stat().st_size,
+        "page_count": None,
+        "page_count_status": "skipped",
+    }
+    if measure:
+        pages, status = measure_page_count(path)
+        rec["page_count"] = pages
+        rec["page_count_status"] = "measured" if pages is not None else status
+    return rec
+
+
+def _version_pages(files: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_ver: dict[str, dict[str, Any]] = {}
+    for rec in files:
+        ver = rec.get("hangul_version")
+        if not ver:
+            continue
+        slot = by_ver.setdefault(
+            ver,
+            {"hangul_version": ver, "files": [], "page_counts": [], "unmeasured": []},
+        )
+        slot["files"].append(rec["path"])
+        if rec["page_count"] is None:
+            slot["unmeasured"].append(
+                {"path": rec["path"], "status": rec["page_count_status"]}
+            )
+        else:
+            slot["page_counts"].append(rec["page_count"])
+    return dict(sorted(by_ver.items()))
+
+
+def classify_stem(files: list[dict[str, Any]]) -> dict[str, Any]:
+    versions = sorted({r["hangul_version"] for r in files if r.get("hangul_version")})
+    by_ver = _version_pages(files)
+    measured_sets = {
+        ver: sorted(set(slot["page_counts"]))
+        for ver, slot in by_ver.items()
+        if slot["page_counts"]
+    }
+    all_pages: set[int] = set()
+    for pages in measured_sets.values():
+        all_pages.update(pages)
+    if len(versions) < 2:
+        kind = "single_version"
+    elif len(measured_sets) < 2:
+        kind = "incomplete"
+    elif len(all_pages) > 1:
+        kind = "page_count_disagree"
+    else:
+        kind = "page_count_agree"
+    return {
+        "stem": files[0]["stem"] if files else "",
+        "kind": kind,
+        "hangul_versions": versions,
+        "file_count": len(files),
+        "trees": sorted({r["tree"] for r in files}),
+        "by_version": by_ver,
+        "measured_page_counts": measured_sets,
+        "min_pages": min(all_pages) if all_pages else None,
+        "max_pages": max(all_pages) if all_pages else None,
+        "files": [r["path"] for r in files],
+    }
+
+
+def build_index(
+    root: Path,
+    trees: tuple[str, ...] | list[str] = DEFAULT_TREES,
+    *,
+    measure: bool = True,
+) -> dict[str, Any]:
+    root = root.resolve()
+    files = [describe_file(root, p, measure=measure) for p in discover_pdfs(root, trees)]
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rec in files:
+        grouped[rec["stem"]].append(rec)
+    stems = [classify_stem(grouped[name]) for name in sorted(grouped)]
+    multiver = [s for s in stems if len(s["hangul_versions"]) >= 2]
+    disagreements = [s for s in multiver if s["kind"] == "page_count_disagree"]
+    agrees = [s for s in multiver if s["kind"] == "page_count_agree"]
+    incomplete = [s for s in multiver if s["kind"] == "incomplete"]
+
+    tree_stats: dict[str, Any] = {}
+    for tree in trees:
+        subset = [r for r in files if r["tree"] == tree]
+        tree_stats[tree] = {
+            "present": (root / tree).is_dir(),
+            "default_hangul_version": DIR_DEFAULT_VERSION.get(tree),
+            "file_count": len(subset),
+            "measured": sum(1 for r in subset if r["page_count"] is not None),
+            "unmeasured": sum(1 for r in subset if r["page_count"] is None),
+        }
+
+    incorporation = {
+        tree: [r for r in files if r["tree"] == tree]
+        for tree in trees
+        if tree != "pdf"
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "claim": CLAIM_ID,
+        "metric": METRIC,
+        "pixel_diff": PIXEL_DIFF_SCOPE,
+        "root": str(root),
+        "trees": tree_stats,
+        "counts": {
+            "files": len(files),
+            "stems": len(stems),
+            "multiver_stems": len(multiver),
+            "page_count_disagree": len(disagreements),
+            "page_count_agree": len(agrees),
+            "incomplete": len(incomplete),
+            "measured_files": sum(1 for r in files if r["page_count"] is not None),
+            "unmeasured_files": sum(1 for r in files if r["page_count"] is None),
+        },
+        "files": files,
+        "stems": stems,
+        "multiver_stems": multiver,
+        "disagreements": disagreements,
+        "incorporation": incorporation,
+    }
+
+
+def render_markdown(index: dict[str, Any]) -> str:
+    counts = index["counts"]
+    trees = index["trees"]
+    lines: list[str] = [
+        "# M01-5 한컴 오라클 편입 · 다중버전 쪽수 불일치",
+        "",
+        f"- 클레임: `{index['claim']}`",
+        f"- 측정: `{index['metric']}` (픽셀 차이는 `{index['pixel_diff']}`)",
+        f"- 파일 {counts['files']} / stem {counts['stems']} / "
+        f"다중버전 stem {counts['multiver_stems']}",
+        f"- 쪽수 불일치 {counts['page_count_disagree']} · "
+        f"쪽수 일치 {counts['page_count_agree']} · "
+        f"미완(쪽수 미측정) {counts['incomplete']}",
+        f"- 측정 {counts['measured_files']} · 미측정 {counts['unmeasured_files']}",
+        "",
+        "## 트리 편입",
+        "",
+        "| 트리 | 존재 | 기본 한글 버전 | 파일 | 측정 | 미측정 |",
+        "| --- | --- | --- | ---: | ---: | ---: |",
+    ]
+    for name, stat in trees.items():
+        default = stat["default_hangul_version"] or "없음"
+        present = "예" if stat["present"] else "아니오"
+        lines.append(
+            f"| `{name}/` | {present} | {default} | {stat['file_count']} | "
+            f"{stat['measured']} | {stat['unmeasured']} |"
+        )
+    lines.extend(["", "## pdf-2020/ · pdf-large/ 편입 목록", ""])
+    for tree, recs in index["incorporation"].items():
+        lines.append(f"### `{tree}/` ({len(recs)}건)")
+        lines.append("")
+        if not recs:
+            lines.append("파일 없음.")
+            lines.append("")
+            continue
+        lines.append("| 경로 | stem | 한글 버전 | 출처 | 쪽수 | 상태 |")
+        lines.append("| --- | --- | --- | --- | ---: | --- |")
+        for rec in recs:
+            ver = rec["hangul_version"] or "—"
+            pages = rec["page_count"] if rec["page_count"] is not None else "—"
+            lines.append(
+                f"| `{rec['path']}` | `{rec['stem']}` | {ver} | "
+                f"{rec['version_source']} | {pages} | {rec['page_count_status']} |"
+            )
+        lines.append("")
+
+    lines.extend(["", "## 쪽수 불일치 (다중버전)", ""])
+    if not index["disagreements"]:
+        lines.append(
+            "측정된 쪽수가 갈리는 다중버전 stem 은 없다. "
+            "픽셀 차이는 측정하지 않았다."
+        )
+        lines.append("")
+    else:
+        lines.append("| stem | 버전별 쪽수(실측) | 최소 | 최대 | 파일 수 |")
+        lines.append("| --- | --- | ---: | ---: | ---: |")
+        for stem in index["disagreements"]:
+            parts = []
+            for ver, pages in stem["measured_page_counts"].items():
+                shown = ",".join(str(p) for p in pages)
+                parts.append(f"{ver}={shown}")
+            lines.append(
+                f"| `{stem['stem']}` | {'; '.join(parts)} | "
+                f"{stem['min_pages']} | {stem['max_pages']} | {stem['file_count']} |"
+            )
+        lines.append("")
+        lines.append("버전별 파일:")
+        lines.append("")
+        for stem in index["disagreements"]:
+            lines.append(f"### `{stem['stem']}`")
+            lines.append("")
+            for ver, slot in stem["by_version"].items():
+                pages = slot["page_counts"]
+                page_txt = ",".join(str(p) for p in pages) if pages else "미측정"
+                lines.append(f"- {ver} (쪽 {page_txt})")
+                for path in slot["files"]:
+                    lines.append(f"  - `{path}`")
+            lines.append("")
+
+    lines.extend(["", "## 다중버전 · 쪽수 일치", ""])
+    agrees = [s for s in index["multiver_stems"] if s["kind"] == "page_count_agree"]
+    if not agrees:
+        lines.append("없음.")
+        lines.append("")
+    else:
+        lines.append(
+            "같은 stem 에 한글 버전이 둘 이상이고, **잰 쪽수는 같다**. "
+            "시각(픽셀) 일치로 읽지 말 것."
+        )
+        lines.append("")
+        lines.append("| stem | 버전 | 쪽수 | 파일 수 |")
+        lines.append("| --- | --- | ---: | ---: |")
+        for stem in agrees:
+            vers = ",".join(stem["hangul_versions"])
+            lines.append(
+                f"| `{stem['stem']}` | {vers} | {stem['min_pages']} | {stem['file_count']} |"
+            )
+        lines.append("")
+
+    incomplete = [s for s in index["multiver_stems"] if s["kind"] == "incomplete"]
+    lines.extend(["", "## 다중버전 · 쪽수 미완", ""])
+    if not incomplete:
+        lines.append("없음.")
+        lines.append("")
+    else:
+        lines.append("버전이 둘 이상이나 쪽수를 두 버전 이상에서 못 잰 stem.")
+        lines.append("")
+        for stem in incomplete:
+            lines.append(f"- `{stem['stem']}` 버전 {', '.join(stem['hangul_versions'])}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## 정직 한계",
+            "",
+            "- 쪽수는 pypdf `len(reader.pages)` 만 사용한다.",
+            "- 픽셀/렌더 차이는 측정하지 않았고, 불일치로 세지 않는다.",
+            "- LFS 포인터·비PDF·pypdf 실패는 `page_count=null` + 상태 코드다.",
+            "- `scripts/visual_sweep.py` 는 이 도구가 수정하지 않는다.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _json_ready(index: dict[str, Any]) -> dict[str, Any]:
+    """보고서용으로 큰 목록을 나눈다."""
+    return index
+
+
+def write_reports(index: dict[str, Any], out_dir: Path) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    manifest = {
+        "schema_version": index["schema_version"],
+        "claim": index["claim"],
+        "metric": index["metric"],
+        "pixel_diff": index["pixel_diff"],
+        "trees": index["trees"],
+        "counts": index["counts"],
+        "incorporation": index["incorporation"],
+    }
+    p_manifest = out_dir / "incorporation_manifest.json"
+    p_manifest.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    written.append(p_manifest)
+
+    disagreements = {
+        "schema_version": index["schema_version"],
+        "claim": index["claim"],
+        "metric": index["metric"],
+        "pixel_diff": index["pixel_diff"],
+        "counts": {
+            "multiver_stems": index["counts"]["multiver_stems"],
+            "page_count_disagree": index["counts"]["page_count_disagree"],
+            "page_count_agree": index["counts"]["page_count_agree"],
+            "incomplete": index["counts"]["incomplete"],
+        },
+        "disagreements": index["disagreements"],
+        "multiver_stems": index["multiver_stems"],
+    }
+    p_dis = out_dir / "multiver_disagreements.json"
+    p_dis.write_text(
+        json.dumps(disagreements, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    written.append(p_dis)
+
+    p_md = out_dir / "multiver_index.md"
+    p_md.write_text(render_markdown(index), encoding="utf-8", newline="\n")
+    written.append(p_md)
+    return written
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="pdf/pdf-2020/pdf-large 다중버전 한글 오라클 색인"
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="저장소 루트 (기본: 이 파일 기준 두 단계 위)",
+    )
+    parser.add_argument(
+        "--trees",
+        default=",".join(DEFAULT_TREES),
+        help="쉼표 구분 트리 (기본: pdf,pdf-2020,pdf-large)",
+    )
+    parser.add_argument(
+        "--write-reports",
+        action="store_true",
+        help="tools/oracle_public/reports/ 에 JSON·MD 를 쓴다",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="보고서 디렉터리 (--write-reports 기본: tools/oracle_public/reports)",
+    )
+    parser.add_argument(
+        "--no-measure",
+        action="store_true",
+        help="쪽수를 재지 않고 파일·stem 만 묶는다",
+    )
+    parser.add_argument("--json", action="store_true", help="전체 색인을 stdout JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = args.root.resolve() if args.root else repo_root_from_here()
+    trees = tuple(t.strip() for t in args.trees.split(",") if t.strip())
+    if not trees:
+        print("trees 가 비었다", file=sys.stderr)
+        return 2
+    if not root.is_dir():
+        print(f"root 가 없다: {root}", file=sys.stderr)
+        return 2
+
+    index = build_index(root, trees, measure=not args.no_measure)
+    if args.write_reports:
+        out_dir = args.out_dir or (Path(__file__).resolve().parent / REPORT_DIRNAME)
+        written = write_reports(index, out_dir)
+        for path in written:
+            print(path.as_posix(), file=sys.stderr)
+    if args.json:
+        json.dump(_json_ready(index), sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_markdown(index))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/oracle_public/reports/incorporation_manifest.json
+++ b/tools/oracle_public/reports/incorporation_manifest.json
@@ -1,0 +1,292 @@
+{
+  "schema_version": "1.0",
+  "claim": "M01-5",
+  "metric": "pypdf_page_count",
+  "pixel_diff": "out_of_scope",
+  "trees": {
+    "pdf": {
+      "present": true,
+      "default_hangul_version": "2022",
+      "file_count": 406,
+      "measured": 406,
+      "unmeasured": 0
+    },
+    "pdf-2020": {
+      "present": true,
+      "default_hangul_version": "2020",
+      "file_count": 1,
+      "measured": 1,
+      "unmeasured": 0
+    },
+    "pdf-large": {
+      "present": true,
+      "default_hangul_version": null,
+      "file_count": 18,
+      "measured": 18,
+      "unmeasured": 0
+    }
+  },
+  "counts": {
+    "files": 425,
+    "stems": 395,
+    "multiver_stems": 9,
+    "page_count_disagree": 1,
+    "page_count_agree": 8,
+    "incomplete": 0,
+    "measured_files": 425,
+    "unmeasured_files": 0
+  },
+  "incorporation": {
+    "pdf-2020": [
+      {
+        "path": "pdf-2020/pr-1674-2020.pdf",
+        "tree": "pdf-2020",
+        "filename": "pr-1674-2020.pdf",
+        "stem": "pr-1674",
+        "hangul_version": "2020",
+        "version_source": "explicit",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 860225,
+        "page_count": 35,
+        "page_count_status": "measured"
+      }
+    ],
+    "pdf-large": [
+      {
+        "path": "pdf-large/3-09월_교육_통합_2024-구분선아래20-2024.pdf",
+        "tree": "pdf-large",
+        "filename": "3-09월_교육_통합_2024-구분선아래20-2024.pdf",
+        "stem": "3-09월_교육_통합_2024-구분선아래20",
+        "hangul_version": "2024",
+        "version_source": "explicit",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 1472249,
+        "page_count": 23,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/3-09월_교육_통합_2024-미주사이20-2024.pdf",
+        "tree": "pdf-large",
+        "filename": "3-09월_교육_통합_2024-미주사이20-2024.pdf",
+        "stem": "3-09월_교육_통합_2024-미주사이20",
+        "hangul_version": "2024",
+        "version_source": "explicit",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 1473246,
+        "page_count": 24,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/143E433F503322BD33.pdf",
+        "tree": "pdf-large",
+        "filename": "143E433F503322BD33.pdf",
+        "stem": "143E433F503322BD33",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 147003,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/2026_oss_rst.pdf",
+        "tree": "pdf-large",
+        "filename": "2026_oss_rst.pdf",
+        "stem": "2026_oss_rst",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 171288,
+        "page_count": 6,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf",
+        "tree": "pdf-large",
+        "filename": "[2027] 온새미로 1 본교재.pdf",
+        "stem": "[2027] 온새미로 1 본교재",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 1255445,
+        "page_count": 46,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/el-school-001.pdf",
+        "tree": "pdf-large",
+        "filename": "el-school-001.pdf",
+        "stem": "el-school-001",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 74746,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/eq-002.pdf",
+        "tree": "pdf-large",
+        "filename": "eq-002.pdf",
+        "stem": "eq-002",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 23807,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/footnote-tbox-01.pdf",
+        "tree": "pdf-large",
+        "filename": "footnote-tbox-01.pdf",
+        "stem": "footnote-tbox-01",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 14537,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/hcar-001.pdf",
+        "tree": "pdf-large",
+        "filename": "hcar-001.pdf",
+        "stem": "hcar-001",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 258069,
+        "page_count": 6,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/hy-001.pdf",
+        "tree": "pdf-large",
+        "filename": "hy-001.pdf",
+        "stem": "hy-001",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 126209,
+        "page_count": 2,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/hy-002.pdf",
+        "tree": "pdf-large",
+        "filename": "hy-002.pdf",
+        "stem": "hy-002",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 112893,
+        "page_count": 2,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/issue_1133.pdf",
+        "tree": "pdf-large",
+        "filename": "issue_1133.pdf",
+        "stem": "issue_1133",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 110523,
+        "page_count": 3,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/k-water-rfp.pdf",
+        "tree": "pdf-large",
+        "filename": "k-water-rfp.pdf",
+        "stem": "k-water-rfp",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 1451239,
+        "page_count": 27,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/math-001.pdf",
+        "tree": "pdf-large",
+        "filename": "math-001.pdf",
+        "stem": "math-001",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 101699,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/shape-001.pdf",
+        "tree": "pdf-large",
+        "filename": "shape-001.pdf",
+        "stem": "shape-001",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 9681,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/ta-pic-001-r.pdf",
+        "tree": "pdf-large",
+        "filename": "ta-pic-001-r.pdf",
+        "stem": "ta-pic-001-r",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 229401,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/hwpx/tb-org-02.pdf",
+        "tree": "pdf-large",
+        "filename": "tb-org-02.pdf",
+        "stem": "tb-org-02",
+        "hangul_version": null,
+        "version_source": "unknown",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 38942,
+        "page_count": 1,
+        "page_count_status": "measured"
+      },
+      {
+        "path": "pdf-large/issue2006/1790387_prep_final_report-2022.pdf",
+        "tree": "pdf-large",
+        "filename": "1790387_prep_final_report-2022.pdf",
+        "stem": "1790387_prep_final_report",
+        "hangul_version": "2022",
+        "version_source": "explicit",
+        "version_inferred": false,
+        "variants": [],
+        "size_bytes": 50228784,
+        "page_count": 146,
+        "page_count_status": "measured"
+      }
+    ]
+  }
+}

--- a/tools/oracle_public/reports/multiver_disagreements.json
+++ b/tools/oracle_public/reports/multiver_disagreements.json
@@ -1,0 +1,559 @@
+{
+  "schema_version": "1.0",
+  "claim": "M01-5",
+  "metric": "pypdf_page_count",
+  "pixel_diff": "out_of_scope",
+  "counts": {
+    "multiver_stems": 9,
+    "page_count_disagree": 1,
+    "page_count_agree": 8,
+    "incomplete": 0
+  },
+  "disagreements": [
+    {
+      "stem": "2025 행정업무운영 편람(최종)",
+      "kind": "page_count_disagree",
+      "hangul_versions": [
+        "2010",
+        "2020",
+        "2024"
+      ],
+      "file_count": 8,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2010": {
+          "hangul_version": "2010",
+          "files": [
+            "pdf/2025 행정업무운영 편람(최종)-2010-kopub.pdf"
+          ],
+          "page_counts": [
+            388
+          ],
+          "unmeasured": []
+        },
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+            "pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf",
+            "pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf",
+            "pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf",
+            "pdf/stage242-hwp2020-page-count/2025 행정업무운영 편람(최종)-2020.pdf",
+            "pdf/stage242-hwp2020-page-count/hwpx/2025 행정업무운영 편람(최종)-2020.pdf"
+          ],
+          "page_counts": [
+            383,
+            383,
+            383,
+            383,
+            383,
+            383
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/2025 행정업무운영 편람(최종)-2024.pdf"
+          ],
+          "page_counts": [
+            383
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2010": [
+          388
+        ],
+        "2020": [
+          383
+        ],
+        "2024": [
+          383
+        ]
+      },
+      "min_pages": 383,
+      "max_pages": 388,
+      "files": [
+        "pdf/2025 행정업무운영 편람(최종)-2010-kopub.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-2024.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf",
+        "pdf/stage242-hwp2020-page-count/2025 행정업무운영 편람(최종)-2020.pdf",
+        "pdf/stage242-hwp2020-page-count/hwpx/2025 행정업무운영 편람(최종)-2020.pdf"
+      ]
+    }
+  ],
+  "multiver_stems": [
+    {
+      "stem": "2025 행정업무운영 편람(최종)",
+      "kind": "page_count_disagree",
+      "hangul_versions": [
+        "2010",
+        "2020",
+        "2024"
+      ],
+      "file_count": 8,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2010": {
+          "hangul_version": "2010",
+          "files": [
+            "pdf/2025 행정업무운영 편람(최종)-2010-kopub.pdf"
+          ],
+          "page_counts": [
+            388
+          ],
+          "unmeasured": []
+        },
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+            "pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf",
+            "pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf",
+            "pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf",
+            "pdf/stage242-hwp2020-page-count/2025 행정업무운영 편람(최종)-2020.pdf",
+            "pdf/stage242-hwp2020-page-count/hwpx/2025 행정업무운영 편람(최종)-2020.pdf"
+          ],
+          "page_counts": [
+            383,
+            383,
+            383,
+            383,
+            383,
+            383
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/2025 행정업무운영 편람(최종)-2024.pdf"
+          ],
+          "page_counts": [
+            383
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2010": [
+          388
+        ],
+        "2020": [
+          383
+        ],
+        "2024": [
+          383
+        ]
+      },
+      "min_pages": 383,
+      "max_pages": 388,
+      "files": [
+        "pdf/2025 행정업무운영 편람(최종)-2010-kopub.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-2024.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf",
+        "pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf",
+        "pdf/stage242-hwp2020-page-count/2025 행정업무운영 편람(최종)-2020.pdf",
+        "pdf/stage242-hwp2020-page-count/hwpx/2025 행정업무운영 편람(최종)-2020.pdf"
+      ]
+    },
+    {
+      "stem": "SO-SUEOP",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2022",
+        "2024"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2022": {
+          "hangul_version": "2022",
+          "files": [
+            "pdf/task4097/SO-SUEOP.pdf"
+          ],
+          "page_counts": [
+            46
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/SO-SUEOP-2024.pdf"
+          ],
+          "page_counts": [
+            46
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2022": [
+          46
+        ],
+        "2024": [
+          46
+        ]
+      },
+      "min_pages": 46,
+      "max_pages": 46,
+      "files": [
+        "pdf/SO-SUEOP-2024.pdf",
+        "pdf/task4097/SO-SUEOP.pdf"
+      ]
+    },
+    {
+      "stem": "hwp3-sample16-hwp5",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2020",
+        "2022"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/hwp3-sample16-hwp5-2020.pdf"
+          ],
+          "page_counts": [
+            64
+          ],
+          "unmeasured": []
+        },
+        "2022": {
+          "hangul_version": "2022",
+          "files": [
+            "pdf/hwp3-sample16-hwp5-2022.pdf"
+          ],
+          "page_counts": [
+            64
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2020": [
+          64
+        ],
+        "2022": [
+          64
+        ]
+      },
+      "min_pages": 64,
+      "max_pages": 64,
+      "files": [
+        "pdf/hwp3-sample16-hwp5-2020.pdf",
+        "pdf/hwp3-sample16-hwp5-2022.pdf"
+      ]
+    },
+    {
+      "stem": "hwpx_sample2",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2020",
+        "2024"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/hwpx_sample2-2020.pdf"
+          ],
+          "page_counts": [
+            29
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/hwpx_sample2-2024.pdf"
+          ],
+          "page_counts": [
+            29
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2020": [
+          29
+        ],
+        "2024": [
+          29
+        ]
+      },
+      "min_pages": 29,
+      "max_pages": 29,
+      "files": [
+        "pdf/hwpx_sample2-2020.pdf",
+        "pdf/hwpx_sample2-2024.pdf"
+      ]
+    },
+    {
+      "stem": "issue1949_giant_cell_nested_tables_perf",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2020",
+        "2024"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/issue1949_giant_cell_nested_tables_perf-2020.pdf"
+          ],
+          "page_counts": [
+            115
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/issue1949_giant_cell_nested_tables_perf-2024.pdf"
+          ],
+          "page_counts": [
+            115
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2020": [
+          115
+        ],
+        "2024": [
+          115
+        ]
+      },
+      "min_pages": 115,
+      "max_pages": 115,
+      "files": [
+        "pdf/issue1949_giant_cell_nested_tables_perf-2020.pdf",
+        "pdf/issue1949_giant_cell_nested_tables_perf-2024.pdf"
+      ]
+    },
+    {
+      "stem": "k-water-rfp",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2022",
+        "2024"
+      ],
+      "file_count": 3,
+      "trees": [
+        "pdf",
+        "pdf-large"
+      ],
+      "by_version": {
+        "2022": {
+          "hangul_version": "2022",
+          "files": [
+            "pdf/k-water-rfp-2022.pdf"
+          ],
+          "page_counts": [
+            27
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/k-water-rfp-2024.pdf"
+          ],
+          "page_counts": [
+            27
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2022": [
+          27
+        ],
+        "2024": [
+          27
+        ]
+      },
+      "min_pages": 27,
+      "max_pages": 27,
+      "files": [
+        "pdf-large/hwpx/k-water-rfp.pdf",
+        "pdf/k-water-rfp-2022.pdf",
+        "pdf/k-water-rfp-2024.pdf"
+      ]
+    },
+    {
+      "stem": "none_table_declared_fits",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2020",
+        "2022"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/task2097/none_table_declared_fits-2020.pdf"
+          ],
+          "page_counts": [
+            2
+          ],
+          "unmeasured": []
+        },
+        "2022": {
+          "hangul_version": "2022",
+          "files": [
+            "pdf/task2097/none_table_declared_fits-2022.pdf"
+          ],
+          "page_counts": [
+            2
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2020": [
+          2
+        ],
+        "2022": [
+          2
+        ]
+      },
+      "min_pages": 2,
+      "max_pages": 2,
+      "files": [
+        "pdf/task2097/none_table_declared_fits-2020.pdf",
+        "pdf/task2097/none_table_declared_fits-2022.pdf"
+      ]
+    },
+    {
+      "stem": "pr-1674",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2020",
+        "2024"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf",
+        "pdf-2020"
+      ],
+      "by_version": {
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf-2020/pr-1674-2020.pdf"
+          ],
+          "page_counts": [
+            35
+          ],
+          "unmeasured": []
+        },
+        "2024": {
+          "hangul_version": "2024",
+          "files": [
+            "pdf/pr-1674-2024.pdf"
+          ],
+          "page_counts": [
+            35
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2020": [
+          35
+        ],
+        "2024": [
+          35
+        ]
+      },
+      "min_pages": 35,
+      "max_pages": 35,
+      "files": [
+        "pdf-2020/pr-1674-2020.pdf",
+        "pdf/pr-1674-2024.pdf"
+      ]
+    },
+    {
+      "stem": "saved_single_line_spacing_after",
+      "kind": "page_count_agree",
+      "hangul_versions": [
+        "2020",
+        "2022"
+      ],
+      "file_count": 2,
+      "trees": [
+        "pdf"
+      ],
+      "by_version": {
+        "2020": {
+          "hangul_version": "2020",
+          "files": [
+            "pdf/task2093/saved_single_line_spacing_after-2020.pdf"
+          ],
+          "page_counts": [
+            1
+          ],
+          "unmeasured": []
+        },
+        "2022": {
+          "hangul_version": "2022",
+          "files": [
+            "pdf/task2093/saved_single_line_spacing_after-2022.pdf"
+          ],
+          "page_counts": [
+            1
+          ],
+          "unmeasured": []
+        }
+      },
+      "measured_page_counts": {
+        "2020": [
+          1
+        ],
+        "2022": [
+          1
+        ]
+      },
+      "min_pages": 1,
+      "max_pages": 1,
+      "files": [
+        "pdf/task2093/saved_single_line_spacing_after-2020.pdf",
+        "pdf/task2093/saved_single_line_spacing_after-2022.pdf"
+      ]
+    }
+  ]
+}

--- a/tools/oracle_public/reports/multiver_index.md
+++ b/tools/oracle_public/reports/multiver_index.md
@@ -1,0 +1,97 @@
+# M01-5 한컴 오라클 편입 · 다중버전 쪽수 불일치
+
+- 클레임: `M01-5`
+- 측정: `pypdf_page_count` (픽셀 차이는 `out_of_scope`)
+- 파일 425 / stem 395 / 다중버전 stem 9
+- 쪽수 불일치 1 · 쪽수 일치 8 · 미완(쪽수 미측정) 0
+- 측정 425 · 미측정 0
+
+## 트리 편입
+
+| 트리 | 존재 | 기본 한글 버전 | 파일 | 측정 | 미측정 |
+| --- | --- | --- | ---: | ---: | ---: |
+| `pdf/` | 예 | 2022 | 406 | 406 | 0 |
+| `pdf-2020/` | 예 | 2020 | 1 | 1 | 0 |
+| `pdf-large/` | 예 | 없음 | 18 | 18 | 0 |
+
+## pdf-2020/ · pdf-large/ 편입 목록
+
+### `pdf-2020/` (1건)
+
+| 경로 | stem | 한글 버전 | 출처 | 쪽수 | 상태 |
+| --- | --- | --- | --- | ---: | --- |
+| `pdf-2020/pr-1674-2020.pdf` | `pr-1674` | 2020 | explicit | 35 | measured |
+
+### `pdf-large/` (18건)
+
+| 경로 | stem | 한글 버전 | 출처 | 쪽수 | 상태 |
+| --- | --- | --- | --- | ---: | --- |
+| `pdf-large/3-09월_교육_통합_2024-구분선아래20-2024.pdf` | `3-09월_교육_통합_2024-구분선아래20` | 2024 | explicit | 23 | measured |
+| `pdf-large/3-09월_교육_통합_2024-미주사이20-2024.pdf` | `3-09월_교육_통합_2024-미주사이20` | 2024 | explicit | 24 | measured |
+| `pdf-large/hwpx/143E433F503322BD33.pdf` | `143E433F503322BD33` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/2026_oss_rst.pdf` | `2026_oss_rst` | — | unknown | 6 | measured |
+| `pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf` | `[2027] 온새미로 1 본교재` | — | unknown | 46 | measured |
+| `pdf-large/hwpx/el-school-001.pdf` | `el-school-001` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/eq-002.pdf` | `eq-002` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/footnote-tbox-01.pdf` | `footnote-tbox-01` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/hcar-001.pdf` | `hcar-001` | — | unknown | 6 | measured |
+| `pdf-large/hwpx/hy-001.pdf` | `hy-001` | — | unknown | 2 | measured |
+| `pdf-large/hwpx/hy-002.pdf` | `hy-002` | — | unknown | 2 | measured |
+| `pdf-large/hwpx/issue_1133.pdf` | `issue_1133` | — | unknown | 3 | measured |
+| `pdf-large/hwpx/k-water-rfp.pdf` | `k-water-rfp` | — | unknown | 27 | measured |
+| `pdf-large/hwpx/math-001.pdf` | `math-001` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/shape-001.pdf` | `shape-001` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/ta-pic-001-r.pdf` | `ta-pic-001-r` | — | unknown | 1 | measured |
+| `pdf-large/hwpx/tb-org-02.pdf` | `tb-org-02` | — | unknown | 1 | measured |
+| `pdf-large/issue2006/1790387_prep_final_report-2022.pdf` | `1790387_prep_final_report` | 2022 | explicit | 146 | measured |
+
+
+## 쪽수 불일치 (다중버전)
+
+| stem | 버전별 쪽수(실측) | 최소 | 최대 | 파일 수 |
+| --- | --- | ---: | ---: | ---: |
+| `2025 행정업무운영 편람(최종)` | 2010=388; 2020=383; 2024=383 | 383 | 388 | 8 |
+
+버전별 파일:
+
+### `2025 행정업무운영 편람(최종)`
+
+- 2010 (쪽 388)
+  - `pdf/2025 행정업무운영 편람(최종)-2010-kopub.pdf`
+- 2020 (쪽 383,383,383,383,383,383)
+  - `pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf`
+  - `pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf`
+  - `pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf`
+  - `pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf`
+  - `pdf/stage242-hwp2020-page-count/2025 행정업무운영 편람(최종)-2020.pdf`
+  - `pdf/stage242-hwp2020-page-count/hwpx/2025 행정업무운영 편람(최종)-2020.pdf`
+- 2024 (쪽 383)
+  - `pdf/2025 행정업무운영 편람(최종)-2024.pdf`
+
+
+## 다중버전 · 쪽수 일치
+
+같은 stem 에 한글 버전이 둘 이상이고, **잰 쪽수는 같다**. 시각(픽셀) 일치로 읽지 말 것.
+
+| stem | 버전 | 쪽수 | 파일 수 |
+| --- | --- | ---: | ---: |
+| `SO-SUEOP` | 2022,2024 | 46 | 2 |
+| `hwp3-sample16-hwp5` | 2020,2022 | 64 | 2 |
+| `hwpx_sample2` | 2020,2024 | 29 | 2 |
+| `issue1949_giant_cell_nested_tables_perf` | 2020,2024 | 115 | 2 |
+| `k-water-rfp` | 2022,2024 | 27 | 3 |
+| `none_table_declared_fits` | 2020,2022 | 2 | 2 |
+| `pr-1674` | 2020,2024 | 35 | 2 |
+| `saved_single_line_spacing_after` | 2020,2022 | 1 | 2 |
+
+
+## 다중버전 · 쪽수 미완
+
+없음.
+
+## 정직 한계
+
+- 쪽수는 pypdf `len(reader.pages)` 만 사용한다.
+- 픽셀/렌더 차이는 측정하지 않았고, 불일치로 세지 않는다.
+- LFS 포인터·비PDF·pypdf 실패는 `page_count=null` + 상태 코드다.
+- `scripts/visual_sweep.py` 는 이 도구가 수정하지 않는다.

--- a/tools/oracle_public/test_multiver_index.py
+++ b/tools/oracle_public/test_multiver_index.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""multiver_index.py 가드 테스트 — 실 코퍼스 불요.
+
+픽스처 PDF 는 테스트가 임시 디렉터리에 직접 만든다. 쪽수 불일치는 실제로
+다른 page count 를 가진 PDF 를 만들어 재고, LFS 포인터는 쪽수를 넣지 않는다.
+픽셀 차이 필드는 색인에 등장하지 않아야 한다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import multiver_index as mx  # noqa: E402
+
+
+def write_minimal_pdf(path: Path, page_count: int) -> None:
+    if page_count < 1:
+        raise ValueError("page_count >= 1")
+    catalog = b"<< /Type /Catalog /Pages 2 0 R >>"
+    page_nums = list(range(3, 3 + page_count))
+    kids = " ".join(f"{n} 0 R" for n in page_nums)
+    pages = f"<< /Type /Pages /Kids [{kids}] /Count {page_count} >>".encode()
+    page_objs = [
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>" for _ in page_nums
+    ]
+    body = [catalog, pages, *page_objs]
+    out = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for i, data in enumerate(body, start=1):
+        offsets.append(len(out))
+        out.extend(f"{i} 0 obj\n".encode())
+        out.extend(data)
+        out.extend(b"\nendobj\n")
+    xref_pos = len(out)
+    out.extend(f"xref\n0 {len(offsets)}\n".encode())
+    out.extend(b"0000000000 65535 f \n")
+    for off in offsets[1:]:
+        out.extend(f"{off:010d} 00000 n \n".encode())
+    out.extend(
+        f"trailer\n<< /Size {len(offsets)} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n".encode()
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(bytes(out))
+
+
+def write_lfs_pointer(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:" + ("ab" * 32) + "\n"
+        "size 99\n",
+        encoding="ascii",
+        newline="\n",
+    )
+
+
+class ParseOracleNameTests(unittest.TestCase):
+    def test_plain_version_suffix(self) -> None:
+        stem, ver, variants = mx.parse_oracle_name("exam_kor-2022")
+        self.assertEqual(stem, "exam_kor")
+        self.assertEqual(ver, "2022")
+        self.assertEqual(variants, [])
+
+    def test_date_stem_keeps_leading_2010(self) -> None:
+        stem, ver, variants = mx.parse_oracle_name("2010-01-06-2022")
+        self.assertEqual(stem, "2010-01-06")
+        self.assertEqual(ver, "2022")
+        self.assertEqual(variants, [])
+
+    def test_underscore_year_stays_in_stem(self) -> None:
+        stem, ver, variants = mx.parse_oracle_name("3-09월_교육_통합_2022")
+        self.assertEqual(stem, "3-09월_교육_통합_2022")
+        self.assertIsNone(ver)
+        self.assertEqual(variants, [])
+
+    def test_variant_after_version(self) -> None:
+        stem, ver, variants = mx.parse_oracle_name("편람-2010-kopub")
+        self.assertEqual(stem, "편람")
+        self.assertEqual(ver, "2010")
+        self.assertEqual(variants, ["kopub"])
+
+    def test_variant_before_version(self) -> None:
+        stem, ver, variants = mx.parse_oracle_name("편람-hwp-kopub-2020")
+        self.assertEqual(stem, "편람")
+        self.assertEqual(ver, "2020")
+        self.assertEqual(variants, ["hwp", "kopub"])
+
+    def test_dual_year_keeps_source_year_in_stem(self) -> None:
+        stem, ver, variants = mx.parse_oracle_name("hwp3-sample16-hwp5-2018-2020")
+        self.assertEqual(stem, "hwp3-sample16-hwp5-2018")
+        self.assertEqual(ver, "2020")
+        self.assertEqual(variants, [])
+
+
+class MeasureTests(unittest.TestCase):
+    def test_pypdf_reads_minimal_page_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "n.pdf"
+            write_minimal_pdf(path, 3)
+            pages, status = mx.measure_page_count(path)
+        self.assertEqual(pages, 3)
+        self.assertEqual(status, "pypdf")
+
+    def test_lfs_pointer_is_unmeasured(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "big.pdf"
+            write_lfs_pointer(path)
+            pages, status = mx.measure_page_count(path)
+        self.assertIsNone(pages)
+        self.assertEqual(status, "lfs_pointer")
+
+    def test_checked_in_lfs_fixture_is_unmeasured(self) -> None:
+        fixture = Path(__file__).with_name("fixtures") / "lfs_pointer.pdf"
+        self.assertTrue(fixture.is_file(), fixture)
+        pages, status = mx.measure_page_count(fixture)
+        self.assertIsNone(pages)
+        self.assertEqual(status, "lfs_pointer")
+
+    def test_not_pdf_is_unmeasured(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "x.pdf"
+            path.write_bytes(b"not a pdf")
+            pages, status = mx.measure_page_count(path)
+        self.assertIsNone(pages)
+        self.assertEqual(status, "not_pdf")
+
+
+class IndexFixtureTests(unittest.TestCase):
+    def _tree(self, root: Path) -> None:
+        write_minimal_pdf(root / "pdf" / "same-2018.pdf", 1)
+        write_minimal_pdf(root / "pdf" / "same-2022.pdf", 2)
+        write_minimal_pdf(root / "pdf" / "agree-2020.pdf", 1)
+        write_minimal_pdf(root / "pdf" / "agree-2022.pdf", 1)
+        write_minimal_pdf(root / "pdf" / "solo-2022.pdf", 1)
+        write_minimal_pdf(root / "pdf" / "nover.pdf", 4)
+        write_minimal_pdf(root / "pdf-2020" / "same-2020.pdf", 1)
+        write_minimal_pdf(root / "pdf-large" / "big-2022.pdf", 5)
+        write_lfs_pointer(root / "pdf-large" / "orphan.pdf")
+
+    def test_incorporation_lists_2020_and_large(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._tree(root)
+            index = mx.build_index(root)
+        self.assertEqual(index["trees"]["pdf-2020"]["file_count"], 1)
+        self.assertEqual(index["trees"]["pdf-large"]["file_count"], 2)
+        paths_2020 = [r["path"] for r in index["incorporation"]["pdf-2020"]]
+        paths_large = [r["path"] for r in index["incorporation"]["pdf-large"]]
+        self.assertEqual(paths_2020, ["pdf-2020/same-2020.pdf"])
+        self.assertIn("pdf-large/big-2022.pdf", paths_large)
+        self.assertIn("pdf-large/orphan.pdf", paths_large)
+
+    def test_disagreement_is_measured_not_invented(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._tree(root)
+            index = mx.build_index(root)
+        disagree = {s["stem"]: s for s in index["disagreements"]}
+        self.assertIn("same", disagree)
+        rec = disagree["same"]
+        self.assertEqual(rec["kind"], "page_count_disagree")
+        self.assertEqual(rec["measured_page_counts"]["2018"], [1])
+        self.assertEqual(rec["measured_page_counts"]["2022"], [2])
+        self.assertEqual(rec["measured_page_counts"]["2020"], [1])
+        self.assertEqual(rec["min_pages"], 1)
+        self.assertEqual(rec["max_pages"], 2)
+        self.assertEqual(index["counts"]["page_count_disagree"], 1)
+
+    def test_agree_same_page_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._tree(root)
+            index = mx.build_index(root)
+        agrees = {s["stem"]: s for s in index["multiver_stems"] if s["kind"] == "page_count_agree"}
+        self.assertIn("agree", agrees)
+        self.assertEqual(agrees["agree"]["min_pages"], 1)
+        self.assertEqual(agrees["agree"]["max_pages"], 1)
+
+    def test_dir_default_version_for_pdf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._tree(root)
+            index = mx.build_index(root)
+        nover = next(r for r in index["files"] if r["path"] == "pdf/nover.pdf")
+        self.assertEqual(nover["hangul_version"], "2022")
+        self.assertEqual(nover["version_source"], "inferred_dir")
+        self.assertEqual(nover["page_count"], 4)
+
+    def test_pdf_large_has_no_default_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._tree(root)
+            index = mx.build_index(root)
+        orphan = next(r for r in index["files"] if r["path"] == "pdf-large/orphan.pdf")
+        self.assertIsNone(orphan["hangul_version"])
+        self.assertEqual(orphan["version_source"], "unknown")
+        self.assertIsNone(orphan["page_count"])
+        self.assertEqual(orphan["page_count_status"], "lfs_pointer")
+
+    def test_pixel_diff_is_marked_out_of_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._tree(root)
+            index = mx.build_index(root)
+            blob = json.dumps(index)
+        self.assertEqual(index["pixel_diff"], "out_of_scope")
+        self.assertEqual(index["metric"], "pypdf_page_count")
+        self.assertNotIn("pixel_delta", blob)
+        self.assertNotIn("ssimulacra", blob.lower())
+
+    def test_write_reports_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            out = Path(tmp) / "reports"
+            self._tree(root)
+            index = mx.build_index(root)
+            written = mx.write_reports(index, out)
+            names = {p.name for p in written}
+            self.assertEqual(
+                names,
+                {
+                    "incorporation_manifest.json",
+                    "multiver_disagreements.json",
+                    "multiver_index.md",
+                },
+            )
+            manifest = json.loads((out / "incorporation_manifest.json").read_text(encoding="utf-8"))
+            dis = json.loads((out / "multiver_disagreements.json").read_text(encoding="utf-8"))
+            md = (out / "multiver_index.md").read_text(encoding="utf-8")
+        self.assertEqual(manifest["counts"]["page_count_disagree"], 1)
+        self.assertEqual(len(dis["disagreements"]), 1)
+        self.assertIn("same", md)
+        self.assertIn("out_of_scope", md)
+
+    def test_missing_tree_is_zero_not_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_minimal_pdf(root / "pdf" / "a-2022.pdf", 1)
+            index = mx.build_index(root)
+        self.assertTrue(index["trees"]["pdf"]["present"])
+        self.assertFalse(index["trees"]["pdf-2020"]["present"])
+        self.assertEqual(index["trees"]["pdf-2020"]["file_count"], 0)
+        self.assertEqual(index["counts"]["files"], 1)
+
+
+class CliTests(unittest.TestCase):
+    def test_usage_error_on_empty_trees(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code = mx.main(["--root", tmp, "--trees", ""])
+        self.assertEqual(code, 2)
+
+    def test_cli_writes_reports(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            out = Path(tmp) / "out"
+            write_minimal_pdf(root / "pdf" / "x-2018.pdf", 1)
+            write_minimal_pdf(root / "pdf" / "x-2022.pdf", 2)
+            code = mx.main(
+                ["--root", str(root), "--write-reports", "--out-dir", str(out), "--json"]
+            )
+            self.assertEqual(code, 0)
+            self.assertTrue((out / "multiver_disagreements.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M01-5. `pdf-2020/`·`pdf-large/` 를 공개 오라클 색인에 편입하고, 같은 stem 의 한글 버전(2018 vs 2022 등) 오라클이 **쪽수**로 갈리는 문서만 목록화한다.

신규 경로만 추가한다. `scripts/visual_sweep.py` 는 수정하지 않았다. gym 없음.

- `tools/oracle_public/multiver_index.py` — 세 트리 순회, stem×한글버전 묶기, pypdf 쪽수 실측
- `tools/oracle_public/reports/incorporation_manifest.json` — 편입 매니페스트
- `tools/oracle_public/reports/multiver_disagreements.json` — 다중버전 목록 + 불일치
- `tools/oracle_public/reports/multiver_index.md` — 사람용 요약
- `tools/oracle_public/test_multiver_index.py` + `fixtures/lfs_pointer.pdf`

### 실측 (pypdf `len(pages)`, 픽셀 차이 미측정)

| 트리 | 파일 | 측정 | 미측정 |
| --- | ---: | ---: | ---: |
| pdf/ | 406 | 406 | 0 |
| pdf-2020/ | 1 | 1 | 0 |
| pdf-large/ | 18 | 18 | 0 |
| 합 | 425 | 425 | 0 |

- 고유 stem 395, 다중버전 stem 9
- **쪽수 불일치 1**: `2025 행정업무운영 편람(최종)` — 2010=388, 2020=383, 2024=383
- 쪽수 일치 8 (시각 일치로 읽지 말 것). 예: `pr-1674` 2020/2024 모두 35쪽
- LFS 포인터·비PDF 는 `page_count=null` + 상태 코드. 이번 작업 트리에서는 0건

## 관련 이슈

closes #5345

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `python -m unittest tools.oracle_public.test_multiver_index` 통과 (20)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 — 이번 PR 은 Python 신규 파일만. Rust 테스트 매니페스트 미변경
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 — 동일
- [ ] `cargo test` 통과 — Rust 변경 없음
- [ ] `cargo clippy -- -D warnings` 통과 — Rust 변경 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우) — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과 — 해당 없음
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 해당 없음 (문서 편집 작업 아님)
- [ ] `.claude/agents/` 등 capability 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (런타임 엔진 미변경)
- 재현·측정: `python tools/oracle_public/multiver_index.py --write-reports`

## 스크린샷

해당 없음. 픽셀 대조는 이 클레임 범위 밖이다.
