### PR TITLE
feat(tools): oracle_public coverage_report — 짝 없는 샘플·버전별 커버리지 표

### DIFF
--- a/tools/oracle_public/coverage_report.py
+++ b/tools/oracle_public/coverage_report.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""samples/ ↔ 한컴 기준 PDF 오라클 커버리지 표 (M01-3).
+
+`samples/` 의 `.hwp`/`.hwpx` 를 재귀 수집한 뒤, 같은 상대 경로의
+`pdf/{stem}-{year}.pdf` (및 `-hwp-2020` 같은 허용 변형) 를 맞춘다.
+`pdf-2020/`, `pdf-large/` 가 있으면 같은 규칙으로 추가 탐색한다.
+한글 버전은 2018 / 2020 / 2022 / 2024 만 센다.
+
+`oracle_resolver.py` 가 devel 에 없어도 동작하도록 매칭을 이 파일 안에 둔다.
+짝 없는 개수는 실측한다. 이슈의 참고값(~276)을 코드에 박지 않는다.
+
+scripts/visual_sweep.py 와 tools/oracle_public/issue_draft.py 는
+읽거나 수정하지 않는다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA_VERSION = "1.0"
+CLAIM_ID = "M01-3"
+GENERATOR = "tools/oracle_public/coverage_report.py"
+MATCHING_RULE = "stem-{year}.pdf"
+SAMPLE_EXTS = {".hwp", ".hwpx"}
+DEFAULT_ORACLE_ROOTS = ("pdf", "pdf-2020", "pdf-large")
+HANCOM_YEARS = ("2018", "2020", "2022", "2024")
+
+# `{stem}` 뒤에 붙는 오라클 접미사. 연도가 반드시 들어가고, 포맷 태그·kopub·
+# 스냅샷 날짜·쪽 범위는 선택이다. `-hwpx-2022` 를 stem 끝의 `hwpx` 와 혼동하지
+# 않도록 샘플 stem 에서 바깥으로만 잘라 검사한다.
+_ORACLE_SUFFIX_RE = re.compile(
+    r"^(?:"
+    r"(?:-(?P<fmt>hwp|hwpx))?"
+    r"(?:-kopub)?"
+    r"-(?P<year>2018|2020|2022|2024)"
+    r"(?:-kopub)?"
+    r"(?:-no-ttf)?"
+    r"(?:-print)?"
+    r"(?:-\d{8})?"
+    r"(?:-p\d+-p\d+)?"
+    r")$",
+    re.IGNORECASE,
+)
+_ALT_SUFFIX_RE = re.compile(
+    r"^-(?:hancom-?|hwp)(?P<year>2018|2020|2022|2024)(?:-\d{8})?$",
+    re.IGNORECASE,
+)
+_YEAR_TOKEN_RE = re.compile(r"(?<!\d)(2018|2020|2022|2024)(?!\d)")
+
+
+class UsageError(Exception):
+    """CLI 사용법·경로 오류."""
+
+
+@dataclass(frozen=True)
+class OracleHit:
+    pdf: str
+    hancom_version: str
+    variant: str
+    format_tag: str | None
+    oracle_root: str
+
+
+@dataclass(frozen=True)
+class SampleDoc:
+    sample: str
+    rel_parent: str
+    stem: str
+    source_format: str
+
+
+def nfc(value: str) -> str:
+    return unicodedata.normalize("NFC", value)
+
+
+def posix_rel(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def discover_repo_root(start: Path | None = None) -> Path:
+    cur = (start or Path.cwd()).resolve()
+    for candidate in (cur, *cur.parents):
+        if (candidate / "samples").is_dir() and (
+            (candidate / ".git").exists() or (candidate / "Cargo.toml").is_file()
+        ):
+            return candidate
+    raise UsageError("저장소 루트를 찾지 못했습니다 (--repo-root 를 지정하세요)")
+
+
+def walk_samples(samples_dir: Path, repo_root: Path) -> list[SampleDoc]:
+    if not samples_dir.is_dir():
+        raise UsageError(f"samples 디렉터리가 없습니다: {samples_dir}")
+    found: list[SampleDoc] = []
+    for path in samples_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in SAMPLE_EXTS:
+            continue
+        rel = Path(posix_rel(path, repo_root))
+        parent = rel.parent.as_posix()
+        if parent == "samples":
+            rel_parent = ""
+        else:
+            rel_parent = Path(parent).relative_to("samples").as_posix()
+        found.append(
+            SampleDoc(
+                sample=rel.as_posix(),
+                rel_parent="" if rel_parent == "." else rel_parent,
+                stem=nfc(path.stem),
+                source_format=path.suffix.lower().lstrip("."),
+            )
+        )
+    found.sort(key=lambda item: (nfc(item.sample).lower(), item.sample))
+    return found
+
+
+def index_oracle_pdfs(
+    repo_root: Path, roots: Sequence[str]
+) -> dict[tuple[str, str, str], list[str]]:
+    """(root, rel_parent, filename_nfc_lower) -> posix paths."""
+    index: dict[tuple[str, str, str], list[str]] = {}
+    for root_name in roots:
+        root_dir = repo_root / root_name
+        if not root_dir.is_dir():
+            continue
+        for path in root_dir.rglob("*.pdf"):
+            if not path.is_file():
+                continue
+            rel = Path(posix_rel(path, root_dir))
+            parent = rel.parent.as_posix()
+            if parent == ".":
+                parent = ""
+            key = (root_name, parent, nfc(path.name).lower())
+            index.setdefault(key, []).append(posix_rel(path, repo_root))
+    for paths in index.values():
+        paths.sort(key=lambda item: (nfc(item).lower(), item))
+    return index
+
+
+def parse_oracle_suffix(stem: str, filename: str) -> dict[str, str | None] | None:
+    """파일명이 `{stem}{suffix}.pdf` 오라클 규칙이면 연도·변형을 돌려준다."""
+    if not filename.lower().endswith(".pdf"):
+        return None
+    base = nfc(filename[:-4])
+    stem_n = nfc(stem)
+    if not base.lower().startswith(stem_n.lower()):
+        return None
+    rest = base[len(stem_n) :]
+    if rest == "":
+        years = _YEAR_TOKEN_RE.findall(stem_n)
+        if not years:
+            return None
+        return {"year": years[-1], "variant": "exact", "fmt": None}
+    match = _ORACLE_SUFFIX_RE.match(rest) or _ALT_SUFFIX_RE.match(rest)
+    if not match:
+        return None
+    groups = match.groupdict()
+    year = groups.get("year")
+    if year not in HANCOM_YEARS:
+        return None
+    fmt = (groups.get("fmt") or "").lower() or None
+    return {"year": year, "variant": rest.lstrip("-"), "fmt": fmt}
+
+
+def format_allows(source_format: str, format_tag: str | None) -> bool:
+    if not format_tag:
+        return True
+    return format_tag.lower() == source_format.lower()
+
+
+def match_sample(
+    sample: SampleDoc,
+    index: dict[tuple[str, str, str], list[str]],
+    roots: Sequence[str],
+) -> list[OracleHit]:
+    hits: list[OracleHit] = []
+    seen: set[str] = set()
+    for (root_name, parent, name), paths in index.items():
+        if root_name not in roots or parent != sample.rel_parent:
+            continue
+        info = parse_oracle_suffix(sample.stem, name)
+        if info is None:
+            continue
+        if not format_allows(sample.source_format, info["fmt"]):
+            continue
+        year = info["year"]
+        if year is None:
+            continue
+        for pdf_path in paths:
+            if pdf_path in seen:
+                continue
+            seen.add(pdf_path)
+            hits.append(
+                OracleHit(
+                    pdf=pdf_path,
+                    hancom_version=year,
+                    variant=info["variant"] or year,
+                    format_tag=info["fmt"],
+                    oracle_root=root_name,
+                )
+            )
+    hits.sort(
+        key=lambda hit: (
+            HANCOM_YEARS[::-1].index(hit.hancom_version)
+            if hit.hancom_version in HANCOM_YEARS
+            else 99,
+            DEFAULT_ORACLE_ROOTS.index(hit.oracle_root)
+            if hit.oracle_root in DEFAULT_ORACLE_ROOTS
+            else 99,
+            nfc(hit.variant).lower(),
+            nfc(hit.pdf).lower(),
+            hit.pdf,
+        )
+    )
+    return hits
+
+
+def pair_record(sample: SampleDoc, hit: OracleHit) -> dict[str, Any]:
+    return {
+        "id": f"{sample.sample}::{hit.pdf}",
+        "sample": sample.sample,
+        "pdf": hit.pdf,
+        "stem": sample.stem,
+        "hancomVersion": hit.hancom_version,
+        "variant": hit.variant,
+        "sourceFormat": sample.source_format,
+        "oracleRoot": hit.oracle_root,
+    }
+
+
+def unmatched_record(sample: SampleDoc) -> dict[str, Any]:
+    return {
+        "sample": sample.sample,
+        "stem": sample.stem,
+        "sourceFormat": sample.source_format,
+        "reason": "no_oracle_pdf",
+    }
+
+
+def _format_bucket() -> dict[str, int]:
+    return {"sampleCount": 0, "matchedSampleCount": 0, "unmatchedCount": 0}
+
+
+def build_report(
+    repo_root: Path,
+    samples_dir: Path | None = None,
+    roots: Sequence[str] = DEFAULT_ORACLE_ROOTS,
+) -> dict[str, Any]:
+    samples_dir = samples_dir or (repo_root / "samples")
+    present_roots = [name for name in roots if (repo_root / name).is_dir()]
+    samples = walk_samples(samples_dir, repo_root)
+    index = index_oracle_pdfs(repo_root, present_roots)
+    pairs: list[dict[str, Any]] = []
+    unmatched: list[dict[str, Any]] = []
+    version_pairs: Counter[str] = Counter()
+    version_samples: dict[str, set[str]] = {year: set() for year in HANCOM_YEARS}
+    by_format = {fmt: _format_bucket() for fmt in ("hwp", "hwpx")}
+
+    for sample in samples:
+        bucket = by_format[sample.source_format]
+        bucket["sampleCount"] += 1
+        hits = match_sample(sample, index, present_roots)
+        if hits:
+            bucket["matchedSampleCount"] += 1
+            for hit in hits:
+                rec = pair_record(sample, hit)
+                pairs.append(rec)
+                version_pairs[hit.hancom_version] += 1
+                version_samples[hit.hancom_version].add(sample.sample)
+        else:
+            bucket["unmatchedCount"] += 1
+            unmatched.append(unmatched_record(sample))
+
+    sample_count = len(samples)
+    matched_count = sample_count - len(unmatched)
+    coverage_ratio = (matched_count / sample_count) if sample_count else 0.0
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "claim": CLAIM_ID,
+        "generator": GENERATOR,
+        "matchingRule": MATCHING_RULE,
+        "hancomYears": list(HANCOM_YEARS),
+        "sampleCount": sample_count,
+        "matchedSampleCount": matched_count,
+        "unmatchedCount": len(unmatched),
+        "pairCount": len(pairs),
+        "coverageRatio": coverage_ratio,
+        "oracleRoots": present_roots,
+        "bySourceFormat": by_format,
+        "byHancomVersion": {
+            year: {
+                "pairCount": version_pairs.get(year, 0),
+                "sampleCount": len(version_samples[year]),
+            }
+            for year in HANCOM_YEARS
+        },
+        "pairs": pairs,
+        "unmatched": unmatched,
+    }
+
+
+def validate_report(data: Any) -> list[str]:
+    """핵심 계약. 외부 jsonschema 없이 필수 키·타입·합만 검사한다."""
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return ["$: object 가 아닙니다"]
+    required = (
+        "schemaVersion",
+        "claim",
+        "sampleCount",
+        "matchedSampleCount",
+        "unmatchedCount",
+        "pairCount",
+        "byHancomVersion",
+        "pairs",
+        "unmatched",
+    )
+    for key in required:
+        if key not in data:
+            errors.append(f"$: required 누락 ({key})")
+    if data.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append("$.schemaVersion: '1.0' 이어야 합니다")
+    if data.get("claim") != CLAIM_ID:
+        errors.append("$.claim: 'M01-3' 이어야 합니다")
+    for key in (
+        "sampleCount",
+        "matchedSampleCount",
+        "unmatchedCount",
+        "pairCount",
+    ):
+        if key in data and not isinstance(data[key], int):
+            errors.append(f"$.{key}: integer 가 아닙니다")
+        if key in data and isinstance(data[key], int) and data[key] < 0:
+            errors.append(f"$.{key}: 0 이상이어야 합니다")
+
+    pairs = data.get("pairs")
+    if not isinstance(pairs, list):
+        errors.append("$.pairs: array 가 아닙니다")
+        pairs = []
+    elif data.get("pairCount") != len(pairs):
+        errors.append("$.pairCount: pairs 길이와 다릅니다")
+
+    unmatched = data.get("unmatched")
+    if not isinstance(unmatched, list):
+        errors.append("$.unmatched: array 가 아닙니다")
+        unmatched = []
+    elif data.get("unmatchedCount") != len(unmatched):
+        errors.append("$.unmatchedCount: unmatched 길이와 다릅니다")
+
+    matched_samples = {item.get("sample") for item in pairs if isinstance(item, dict)}
+    if data.get("matchedSampleCount") != len(matched_samples):
+        errors.append("$.matchedSampleCount: 서로 다른 sample 수와 다릅니다")
+    if isinstance(data.get("sampleCount"), int) and isinstance(
+        data.get("unmatchedCount"), int
+    ):
+        expected_total = len(matched_samples) + len(unmatched)
+        if data["sampleCount"] != expected_total:
+            errors.append("$.sampleCount: matched+unmatched 와 다릅니다")
+        if (
+            isinstance(data.get("matchedSampleCount"), int)
+            and data["matchedSampleCount"] + data["unmatchedCount"]
+            != data["sampleCount"]
+        ):
+            errors.append("$.matchedSampleCount+unmatchedCount: sampleCount 와 다릅니다")
+
+    pair_required = (
+        "sample",
+        "pdf",
+        "stem",
+        "hancomVersion",
+        "sourceFormat",
+        "oracleRoot",
+    )
+    seen_ids: set[str] = set()
+    for i, item in enumerate(pairs):
+        loc = f"$.pairs[{i}]"
+        if not isinstance(item, dict):
+            errors.append(f"{loc}: object 가 아닙니다")
+            continue
+        for key in pair_required:
+            if key not in item:
+                errors.append(f"{loc}: required 누락 ({key})")
+        year = item.get("hancomVersion")
+        if year not in HANCOM_YEARS:
+            errors.append(f"{loc}.hancomVersion: {HANCOM_YEARS} 중 하나여야 합니다")
+        if item.get("sourceFormat") not in {"hwp", "hwpx"}:
+            errors.append(f"{loc}.sourceFormat: hwp|hwpx 여야 합니다")
+        pair_id = item.get("id")
+        if isinstance(pair_id, str):
+            if pair_id in seen_ids:
+                errors.append(f"{loc}.id: 중복입니다")
+            seen_ids.add(pair_id)
+
+    for i, item in enumerate(unmatched):
+        loc = f"$.unmatched[{i}]"
+        if not isinstance(item, dict):
+            errors.append(f"{loc}: object 가 아닙니다")
+            continue
+        if "sample" not in item:
+            errors.append(f"{loc}: required 누락 (sample)")
+
+    by_ver = data.get("byHancomVersion")
+    if not isinstance(by_ver, dict):
+        errors.append("$.byHancomVersion: object 가 아닙니다")
+    else:
+        for year in HANCOM_YEARS:
+            bucket = by_ver.get(year)
+            if not isinstance(bucket, dict):
+                errors.append(f"$.byHancomVersion.{year}: object 가 아닙니다")
+                continue
+            expected_pairs = sum(
+                1 for item in pairs if isinstance(item, dict) and item.get("hancomVersion") == year
+            )
+            expected_samples = len(
+                {
+                    item.get("sample")
+                    for item in pairs
+                    if isinstance(item, dict) and item.get("hancomVersion") == year
+                }
+            )
+            if bucket.get("pairCount") != expected_pairs:
+                errors.append(f"$.byHancomVersion.{year}.pairCount: pairs 집계와 다릅니다")
+            if bucket.get("sampleCount") != expected_samples:
+                errors.append(f"$.byHancomVersion.{year}.sampleCount: pairs 집계와 다릅니다")
+    return errors
+
+
+def _md_cell(value: str) -> str:
+    return nfc(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _pct(part: int, whole: int) -> str:
+    if whole <= 0:
+        return "—"
+    return f"{(100.0 * part / whole):.1f}%"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    sample_count = int(report["sampleCount"])
+    matched = int(report["matchedSampleCount"])
+    unmatched_n = int(report["unmatchedCount"])
+    pair_count = int(report["pairCount"])
+    roots = ", ".join(f"`{name}/`" for name in report.get("oracleRoots") or []) or "(없음)"
+    years = report.get("hancomYears") or list(HANCOM_YEARS)
+    by_fmt = report.get("bySourceFormat") or {}
+    by_ver = report.get("byHancomVersion") or {}
+    unmatched = report.get("unmatched") or []
+
+    lines = [
+        "# M01-3 오라클 커버리지",
+        "",
+        "`samples/` 의 `.hwp`/`.hwpx` 와 `{stem}-{year}.pdf` (2018/2020/2022/2024) 짝.",
+        "같은 상대 하위 경로를 `pdf/` · `pdf-2020/` · `pdf-large/` 에서 찾는다.",
+        "`oracle_resolver.py` 가 없어도 이 도구가 같은 규칙으로 직접 맞춘다.",
+        "짝 없는 개수는 아래 표의 실측값이다.",
+        "",
+        f"- 클레임: `{report.get('claim', CLAIM_ID)}`",
+        f"- 생성기: `{report.get('generator', GENERATOR)}`",
+        f"- 매칭: `{report.get('matchingRule', MATCHING_RULE)}`",
+        f"- 오라클 루트: {roots}",
+        "",
+        "## 요약",
+        "",
+        "| 항목 | 수 |",
+        "| --- | ---: |",
+        f"| 샘플 (`.hwp`/`.hwpx`) | {sample_count} |",
+        f"| 짝 있는 샘플 | {matched} |",
+        f"| 짝 없는 샘플 | {unmatched_n} |",
+        f"| 오라클 링크 (샘플×PDF) | {pair_count} |",
+        f"| 커버리지 (짝 있는 샘플 / 전체) | {_pct(matched, sample_count)} |",
+        "",
+        "### 형식별",
+        "",
+        "| 형식 | 샘플 | 짝 있음 | 짝 없음 | 커버리지 |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for fmt in ("hwp", "hwpx"):
+        bucket = by_fmt.get(fmt) or {}
+        total = int(bucket.get("sampleCount") or 0)
+        ok = int(bucket.get("matchedSampleCount") or 0)
+        miss = int(bucket.get("unmatchedCount") or 0)
+        lines.append(f"| `{fmt}` | {total} | {ok} | {miss} | {_pct(ok, total)} |")
+
+    lines.extend(
+        [
+            "",
+            "## 한글 버전별 (2018 / 2020 / 2022 / 2024)",
+            "",
+            "한 샘플이 여러 버전 PDF 를 가지면 각 버전에 모두 센다.",
+            "분모는 전체 샘플 수다. 2010·2014 접미 PDF 는 이 표에 넣지 않는다.",
+            "",
+            "| 한글 버전 | 링크 수 | 해당 버전이 있는 샘플 | 샘플 대비 |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for year in years:
+        bucket = by_ver.get(year) or {}
+        links = int(bucket.get("pairCount") or 0)
+        have = int(bucket.get("sampleCount") or 0)
+        lines.append(f"| {year} | {links} | {have} | {_pct(have, sample_count)} |")
+
+    lines.extend(
+        [
+            "",
+            f"## 짝 없는 샘플 ({unmatched_n}건)",
+            "",
+        ]
+    )
+    if unmatched_n == 0:
+        lines.append("짝 없는 샘플이 없다.")
+        lines.append("")
+    else:
+        lines.extend(
+            [
+                "| # | 경로 | 형식 | 이유 |",
+                "| ---: | --- | --- | --- |",
+            ]
+        )
+        for i, item in enumerate(unmatched, start=1):
+            path = _md_cell(str(item.get("sample") or ""))
+            fmt = _md_cell(str(item.get("sourceFormat") or ""))
+            reason = _md_cell(str(item.get("reason") or "no_oracle_pdf"))
+            lines.append(f"| {i} | `{path}` | {fmt} | {reason} |")
+        lines.append("")
+
+    text = "\n".join(lines)
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def emit_text(text: str, output: Path | None) -> None:
+    if not text.endswith("\n"):
+        text += "\n"
+    if output is None or str(output) == "-":
+        sys.stdout.write(text)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8", newline="\n")
+
+
+def emit_json(data: dict[str, Any], output: Path | None, pretty: bool) -> None:
+    text = json.dumps(data, ensure_ascii=False, indent=2 if pretty else None)
+    emit_text(text, output)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="samples/ ↔ 한컴 기준 PDF 오라클 커버리지 표 (짝 없는 샘플·버전별)."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="저장소 루트. 생략 시 cwd 에서 samples/ 와 .git|Cargo.toml 을 찾는다.",
+    )
+    parser.add_argument(
+        "--samples-dir",
+        type=Path,
+        default=None,
+        help="samples 디렉터리. 기본은 <repo-root>/samples",
+    )
+    parser.add_argument(
+        "--roots",
+        default=",".join(DEFAULT_ORACLE_ROOTS),
+        help="오라클 PDF 루트(쉼표 구분). 기본 pdf,pdf-2020,pdf-large",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="커버리지 JSON 경로. 생략하고 --md-out 도 없으면 stdout",
+    )
+    parser.add_argument(
+        "--md-out",
+        type=Path,
+        default=None,
+        help="커버리지 Markdown 표 경로",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="들여쓰기 JSON",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="방출 전 핵심 계약을 검사한다",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        repo_root = args.repo_root.resolve() if args.repo_root else discover_repo_root()
+        roots = tuple(item.strip() for item in args.roots.split(",") if item.strip())
+        if not roots:
+            raise UsageError("--roots 가 비어 있습니다")
+        report = build_report(repo_root, args.samples_dir, roots)
+        if args.validate:
+            errors = validate_report(report)
+            if errors:
+                sys.stderr.write("커버리지 표 계약 위반:\n")
+                for err in errors:
+                    sys.stderr.write(f"  {err}\n")
+                return 1
+        wrote = False
+        if args.json_out is not None:
+            emit_json(report, args.json_out, pretty=args.pretty or True)
+            wrote = True
+        if args.md_out is not None:
+            emit_text(render_markdown(report), args.md_out)
+            wrote = True
+        if not wrote:
+            emit_json(report, None, pretty=args.pretty)
+    except UsageError as exc:
+        sys.stderr.write(f"사용법 오류: {exc}\n")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/oracle_public/fixtures/mini_repo/pdf-2020/exam_kor-2020.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf-2020/exam_kor-2020.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf-large/hwpx/lonely.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf-large/hwpx/lonely.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/3-09월_교육_통합_2022.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/3-09월_교육_통합_2022.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/basic/calendar_year-2022.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/basic/calendar_year-2022.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/exam_kor-2022.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/exam_kor-2022.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/hwp3-sample-hwpx-2022.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/hwp3-sample-hwpx-2022.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/multi-2018.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/multi-2018.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/multi-2024.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/multi-2024.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/unused-2022.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/unused-2022.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/편람-hwp-2020.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/편람-hwp-2020.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/pdf/편람-hwpx-2020.pdf
+++ b/tools/oracle_public/fixtures/mini_repo/pdf/편람-hwpx-2020.pdf
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/3-09월_교육_통합_2022.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/3-09월_교육_통합_2022.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/basic/calendar_year.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/basic/calendar_year.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/exam_kor.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/exam_kor.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/exam_kor.hwpx
+++ b/tools/oracle_public/fixtures/mini_repo/samples/exam_kor.hwpx
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/hwp3-sample-hwpx.hwpx
+++ b/tools/oracle_public/fixtures/mini_repo/samples/hwp3-sample-hwpx.hwpx
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/hwp3-sample.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/hwp3-sample.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/lonely.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/lonely.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/multi.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/multi.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/readme.txt
+++ b/tools/oracle_public/fixtures/mini_repo/samples/readme.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/편람.hwp
+++ b/tools/oracle_public/fixtures/mini_repo/samples/편람.hwp
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/fixtures/mini_repo/samples/편람.hwpx
+++ b/tools/oracle_public/fixtures/mini_repo/samples/편람.hwpx
@@ -1,0 +1,1 @@
+placeholder

--- a/tools/oracle_public/reports/coverage.json
+++ b/tools/oracle_public/reports/coverage.json
@@ -1,0 +1,5976 @@
+{
+  "schemaVersion": "1.0",
+  "claim": "M01-3",
+  "generator": "tools/oracle_public/coverage_report.py",
+  "matchingRule": "stem-{year}.pdf",
+  "hancomYears": [
+    "2018",
+    "2020",
+    "2022",
+    "2024"
+  ],
+  "sampleCount": 694,
+  "matchedSampleCount": 389,
+  "unmatchedCount": 305,
+  "pairCount": 409,
+  "coverageRatio": 0.5605187319884726,
+  "oracleRoots": [
+    "pdf",
+    "pdf-2020",
+    "pdf-large"
+  ],
+  "bySourceFormat": {
+    "hwp": {
+      "sampleCount": 412,
+      "matchedSampleCount": 270,
+      "unmatchedCount": 142
+    },
+    "hwpx": {
+      "sampleCount": 282,
+      "matchedSampleCount": 119,
+      "unmatchedCount": 163
+    }
+  },
+  "byHancomVersion": {
+    "2018": {
+      "pairCount": 0,
+      "sampleCount": 0
+    },
+    "2020": {
+      "pairCount": 56,
+      "sampleCount": 53
+    },
+    "2022": {
+      "pairCount": 294,
+      "sampleCount": 294
+    },
+    "2024": {
+      "pairCount": 59,
+      "sampleCount": 57
+    }
+  },
+  "pairs": [
+    {
+      "id": "samples/2010-01-06.hwp::pdf/2010-01-06-2022.pdf",
+      "sample": "samples/2010-01-06.hwp",
+      "pdf": "pdf/2010-01-06-2022.pdf",
+      "stem": "2010-01-06",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2022년 국립국어원 업무계획.hwp::pdf/2022년 국립국어원 업무계획-2022.pdf",
+      "sample": "samples/2022년 국립국어원 업무계획.hwp",
+      "pdf": "pdf/2022년 국립국어원 업무계획-2022.pdf",
+      "stem": "2022년 국립국어원 업무계획",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwp::pdf/2025 행정업무운영 편람(최종)-2024.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwp",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-2024.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwp::pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwp",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2020",
+      "variant": "2020-kopub",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwp::pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwp",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-hwp-2020.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2020",
+      "variant": "hwp-2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwp::pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwp",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-hwp-kopub-2020.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2020",
+      "variant": "hwp-kopub-2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwpx::pdf/2025 행정업무운영 편람(최종)-2024.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwpx",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-2024.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwpx::pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwpx",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-2020-kopub.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2020",
+      "variant": "2020-kopub",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025 행정업무운영 편람(최종).hwpx::pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf",
+      "sample": "samples/2025 행정업무운영 편람(최종).hwpx",
+      "pdf": "pdf/2025 행정업무운영 편람(최종)-hwpx-kopub-2020.pdf",
+      "stem": "2025 행정업무운영 편람(최종)",
+      "hancomVersion": "2020",
+      "variant": "hwpx-kopub-2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/20250130-hongbo.hwp::pdf/20250130-hongbo-2022.pdf",
+      "sample": "samples/20250130-hongbo.hwp",
+      "pdf": "pdf/20250130-hongbo-2022.pdf",
+      "stem": "20250130-hongbo",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx::pdf/2025년 기부·답례품 실적 지자체 보고서_양식-2022.pdf",
+      "sample": "samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx",
+      "pdf": "pdf/2025년 기부·답례품 실적 지자체 보고서_양식-2022.pdf",
+      "stem": "2025년 기부·답례품 실적 지자체 보고서_양식",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/21_언어_기출_편집가능본.hwp::pdf/21_언어_기출_편집가능본-2022.pdf",
+      "sample": "samples/21_언어_기출_편집가능본.hwp",
+      "pdf": "pdf/21_언어_기출_편집가능본-2022.pdf",
+      "stem": "21_언어_기출_편집가능본",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2022.hwp::pdf/3-09월_교육_통합_2022.pdf",
+      "sample": "samples/3-09월_교육_통합_2022.hwp",
+      "pdf": "pdf/3-09월_교육_통합_2022.pdf",
+      "stem": "3-09월_교육_통합_2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2022.hwpx::pdf/3-09월_교육_통합_2022.pdf",
+      "sample": "samples/3-09월_교육_통합_2022.hwpx",
+      "pdf": "pdf/3-09월_교육_통합_2022.pdf",
+      "stem": "3-09월_교육_통합_2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2024-구분선아래20.hwp::pdf/3-09월_교육_통합_2024-구분선아래20-2024.pdf",
+      "sample": "samples/3-09월_교육_통합_2024-구분선아래20.hwp",
+      "pdf": "pdf/3-09월_교육_통합_2024-구분선아래20-2024.pdf",
+      "stem": "3-09월_교육_통합_2024-구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2024-구분선아래20.hwp::pdf-large/3-09월_교육_통합_2024-구분선아래20-2024.pdf",
+      "sample": "samples/3-09월_교육_통합_2024-구분선아래20.hwp",
+      "pdf": "pdf-large/3-09월_교육_통합_2024-구분선아래20-2024.pdf",
+      "stem": "3-09월_교육_통합_2024-구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf-large"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp::pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf",
+      "sample": "samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp",
+      "pdf": "pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf",
+      "stem": "3-09월_교육_통합_2024-구분선아래20구분선위20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwpx::pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf",
+      "sample": "samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwpx",
+      "pdf": "pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf",
+      "stem": "3-09월_교육_통합_2024-구분선아래20구분선위20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2024-미주사이20.hwp::pdf/3-09월_교육_통합_2024-미주사이20-2024.pdf",
+      "sample": "samples/3-09월_교육_통합_2024-미주사이20.hwp",
+      "pdf": "pdf/3-09월_교육_통합_2024-미주사이20-2024.pdf",
+      "stem": "3-09월_교육_통합_2024-미주사이20",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-09월_교육_통합_2024-미주사이20.hwp::pdf-large/3-09월_교육_통합_2024-미주사이20-2024.pdf",
+      "sample": "samples/3-09월_교육_통합_2024-미주사이20.hwp",
+      "pdf": "pdf-large/3-09월_교육_통합_2024-미주사이20-2024.pdf",
+      "stem": "3-09월_교육_통합_2024-미주사이20",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf-large"
+    },
+    {
+      "id": "samples/3-10월_교육_통합_2022.hwp::pdf/3-10월_교육_통합_2022.pdf",
+      "sample": "samples/3-10월_교육_통합_2022.hwp",
+      "pdf": "pdf/3-10월_교육_통합_2022.pdf",
+      "stem": "3-10월_교육_통합_2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-10월_교육_통합_2022.hwpx::pdf/3-10월_교육_통합_2022.pdf",
+      "sample": "samples/3-10월_교육_통합_2022.hwpx",
+      "pdf": "pdf/3-10월_교육_통합_2022.pdf",
+      "stem": "3-10월_교육_통합_2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2022.hwp::pdf/3-11월_실전_통합_2022.pdf",
+      "sample": "samples/3-11월_실전_통합_2022.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2022.pdf",
+      "stem": "3-11월_실전_통합_2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2022.hwpx::pdf/3-11월_실전_통합_2022.pdf",
+      "sample": "samples/3-11월_실전_통합_2022.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2022.pdf",
+      "stem": "3-11월_실전_통합_2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwp::pdf/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwpx::pdf/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwp::pdf/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwpx::pdf/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwp::pdf/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwpx::pdf/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwp::pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwpx::pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwp::pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwpx::pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwp::pdf/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx::pdf/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwp::pdf/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwpx::pdf/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp::pdf/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwpx::pdf/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.pdf",
+      "sample": "samples/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwpx",
+      "pdf": "pdf/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.pdf",
+      "stem": "3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/80168_regulatory_analysis.hwp::pdf/80168_regulatory_analysis-2022.pdf",
+      "sample": "samples/80168_regulatory_analysis.hwp",
+      "pdf": "pdf/80168_regulatory_analysis-2022.pdf",
+      "stem": "80168_regulatory_analysis",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/[2027] 온새미로 1 본교재.hwp::pdf/[2027] 온새미로 1 본교재-2024.pdf",
+      "sample": "samples/[2027] 온새미로 1 본교재.hwp",
+      "pdf": "pdf/[2027] 온새미로 1 본교재-2024.pdf",
+      "stem": "[2027] 온새미로 1 본교재",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/[2027] 온새미로 1 본교재.hwpx::pdf/[2027] 온새미로 1 본교재-2024.pdf",
+      "sample": "samples/[2027] 온새미로 1 본교재.hwpx",
+      "pdf": "pdf/[2027] 온새미로 1 본교재-2024.pdf",
+      "stem": "[2027] 온새미로 1 본교재",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/aift.hwp::pdf/aift-2022.pdf",
+      "sample": "samples/aift.hwp",
+      "pdf": "pdf/aift-2022.pdf",
+      "stem": "aift",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/atop-equation-01.hwp::pdf/atop-equation-01-2022.pdf",
+      "sample": "samples/atop-equation-01.hwp",
+      "pdf": "pdf/atop-equation-01-2022.pdf",
+      "stem": "atop-equation-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/BlogForm_BookReview.hwp::pdf/basic/BlogForm_BookReview-2022.pdf",
+      "sample": "samples/basic/BlogForm_BookReview.hwp",
+      "pdf": "pdf/basic/BlogForm_BookReview-2022.pdf",
+      "stem": "BlogForm_BookReview",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/BlogForm_MovieReview.hwp::pdf/basic/BlogForm_MovieReview-2022.pdf",
+      "sample": "samples/basic/BlogForm_MovieReview.hwp",
+      "pdf": "pdf/basic/BlogForm_MovieReview-2022.pdf",
+      "stem": "BlogForm_MovieReview",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/BlogForm_Recipe.hwp::pdf/basic/BlogForm_Recipe-2022.pdf",
+      "sample": "samples/basic/BlogForm_Recipe.hwp",
+      "pdf": "pdf/basic/BlogForm_Recipe-2022.pdf",
+      "stem": "BlogForm_Recipe",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/BookReview.hwp::pdf/basic/BookReview-2022.pdf",
+      "sample": "samples/basic/BookReview.hwp",
+      "pdf": "pdf/basic/BookReview-2022.pdf",
+      "stem": "BookReview",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/calendar_year.hwp::pdf/basic/calendar_year-2022.pdf",
+      "sample": "samples/basic/calendar_year.hwp",
+      "pdf": "pdf/basic/calendar_year-2022.pdf",
+      "stem": "calendar_year",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/english.hwp::pdf/basic/english-2022.pdf",
+      "sample": "samples/basic/english.hwp",
+      "pdf": "pdf/basic/english-2022.pdf",
+      "stem": "english",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/Hyper(hwp2010).hwp::pdf/basic/Hyper(hwp2010)-2022.pdf",
+      "sample": "samples/basic/Hyper(hwp2010).hwp",
+      "pdf": "pdf/basic/Hyper(hwp2010)-2022.pdf",
+      "stem": "Hyper(hwp2010)",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/interview.hwp::pdf/basic/interview-2022.pdf",
+      "sample": "samples/basic/interview.hwp",
+      "pdf": "pdf/basic/interview-2022.pdf",
+      "stem": "interview",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/issue2007_nested_cell_pagination_42065.hwp::pdf/basic/issue2007_nested_cell_pagination_42065-2020.pdf",
+      "sample": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+      "pdf": "pdf/basic/issue2007_nested_cell_pagination_42065-2020.pdf",
+      "stem": "issue2007_nested_cell_pagination_42065",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/KTX-003.hwp::pdf/basic/KTX-003-2022.pdf",
+      "sample": "samples/basic/KTX-003.hwp",
+      "pdf": "pdf/basic/KTX-003-2022.pdf",
+      "stem": "KTX-003",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/KTX.hwp::pdf/basic/KTX-2022.pdf",
+      "sample": "samples/basic/KTX.hwp",
+      "pdf": "pdf/basic/KTX-2022.pdf",
+      "stem": "KTX",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/NewYear_s_Day.hwp::pdf/basic/NewYear_s_Day-2022.pdf",
+      "sample": "samples/basic/NewYear_s_Day.hwp",
+      "pdf": "pdf/basic/NewYear_s_Day-2022.pdf",
+      "stem": "NewYear_s_Day",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/request.hwp::pdf/basic/request-2022.pdf",
+      "sample": "samples/basic/request.hwp",
+      "pdf": "pdf/basic/request-2022.pdf",
+      "stem": "request",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/shortcut.hwp::pdf/basic/shortcut-2022.pdf",
+      "sample": "samples/basic/shortcut.hwp",
+      "pdf": "pdf/basic/shortcut-2022.pdf",
+      "stem": "shortcut",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/sungeo.hwp::pdf/basic/sungeo-2022.pdf",
+      "sample": "samples/basic/sungeo.hwp",
+      "pdf": "pdf/basic/sungeo-2022.pdf",
+      "stem": "sungeo",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/Textmail.hwp::pdf/basic/Textmail-2022.pdf",
+      "sample": "samples/basic/Textmail.hwp",
+      "pdf": "pdf/basic/Textmail-2022.pdf",
+      "stem": "Textmail",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/treatise sample.hwp::pdf/basic/treatise sample-2022.pdf",
+      "sample": "samples/basic/treatise sample.hwp",
+      "pdf": "pdf/basic/treatise sample-2022.pdf",
+      "stem": "treatise sample",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/basic/Worldcup_FIFA2010_32.hwp::pdf/basic/Worldcup_FIFA2010_32-2022.pdf",
+      "sample": "samples/basic/Worldcup_FIFA2010_32.hwp",
+      "pdf": "pdf/basic/Worldcup_FIFA2010_32-2022.pdf",
+      "stem": "Worldcup_FIFA2010_32",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/bitmap.hwp::pdf/bitmap-2022.pdf",
+      "sample": "samples/bitmap.hwp",
+      "pdf": "pdf/bitmap-2022.pdf",
+      "stem": "bitmap",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/biz_plan.hwp::pdf/biz_plan-2022.pdf",
+      "sample": "samples/biz_plan.hwp",
+      "pdf": "pdf/biz_plan-2022.pdf",
+      "stem": "biz_plan",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/calc-cell.hwp::pdf/calc-cell-2022.pdf",
+      "sample": "samples/calc-cell.hwp",
+      "pdf": "pdf/calc-cell-2022.pdf",
+      "stem": "calc-cell",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/3차원누적가로막대형.hwp::pdf/chart/가로막대형/3차원누적가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/3차원누적가로막대형.hwp",
+      "pdf": "pdf/chart/가로막대형/3차원누적가로막대형-2022.pdf",
+      "stem": "3차원누적가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/3차원누적가로막대형.hwpx::pdf/chart/가로막대형/3차원누적가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/3차원누적가로막대형.hwpx",
+      "pdf": "pdf/chart/가로막대형/3차원누적가로막대형-2022.pdf",
+      "stem": "3차원누적가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/3차원묶은가로막대형.hwp::pdf/chart/가로막대형/3차원묶은가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/3차원묶은가로막대형.hwp",
+      "pdf": "pdf/chart/가로막대형/3차원묶은가로막대형-2022.pdf",
+      "stem": "3차원묶은가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/3차원묶은가로막대형.hwpx::pdf/chart/가로막대형/3차원묶은가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/3차원묶은가로막대형.hwpx",
+      "pdf": "pdf/chart/가로막대형/3차원묶은가로막대형-2022.pdf",
+      "stem": "3차원묶은가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/누적가로막대형.hwp::pdf/chart/가로막대형/누적가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/누적가로막대형.hwp",
+      "pdf": "pdf/chart/가로막대형/누적가로막대형-2022.pdf",
+      "stem": "누적가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/누적가로막대형.hwpx::pdf/chart/가로막대형/누적가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/누적가로막대형.hwpx",
+      "pdf": "pdf/chart/가로막대형/누적가로막대형-2022.pdf",
+      "stem": "누적가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/묶은가로막대형.hwp::pdf/chart/가로막대형/묶은가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/묶은가로막대형.hwp",
+      "pdf": "pdf/chart/가로막대형/묶은가로막대형-2022.pdf",
+      "stem": "묶은가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/묶은가로막대형.hwpx::pdf/chart/가로막대형/묶은가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/묶은가로막대형.hwpx",
+      "pdf": "pdf/chart/가로막대형/묶은가로막대형-2022.pdf",
+      "stem": "묶은가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/백프로기준누적가로막대형.hwp::pdf/chart/가로막대형/백프로기준누적가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/백프로기준누적가로막대형.hwp",
+      "pdf": "pdf/chart/가로막대형/백프로기준누적가로막대형-2022.pdf",
+      "stem": "백프로기준누적가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/가로막대형/백프로기준누적가로막대형.hwpx::pdf/chart/가로막대형/백프로기준누적가로막대형-2022.pdf",
+      "sample": "samples/chart/가로막대형/백프로기준누적가로막대형.hwpx",
+      "pdf": "pdf/chart/가로막대형/백프로기준누적가로막대형-2022.pdf",
+      "stem": "백프로기준누적가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/기타/고가저가종가.hwp::pdf/chart/기타/고가저가종가-2022.pdf",
+      "sample": "samples/chart/기타/고가저가종가.hwp",
+      "pdf": "pdf/chart/기타/고가저가종가-2022.pdf",
+      "stem": "고가저가종가",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/기타/고가저가종가.hwpx::pdf/chart/기타/고가저가종가-2022.pdf",
+      "sample": "samples/chart/기타/고가저가종가.hwpx",
+      "pdf": "pdf/chart/기타/고가저가종가-2022.pdf",
+      "stem": "고가저가종가",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/기타/시가고가저가종가.hwp::pdf/chart/기타/시가고가저가종가-2022.pdf",
+      "sample": "samples/chart/기타/시가고가저가종가.hwp",
+      "pdf": "pdf/chart/기타/시가고가저가종가-2022.pdf",
+      "stem": "시가고가저가종가",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/기타/시가고가저가종가.hwpx::pdf/chart/기타/시가고가저가종가-2022.pdf",
+      "sample": "samples/chart/기타/시가고가저가종가.hwpx",
+      "pdf": "pdf/chart/기타/시가고가저가종가-2022.pdf",
+      "stem": "시가고가저가종가",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/꺽은선형.hwp::pdf/chart/라인/꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/꺽은선형.hwp",
+      "pdf": "pdf/chart/라인/꺽은선형-2022.pdf",
+      "stem": "꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/꺽은선형.hwpx::pdf/chart/라인/꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/꺽은선형.hwpx",
+      "pdf": "pdf/chart/라인/꺽은선형-2022.pdf",
+      "stem": "꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/누적꺽은선형.hwp::pdf/chart/라인/누적꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/누적꺽은선형.hwp",
+      "pdf": "pdf/chart/라인/누적꺽은선형-2022.pdf",
+      "stem": "누적꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/누적꺽은선형.hwpx::pdf/chart/라인/누적꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/누적꺽은선형.hwpx",
+      "pdf": "pdf/chart/라인/누적꺽은선형-2022.pdf",
+      "stem": "누적꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/백프로기준누적꺽은선형.hwp::pdf/chart/라인/백프로기준누적꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/백프로기준누적꺽은선형.hwp",
+      "pdf": "pdf/chart/라인/백프로기준누적꺽은선형-2022.pdf",
+      "stem": "백프로기준누적꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/백프로기준누적꺽은선형.hwpx::pdf/chart/라인/백프로기준누적꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/백프로기준누적꺽은선형.hwpx",
+      "pdf": "pdf/chart/라인/백프로기준누적꺽은선형-2022.pdf",
+      "stem": "백프로기준누적꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/표식이있는꺽은선형.hwp::pdf/chart/라인/표식이있는꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/표식이있는꺽은선형.hwp",
+      "pdf": "pdf/chart/라인/표식이있는꺽은선형-2022.pdf",
+      "stem": "표식이있는꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/표식이있는꺽은선형.hwpx::pdf/chart/라인/표식이있는꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/표식이있는꺽은선형.hwpx",
+      "pdf": "pdf/chart/라인/표식이있는꺽은선형-2022.pdf",
+      "stem": "표식이있는꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/표식이있는누적꺽은선형.hwp::pdf/chart/라인/표식이있는누적꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/표식이있는누적꺽은선형.hwp",
+      "pdf": "pdf/chart/라인/표식이있는누적꺽은선형-2022.pdf",
+      "stem": "표식이있는누적꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/라인/표식이있는누적꺽은선형.hwpx::pdf/chart/라인/표식이있는누적꺽은선형-2022.pdf",
+      "sample": "samples/chart/라인/표식이있는누적꺽은선형.hwpx",
+      "pdf": "pdf/chart/라인/표식이있는누적꺽은선형-2022.pdf",
+      "stem": "표식이있는누적꺽은선형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/곡선및표식이있는분산형.hwp::pdf/chart/분산형/곡선및표식이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/곡선및표식이있는분산형.hwp",
+      "pdf": "pdf/chart/분산형/곡선및표식이있는분산형-2022.pdf",
+      "stem": "곡선및표식이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/곡선및표식이있는분산형.hwpx::pdf/chart/분산형/곡선및표식이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/곡선및표식이있는분산형.hwpx",
+      "pdf": "pdf/chart/분산형/곡선및표식이있는분산형-2022.pdf",
+      "stem": "곡선및표식이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/곡선이있는분산형.hwp::pdf/chart/분산형/곡선이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/곡선이있는분산형.hwp",
+      "pdf": "pdf/chart/분산형/곡선이있는분산형-2022.pdf",
+      "stem": "곡선이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/곡선이있는분산형.hwpx::pdf/chart/분산형/곡선이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/곡선이있는분산형.hwpx",
+      "pdf": "pdf/chart/분산형/곡선이있는분산형-2022.pdf",
+      "stem": "곡선이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/직선및표식이있는분산형.hwp::pdf/chart/분산형/직선및표식이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/직선및표식이있는분산형.hwp",
+      "pdf": "pdf/chart/분산형/직선및표식이있는분산형-2022.pdf",
+      "stem": "직선및표식이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/직선및표식이있는분산형.hwpx::pdf/chart/분산형/직선및표식이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/직선및표식이있는분산형.hwpx",
+      "pdf": "pdf/chart/분산형/직선및표식이있는분산형-2022.pdf",
+      "stem": "직선및표식이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/직선이있는분산형.hwp::pdf/chart/분산형/직선이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/직선이있는분산형.hwp",
+      "pdf": "pdf/chart/분산형/직선이있는분산형-2022.pdf",
+      "stem": "직선이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/직선이있는분산형.hwpx::pdf/chart/분산형/직선이있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/직선이있는분산형.hwpx",
+      "pdf": "pdf/chart/분산형/직선이있는분산형-2022.pdf",
+      "stem": "직선이있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/표식만있는분산형.hwp::pdf/chart/분산형/표식만있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/표식만있는분산형.hwp",
+      "pdf": "pdf/chart/분산형/표식만있는분산형-2022.pdf",
+      "stem": "표식만있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/분산형/표식만있는분산형.hwpx::pdf/chart/분산형/표식만있는분산형-2022.pdf",
+      "sample": "samples/chart/분산형/표식만있는분산형.hwpx",
+      "pdf": "pdf/chart/분산형/표식만있는분산형-2022.pdf",
+      "stem": "표식만있는분산형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/3차원누적세로막대형.hwp::pdf/chart/세로막대형/3차원누적세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/3차원누적세로막대형.hwp",
+      "pdf": "pdf/chart/세로막대형/3차원누적세로막대형-2022.pdf",
+      "stem": "3차원누적세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/3차원누적세로막대형.hwpx::pdf/chart/세로막대형/3차원누적세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/3차원누적세로막대형.hwpx",
+      "pdf": "pdf/chart/세로막대형/3차원누적세로막대형-2022.pdf",
+      "stem": "3차원누적세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/3차원묶은세로막대형.hwp::pdf/chart/세로막대형/3차원묶은세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/3차원묶은세로막대형.hwp",
+      "pdf": "pdf/chart/세로막대형/3차원묶은세로막대형-2022.pdf",
+      "stem": "3차원묶은세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/3차원묶은세로막대형.hwpx::pdf/chart/세로막대형/3차원묶은세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/3차원묶은세로막대형.hwpx",
+      "pdf": "pdf/chart/세로막대형/3차원묶은세로막대형-2022.pdf",
+      "stem": "3차원묶은세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/누적세로막대형.hwp::pdf/chart/세로막대형/누적세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/누적세로막대형.hwp",
+      "pdf": "pdf/chart/세로막대형/누적세로막대형-2022.pdf",
+      "stem": "누적세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/누적세로막대형.hwpx::pdf/chart/세로막대형/누적세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/누적세로막대형.hwpx",
+      "pdf": "pdf/chart/세로막대형/누적세로막대형-2022.pdf",
+      "stem": "누적세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/묶은세로막대형.hwp::pdf/chart/세로막대형/묶은세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/묶은세로막대형.hwp",
+      "pdf": "pdf/chart/세로막대형/묶은세로막대형-2022.pdf",
+      "stem": "묶은세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/묶은세로막대형.hwpx::pdf/chart/세로막대형/묶은세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/묶은세로막대형.hwpx",
+      "pdf": "pdf/chart/세로막대형/묶은세로막대형-2022.pdf",
+      "stem": "묶은세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/백프로기준누적세로막대형.hwp::pdf/chart/세로막대형/백프로기준누적세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/백프로기준누적세로막대형.hwp",
+      "pdf": "pdf/chart/세로막대형/백프로기준누적세로막대형-2022.pdf",
+      "stem": "백프로기준누적세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/세로막대형/백프로기준누적세로막대형.hwpx::pdf/chart/세로막대형/백프로기준누적세로막대형-2022.pdf",
+      "sample": "samples/chart/세로막대형/백프로기준누적세로막대형.hwpx",
+      "pdf": "pdf/chart/세로막대형/백프로기준누적세로막대형-2022.pdf",
+      "stem": "백프로기준누적세로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/2차원원형.hwp::pdf/chart/원형/2차원원형-2022.pdf",
+      "sample": "samples/chart/원형/2차원원형.hwp",
+      "pdf": "pdf/chart/원형/2차원원형-2022.pdf",
+      "stem": "2차원원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/2차원원형.hwpx::pdf/chart/원형/2차원원형-2022.pdf",
+      "sample": "samples/chart/원형/2차원원형.hwpx",
+      "pdf": "pdf/chart/원형/2차원원형-2022.pdf",
+      "stem": "2차원원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/3차원원형.hwp::pdf/chart/원형/3차원원형-2022.pdf",
+      "sample": "samples/chart/원형/3차원원형.hwp",
+      "pdf": "pdf/chart/원형/3차원원형-2022.pdf",
+      "stem": "3차원원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/3차원원형.hwpx::pdf/chart/원형/3차원원형-2022.pdf",
+      "sample": "samples/chart/원형/3차원원형.hwpx",
+      "pdf": "pdf/chart/원형/3차원원형-2022.pdf",
+      "stem": "3차원원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/원형대가로막대형.hwp::pdf/chart/원형/원형대가로막대형-2022.pdf",
+      "sample": "samples/chart/원형/원형대가로막대형.hwp",
+      "pdf": "pdf/chart/원형/원형대가로막대형-2022.pdf",
+      "stem": "원형대가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/원형대가로막대형.hwpx::pdf/chart/원형/원형대가로막대형-2022.pdf",
+      "sample": "samples/chart/원형/원형대가로막대형.hwpx",
+      "pdf": "pdf/chart/원형/원형대가로막대형-2022.pdf",
+      "stem": "원형대가로막대형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/원형대원형.hwp::pdf/chart/원형/원형대원형-2022.pdf",
+      "sample": "samples/chart/원형/원형대원형.hwp",
+      "pdf": "pdf/chart/원형/원형대원형-2022.pdf",
+      "stem": "원형대원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/원형대원형.hwpx::pdf/chart/원형/원형대원형-2022.pdf",
+      "sample": "samples/chart/원형/원형대원형.hwpx",
+      "pdf": "pdf/chart/원형/원형대원형-2022.pdf",
+      "stem": "원형대원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/쪼개진원형.hwp::pdf/chart/원형/쪼개진원형-2022.pdf",
+      "sample": "samples/chart/원형/쪼개진원형.hwp",
+      "pdf": "pdf/chart/원형/쪼개진원형-2022.pdf",
+      "stem": "쪼개진원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/원형/쪼개진원형.hwpx::pdf/chart/원형/쪼개진원형-2022.pdf",
+      "sample": "samples/chart/원형/쪼개진원형.hwpx",
+      "pdf": "pdf/chart/원형/쪼개진원형-2022.pdf",
+      "stem": "쪼개진원형",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목.hwp::pdf/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목-2022.pdf",
+      "sample": "samples/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목.hwp",
+      "pdf": "pdf/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목-2022.pdf",
+      "stem": "가로막대형_하나만있을떄_단일시리즈제목",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목.hwpx::pdf/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목-2022.pdf",
+      "sample": "samples/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목.hwpx",
+      "pdf": "pdf/chart/특이케이스/가로막대형_하나만있을떄_단일시리즈제목-2022.pdf",
+      "stem": "가로막대형_하나만있을떄_단일시리즈제목",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/draw-group.hwp::pdf/draw-group-2022.pdf",
+      "sample": "samples/draw-group.hwp",
+      "pdf": "pdf/draw-group-2022.pdf",
+      "stem": "draw-group",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/endnote-01.hwp::pdf/endnote-01-2022.pdf",
+      "sample": "samples/endnote-01.hwp",
+      "pdf": "pdf/endnote-01-2022.pdf",
+      "stem": "endnote-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/eq-01.hwp::pdf/eq-01-2022.pdf",
+      "sample": "samples/eq-01.hwp",
+      "pdf": "pdf/eq-01-2022.pdf",
+      "stem": "eq-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/equation-lim.hwp::pdf/equation-lim-2022.pdf",
+      "sample": "samples/equation-lim.hwp",
+      "pdf": "pdf/equation-lim-2022.pdf",
+      "stem": "equation-lim",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_eng.hwp::pdf/exam_eng-2022.pdf",
+      "sample": "samples/exam_eng.hwp",
+      "pdf": "pdf/exam_eng-2022.pdf",
+      "stem": "exam_eng",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_kor.hwp::pdf/exam_kor-2022.pdf",
+      "sample": "samples/exam_kor.hwp",
+      "pdf": "pdf/exam_kor-2022.pdf",
+      "stem": "exam_kor",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_math.hwp::pdf/exam_math-2022.pdf",
+      "sample": "samples/exam_math.hwp",
+      "pdf": "pdf/exam_math-2022.pdf",
+      "stem": "exam_math",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_math_8.hwp::pdf/exam_math_8-2022.pdf",
+      "sample": "samples/exam_math_8.hwp",
+      "pdf": "pdf/exam_math_8-2022.pdf",
+      "stem": "exam_math_8",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_math_no.hwp::pdf/exam_math_no-2022.pdf",
+      "sample": "samples/exam_math_no.hwp",
+      "pdf": "pdf/exam_math_no-2022.pdf",
+      "stem": "exam_math_no",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_science.hwp::pdf/exam_science-2022.pdf",
+      "sample": "samples/exam_science.hwp",
+      "pdf": "pdf/exam_science-2022.pdf",
+      "stem": "exam_science",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/exam_social.hwp::pdf/exam_social-2022.pdf",
+      "sample": "samples/exam_social.hwp",
+      "pdf": "pdf/exam_social-2022.pdf",
+      "stem": "exam_social",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/field-01-memo.hwp::pdf/field-01-memo-2022.pdf",
+      "sample": "samples/field-01-memo.hwp",
+      "pdf": "pdf/field-01-memo-2022.pdf",
+      "stem": "field-01-memo",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/field-01.hwp::pdf/field-01-2022.pdf",
+      "sample": "samples/field-01.hwp",
+      "pdf": "pdf/field-01-2022.pdf",
+      "stem": "field-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/float-stack-defer.hwp::pdf/float-stack-defer-2022.pdf",
+      "sample": "samples/float-stack-defer.hwp",
+      "pdf": "pdf/float-stack-defer-2022.pdf",
+      "stem": "float-stack-defer",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/footnote-01.hwp::pdf/footnote-01-2022.pdf",
+      "sample": "samples/footnote-01.hwp",
+      "pdf": "pdf/footnote-01-2022.pdf",
+      "stem": "footnote-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/form-01.hwp::pdf/form-01-2022.pdf",
+      "sample": "samples/form-01.hwp",
+      "pdf": "pdf/form-01-2022.pdf",
+      "stem": "form-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/group-box.hwp::pdf/group-box-2022.pdf",
+      "sample": "samples/group-box.hwp",
+      "pdf": "pdf/group-box-2022.pdf",
+      "stem": "group-box",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/group-drawing-02.hwp::pdf/group-drawing-02-2022.pdf",
+      "sample": "samples/group-drawing-02.hwp",
+      "pdf": "pdf/group-drawing-02-2022.pdf",
+      "stem": "group-drawing-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/h-pen-01.hwp::pdf/h-pen-01-2022.pdf",
+      "sample": "samples/h-pen-01.hwp",
+      "pdf": "pdf/h-pen-01-2022.pdf",
+      "stem": "h-pen-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp-img-001.hwp::pdf/hwp-img-001-2022.pdf",
+      "sample": "samples/hwp-img-001.hwp",
+      "pdf": "pdf/hwp-img-001-2022.pdf",
+      "stem": "hwp-img-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp-multi-001.hwp::pdf/hwp-multi-001-2022.pdf",
+      "sample": "samples/hwp-multi-001.hwp",
+      "pdf": "pdf/hwp-multi-001-2022.pdf",
+      "stem": "hwp-multi-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp-multi-002.hwp::pdf/hwp-multi-002-2022.pdf",
+      "sample": "samples/hwp-multi-002.hwp",
+      "pdf": "pdf/hwp-multi-002-2022.pdf",
+      "stem": "hwp-multi-002",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample-hwp5.hwp::pdf/hwp3-sample-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample-hwp5-2022.pdf",
+      "stem": "hwp3-sample-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample-hwpx.hwpx::pdf/hwp3-sample-hwpx-2022.pdf",
+      "sample": "samples/hwp3-sample-hwpx.hwpx",
+      "pdf": "pdf/hwp3-sample-hwpx-2022.pdf",
+      "stem": "hwp3-sample-hwpx",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample.hwp::pdf/hwp3-sample-2022.pdf",
+      "sample": "samples/hwp3-sample.hwp",
+      "pdf": "pdf/hwp3-sample-2022.pdf",
+      "stem": "hwp3-sample",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample11.hwp::pdf/hwp3-sample11-2020.pdf",
+      "sample": "samples/hwp3-sample11.hwp",
+      "pdf": "pdf/hwp3-sample11-2020.pdf",
+      "stem": "hwp3-sample11",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample13-hwp5.hwp::pdf/hwp3-sample13-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample13-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample13-hwp5-2022.pdf",
+      "stem": "hwp3-sample13-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample13-hwp5.hwpx::pdf/hwp3-sample13-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample13-hwp5.hwpx",
+      "pdf": "pdf/hwp3-sample13-hwp5-2022.pdf",
+      "stem": "hwp3-sample13-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample14-hwp5.hwp::pdf/hwp3-sample14-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample14-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample14-hwp5-2022.pdf",
+      "stem": "hwp3-sample14-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample14-hwp5.hwpx::pdf/hwp3-sample14-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample14-hwp5.hwpx",
+      "pdf": "pdf/hwp3-sample14-hwp5-2022.pdf",
+      "stem": "hwp3-sample14-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5-2010.hwp::pdf/hwp3-sample16-hwp5-2010-2020.pdf",
+      "sample": "samples/hwp3-sample16-hwp5-2010.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2010-2020.pdf",
+      "stem": "hwp3-sample16-hwp5-2010",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5-2018.hwp::pdf/hwp3-sample16-hwp5-2018-2020.pdf",
+      "sample": "samples/hwp3-sample16-hwp5-2018.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2018-2020.pdf",
+      "stem": "hwp3-sample16-hwp5-2018",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5-2022.hwp::pdf/hwp3-sample16-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample16-hwp5-2022.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2022.pdf",
+      "stem": "hwp3-sample16-hwp5-2022",
+      "hancomVersion": "2022",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5-2022.hwp::pdf/hwp3-sample16-hwp5-2022-2020.pdf",
+      "sample": "samples/hwp3-sample16-hwp5-2022.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2022-2020.pdf",
+      "stem": "hwp3-sample16-hwp5-2022",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5-2024.hwp::pdf/hwp3-sample16-hwp5-2024-2020.pdf",
+      "sample": "samples/hwp3-sample16-hwp5-2024.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2024-2020.pdf",
+      "stem": "hwp3-sample16-hwp5-2024",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5.hwp::pdf/hwp3-sample16-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample16-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2022.pdf",
+      "stem": "hwp3-sample16-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5.hwp::pdf/hwp3-sample16-hwp5-2020.pdf",
+      "sample": "samples/hwp3-sample16-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample16-hwp5-2020.pdf",
+      "stem": "hwp3-sample16-hwp5",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5.hwpx::pdf/hwp3-sample16-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample16-hwp5.hwpx",
+      "pdf": "pdf/hwp3-sample16-hwp5-2022.pdf",
+      "stem": "hwp3-sample16-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16-hwp5.hwpx::pdf/hwp3-sample16-hwp5-2020.pdf",
+      "sample": "samples/hwp3-sample16-hwp5.hwpx",
+      "pdf": "pdf/hwp3-sample16-hwp5-2020.pdf",
+      "stem": "hwp3-sample16-hwp5",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample16.hwp::pdf/hwp3-sample16-2020.pdf",
+      "sample": "samples/hwp3-sample16.hwp",
+      "pdf": "pdf/hwp3-sample16-2020.pdf",
+      "stem": "hwp3-sample16",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample19-hwp5.hwp::pdf/hwp3-sample19-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample19-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample19-hwp5-2022.pdf",
+      "stem": "hwp3-sample19-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample4-hwp5.hwp::pdf/hwp3-sample4-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample4-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample4-hwp5-2022.pdf",
+      "stem": "hwp3-sample4-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample4.hwp::pdf/hwp3-sample4-2022.pdf",
+      "sample": "samples/hwp3-sample4.hwp",
+      "pdf": "pdf/hwp3-sample4-2022.pdf",
+      "stem": "hwp3-sample4",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample5-hwp5.hwp::pdf/hwp3-sample5-hwp5-2022.pdf",
+      "sample": "samples/hwp3-sample5-hwp5.hwp",
+      "pdf": "pdf/hwp3-sample5-hwp5-2022.pdf",
+      "stem": "hwp3-sample5-hwp5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample5-hwpx.hwpx::pdf/hwp3-sample5-hwpx-2022.pdf",
+      "sample": "samples/hwp3-sample5-hwpx.hwpx",
+      "pdf": "pdf/hwp3-sample5-hwpx-2022.pdf",
+      "stem": "hwp3-sample5-hwpx",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp3-sample5.hwp::pdf/hwp3-sample5-2022.pdf",
+      "sample": "samples/hwp3-sample5.hwp",
+      "pdf": "pdf/hwp3-sample5-2022.pdf",
+      "stem": "hwp3-sample5",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp_table_test-m.hwp::pdf/hwp_table_test-m-2022.pdf",
+      "sample": "samples/hwp_table_test-m.hwp",
+      "pdf": "pdf/hwp_table_test-m-2022.pdf",
+      "stem": "hwp_table_test-m",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwp_table_test.hwp::pdf/hwp_table_test-2022.pdf",
+      "sample": "samples/hwp_table_test.hwp",
+      "pdf": "pdf/hwp_table_test-2022.pdf",
+      "stem": "hwp_table_test",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpctl_Action_Table__v1.1.hwp::pdf/hwpctl_Action_Table__v1.1-2022.pdf",
+      "sample": "samples/hwpctl_Action_Table__v1.1.hwp",
+      "pdf": "pdf/hwpctl_Action_Table__v1.1-2022.pdf",
+      "stem": "hwpctl_Action_Table__v1.1",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpctl_API_v2.4.hwp::pdf/hwpctl_API_v2.4-2022.pdf",
+      "sample": "samples/hwpctl_API_v2.4.hwp",
+      "pdf": "pdf/hwpctl_API_v2.4-2022.pdf",
+      "stem": "hwpctl_API_v2.4",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpctl_ParameterSetID_Item_v1.2.hwp::pdf/hwpctl_ParameterSetID_Item_v1.2-2022.pdf",
+      "sample": "samples/hwpctl_ParameterSetID_Item_v1.2.hwp",
+      "pdf": "pdf/hwpctl_ParameterSetID_Item_v1.2-2022.pdf",
+      "stem": "hwpctl_ParameterSetID_Item_v1.2",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpspec.hwp::pdf/hwpspec-2024.pdf",
+      "sample": "samples/hwpspec.hwp",
+      "pdf": "pdf/hwpspec-2024.pdf",
+      "stem": "hwpspec",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp::pdf/hwpx/2024년 1분기 해외직접투자 보도자료 ff-2022.pdf",
+      "sample": "samples/hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp",
+      "pdf": "pdf/hwpx/2024년 1분기 해외직접투자 보도자료 ff-2022.pdf",
+      "stem": "2024년 1분기 해외직접투자 보도자료 ff",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx::pdf/hwpx/2024년 1분기 해외직접투자 보도자료 ff-2022.pdf",
+      "sample": "samples/hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx",
+      "pdf": "pdf/hwpx/2024년 1분기 해외직접투자 보도자료 ff-2022.pdf",
+      "stem": "2024년 1분기 해외직접투자 보도자료 ff",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx::pdf/hwpx/2024년 2분기 해외직접투자 보도자료ff-2022.pdf",
+      "sample": "samples/hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx",
+      "pdf": "pdf/hwpx/2024년 2분기 해외직접투자 보도자료ff-2022.pdf",
+      "stem": "2024년 2분기 해외직접투자 보도자료ff",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx::pdf/hwpx/2024년 연간 해외직접투자 보도자료 _ ff-2022.pdf",
+      "sample": "samples/hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx",
+      "pdf": "pdf/hwpx/2024년 연간 해외직접투자 보도자료 _ ff-2022.pdf",
+      "stem": "2024년 연간 해외직접투자 보도자료 _ ff",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx::pdf/hwpx/2025년 1분기 해외직접투자 보도자료f-2022.pdf",
+      "sample": "samples/hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx",
+      "pdf": "pdf/hwpx/2025년 1분기 해외직접투자 보도자료f-2022.pdf",
+      "stem": "2025년 1분기 해외직접투자 보도자료f",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/2025년 2분기 해외직접투자 (최종).hwpx::pdf/hwpx/2025년 2분기 해외직접투자 (최종)-2022.pdf",
+      "sample": "samples/hwpx/2025년 2분기 해외직접투자 (최종).hwpx",
+      "pdf": "pdf/hwpx/2025년 2분기 해외직접투자 (최종)-2022.pdf",
+      "stem": "2025년 2분기 해외직접투자 (최종)",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/aift.hwpx::pdf/hwpx/aift-2022.pdf",
+      "sample": "samples/hwpx/aift.hwpx",
+      "pdf": "pdf/hwpx/aift-2022.pdf",
+      "stem": "aift",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/blank_hwpx.hwpx::pdf/hwpx/blank_hwpx-2022.pdf",
+      "sample": "samples/hwpx/blank_hwpx.hwpx",
+      "pdf": "pdf/hwpx/blank_hwpx-2022.pdf",
+      "stem": "blank_hwpx",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/form-002.hwpx::pdf/hwpx/form-002-2022.pdf",
+      "sample": "samples/hwpx/form-002.hwpx",
+      "pdf": "pdf/hwpx/form-002-2022.pdf",
+      "stem": "form-002",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/hwpx-01.hwpx::pdf/hwpx/hwpx-01-2022.pdf",
+      "sample": "samples/hwpx/hwpx-01.hwpx",
+      "pdf": "pdf/hwpx/hwpx-01-2022.pdf",
+      "stem": "hwpx-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/hwpx-02.hwpx::pdf/hwpx/hwpx-02-2022.pdf",
+      "sample": "samples/hwpx/hwpx-02.hwpx",
+      "pdf": "pdf/hwpx/hwpx-02-2022.pdf",
+      "stem": "hwpx-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/hwpx-h-01.hwpx::pdf/hwpx/hwpx-h-01-2022.pdf",
+      "sample": "samples/hwpx/hwpx-h-01.hwpx",
+      "pdf": "pdf/hwpx/hwpx-h-01-2022.pdf",
+      "stem": "hwpx-h-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/hwpx-h-02.hwpx::pdf/hwpx/hwpx-h-02-2022.pdf",
+      "sample": "samples/hwpx/hwpx-h-02.hwpx",
+      "pdf": "pdf/hwpx/hwpx-h-02-2022.pdf",
+      "stem": "hwpx-h-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/hwpx-h-03.hwpx::pdf/hwpx/hwpx-h-03-2022.pdf",
+      "sample": "samples/hwpx/hwpx-h-03.hwpx",
+      "pdf": "pdf/hwpx/hwpx-h-03-2022.pdf",
+      "stem": "hwpx-h-03",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/issue_157.hwpx::pdf/hwpx/issue_157-2022.pdf",
+      "sample": "samples/hwpx/issue_157.hwpx",
+      "pdf": "pdf/hwpx/issue_157-2022.pdf",
+      "stem": "issue_157",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/issue_241.hwpx::pdf/hwpx/issue_241-2022.pdf",
+      "sample": "samples/hwpx/issue_241.hwpx",
+      "pdf": "pdf/hwpx/issue_241-2022.pdf",
+      "stem": "issue_241",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/mel-001.hwpx::pdf/hwpx/mel-001-2022.pdf",
+      "sample": "samples/hwpx/mel-001.hwpx",
+      "pdf": "pdf/hwpx/mel-001-2022.pdf",
+      "stem": "mel-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/ref/ref_empty.hwpx::pdf/hwpx/ref/ref_empty-2022.pdf",
+      "sample": "samples/hwpx/ref/ref_empty.hwpx",
+      "pdf": "pdf/hwpx/ref/ref_empty-2022.pdf",
+      "stem": "ref_empty",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/ref/ref_mixed.hwpx::pdf/hwpx/ref/ref_mixed-2022.pdf",
+      "sample": "samples/hwpx/ref/ref_mixed.hwpx",
+      "pdf": "pdf/hwpx/ref/ref_mixed-2022.pdf",
+      "stem": "ref_mixed",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/ref/ref_table.hwpx::pdf/hwpx/ref/ref_table-2022.pdf",
+      "sample": "samples/hwpx/ref/ref_table.hwpx",
+      "pdf": "pdf/hwpx/ref/ref_table-2022.pdf",
+      "stem": "ref_table",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/ref/ref_text.hwpx::pdf/hwpx/ref/ref_text-2022.pdf",
+      "sample": "samples/hwpx/ref/ref_text.hwpx",
+      "pdf": "pdf/hwpx/ref/ref_text-2022.pdf",
+      "stem": "ref_text",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/table-text.hwpx::pdf/hwpx/table-text-2022.pdf",
+      "sample": "samples/hwpx/table-text.hwpx",
+      "pdf": "pdf/hwpx/table-text-2022.pdf",
+      "stem": "table-text",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx/tbox-v-flow-01.hwpx::pdf/hwpx/tbox-v-flow-01-2022.pdf",
+      "sample": "samples/hwpx/tbox-v-flow-01.hwpx",
+      "pdf": "pdf/hwpx/tbox-v-flow-01-2022.pdf",
+      "stem": "tbox-v-flow-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx_sample2.hwp::pdf/hwpx_sample2-2024.pdf",
+      "sample": "samples/hwpx_sample2.hwp",
+      "pdf": "pdf/hwpx_sample2-2024.pdf",
+      "stem": "hwpx_sample2",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx_sample2.hwp::pdf/hwpx_sample2-2020.pdf",
+      "sample": "samples/hwpx_sample2.hwp",
+      "pdf": "pdf/hwpx_sample2-2020.pdf",
+      "stem": "hwpx_sample2",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx_sample2.hwpx::pdf/hwpx_sample2-2024.pdf",
+      "sample": "samples/hwpx_sample2.hwpx",
+      "pdf": "pdf/hwpx_sample2-2024.pdf",
+      "stem": "hwpx_sample2",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/hwpx_sample2.hwpx::pdf/hwpx_sample2-2020.pdf",
+      "sample": "samples/hwpx_sample2.hwpx",
+      "pdf": "pdf/hwpx_sample2-2020.pdf",
+      "stem": "hwpx_sample2",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/img-start-001.hwp::pdf/img-start-001-2022.pdf",
+      "sample": "samples/img-start-001.hwp",
+      "pdf": "pdf/img-start-001-2022.pdf",
+      "stem": "img-start-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/inner-table-01.hwp::pdf/inner-table-01-2022.pdf",
+      "sample": "samples/inner-table-01.hwp",
+      "pdf": "pdf/inner-table-01-2022.pdf",
+      "stem": "inner-table-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue-505-equations.hwp::pdf/issue-505-equations-2022.pdf",
+      "sample": "samples/issue-505-equations.hwp",
+      "pdf": "pdf/issue-505-equations-2022.pdf",
+      "stem": "issue-505-equations",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1510_coanchored_float_tables.hwp::pdf/issue1510_coanchored_float_tables-hwp-2024.pdf",
+      "sample": "samples/issue1510_coanchored_float_tables.hwp",
+      "pdf": "pdf/issue1510_coanchored_float_tables-hwp-2024.pdf",
+      "stem": "issue1510_coanchored_float_tables",
+      "hancomVersion": "2024",
+      "variant": "hwp-2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1510_coanchored_float_tables.hwpx::pdf/issue1510_coanchored_float_tables-hwpx-2024.pdf",
+      "sample": "samples/issue1510_coanchored_float_tables.hwpx",
+      "pdf": "pdf/issue1510_coanchored_float_tables-hwpx-2024.pdf",
+      "stem": "issue1510_coanchored_float_tables",
+      "hancomVersion": "2024",
+      "variant": "hwpx-2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1663_coanchored_float_orphan.hwpx::pdf/issue1663_coanchored_float_orphan-2024.pdf",
+      "sample": "samples/issue1663_coanchored_float_orphan.hwpx",
+      "pdf": "pdf/issue1663_coanchored_float_orphan-2024.pdf",
+      "stem": "issue1663_coanchored_float_orphan",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1770_rowsplit_tolerance.hwpx::pdf/issue1770_rowsplit_tolerance-2024.pdf",
+      "sample": "samples/issue1770_rowsplit_tolerance.hwpx",
+      "pdf": "pdf/issue1770_rowsplit_tolerance-2024.pdf",
+      "stem": "issue1770_rowsplit_tolerance",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1835_tac_stale_height.hwp::pdf/issue1835_tac_stale_height-2022.pdf",
+      "sample": "samples/issue1835_tac_stale_height.hwp",
+      "pdf": "pdf/issue1835_tac_stale_height-2022.pdf",
+      "stem": "issue1835_tac_stale_height",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1853_caption_precedes_body_split.hwpx::pdf/issue1853_caption_precedes_body_split-2024.pdf",
+      "sample": "samples/issue1853_caption_precedes_body_split.hwpx",
+      "pdf": "pdf/issue1853_caption_precedes_body_split-2024.pdf",
+      "stem": "issue1853_caption_precedes_body_split",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1893_clickhere_field_roundtrip.hwpx::pdf/issue1893_clickhere_field_roundtrip-2022.pdf",
+      "sample": "samples/issue1893_clickhere_field_roundtrip.hwpx",
+      "pdf": "pdf/issue1893_clickhere_field_roundtrip-2022.pdf",
+      "stem": "issue1893_clickhere_field_roundtrip",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1921/59043_regulatory_analysis.hwp::pdf/issue1921/59043_regulatory_analysis-2022.pdf",
+      "sample": "samples/issue1921/59043_regulatory_analysis.hwp",
+      "pdf": "pdf/issue1921/59043_regulatory_analysis-2022.pdf",
+      "stem": "59043_regulatory_analysis",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1949_giant_cell_nested_tables_perf.hwp::pdf/issue1949_giant_cell_nested_tables_perf-2024.pdf",
+      "sample": "samples/issue1949_giant_cell_nested_tables_perf.hwp",
+      "pdf": "pdf/issue1949_giant_cell_nested_tables_perf-2024.pdf",
+      "stem": "issue1949_giant_cell_nested_tables_perf",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1949_giant_cell_nested_tables_perf.hwp::pdf/issue1949_giant_cell_nested_tables_perf-2020.pdf",
+      "sample": "samples/issue1949_giant_cell_nested_tables_perf.hwp",
+      "pdf": "pdf/issue1949_giant_cell_nested_tables_perf-2020.pdf",
+      "stem": "issue1949_giant_cell_nested_tables_perf",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1949_giant_cell_nested_tables_perf.hwpx::pdf/issue1949_giant_cell_nested_tables_perf-2024.pdf",
+      "sample": "samples/issue1949_giant_cell_nested_tables_perf.hwpx",
+      "pdf": "pdf/issue1949_giant_cell_nested_tables_perf-2024.pdf",
+      "stem": "issue1949_giant_cell_nested_tables_perf",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1949_giant_cell_nested_tables_perf.hwpx::pdf/issue1949_giant_cell_nested_tables_perf-2020.pdf",
+      "sample": "samples/issue1949_giant_cell_nested_tables_perf.hwpx",
+      "pdf": "pdf/issue1949_giant_cell_nested_tables_perf-2020.pdf",
+      "stem": "issue1949_giant_cell_nested_tables_perf",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue1950_hwp3_tab_charoffset.hwp::pdf/issue1950_hwp3_tab_charoffset-2024.pdf",
+      "sample": "samples/issue1950_hwp3_tab_charoffset.hwp",
+      "pdf": "pdf/issue1950_hwp3_tab_charoffset-2024.pdf",
+      "stem": "issue1950_hwp3_tab_charoffset",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2004_cell_image_stack.hwp::pdf/issue2004_cell_image_stack-2022.pdf",
+      "sample": "samples/issue2004_cell_image_stack.hwp",
+      "pdf": "pdf/issue2004_cell_image_stack-2022.pdf",
+      "stem": "issue2004_cell_image_stack",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2004_cell_image_stack.hwpx::pdf/issue2004_cell_image_stack-2022.pdf",
+      "sample": "samples/issue2004_cell_image_stack.hwpx",
+      "pdf": "pdf/issue2004_cell_image_stack-2022.pdf",
+      "stem": "issue2004_cell_image_stack",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2006/1790387_prep_final_report.hwpx::pdf-large/issue2006/1790387_prep_final_report-2022.pdf",
+      "sample": "samples/issue2006/1790387_prep_final_report.hwpx",
+      "pdf": "pdf-large/issue2006/1790387_prep_final_report-2022.pdf",
+      "stem": "1790387_prep_final_report",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf-large"
+    },
+    {
+      "id": "samples/issue2006/1790387_prep_final_report.hwpx::pdf/issue2006/1790387_prep_final_report-hwp2020-20260814.pdf",
+      "sample": "samples/issue2006/1790387_prep_final_report.hwpx",
+      "pdf": "pdf/issue2006/1790387_prep_final_report-hwp2020-20260814.pdf",
+      "stem": "1790387_prep_final_report",
+      "hancomVersion": "2020",
+      "variant": "hwp2020-20260814",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향.hwp::pdf/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향-hwp-2022.pdf",
+      "sample": "samples/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향.hwp",
+      "pdf": "pdf/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향-hwp-2022.pdf",
+      "stem": "(250813) (보도자료) 2025년 7월중 가계대출 동향",
+      "hancomVersion": "2022",
+      "variant": "hwp-2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향.hwpx::pdf/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향-hwpx-2022.pdf",
+      "sample": "samples/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향.hwpx",
+      "pdf": "pdf/issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향-hwpx-2022.pdf",
+      "stem": "(250813) (보도자료) 2025년 7월중 가계대출 동향",
+      "hancomVersion": "2022",
+      "variant": "hwpx-2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2020/passport_application_lawgo.hwp::pdf/issue2020/passport_application_lawgo-2022.pdf",
+      "sample": "samples/issue2020/passport_application_lawgo.hwp",
+      "pdf": "pdf/issue2020/passport_application_lawgo-2022.pdf",
+      "stem": "passport_application_lawgo",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2063_huge_cellbreak_table.hwp::pdf/issue2063_huge_cellbreak_table-2020.pdf",
+      "sample": "samples/issue2063_huge_cellbreak_table.hwp",
+      "pdf": "pdf/issue2063_huge_cellbreak_table-2020.pdf",
+      "stem": "issue2063_huge_cellbreak_table",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2083_hide_fill_page.hwpx::pdf/issue2083_hide_fill_page-2020.pdf",
+      "sample": "samples/issue2083_hide_fill_page.hwpx",
+      "pdf": "pdf/issue2083_hide_fill_page-2020.pdf",
+      "stem": "issue2083_hide_fill_page",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2164/의견제출서(양식).hwp::pdf/issue2164/의견제출서(양식)-2020.pdf",
+      "sample": "samples/issue2164/의견제출서(양식).hwp",
+      "pdf": "pdf/issue2164/의견제출서(양식)-2020.pdf",
+      "stem": "의견제출서(양식)",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2217/20200830.hwp::pdf/issue2217/20200830-2020.pdf",
+      "sample": "samples/issue2217/20200830.hwp",
+      "pdf": "pdf/issue2217/20200830-2020.pdf",
+      "stem": "20200830",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2373/156689818_kftc_press.hwpx::pdf/issue2373/156689818_kftc_press-2020.pdf",
+      "sample": "samples/issue2373/156689818_kftc_press.hwpx",
+      "pdf": "pdf/issue2373/156689818_kftc_press-2020.pdf",
+      "stem": "156689818_kftc_press",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2470/36341511_masked.hwpx::pdf/issue2470/36341511_masked-2022.pdf",
+      "sample": "samples/issue2470/36341511_masked.hwpx",
+      "pdf": "pdf/issue2470/36341511_masked-2022.pdf",
+      "stem": "36341511_masked",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2470/36382471_masked.hwpx::pdf/issue2470/36382471_masked-2022.pdf",
+      "sample": "samples/issue2470/36382471_masked.hwpx",
+      "pdf": "pdf/issue2470/36382471_masked-2022.pdf",
+      "stem": "36382471_masked",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2559/1341000_research_report_footnotes.hwp::pdf/issue2559/1341000_research_report_footnotes-2020-print.pdf",
+      "sample": "samples/issue2559/1341000_research_report_footnotes.hwp",
+      "pdf": "pdf/issue2559/1341000_research_report_footnotes-2020-print.pdf",
+      "stem": "1341000_research_report_footnotes",
+      "hancomVersion": "2020",
+      "variant": "2020-print",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2808_report_physical_ladder.hwp::pdf/issue2808_report_physical_ladder-2020.pdf",
+      "sample": "samples/issue2808_report_physical_ladder.hwp",
+      "pdf": "pdf/issue2808_report_physical_ladder-2020.pdf",
+      "stem": "issue2808_report_physical_ladder",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2808_single_table_form_physical_ladder.hwpx::pdf/issue2808_single_table_form_physical_ladder-2020.pdf",
+      "sample": "samples/issue2808_single_table_form_physical_ladder.hwpx",
+      "pdf": "pdf/issue2808_single_table_form_physical_ladder-2020.pdf",
+      "stem": "issue2808_single_table_form_physical_ladder",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2813/dangjik_dutylog.hwpx::pdf/issue2813/dangjik_dutylog-2020.pdf",
+      "sample": "samples/issue2813/dangjik_dutylog.hwpx",
+      "pdf": "pdf/issue2813/dangjik_dutylog-2020.pdf",
+      "stem": "dangjik_dutylog",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2816/imgbrush_total_page_fill.hwpx::pdf/issue2816/imgbrush_total_page_fill-2020.pdf",
+      "sample": "samples/issue2816/imgbrush_total_page_fill.hwpx",
+      "pdf": "pdf/issue2816/imgbrush_total_page_fill-2020.pdf",
+      "stem": "imgbrush_total_page_fill",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue2817/paper_anchor_infront_pic.hwpx::pdf/issue2817/paper_anchor_infront_pic-2020.pdf",
+      "sample": "samples/issue2817/paper_anchor_infront_pic.hwpx",
+      "pdf": "pdf/issue2817/paper_anchor_infront_pic-2020.pdf",
+      "stem": "paper_anchor_infront_pic",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3239/evaluation_form_200dpi_scan.hwp::pdf/issue3239/evaluation_form_200dpi_scan-2020.pdf",
+      "sample": "samples/issue3239/evaluation_form_200dpi_scan.hwp",
+      "pdf": "pdf/issue3239/evaluation_form_200dpi_scan-2020.pdf",
+      "stem": "evaluation_form_200dpi_scan",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3257/webhangul_product_spec_v1.1.hwp::pdf/issue3257/webhangul_product_spec_v1.1-2020.pdf",
+      "sample": "samples/issue3257/webhangul_product_spec_v1.1.hwp",
+      "pdf": "pdf/issue3257/webhangul_product_spec_v1.1-2020.pdf",
+      "stem": "webhangul_product_spec_v1.1",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3460/svg_picture_repro.hwpx::pdf/issue3460/svg_picture_repro-2020.pdf",
+      "sample": "samples/issue3460/svg_picture_repro.hwpx",
+      "pdf": "pdf/issue3460/svg_picture_repro-2020.pdf",
+      "stem": "svg_picture_repro",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3637/press_release_split_cell_nested_table.hwpx::pdf/issue3637/press_release_split_cell_nested_table-2020.pdf",
+      "sample": "samples/issue3637/press_release_split_cell_nested_table.hwpx",
+      "pdf": "pdf/issue3637/press_release_split_cell_nested_table-2020.pdf",
+      "stem": "press_release_split_cell_nested_table",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3637/press_release_topbottom_float.hwpx::pdf/issue3637/press_release_topbottom_float-2020.pdf",
+      "sample": "samples/issue3637/press_release_topbottom_float.hwpx",
+      "pdf": "pdf/issue3637/press_release_topbottom_float-2020.pdf",
+      "stem": "press_release_topbottom_float",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3765/zone_switch_ladder_understates_page.hwpx::pdf/issue3765/zone_switch_ladder_understates_page-2020.pdf",
+      "sample": "samples/issue3765/zone_switch_ladder_understates_page.hwpx",
+      "pdf": "pdf/issue3765/zone_switch_ladder_understates_page-2020.pdf",
+      "stem": "zone_switch_ladder_understates_page",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue3837/stored_vpos_rewind_form.hwp::pdf/issue3837/stored_vpos_rewind_form-2020.pdf",
+      "sample": "samples/issue3837/stored_vpos_rewind_form.hwp",
+      "pdf": "pdf/issue3837/stored_vpos_rewind_form-2020.pdf",
+      "stem": "stored_vpos_rewind_form",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue4514/sample1-repro.hwp::pdf/issue4514/sample1-repro-2020.pdf",
+      "sample": "samples/issue4514/sample1-repro.hwp",
+      "pdf": "pdf/issue4514/sample1-repro-2020.pdf",
+      "stem": "sample1-repro",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue4889/18098267_nested_fragment_origin.hwp::pdf/issue4889/18098267_nested_fragment_origin-2020.pdf",
+      "sample": "samples/issue4889/18098267_nested_fragment_origin.hwp",
+      "pdf": "pdf/issue4889/18098267_nested_fragment_origin-2020.pdf",
+      "stem": "18098267_nested_fragment_origin",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/issue_265.hwp::pdf/issue_265-2022.pdf",
+      "sample": "samples/issue_265.hwp",
+      "pdf": "pdf/issue_265-2022.pdf",
+      "stem": "issue_265",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/k-water-rfp-2024.hwp::pdf/k-water-rfp-2024.pdf",
+      "sample": "samples/k-water-rfp-2024.hwp",
+      "pdf": "pdf/k-water-rfp-2024.pdf",
+      "stem": "k-water-rfp-2024",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/k-water-rfp.hwp::pdf/k-water-rfp-2024.pdf",
+      "sample": "samples/k-water-rfp.hwp",
+      "pdf": "pdf/k-water-rfp-2024.pdf",
+      "stem": "k-water-rfp",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/k-water-rfp.hwp::pdf/k-water-rfp-2022.pdf",
+      "sample": "samples/k-water-rfp.hwp",
+      "pdf": "pdf/k-water-rfp-2022.pdf",
+      "stem": "k-water-rfp",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/kps-ai.hwp::pdf/kps-ai-2022.pdf",
+      "sample": "samples/kps-ai.hwp",
+      "pdf": "pdf/kps-ai-2022.pdf",
+      "stem": "kps-ai",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/KTX.hwp::pdf/KTX-2022.pdf",
+      "sample": "samples/KTX.hwp",
+      "pdf": "pdf/KTX-2022.pdf",
+      "stem": "KTX",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/loading-fail-01.hwp::pdf/loading-fail-01-2022.pdf",
+      "sample": "samples/loading-fail-01.hwp",
+      "pdf": "pdf/loading-fail-01-2022.pdf",
+      "stem": "loading-fail-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/lseg-01-basic.hwp::pdf/lseg-01-basic-2022.pdf",
+      "sample": "samples/lseg-01-basic.hwp",
+      "pdf": "pdf/lseg-01-basic-2022.pdf",
+      "stem": "lseg-01-basic",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/lseg-02-mixed.hwp::pdf/lseg-02-mixed-2022.pdf",
+      "sample": "samples/lseg-02-mixed.hwp",
+      "pdf": "pdf/lseg-02-mixed-2022.pdf",
+      "stem": "lseg-02-mixed",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/lseg-03-spacing.hwp::pdf/lseg-03-spacing-2022.pdf",
+      "sample": "samples/lseg-03-spacing.hwp",
+      "pdf": "pdf/lseg-03-spacing-2022.pdf",
+      "stem": "lseg-03-spacing",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/lseg-04-indent.hwp::pdf/lseg-04-indent-2022.pdf",
+      "sample": "samples/lseg-04-indent.hwp",
+      "pdf": "pdf/lseg-04-indent-2022.pdf",
+      "stem": "lseg-04-indent",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/lseg-05-tab.hwp::pdf/lseg-05-tab-2022.pdf",
+      "sample": "samples/lseg-05-tab.hwp",
+      "pdf": "pdf/lseg-05-tab-2022.pdf",
+      "stem": "lseg-05-tab",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/lseg-06-multisize.hwp::pdf/lseg-06-multisize-2022.pdf",
+      "sample": "samples/lseg-06-multisize.hwp",
+      "pdf": "pdf/lseg-06-multisize-2022.pdf",
+      "stem": "lseg-06-multisize",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/mel-001.hwp::pdf/mel-001-2022.pdf",
+      "sample": "samples/mel-001.hwp",
+      "pdf": "pdf/mel-001-2022.pdf",
+      "stem": "mel-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/mix-shape-01.hwp::pdf/mix-shape-01-2022.pdf",
+      "sample": "samples/mix-shape-01.hwp",
+      "pdf": "pdf/mix-shape-01-2022.pdf",
+      "stem": "mix-shape-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/multi-table-001.hwp::pdf/multi-table-001-2022.pdf",
+      "sample": "samples/multi-table-001.hwp",
+      "pdf": "pdf/multi-table-001-2022.pdf",
+      "stem": "multi-table-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/multi-table-002.hwp::pdf/multi-table-002-2022.pdf",
+      "sample": "samples/multi-table-002.hwp",
+      "pdf": "pdf/multi-table-002-2022.pdf",
+      "stem": "multi-table-002",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/p122.hwp::pdf/p122-2022.pdf",
+      "sample": "samples/p122.hwp",
+      "pdf": "pdf/p122-2022.pdf",
+      "stem": "p122",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pic-crop-01.hwp::pdf/pic-crop-01-2022.pdf",
+      "sample": "samples/pic-crop-01.hwp",
+      "pdf": "pdf/pic-crop-01-2022.pdf",
+      "stem": "pic-crop-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pic-in-head-01.hwp::pdf/pic-in-head-01-2022.pdf",
+      "sample": "samples/pic-in-head-01.hwp",
+      "pdf": "pdf/pic-in-head-01-2022.pdf",
+      "stem": "pic-in-head-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pic-in-head-02.hwp::pdf/pic-in-head-02-2022.pdf",
+      "sample": "samples/pic-in-head-02.hwp",
+      "pdf": "pdf/pic-in-head-02-2022.pdf",
+      "stem": "pic-in-head-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pic-in-table-01.hwp::pdf/pic-in-table-01-2022.pdf",
+      "sample": "samples/pic-in-table-01.hwp",
+      "pdf": "pdf/pic-in-table-01-2022.pdf",
+      "stem": "pic-in-table-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pic2.hwp::pdf/pic2-2022.pdf",
+      "sample": "samples/pic2.hwp",
+      "pdf": "pdf/pic2-2022.pdf",
+      "stem": "pic2",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pic2.hwpx::pdf/pic2-2022.pdf",
+      "sample": "samples/pic2.hwpx",
+      "pdf": "pdf/pic2-2022.pdf",
+      "stem": "pic2",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pr-149.hwp::pdf/pr-149-2022.pdf",
+      "sample": "samples/pr-149.hwp",
+      "pdf": "pdf/pr-149-2022.pdf",
+      "stem": "pr-149",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pr-1674.hwp::pdf/pr-1674-2024.pdf",
+      "sample": "samples/pr-1674.hwp",
+      "pdf": "pdf/pr-1674-2024.pdf",
+      "stem": "pr-1674",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/pr-1674.hwp::pdf-2020/pr-1674-2020.pdf",
+      "sample": "samples/pr-1674.hwp",
+      "pdf": "pdf-2020/pr-1674-2020.pdf",
+      "stem": "pr-1674",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf-2020"
+    },
+    {
+      "id": "samples/pua-test.hwp::pdf/pua-test-2022.pdf",
+      "sample": "samples/pua-test.hwp",
+      "pdf": "pdf/pua-test-2022.pdf",
+      "stem": "pua-test",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-01-hangul-only-empty-hancom.hwp::pdf/re-01-hangul-only-empty-hancom-2022.pdf",
+      "sample": "samples/re-01-hangul-only-empty-hancom.hwp",
+      "pdf": "pdf/re-01-hangul-only-empty-hancom-2022.pdf",
+      "stem": "re-01-hangul-only-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-01-hangul-only-hancom.hwp::pdf/re-01-hangul-only-hancom-2022.pdf",
+      "sample": "samples/re-01-hangul-only-hancom.hwp",
+      "pdf": "pdf/re-01-hangul-only-hancom-2022.pdf",
+      "stem": "re-01-hangul-only-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-02-space-count-empty-hancom.hwp::pdf/re-02-space-count-empty-hancom-2022.pdf",
+      "sample": "samples/re-02-space-count-empty-hancom.hwp",
+      "pdf": "pdf/re-02-space-count-empty-hancom-2022.pdf",
+      "stem": "re-02-space-count-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-02-space-count-hancom.hwp::pdf/re-02-space-count-hancom-2022.pdf",
+      "sample": "samples/re-02-space-count-hancom.hwp",
+      "pdf": "pdf/re-02-space-count-hancom-2022.pdf",
+      "stem": "re-02-space-count-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-03-latin-only-empty-hancom.hwp::pdf/re-03-latin-only-empty-hancom-2022.pdf",
+      "sample": "samples/re-03-latin-only-empty-hancom.hwp",
+      "pdf": "pdf/re-03-latin-only-empty-hancom-2022.pdf",
+      "stem": "re-03-latin-only-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-03-latin-only-hancom.hwp::pdf/re-03-latin-only-hancom-2022.pdf",
+      "sample": "samples/re-03-latin-only-hancom.hwp",
+      "pdf": "pdf/re-03-latin-only-hancom-2022.pdf",
+      "stem": "re-03-latin-only-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-04-digit-only-empty-hancom.hwp::pdf/re-04-digit-only-empty-hancom-2022.pdf",
+      "sample": "samples/re-04-digit-only-empty-hancom.hwp",
+      "pdf": "pdf/re-04-digit-only-empty-hancom-2022.pdf",
+      "stem": "re-04-digit-only-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-04-digit-only-hancom.hwp::pdf/re-04-digit-only-hancom-2022.pdf",
+      "sample": "samples/re-04-digit-only-hancom.hwp",
+      "pdf": "pdf/re-04-digit-only-hancom-2022.pdf",
+      "stem": "re-04-digit-only-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-05-mixed-koen-empty-hancom.hwp::pdf/re-05-mixed-koen-empty-hancom-2022.pdf",
+      "sample": "samples/re-05-mixed-koen-empty-hancom.hwp",
+      "pdf": "pdf/re-05-mixed-koen-empty-hancom-2022.pdf",
+      "stem": "re-05-mixed-koen-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-05-mixed-koen-hancom.hwp::pdf/re-05-mixed-koen-hancom-2022.pdf",
+      "sample": "samples/re-05-mixed-koen-hancom.hwp",
+      "pdf": "pdf/re-05-mixed-koen-hancom-2022.pdf",
+      "stem": "re-05-mixed-koen-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-06-punctuation-empty-hancom.hwp::pdf/re-06-punctuation-empty-hancom-2022.pdf",
+      "sample": "samples/re-06-punctuation-empty-hancom.hwp",
+      "pdf": "pdf/re-06-punctuation-empty-hancom-2022.pdf",
+      "stem": "re-06-punctuation-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-06-punctuation-hancom.hwp::pdf/re-06-punctuation-hancom-2022.pdf",
+      "sample": "samples/re-06-punctuation-hancom.hwp",
+      "pdf": "pdf/re-06-punctuation-hancom-2022.pdf",
+      "stem": "re-06-punctuation-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-center-empty-hancom.hwp::pdf/re-align-center-empty-hancom-2022.pdf",
+      "sample": "samples/re-align-center-empty-hancom.hwp",
+      "pdf": "pdf/re-align-center-empty-hancom-2022.pdf",
+      "stem": "re-align-center-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-center-hancom.hwp::pdf/re-align-center-hancom-2022.pdf",
+      "sample": "samples/re-align-center-hancom.hwp",
+      "pdf": "pdf/re-align-center-hancom-2022.pdf",
+      "stem": "re-align-center-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-justify-empty-hancom.hwp::pdf/re-align-justify-empty-hancom-2022.pdf",
+      "sample": "samples/re-align-justify-empty-hancom.hwp",
+      "pdf": "pdf/re-align-justify-empty-hancom-2022.pdf",
+      "stem": "re-align-justify-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-justify-hancom.hwp::pdf/re-align-justify-hancom-2022.pdf",
+      "sample": "samples/re-align-justify-hancom.hwp",
+      "pdf": "pdf/re-align-justify-hancom-2022.pdf",
+      "stem": "re-align-justify-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-left-empty-hancom.hwp::pdf/re-align-left-empty-hancom-2022.pdf",
+      "sample": "samples/re-align-left-empty-hancom.hwp",
+      "pdf": "pdf/re-align-left-empty-hancom-2022.pdf",
+      "stem": "re-align-left-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-left-hancom.hwp::pdf/re-align-left-hancom-2022.pdf",
+      "sample": "samples/re-align-left-hancom.hwp",
+      "pdf": "pdf/re-align-left-hancom-2022.pdf",
+      "stem": "re-align-left-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-right-empty-hancom.hwp::pdf/re-align-right-empty-hancom-2022.pdf",
+      "sample": "samples/re-align-right-empty-hancom.hwp",
+      "pdf": "pdf/re-align-right-empty-hancom-2022.pdf",
+      "stem": "re-align-right-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-align-right-hancom.hwp::pdf/re-align-right-hancom-2022.pdf",
+      "sample": "samples/re-align-right-hancom.hwp",
+      "pdf": "pdf/re-align-right-hancom-2022.pdf",
+      "stem": "re-align-right-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-batang-arial-empty-hancom.hwp::pdf/re-eng-mixed-batang-arial-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-batang-arial-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-batang-arial-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-batang-arial-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-batang-empty-hancom.hwp::pdf/re-eng-mixed-batang-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-batang-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-batang-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-batang-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-batangche-empty-hancom.hwp::pdf/re-eng-mixed-batangche-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-batangche-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-batangche-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-batangche-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-dotum-empty-hancom.hwp::pdf/re-eng-mixed-dotum-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-dotum-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-dotum-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-dotum-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-dotum-times-empty-hancom.hwp::pdf/re-eng-mixed-dotum-times-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-dotum-times-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-dotum-times-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-dotum-times-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-malgun-courier-empty-hancom.hwp::pdf/re-eng-mixed-malgun-courier-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-malgun-courier-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-malgun-courier-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-malgun-courier-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-malgun-empty-hancom.hwp::pdf/re-eng-mixed-malgun-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-malgun-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-malgun-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-malgun-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-mixed-malgun-times-empty-hancom.hwp::pdf/re-eng-mixed-malgun-times-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-mixed-malgun-times-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-mixed-malgun-times-empty-hancom-2022.pdf",
+      "stem": "re-eng-mixed-malgun-times-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-batang-arial-empty-hancom.hwp::pdf/re-eng-nospace-batang-arial-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-batang-arial-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-batang-arial-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-batang-arial-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-batang-empty-hancom.hwp::pdf/re-eng-nospace-batang-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-batang-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-batang-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-batang-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-batangche-empty-hancom.hwp::pdf/re-eng-nospace-batangche-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-batangche-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-batangche-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-batangche-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-dotum-empty-hancom.hwp::pdf/re-eng-nospace-dotum-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-dotum-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-dotum-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-dotum-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-dotum-times-empty-hancom.hwp::pdf/re-eng-nospace-dotum-times-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-dotum-times-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-dotum-times-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-dotum-times-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-malgun-courier-empty-hancom.hwp::pdf/re-eng-nospace-malgun-courier-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-malgun-courier-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-malgun-courier-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-malgun-courier-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-malgun-empty-hancom.hwp::pdf/re-eng-nospace-malgun-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-malgun-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-malgun-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-malgun-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-nospace-malgun-times-empty-hancom.hwp::pdf/re-eng-nospace-malgun-times-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-nospace-malgun-times-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-nospace-malgun-times-empty-hancom-2022.pdf",
+      "stem": "re-eng-nospace-malgun-times-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-batang-arial-empty-hancom.hwp::pdf/re-eng-words-batang-arial-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-batang-arial-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-batang-arial-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-batang-arial-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-batang-empty-hancom.hwp::pdf/re-eng-words-batang-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-batang-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-batang-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-batang-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-batangche-empty-hancom.hwp::pdf/re-eng-words-batangche-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-batangche-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-batangche-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-batangche-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-dotum-empty-hancom.hwp::pdf/re-eng-words-dotum-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-dotum-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-dotum-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-dotum-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-dotum-times-empty-hancom.hwp::pdf/re-eng-words-dotum-times-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-dotum-times-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-dotum-times-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-dotum-times-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-malgun-courier-empty-hancom.hwp::pdf/re-eng-words-malgun-courier-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-malgun-courier-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-malgun-courier-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-malgun-courier-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-malgun-empty-hancom.hwp::pdf/re-eng-words-malgun-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-malgun-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-malgun-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-malgun-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-eng-words-malgun-times-empty-hancom.hwp::pdf/re-eng-words-malgun-times-empty-hancom-2022.pdf",
+      "sample": "samples/re-eng-words-malgun-times-empty-hancom.hwp",
+      "pdf": "pdf/re-eng-words-malgun-times-empty-hancom-2022.pdf",
+      "stem": "re-eng-words-malgun-times-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-batang-empty-hancom.hwp::pdf/re-font-batang-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-batang-empty-hancom.hwp",
+      "pdf": "pdf/re-font-batang-empty-hancom-2022.pdf",
+      "stem": "re-font-batang-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-batang-hancom.hwp::pdf/re-font-batang-hancom-2022.pdf",
+      "sample": "samples/re-font-batang-hancom.hwp",
+      "pdf": "pdf/re-font-batang-hancom-2022.pdf",
+      "stem": "re-font-batang-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-batangche-empty-hancom.hwp::pdf/re-font-batangche-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-batangche-empty-hancom.hwp",
+      "pdf": "pdf/re-font-batangche-empty-hancom-2022.pdf",
+      "stem": "re-font-batangche-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-batangche-hancom.hwp::pdf/re-font-batangche-hancom-2022.pdf",
+      "sample": "samples/re-font-batangche-hancom.hwp",
+      "pdf": "pdf/re-font-batangche-hancom-2022.pdf",
+      "stem": "re-font-batangche-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-dotum-empty-hancom.hwp::pdf/re-font-dotum-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-dotum-empty-hancom.hwp",
+      "pdf": "pdf/re-font-dotum-empty-hancom-2022.pdf",
+      "stem": "re-font-dotum-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-dotum-hancom.hwp::pdf/re-font-dotum-hancom-2022.pdf",
+      "sample": "samples/re-font-dotum-hancom.hwp",
+      "pdf": "pdf/re-font-dotum-hancom-2022.pdf",
+      "stem": "re-font-dotum-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-dotumche-empty-hancom.hwp::pdf/re-font-dotumche-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-dotumche-empty-hancom.hwp",
+      "pdf": "pdf/re-font-dotumche-empty-hancom-2022.pdf",
+      "stem": "re-font-dotumche-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-dotumche-hancom.hwp::pdf/re-font-dotumche-hancom-2022.pdf",
+      "sample": "samples/re-font-dotumche-hancom.hwp",
+      "pdf": "pdf/re-font-dotumche-hancom-2022.pdf",
+      "stem": "re-font-dotumche-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-gulim-empty-hancom.hwp::pdf/re-font-gulim-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-gulim-empty-hancom.hwp",
+      "pdf": "pdf/re-font-gulim-empty-hancom-2022.pdf",
+      "stem": "re-font-gulim-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-gulim-hancom.hwp::pdf/re-font-gulim-hancom-2022.pdf",
+      "sample": "samples/re-font-gulim-hancom.hwp",
+      "pdf": "pdf/re-font-gulim-hancom-2022.pdf",
+      "stem": "re-font-gulim-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-gulimche-empty-hancom.hwp::pdf/re-font-gulimche-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-gulimche-empty-hancom.hwp",
+      "pdf": "pdf/re-font-gulimche-empty-hancom-2022.pdf",
+      "stem": "re-font-gulimche-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-gulimche-hancom.hwp::pdf/re-font-gulimche-hancom-2022.pdf",
+      "sample": "samples/re-font-gulimche-hancom.hwp",
+      "pdf": "pdf/re-font-gulimche-hancom-2022.pdf",
+      "stem": "re-font-gulimche-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-malgun-empty-hancom.hwp::pdf/re-font-malgun-empty-hancom-2022.pdf",
+      "sample": "samples/re-font-malgun-empty-hancom.hwp",
+      "pdf": "pdf/re-font-malgun-empty-hancom-2022.pdf",
+      "stem": "re-font-malgun-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-font-malgun-hancom.hwp::pdf/re-font-malgun-hancom-2022.pdf",
+      "sample": "samples/re-font-malgun-hancom.hwp",
+      "pdf": "pdf/re-font-malgun-hancom-2022.pdf",
+      "stem": "re-font-malgun-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-mixed-0tr-empty-hancom.hwp::pdf/re-mixed-0tr-empty-hancom-2022.pdf",
+      "sample": "samples/re-mixed-0tr-empty-hancom.hwp",
+      "pdf": "pdf/re-mixed-0tr-empty-hancom-2022.pdf",
+      "stem": "re-mixed-0tr-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-mixed-1tr-empty-hancom.hwp::pdf/re-mixed-1tr-empty-hancom-2022.pdf",
+      "sample": "samples/re-mixed-1tr-empty-hancom.hwp",
+      "pdf": "pdf/re-mixed-1tr-empty-hancom-2022.pdf",
+      "stem": "re-mixed-1tr-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-mixed-2tr-empty-hancom.hwp::pdf/re-mixed-2tr-empty-hancom-2022.pdf",
+      "sample": "samples/re-mixed-2tr-empty-hancom.hwp",
+      "pdf": "pdf/re-mixed-2tr-empty-hancom-2022.pdf",
+      "stem": "re-mixed-2tr-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-mixed-malgun-timesnew-hancom.hwp::pdf/re-mixed-malgun-timesnew-hancom-2022.pdf",
+      "sample": "samples/re-mixed-malgun-timesnew-hancom.hwp",
+      "pdf": "pdf/re-mixed-malgun-timesnew-hancom-2022.pdf",
+      "stem": "re-mixed-malgun-timesnew-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-multisize-10-10-empty-hancom.hwp::pdf/re-multisize-10-10-empty-hancom-2022.pdf",
+      "sample": "samples/re-multisize-10-10-empty-hancom.hwp",
+      "pdf": "pdf/re-multisize-10-10-empty-hancom-2022.pdf",
+      "stem": "re-multisize-10-10-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-multisize-10-20-empty-hancom.hwp::pdf/re-multisize-10-20-empty-hancom-2022.pdf",
+      "sample": "samples/re-multisize-10-20-empty-hancom.hwp",
+      "pdf": "pdf/re-multisize-10-20-empty-hancom-2022.pdf",
+      "stem": "re-multisize-10-20-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/re-multisize-8-14-empty-hancom.hwp::pdf/re-multisize-8-14-empty-hancom-2022.pdf",
+      "sample": "samples/re-multisize-8-14-empty-hancom.hwp",
+      "pdf": "pdf/re-multisize-8-14-empty-hancom-2022.pdf",
+      "stem": "re-multisize-8-14-empty-hancom",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/rowbreak-problem-pages.hwp::pdf/rowbreak-problem-pages-2024.pdf",
+      "sample": "samples/rowbreak-problem-pages.hwp",
+      "pdf": "pdf/rowbreak-problem-pages-2024.pdf",
+      "stem": "rowbreak-problem-pages",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/rowbreak-problem-pages.hwpx::pdf/rowbreak-problem-pages-2024.pdf",
+      "sample": "samples/rowbreak-problem-pages.hwpx",
+      "pdf": "pdf/rowbreak-problem-pages-2024.pdf",
+      "stem": "rowbreak-problem-pages",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/shape-group-02.hwp::pdf/shape-group-02-2022.pdf",
+      "sample": "samples/shape-group-02.hwp",
+      "pdf": "pdf/shape-group-02-2022.pdf",
+      "stem": "shape-group-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/shift-return.hwp::pdf/shift-return-2022.pdf",
+      "sample": "samples/shift-return.hwp",
+      "pdf": "pdf/shift-return-2022.pdf",
+      "stem": "shift-return",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/SO-SUEOP.hwp::pdf/SO-SUEOP-2024.pdf",
+      "sample": "samples/SO-SUEOP.hwp",
+      "pdf": "pdf/SO-SUEOP-2024.pdf",
+      "stem": "SO-SUEOP",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/SO-SUEOP.hwpx::pdf/SO-SUEOP-2024.pdf",
+      "sample": "samples/SO-SUEOP.hwpx",
+      "pdf": "pdf/SO-SUEOP-2024.pdf",
+      "stem": "SO-SUEOP",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/synam-001.hwp::pdf/synam-001-2022.pdf",
+      "sample": "samples/synam-001.hwp",
+      "pdf": "pdf/synam-001-2022.pdf",
+      "stem": "synam-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/ta-pic-001-r-쪽영역안제한.hwp::pdf/ta-pic-001-r-쪽영역안제한-2024.pdf",
+      "sample": "samples/ta-pic-001-r-쪽영역안제한.hwp",
+      "pdf": "pdf/ta-pic-001-r-쪽영역안제한-2024.pdf",
+      "stem": "ta-pic-001-r-쪽영역안제한",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/ta-pic-001-r-쪽영역안제한.hwpx::pdf/ta-pic-001-r-쪽영역안제한-2024.pdf",
+      "sample": "samples/ta-pic-001-r-쪽영역안제한.hwpx",
+      "pdf": "pdf/ta-pic-001-r-쪽영역안제한-2024.pdf",
+      "stem": "ta-pic-001-r-쪽영역안제한",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/ta-pic-001-r-쪽영역안제한no.hwp::pdf/ta-pic-001-r-쪽영역안제한no-2024.pdf",
+      "sample": "samples/ta-pic-001-r-쪽영역안제한no.hwp",
+      "pdf": "pdf/ta-pic-001-r-쪽영역안제한no-2024.pdf",
+      "stem": "ta-pic-001-r-쪽영역안제한no",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/ta-pic-001-r-쪽영역안제한no.hwpx::pdf/ta-pic-001-r-쪽영역안제한no-2024.pdf",
+      "sample": "samples/ta-pic-001-r-쪽영역안제한no.hwpx",
+      "pdf": "pdf/ta-pic-001-r-쪽영역안제한no-2024.pdf",
+      "stem": "ta-pic-001-r-쪽영역안제한no",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-001.hwp::pdf/table-001-2022.pdf",
+      "sample": "samples/table-001.hwp",
+      "pdf": "pdf/table-001-2022.pdf",
+      "stem": "table-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-004.hwp::pdf/table-004-2022.pdf",
+      "sample": "samples/table-004.hwp",
+      "pdf": "pdf/table-004-2022.pdf",
+      "stem": "table-004",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-complex.hwp::pdf/table-complex-2022.pdf",
+      "sample": "samples/table-complex.hwp",
+      "pdf": "pdf/table-complex-2022.pdf",
+      "stem": "table-complex",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-in-tbox.hwp::pdf/table-in-tbox-2022.pdf",
+      "sample": "samples/table-in-tbox.hwp",
+      "pdf": "pdf/table-in-tbox-2022.pdf",
+      "stem": "table-in-tbox",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-ipc.hwp::pdf/table-ipc-2022.pdf",
+      "sample": "samples/table-ipc.hwp",
+      "pdf": "pdf/table-ipc-2022.pdf",
+      "stem": "table-ipc",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-vpos-01.hwp::pdf/table-vpos-01-2022.pdf",
+      "sample": "samples/table-vpos-01.hwp",
+      "pdf": "pdf/table-vpos-01-2022.pdf",
+      "stem": "table-vpos-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table-vpos-01.hwpx::pdf/table-vpos-01-2022.pdf",
+      "sample": "samples/table-vpos-01.hwpx",
+      "pdf": "pdf/table-vpos-01-2022.pdf",
+      "stem": "table-vpos-01",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table_giant_cell_overfill.hwpx::pdf/table_giant_cell_overfill-2024.pdf",
+      "sample": "samples/table_giant_cell_overfill.hwpx",
+      "pdf": "pdf/table_giant_cell_overfill-2024.pdf",
+      "stem": "table_giant_cell_overfill",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table_scattered_header_rowbreak.hwp::pdf/table_scattered_header_rowbreak-2024.pdf",
+      "sample": "samples/table_scattered_header_rowbreak.hwp",
+      "pdf": "pdf/table_scattered_header_rowbreak-2024.pdf",
+      "stem": "table_scattered_header_rowbreak",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/table_text_anchor_wrap.hwpx::pdf/table_text_anchor_wrap-2024.pdf",
+      "sample": "samples/table_text_anchor_wrap.hwpx",
+      "pdf": "pdf/table_text_anchor_wrap-2024.pdf",
+      "stem": "table_text_anchor_wrap",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-case-001.hwp::pdf/tac-case-001-2022.pdf",
+      "sample": "samples/tac-case-001.hwp",
+      "pdf": "pdf/tac-case-001-2022.pdf",
+      "stem": "tac-case-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-case-002.hwp::pdf/tac-case-002-2022.pdf",
+      "sample": "samples/tac-case-002.hwp",
+      "pdf": "pdf/tac-case-002-2022.pdf",
+      "stem": "tac-case-002",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-case-003.hwp::pdf/tac-case-003-2022.pdf",
+      "sample": "samples/tac-case-003.hwp",
+      "pdf": "pdf/tac-case-003-2022.pdf",
+      "stem": "tac-case-003",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-case-004.hwp::pdf/tac-case-004-2022.pdf",
+      "sample": "samples/tac-case-004.hwp",
+      "pdf": "pdf/tac-case-004-2022.pdf",
+      "stem": "tac-case-004",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-case-005.hwp::pdf/tac-case-005-2022.pdf",
+      "sample": "samples/tac-case-005.hwp",
+      "pdf": "pdf/tac-case-005-2022.pdf",
+      "stem": "tac-case-005",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-img-02.hwp::pdf/tac-img-02-2022.pdf",
+      "sample": "samples/tac-img-02.hwp",
+      "pdf": "pdf/tac-img-02-2022.pdf",
+      "stem": "tac-img-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/tac-img-02.hwpx::pdf/tac-img-02-2022.pdf",
+      "sample": "samples/tac-img-02.hwpx",
+      "pdf": "pdf/tac-img-02-2022.pdf",
+      "stem": "tac-img-02",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task-001.hwp::pdf/task-001-2022.pdf",
+      "sample": "samples/task-001.hwp",
+      "pdf": "pdf/task-001-2022.pdf",
+      "stem": "task-001",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp::pdf/task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사-2022.pdf",
+      "sample": "samples/task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp",
+      "pdf": "pdf/task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사-2022.pdf",
+      "stem": "1130000-201900011_D0150004-1-002_2017년기준 시장구조조사",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2093/1192000_hydrogen_policy_research.hwp::pdf/task2093/1192000_hydrogen_policy_research-2022.pdf",
+      "sample": "samples/task2093/1192000_hydrogen_policy_research.hwp",
+      "pdf": "pdf/task2093/1192000_hydrogen_policy_research-2022.pdf",
+      "stem": "1192000_hydrogen_policy_research",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2093/saved_single_line_spacing_after.hwpx::pdf/task2093/saved_single_line_spacing_after-2022.pdf",
+      "sample": "samples/task2093/saved_single_line_spacing_after.hwpx",
+      "pdf": "pdf/task2093/saved_single_line_spacing_after-2022.pdf",
+      "stem": "saved_single_line_spacing_after",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2093/saved_single_line_spacing_after.hwpx::pdf/task2093/saved_single_line_spacing_after-2020.pdf",
+      "sample": "samples/task2093/saved_single_line_spacing_after.hwpx",
+      "pdf": "pdf/task2093/saved_single_line_spacing_after-2020.pdf",
+      "stem": "saved_single_line_spacing_after",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/1730000_selection_report.hwp::pdf/task2097/1730000_selection_report-2022.pdf",
+      "sample": "samples/task2097/1730000_selection_report.hwp",
+      "pdf": "pdf/task2097/1730000_selection_report-2022.pdf",
+      "stem": "1730000_selection_report",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/1741000_project_application.hwp::pdf/task2097/1741000_project_application-2020.pdf",
+      "sample": "samples/task2097/1741000_project_application.hwp",
+      "pdf": "pdf/task2097/1741000_project_application-2020.pdf",
+      "stem": "1741000_project_application",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/21298295_byeolpyo5_disaster.hwp::pdf/task2097/21298295_byeolpyo5_disaster-2020.pdf",
+      "sample": "samples/task2097/21298295_byeolpyo5_disaster.hwp",
+      "pdf": "pdf/task2097/21298295_byeolpyo5_disaster-2020.pdf",
+      "stem": "21298295_byeolpyo5_disaster",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/3080901_pii_ledger.hwp::pdf/task2097/3080901_pii_ledger-2022.pdf",
+      "sample": "samples/task2097/3080901_pii_ledger.hwp",
+      "pdf": "pdf/task2097/3080901_pii_ledger-2022.pdf",
+      "stem": "3080901_pii_ledger",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/75544_pii_bunseok.hwpx::pdf/task2097/75544_pii_bunseok-2020.pdf",
+      "sample": "samples/task2097/75544_pii_bunseok.hwpx",
+      "pdf": "pdf/task2097/75544_pii_bunseok-2020.pdf",
+      "stem": "75544_pii_bunseok",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/none_table_declared_fits.hwpx::pdf/task2097/none_table_declared_fits-2022.pdf",
+      "sample": "samples/task2097/none_table_declared_fits.hwpx",
+      "pdf": "pdf/task2097/none_table_declared_fits-2022.pdf",
+      "stem": "none_table_declared_fits",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2097/none_table_declared_fits.hwpx::pdf/task2097/none_table_declared_fits-2020.pdf",
+      "sample": "samples/task2097/none_table_declared_fits.hwpx",
+      "pdf": "pdf/task2097/none_table_declared_fits-2020.pdf",
+      "stem": "none_table_declared_fits",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2098/page_bottom_fixed_anchor_margin_split.hwpx::pdf/task2098/page_bottom_fixed_anchor_margin_split-2020.pdf",
+      "sample": "samples/task2098/page_bottom_fixed_anchor_margin_split.hwpx",
+      "pdf": "pdf/task2098/page_bottom_fixed_anchor_margin_split-2020.pdf",
+      "stem": "page_bottom_fixed_anchor_margin_split",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2098/page_bottom_fixed_anchor_vpos0.hwpx::pdf/task2098/page_bottom_fixed_anchor_vpos0-2020.pdf",
+      "sample": "samples/task2098/page_bottom_fixed_anchor_vpos0.hwpx",
+      "pdf": "pdf/task2098/page_bottom_fixed_anchor_vpos0-2020.pdf",
+      "stem": "page_bottom_fixed_anchor_vpos0",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2136/neartop_reset_sb2500.hwpx::pdf/task2136/neartop_reset_sb2500-2020.pdf",
+      "sample": "samples/task2136/neartop_reset_sb2500.hwpx",
+      "pdf": "pdf/task2136/neartop_reset_sb2500-2020.pdf",
+      "stem": "neartop_reset_sb2500",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2137/156618554_petfood_press.hwp::pdf/task2137/156618554_petfood_press-2020.pdf",
+      "sample": "samples/task2137/156618554_petfood_press.hwp",
+      "pdf": "pdf/task2137/156618554_petfood_press-2020.pdf",
+      "stem": "156618554_petfood_press",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2146/21761835_jeonjik_exemption_table.hwp::pdf/task2146/21761835_jeonjik_exemption_table-2020.pdf",
+      "sample": "samples/task2146/21761835_jeonjik_exemption_table.hwp",
+      "pdf": "pdf/task2146/21761835_jeonjik_exemption_table-2020.pdf",
+      "stem": "21761835_jeonjik_exemption_table",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2243/156631374_taxi_press.hwpx::pdf/task2243/156631374_taxi_press-2020.pdf",
+      "sample": "samples/task2243/156631374_taxi_press.hwpx",
+      "pdf": "pdf/task2243/156631374_taxi_press-2020.pdf",
+      "stem": "156631374_taxi_press",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2243/36382819_gyeoljae_pm_traffic.hwpx::pdf/task2243/36382819_gyeoljae_pm_traffic-2020.pdf",
+      "sample": "samples/task2243/36382819_gyeoljae_pm_traffic.hwpx",
+      "pdf": "pdf/task2243/36382819_gyeoljae_pm_traffic-2020.pdf",
+      "stem": "36382819_gyeoljae_pm_traffic",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2243/36386907_gyeoljae_sewoon.hwpx::pdf/task2243/36386907_gyeoljae_sewoon-2020.pdf",
+      "sample": "samples/task2243/36386907_gyeoljae_sewoon.hwpx",
+      "pdf": "pdf/task2243/36386907_gyeoljae_sewoon-2020.pdf",
+      "stem": "36386907_gyeoljae_sewoon",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2243/36395325_gyeoljae_consulting.hwpx::pdf/task2243/36395325_gyeoljae_consulting-2020.pdf",
+      "sample": "samples/task2243/36395325_gyeoljae_consulting.hwpx",
+      "pdf": "pdf/task2243/36395325_gyeoljae_consulting-2020.pdf",
+      "stem": "36395325_gyeoljae_consulting",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2287/1342000_edu_curriculum_map.hwp::pdf/task2287/1342000_edu_curriculum_map-2022.pdf",
+      "sample": "samples/task2287/1342000_edu_curriculum_map.hwp",
+      "pdf": "pdf/task2287/1342000_edu_curriculum_map-2022.pdf",
+      "stem": "1342000_edu_curriculum_map",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task2287/1342000_edu_curriculum_map.hwp::pdf/task2287/1342000_edu_curriculum_map-2020-p025-p035.pdf",
+      "sample": "samples/task2287/1342000_edu_curriculum_map.hwp",
+      "pdf": "pdf/task2287/1342000_edu_curriculum_map-2020-p025-p035.pdf",
+      "stem": "1342000_edu_curriculum_map",
+      "hancomVersion": "2020",
+      "variant": "2020-p025-p035",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/task3236/issue3236_split_table.hwpx::pdf/task3236/issue3236_split_table-2020.pdf",
+      "sample": "samples/task3236/issue3236_split_table.hwpx",
+      "pdf": "pdf/task3236/issue3236_split_table-2020.pdf",
+      "stem": "issue3236_split_table",
+      "hancomVersion": "2020",
+      "variant": "2020",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/text-align-2.hwp::pdf/text-align-2-2022.pdf",
+      "sample": "samples/text-align-2.hwp",
+      "pdf": "pdf/text-align-2-2022.pdf",
+      "stem": "text-align-2",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/text-align.hwp::pdf/text-align-2022.pdf",
+      "sample": "samples/text-align.hwp",
+      "pdf": "pdf/text-align-2022.pdf",
+      "stem": "text-align",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/누름틀-2024.hwp::pdf/누름틀-2024.pdf",
+      "sample": "samples/누름틀-2024.hwp",
+      "pdf": "pdf/누름틀-2024.pdf",
+      "stem": "누름틀-2024",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/누름틀-2024.hwpx::pdf/누름틀-2024.pdf",
+      "sample": "samples/누름틀-2024.hwpx",
+      "pdf": "pdf/누름틀-2024.pdf",
+      "stem": "누름틀-2024",
+      "hancomVersion": "2024",
+      "variant": "exact",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/대각선샘플.hwp::pdf/대각선샘플-2024.pdf",
+      "sample": "samples/대각선샘플.hwp",
+      "pdf": "pdf/대각선샘플-2024.pdf",
+      "stem": "대각선샘플",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/대각선샘플.hwpx::pdf/대각선샘플-2024.pdf",
+      "sample": "samples/대각선샘플.hwpx",
+      "pdf": "pdf/대각선샘플-2024.pdf",
+      "stem": "대각선샘플",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/복학원서.hwp::pdf/복학원서-2022.pdf",
+      "sample": "samples/복학원서.hwp",
+      "pdf": "pdf/복학원서-2022.pdf",
+      "stem": "복학원서",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/복학원서.hwpx::pdf/복학원서-2022.pdf",
+      "sample": "samples/복학원서.hwpx",
+      "pdf": "pdf/복학원서-2022.pdf",
+      "stem": "복학원서",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/셀보호2.hwp::pdf/셀보호2-2024.pdf",
+      "sample": "samples/셀보호2.hwp",
+      "pdf": "pdf/셀보호2-2024.pdf",
+      "stem": "셀보호2",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/셀보호2.hwpx::pdf/셀보호2-2024.pdf",
+      "sample": "samples/셀보호2.hwpx",
+      "pdf": "pdf/셀보호2-2024.pdf",
+      "stem": "셀보호2",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/추진일정.hwp::pdf/추진일정-2024.pdf",
+      "sample": "samples/추진일정.hwp",
+      "pdf": "pdf/추진일정-2024.pdf",
+      "stem": "추진일정",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/추진일정.hwpx::pdf/추진일정-2024.pdf",
+      "sample": "samples/추진일정.hwpx",
+      "pdf": "pdf/추진일정-2024.pdf",
+      "stem": "추진일정",
+      "hancomVersion": "2024",
+      "variant": "2024",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/통합재정통계(2010.11월).hwp::pdf/통합재정통계(2010.11월)-2022.pdf",
+      "sample": "samples/통합재정통계(2010.11월).hwp",
+      "pdf": "pdf/통합재정통계(2010.11월)-2022.pdf",
+      "stem": "통합재정통계(2010.11월)",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/통합재정통계(2011.10월).hwp::pdf/통합재정통계(2011.10월)-2022.pdf",
+      "sample": "samples/통합재정통계(2011.10월).hwp",
+      "pdf": "pdf/통합재정통계(2011.10월)-2022.pdf",
+      "stem": "통합재정통계(2011.10월)",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/통합재정통계(2014.8월).hwp::pdf/통합재정통계(2014.8월)-2022.pdf",
+      "sample": "samples/통합재정통계(2014.8월).hwp",
+      "pdf": "pdf/통합재정통계(2014.8월)-2022.pdf",
+      "stem": "통합재정통계(2014.8월)",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/표-텍스트.hwpx::pdf/표-텍스트-2022.pdf",
+      "sample": "samples/표-텍스트.hwpx",
+      "pdf": "pdf/표-텍스트-2022.pdf",
+      "stem": "표-텍스트",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/한셀OLE.hwp::pdf/한셀OLE-2022.pdf",
+      "sample": "samples/한셀OLE.hwp",
+      "pdf": "pdf/한셀OLE-2022.pdf",
+      "stem": "한셀OLE",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwp",
+      "oracleRoot": "pdf"
+    },
+    {
+      "id": "samples/한셀OLE.hwpx::pdf/한셀OLE-2022.pdf",
+      "sample": "samples/한셀OLE.hwpx",
+      "pdf": "pdf/한셀OLE-2022.pdf",
+      "stem": "한셀OLE",
+      "hancomVersion": "2022",
+      "variant": "2022",
+      "sourceFormat": "hwpx",
+      "oracleRoot": "pdf"
+    }
+  ],
+  "unmatched": [
+    {
+      "sample": "samples/143E433F503322BD33.hwp",
+      "stem": "143E433F503322BD33",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/156457624_210622 7월부터 해외직구 구매대행업체 등록제 시행.hwp",
+      "stem": "156457624_210622 7월부터 해외직구 구매대행업체 등록제 시행",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp",
+      "stem": "156636617_240617 2024년 5월 월간 수출입 현황(확정치)",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/20250130-hongbo-no.hwp",
+      "stem": "20250130-hongbo-no",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/20250130-hongbo_saved.hwp",
+      "stem": "20250130-hongbo_saved",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/2026_oss_rst.hwp",
+      "stem": "2026_oss_rst",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/21868765_별표2_보건소_분장사무.hwp",
+      "stem": "21868765_별표2_보건소_분장사무",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/253E164F57A1BC6934-empty.hwp",
+      "stem": "253E164F57A1BC6934-empty",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/3-09월_교육_통합_2023.hwp",
+      "stem": "3-09월_교육_통합_2023",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/3-09월_교육_통합_2023.hwpx",
+      "stem": "3-09월_교육_통합_2023",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/3-09월_교육_통합_2024-격자기준종이.hwp",
+      "stem": "3-09월_교육_통합_2024-격자기준종이",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/3-09월_교육_통합_2024-격자기준쪽.hwp",
+      "stem": "3-09월_교육_통합_2024-격자기준쪽",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/76076_regulatory_analysis.hwp",
+      "stem": "76076_regulatory_analysis",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/80250_regulatory_analysis.hwp",
+      "stem": "80250_regulatory_analysis",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/86712_regulatory_analysis.hwp",
+      "stem": "86712_regulatory_analysis",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/basic/calendar_monthly.hwp",
+      "stem": "calendar_monthly",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/basic/issue1994_behindtext_table_20200830.hwp",
+      "stem": "issue1994_behindtext_table_20200830",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/basic/pau-004.hwp",
+      "stem": "pau-004",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/byeolpyo1.hwp",
+      "stem": "byeolpyo1",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/byeolpyo4.hwp",
+      "stem": "byeolpyo4",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/el-school-001.hwp",
+      "stem": "el-school-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/eq-002.hwp",
+      "stem": "eq-002",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/exam-kor-1p.hwp",
+      "stem": "exam-kor-1p",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/exam-kor-2p.hwp",
+      "stem": "exam-kor-2p",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/exam-kor-3p.hwp",
+      "stem": "exam-kor-3p",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/exam-kor-4p.hwp",
+      "stem": "exam-kor-4p",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/exam_social-p1.hwp",
+      "stem": "exam_social-p1",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/footnote-tbox-01.hwp",
+      "stem": "footnote-tbox-01",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/form-02.hwp",
+      "stem": "form-02",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hcar-001.hwp",
+      "stem": "hcar-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/honbo-save.hwp",
+      "stem": "honbo-save",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp-3.0-HWPML.hwp",
+      "stem": "hwp-3.0-HWPML",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-curve.hwp",
+      "stem": "hwp3-curve",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-ellipse-empty-textbox.hwp",
+      "stem": "hwp3-ellipse-empty-textbox",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-empty-cell.hwp",
+      "stem": "hwp3-empty-cell",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-pagedef-1915.hwp",
+      "stem": "hwp3-pagedef-1915",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/HWP3-password-123456.hwp",
+      "stem": "HWP3-password-123456",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample10-hwp5.hwp",
+      "stem": "hwp3-sample10-hwp5",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample10-hwpx.hwpx",
+      "stem": "hwp3-sample10-hwpx",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample10.hwp",
+      "stem": "hwp3-sample10",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample11-hwp5.hwp",
+      "stem": "hwp3-sample11-hwp5",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample11-hwpx.hwpx",
+      "stem": "hwp3-sample11-hwpx",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample13.hwp",
+      "stem": "hwp3-sample13",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample14.hwp",
+      "stem": "hwp3-sample14",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample16-hwp5-2024-password-123456.hwp",
+      "stem": "hwp3-sample16-hwp5-2024-password-123456",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample19-hwpx.hwpx",
+      "stem": "hwp3-sample19-hwpx",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample19.hwp",
+      "stem": "hwp3-sample19",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample5-hwp5-v2018.hwp",
+      "stem": "hwp3-sample5-hwp5-v2018",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-sample5-hwp5-v2024.hwp",
+      "stem": "hwp3-sample5-hwp5-v2024",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-table-caption.hwp",
+      "stem": "hwp3-table-caption",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-table-cell-order.hwp",
+      "stem": "hwp3-table-cell-order",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-table-cell-overlap.hwp",
+      "stem": "hwp3-table-cell-overlap",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp3-table-grid-gap.hwp",
+      "stem": "hwp3-table-grid-gap",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/HWP5-nopassword-123456.hwp",
+      "stem": "HWP5-nopassword-123456",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/HWP5-nopassword-123456.hwpx",
+      "stem": "HWP5-nopassword-123456",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/HWP5-password-123456.hwpx",
+      "stem": "HWP5-password-123456",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp5-tbl-attr-1916.hwp",
+      "stem": "hwp5-tbl-attr-1916",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwp_table_test_saved.hwp",
+      "stem": "hwp_table_test_saved",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpers_test4_complex_table.hwp",
+      "stem": "hwpers_test4_complex_table",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/143E433F503322BD33.hwpx",
+      "stem": "143E433F503322BD33",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/2026_oss_rst.hwpx",
+      "stem": "2026_oss_rst",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/[2027] 온새미로 1 본교재.hwpx",
+      "stem": "[2027] 온새미로 1 본교재",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/basic-table-01.hwpx",
+      "stem": "basic-table-01",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/business_overview.hwpx",
+      "stem": "business_overview",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/el-school-001.hwpx",
+      "stem": "el-school-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/eq-002.hwpx",
+      "stem": "eq-002",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam-kor-1p.hwpx",
+      "stem": "exam-kor-1p",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam-kor-2p.hwpx",
+      "stem": "exam-kor-2p",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam-kor-3p.hwpx",
+      "stem": "exam-kor-3p",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam-kor-4p.hwpx",
+      "stem": "exam-kor-4p",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam_kor.hwpx",
+      "stem": "exam_kor",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam_social-p1.hwpx",
+      "stem": "exam_social-p1",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/exam_social.hwpx",
+      "stem": "exam_social",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/expense_report.hwpx",
+      "stem": "expense_report",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/field-multipara-clickhere.hwpx",
+      "stem": "field-multipara-clickhere",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/footnote-01.hwpx",
+      "stem": "footnote-01",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/footnote-tbox-01.hwpx",
+      "stem": "footnote-tbox-01",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/form-01.hwpx",
+      "stem": "form-01",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/form-02.hwpx",
+      "stem": "form-02",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp",
+      "stem": "2024년 1분기 해외직접투자 보도자료 ff",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp",
+      "stem": "2024년 2분기 해외직접투자 보도자료ff",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp",
+      "stem": "2024년 연간 해외직접투자 보도자료 _ ff",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp",
+      "stem": "2025년 1분기 해외직접투자 보도자료f",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp",
+      "stem": "2025년 2분기 해외직접투자 (최종)",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/[2027] 온새미로 1 본교재.hwp",
+      "stem": "[2027] 온새미로 1 본교재",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/activity_report.hwp",
+      "stem": "activity_report",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/blank_hwpx.hwp",
+      "stem": "blank_hwpx",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/business_overview.hwp",
+      "stem": "business_overview",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/expense_report.hwp",
+      "stem": "expense_report",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/form-002.hwp",
+      "stem": "form-002",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hang_job_01.hwp",
+      "stem": "hang_job_01",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hwpx-01.hwp",
+      "stem": "hwpx-01",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hwpx-02.hwp",
+      "stem": "hwpx-02",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hwpx-h-01.hwp",
+      "stem": "hwpx-h-01",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hwpx-h-02.hwp",
+      "stem": "hwpx-h-02",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hwpx-h-03.hwp",
+      "stem": "hwpx-h-03",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hy-001.hwp",
+      "stem": "hy-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/hy-002.hwp",
+      "stem": "hy-002",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/issue_157.hwp",
+      "stem": "issue_157",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/issue_241.hwp",
+      "stem": "issue_241",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/mel-001.hwp",
+      "stem": "mel-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/service_agreement.hwp",
+      "stem": "service_agreement",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/tb-org-02.hwp",
+      "stem": "tb-org-02",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hancom-hwp/tbox-v-flow-01.hwp",
+      "stem": "tbox-v-flow-01",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hcar-001.hwpx",
+      "stem": "hcar-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hwpx-centered-cell-vpos-after-tac-shape.hwpx",
+      "stem": "hwpx-centered-cell-vpos-after-tac-shape",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hy-001.hwpx",
+      "stem": "hy-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/hy-002.hwpx",
+      "stem": "hy-002",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/issue1535_coanchored_float_exclusion.hwpx",
+      "stem": "issue1535_coanchored_float_exclusion",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/issue1948_cross_para_fieldend.hwpx",
+      "stem": "issue1948_cross_para_fieldend",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/issue2019_floating_form_74312.hwpx",
+      "stem": "issue2019_floating_form_74312",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/issue2439_page_local_float_exclusion.hwpx",
+      "stem": "issue2439_page_local_float_exclusion",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/issue_1133.hwpx",
+      "stem": "issue_1133",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/k-water-rfp.hwpx",
+      "stem": "k-water-rfp",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/landscape-001.hwpx",
+      "stem": "landscape-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/local-font-nanumsquare-bold.hwpx",
+      "stem": "local-font-nanumsquare-bold",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/math-001.hwpx",
+      "stem": "math-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36382399_결재문서본문_일반지출결의서_기간제 소블록 세척 작업용품 구매.hwpx",
+      "stem": "36382399_결재문서본문_일반지출결의서_기간제 소블록 세척 작업용품 구매",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과.hwpx",
+      "stem": "36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36383351_결재문서본문_[관악산] 산악구조대 구급의약품 폐기 계획 보고.hwpx",
+      "stem": "36383351_결재문서본문_[관악산] 산악구조대 구급의약품 폐기 계획 보고",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36383351_결재문서본문_관악산산악구조대급식의약품폐기.hwpx",
+      "stem": "36383351_결재문서본문_관악산산악구조대급식의약품폐기",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36384285_결재문서본문_[여의도] 2026년 6월 기본업무수행 급식비 지급.hwpx",
+      "stem": "36384285_결재문서본문_[여의도] 2026년 6월 기본업무수행 급식비 지급",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx",
+      "stem": "36384689_결재문서본문_화재발생종합보고서(제2026-298호)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고.hwpx",
+      "stem": "36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36385445_결재문서본문_화재발생종합보고서(제2026-189호, 2026. 5. 14.).hwpx",
+      "stem": "36385445_결재문서본문_화재발생종합보고서(제2026-189호, 2026. 5. 14.)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36385464_결재문서본문_근무변경(반포수난구조대, 2026-06).hwpx",
+      "stem": "36385464_결재문서본문_근무변경(반포수난구조대, 2026-06)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36386761_백제학연구총서위탁판매의뢰목록.hwpx",
+      "stem": "36386761_백제학연구총서위탁판매의뢰목록",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내.hwpx",
+      "stem": "36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36387725_footer_page_bottom.hwpx",
+      "stem": "36387725_footer_page_bottom",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36388571_결재문서본문_2026년 6월 생일 축하품 수령증 제출(119항공대).hwpx",
+      "stem": "36388571_결재문서본문_2026년 6월 생일 축하품 수령증 제출(119항공대)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36388711_사회보장제도 신설 협의요청서(청년오피스)_260624.hwpx",
+      "stem": "36388711_사회보장제도 신설 협의요청서(청년오피스)_260624",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36388853_결재문서본문_일상감사 의견서 송부.hwpx",
+      "stem": "36388853_결재문서본문_일상감사 의견서 송부",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36389298_결재문서본문_물품검사(수)조서(라벨테이프 등).hwpx",
+      "stem": "36389298_결재문서본문_물품검사(수)조서(라벨테이프 등)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36389301_결재문서본문_직장훈련계획_덧말.hwpx",
+      "stem": "36389301_결재문서본문_직장훈련계획_덧말",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36389312_결재문서본문_특정소방대상물 화재발생 알림(화재번호 2026-177).hwpx",
+      "stem": "36389312_결재문서본문_특정소방대상물 화재발생 알림(화재번호 2026-177)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36392900_결재문서본문_일일굴착복구공사현황보고.hwpx",
+      "stem": "36392900_결재문서본문_일일굴착복구공사현황보고",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36395270_footer_overpush.hwpx",
+      "stem": "36395270_footer_overpush",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/opengov/36398366_결재문서본문_PC 셧다운 제외 및 초과근무 인정 요청(데이터전략과).hwpx",
+      "stem": "36398366_결재문서본문_PC 셧다운 제외 및 초과근무 인정 요청(데이터전략과)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/pagenation-001.hwpx",
+      "stem": "pagenation-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/para-001.hwpx",
+      "stem": "para-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/para-unit-01.hwpx",
+      "stem": "para-unit-01",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/pr-1674.hwpx",
+      "stem": "pr-1674",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/shape-001.hwpx",
+      "stem": "shape-001",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/ta-pic-001-r.hwpx",
+      "stem": "ta-pic-001-r",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/tb-img-03.hwpx",
+      "stem": "tb-img-03",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/tb-org-02.hwpx",
+      "stem": "tb-org-02",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/hwpx/water-mark.hwpx",
+      "stem": "water-mark",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue-986-receipt.hwp",
+      "stem": "issue-986-receipt",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1549_empty_host_float_clamp.hwpx",
+      "stem": "issue1549_empty_host_float_clamp",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1549_multipositive_float_tables.hwpx",
+      "stem": "issue1549_multipositive_float_tables",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1639_empty_host_negative_offset_float.hwpx",
+      "stem": "issue1639_empty_host_negative_offset_float",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1639_empty_host_positive_only_float.hwpx",
+      "stem": "issue1639_empty_host_positive_only_float",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1842_cell_tac_group_lineheight.hwp",
+      "stem": "issue1842_cell_tac_group_lineheight",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1858_paper_anchor_float_stack.hwpx",
+      "stem": "issue1858_paper_anchor_float_stack",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1880_anchor_stack_sb_convert.hwpx",
+      "stem": "issue1880_anchor_stack_sb_convert",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1880_takeplace_host_before.hwpx",
+      "stem": "issue1880_takeplace_host_before",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1880_takeplace_oracle_p13.hwpx",
+      "stem": "issue1880_takeplace_oracle_p13",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1891/76076_regulatory_analysis.hwpx",
+      "stem": "76076_regulatory_analysis",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1891/80168_regulatory_analysis.hwpx",
+      "stem": "80168_regulatory_analysis",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1891/80250_regulatory_analysis.hwpx",
+      "stem": "80250_regulatory_analysis",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1891/86712_regulatory_analysis.hwpx",
+      "stem": "86712_regulatory_analysis",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1891_external_bindata_link.hwpx",
+      "stem": "issue1891_external_bindata_link",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1892_hwp3_drawing_group_roundtrip.hwp",
+      "stem": "issue1892_hwp3_drawing_group_roundtrip",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1892_hwp3_tab_roundtrip.hwp",
+      "stem": "issue1892_hwp3_tab_roundtrip",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue1937_rowbreak_footnote_overpagination.hwp",
+      "stem": "issue1937_rowbreak_footnote_overpagination",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue2439/issue2439_repeat_table_overlap.hwp",
+      "stem": "issue2439_repeat_table_overlap",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue2439_zero_offset_coanchored_float_exclusion.hwp",
+      "stem": "issue2439_zero_offset_coanchored_float_exclusion",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue2527_empty_linesegs.hwpx",
+      "stem": "issue2527_empty_linesegs",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue3637/regulatory_impact_nested_table_escape.hwpx",
+      "stem": "regulatory_impact_nested_table_escape",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue3738/tac_sibling_shape_line_advance.hwpx",
+      "stem": "tac_sibling_shape_line_advance",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue3751/vpos_reset_midparagraph_fit.hwpx",
+      "stem": "vpos_reset_midparagraph_fit",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue3798/page_end_trailing_spill.hwpx",
+      "stem": "page_end_trailing_spill",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue3834/flow_with_text_zero.hwpx",
+      "stem": "flow_with_text_zero",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue4090/156492236_규제샌드박스_min.hwpx",
+      "stem": "156492236_규제샌드박스_min",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue4490/148720174_111014(인력기획과)민간경력자_5급_일괄채용_필기_합격자_발표.hwp",
+      "stem": "148720174_111014(인력기획과)민간경력자_5급_일괄채용_필기_합격자_발표",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue4491/30213_1.혼합단지등 제도개선 방안.hwp",
+      "stem": "30213_1.혼합단지등 제도개선 방안",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue4657/distribute-alignment-sample.hwpx",
+      "stem": "distribute-alignment-sample",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue4690/30098_indent_over_stored_cs.hwp",
+      "stem": "30098_indent_over_stored_cs",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue_1133.hwp",
+      "stem": "issue_1133",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issue_2148_degenerate_cell_vpos.hwpx",
+      "stem": "issue_2148_degenerate_cell_vpos",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/issues/2809/jubo_20260104.hwp",
+      "stem": "jubo_20260104",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/landscape-001.hwp",
+      "stem": "landscape-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/math-001.hwp",
+      "stem": "math-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/para-001.hwp",
+      "stem": "para-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/para-unit-01.hwp",
+      "stem": "para-unit-01",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/pic-in-table-with-toggle.hwp",
+      "stem": "pic-in-table-with-toggle",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/pic2-2018.hwp",
+      "stem": "pic2-2018",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/pr4093/outline_navigation_panel_demo.hwpx",
+      "stem": "outline_navigation_panel_demo",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/pr4093/outline_navigation_table_cell_number.hwpx",
+      "stem": "outline_navigation_table_cell_number",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/render-p35-font-native-bitmap.hwpx",
+      "stem": "render-p35-font-native-bitmap",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/shape-001.hwp",
+      "stem": "shape-001",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/ta-pic-001-r.hwp",
+      "stem": "ta-pic-001-r",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/ta-pic-cell-center-pos-bottom.hwpx",
+      "stem": "ta-pic-cell-center-pos-bottom",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/ta-pic-cell-top-pos-center.hwpx",
+      "stem": "ta-pic-cell-top-pos-center",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-host-spacing.hwpx",
+      "stem": "tac-host-spacing",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-a-after.hwp",
+      "stem": "scenario-a-after",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-a-before.hwp",
+      "stem": "scenario-a-before",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-b-after.hwp",
+      "stem": "scenario-b-after",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-b-before.hwp",
+      "stem": "scenario-b-before",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-c-after.hwp",
+      "stem": "scenario-c-after",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-c-before.hwp",
+      "stem": "scenario-c-before",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-d-after.hwp",
+      "stem": "scenario-d-after",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tac-verify/scenario-d-before.hwp",
+      "stem": "scenario-d-before",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1700/byeolpyo1_uujeong_wrap_singlepage.hwp",
+      "stem": "byeolpyo1_uujeong_wrap_singlepage",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1700/myeonjeok_wrap_10page.hwp",
+      "stem": "myeonjeok_wrap_10page",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1705/wrap_empty_para_anchor_page.hwp",
+      "stem": "wrap_empty_para_anchor_page",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1706/empty_para_before_pagebreak.hwpx",
+      "stem": "empty_para_before_pagebreak",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1706/empty_para_between_tac_tables.hwp",
+      "stem": "empty_para_between_tac_tables",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1716/table_scattered_header_rowbreak.hwpx",
+      "stem": "table_scattered_header_rowbreak",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1718/table_giant_cell_overfill.hwp",
+      "stem": "table_giant_cell_overfill",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1725/text_footnote_tail_overpagination.hwp",
+      "stem": "text_footnote_tail_overpagination",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1725/text_footnote_tail_overpagination.hwpx",
+      "stem": "text_footnote_tail_overpagination",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1745/table_text_anchor_wrap.hwp",
+      "stem": "table_text_anchor_wrap",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1749/saved_bounds_cumulative_page_break.hwp",
+      "stem": "saved_bounds_cumulative_page_break",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1749/saved_bounds_cumulative_page_break.hwpx",
+      "stem": "saved_bounds_cumulative_page_break",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1749/saved_bounds_cumulative_vpos.hwp",
+      "stem": "saved_bounds_cumulative_vpos",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1749/saved_bounds_cumulative_vpos.hwpx",
+      "stem": "saved_bounds_cumulative_vpos",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1750/split_guard_spacing_before.hwp",
+      "stem": "split_guard_spacing_before",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1750/split_guard_spacing_before.hwpx",
+      "stem": "split_guard_spacing_before",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1753/deferred_takeplace_fill_ahead.hwp",
+      "stem": "deferred_takeplace_fill_ahead",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1753/deferred_takeplace_fill_ahead.hwpx",
+      "stem": "deferred_takeplace_fill_ahead",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1763/cell_trailing_ls_expand.hwp",
+      "stem": "cell_trailing_ls_expand",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1763/cell_trailing_ls_expand.hwpx",
+      "stem": "cell_trailing_ls_expand",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1765/merged_cell_trailing_ls.hwp",
+      "stem": "merged_cell_trailing_ls",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1765/merged_cell_trailing_ls.hwpx",
+      "stem": "merged_cell_trailing_ls",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1768/distribution_doc.hwpx",
+      "stem": "distribution_doc",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1771/nested_group_vectors.hwpx",
+      "stem": "nested_group_vectors",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1772/table_outer_margin_common_sync.hwpx",
+      "stem": "table_outer_margin_common_sync",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task1789/exclusion_probe_line_spacing.hwpx",
+      "stem": "exclusion_probe_line_spacing",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2070/hy_ladder3.hwpx",
+      "stem": "hy_ladder3",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2070/hy_ladder4.hwpx",
+      "stem": "hy_ladder4",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2097/17809123_jawonbongsa.hwpx",
+      "stem": "17809123_jawonbongsa",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2097/18095317_eogu_geumji.hwp",
+      "stem": "18095317_eogu_geumji",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2097/21217935_simsa_jipyo.hwp",
+      "stem": "21217935_simsa_jipyo",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2097/3023771_wichokjang.hwpx",
+      "stem": "3023771_wichokjang",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2097/3248363_upmu_bunjang.hwpx",
+      "stem": "3248363_upmu_bunjang",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2097/rowbreak_midpage_declared_fits.hwpx",
+      "stem": "rowbreak_midpage_declared_fits",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2105/rowbreak_table_declared_fits.hwpx",
+      "stem": "rowbreak_table_declared_fits",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2137/156637323_unification_lecture.hwpx",
+      "stem": "156637323_unification_lecture",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2156/width_ladder.hwpx",
+      "stem": "width_ladder",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2169/anchor_ladder.hwpx",
+      "stem": "anchor_ladder",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2169/empty_ladder.hwpx",
+      "stem": "empty_ladder",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36353832_gyeoljae.hwpx",
+      "stem": "36353832_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36358528_gyeoljae.hwpx",
+      "stem": "36358528_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36365360_gyeoljae.hwpx",
+      "stem": "36365360_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36376848_gyeoljae.hwpx",
+      "stem": "36376848_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36378128_gyeoljae.hwpx",
+      "stem": "36378128_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36378481_gyeoljae.hwpx",
+      "stem": "36378481_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36394733_gyeoljae.hwpx",
+      "stem": "36394733_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36395825_gyeoljae.hwpx",
+      "stem": "36395825_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36398724_gyeoljae.hwpx",
+      "stem": "36398724_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36404953_gyeoljae.hwpx",
+      "stem": "36404953_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36406174_gyeoljae.hwpx",
+      "stem": "36406174_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36407074_gyeoljae.hwpx",
+      "stem": "36407074_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36410902_gyeoljae.hwpx",
+      "stem": "36410902_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36417406_gyeoljae.hwpx",
+      "stem": "36417406_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36423194_gyeoljae.hwpx",
+      "stem": "36423194_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36423558_gyeoljae.hwpx",
+      "stem": "36423558_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36425476_gyeoljae.hwpx",
+      "stem": "36425476_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36433160_gyeoljae.hwpx",
+      "stem": "36433160_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36434078_gyeoljae.hwpx",
+      "stem": "36434078_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36437313_gyeoljae.hwpx",
+      "stem": "36437313_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36446358_gyeoljae.hwpx",
+      "stem": "36446358_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36455850_gyeoljae.hwpx",
+      "stem": "36455850_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36456688_gyeoljae.hwpx",
+      "stem": "36456688_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36477251_gyeoljae.hwpx",
+      "stem": "36477251_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2279/36477373_gyeoljae.hwpx",
+      "stem": "36477373_gyeoljae",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2311/156744475_nano_plan_poster.hwpx",
+      "stem": "156744475_nano_plan_poster",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2319/20544835_jinan_apt_form.hwp",
+      "stem": "20544835_jinan_apt_form",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2322/19439117_gokseong_voucher_form.hwp",
+      "stem": "19439117_gokseong_voucher_form",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2322/20862337_cheongyang_voucher_form.hwp",
+      "stem": "20862337_cheongyang_voucher_form",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task2430/1382000_domestic_violence_survey.hwp",
+      "stem": "1382000_domestic_violence_survey",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/task3307/issue3307_outline_number.hwpx",
+      "stem": "issue3307_outline_number",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/tb-img-03.hwp",
+      "stem": "tb-img-03",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/test-image.hwp",
+      "stem": "test-image",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/test-image.hwpx",
+      "stem": "test-image",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/test-image2.hwp",
+      "stem": "test-image2",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/textbox-under-image.hwp",
+      "stem": "textbox-under-image",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/unicode/각 항목에 명시되어 있는_유니코드.hwp",
+      "stem": "각 항목에 명시되어 있는_유니코드",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/valign_fixtures/cell_vbottom_nested_overcount.hwpx",
+      "stem": "cell_vbottom_nested_overcount",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/valign_fixtures/cell_vcenter_multi_nested_overcount.hwpx",
+      "stem": "cell_vcenter_multi_nested_overcount",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/valign_fixtures/cell_vcenter_nested_undercount.hwpx",
+      "stem": "cell_vcenter_nested_undercount",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/valign_fixtures/centered_cell_nested_table.hwpx",
+      "stem": "centered_cell_nested_table",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/water-mark.hwp",
+      "stem": "water-mark",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/대각선샘플3.hwp",
+      "stem": "대각선샘플3",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/대각선샘플3.hwpx",
+      "stem": "대각선샘플3",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/대각선샘플4.hwp",
+      "stem": "대각선샘플4",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/대각선샘플4.hwpx",
+      "stem": "대각선샘플4",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/대각선샘플5.hwp",
+      "stem": "대각선샘플5",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/대각선샘플5.hwpx",
+      "stem": "대각선샘플5",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/셀보호.hwp",
+      "stem": "셀보호",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/셀보호.hwpx",
+      "stem": "셀보호",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/수식-문자처럼취급-아님.hwp",
+      "stem": "수식-문자처럼취급-아님",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/수식-문자처럼취급-아님.hwpx",
+      "stem": "수식-문자처럼취급-아님",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp",
+      "stem": "정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구)",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx",
+      "stem": "정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구)",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/종이기준.hwp",
+      "stem": "종이기준",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/종이기준.hwpx",
+      "stem": "종이기준",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/쪽기준.hwp",
+      "stem": "쪽기준",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/쪽기준.hwpx",
+      "stem": "쪽기준",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/투명도0-50-2nd그림글차처럼off.hwp",
+      "stem": "투명도0-50-2nd그림글차처럼off",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/투명도0-50-2nd그림글차처럼off.hwpx",
+      "stem": "투명도0-50-2nd그림글차처럼off",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/투명도0-50.hwp",
+      "stem": "투명도0-50",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/투명도0-50.hwpx",
+      "stem": "투명도0-50",
+      "sourceFormat": "hwpx",
+      "reason": "no_oracle_pdf"
+    },
+    {
+      "sample": "samples/한글문서파일형식_5.0_revision1.3.hwp",
+      "stem": "한글문서파일형식_5.0_revision1.3",
+      "sourceFormat": "hwp",
+      "reason": "no_oracle_pdf"
+    }
+  ]
+}

--- a/tools/oracle_public/reports/coverage.md
+++ b/tools/oracle_public/reports/coverage.md
@@ -1,0 +1,350 @@
+# M01-3 오라클 커버리지
+
+`samples/` 의 `.hwp`/`.hwpx` 와 `{stem}-{year}.pdf` (2018/2020/2022/2024) 짝.
+같은 상대 하위 경로를 `pdf/` · `pdf-2020/` · `pdf-large/` 에서 찾는다.
+`oracle_resolver.py` 가 없어도 이 도구가 같은 규칙으로 직접 맞춘다.
+짝 없는 개수는 아래 표의 실측값이다.
+
+- 클레임: `M01-3`
+- 생성기: `tools/oracle_public/coverage_report.py`
+- 매칭: `stem-{year}.pdf`
+- 오라클 루트: `pdf/`, `pdf-2020/`, `pdf-large/`
+
+## 요약
+
+| 항목 | 수 |
+| --- | ---: |
+| 샘플 (`.hwp`/`.hwpx`) | 694 |
+| 짝 있는 샘플 | 389 |
+| 짝 없는 샘플 | 305 |
+| 오라클 링크 (샘플×PDF) | 409 |
+| 커버리지 (짝 있는 샘플 / 전체) | 56.1% |
+
+### 형식별
+
+| 형식 | 샘플 | 짝 있음 | 짝 없음 | 커버리지 |
+| --- | ---: | ---: | ---: | ---: |
+| `hwp` | 412 | 270 | 142 | 65.5% |
+| `hwpx` | 282 | 119 | 163 | 42.2% |
+
+## 한글 버전별 (2018 / 2020 / 2022 / 2024)
+
+한 샘플이 여러 버전 PDF 를 가지면 각 버전에 모두 센다.
+분모는 전체 샘플 수다. 2010·2014 접미 PDF 는 이 표에 넣지 않는다.
+
+| 한글 버전 | 링크 수 | 해당 버전이 있는 샘플 | 샘플 대비 |
+| --- | ---: | ---: | ---: |
+| 2018 | 0 | 0 | 0.0% |
+| 2020 | 56 | 53 | 7.6% |
+| 2022 | 294 | 294 | 42.4% |
+| 2024 | 59 | 57 | 8.2% |
+
+## 짝 없는 샘플 (305건)
+
+| # | 경로 | 형식 | 이유 |
+| ---: | --- | --- | --- |
+| 1 | `samples/143E433F503322BD33.hwp` | hwp | no_oracle_pdf |
+| 2 | `samples/156457624_210622 7월부터 해외직구 구매대행업체 등록제 시행.hwp` | hwp | no_oracle_pdf |
+| 3 | `samples/156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp` | hwp | no_oracle_pdf |
+| 4 | `samples/20250130-hongbo-no.hwp` | hwp | no_oracle_pdf |
+| 5 | `samples/20250130-hongbo_saved.hwp` | hwp | no_oracle_pdf |
+| 6 | `samples/2026_oss_rst.hwp` | hwp | no_oracle_pdf |
+| 7 | `samples/21868765_별표2_보건소_분장사무.hwp` | hwp | no_oracle_pdf |
+| 8 | `samples/253E164F57A1BC6934-empty.hwp` | hwp | no_oracle_pdf |
+| 9 | `samples/3-09월_교육_통합_2023.hwp` | hwp | no_oracle_pdf |
+| 10 | `samples/3-09월_교육_통합_2023.hwpx` | hwpx | no_oracle_pdf |
+| 11 | `samples/3-09월_교육_통합_2024-격자기준종이.hwp` | hwp | no_oracle_pdf |
+| 12 | `samples/3-09월_교육_통합_2024-격자기준쪽.hwp` | hwp | no_oracle_pdf |
+| 13 | `samples/76076_regulatory_analysis.hwp` | hwp | no_oracle_pdf |
+| 14 | `samples/80250_regulatory_analysis.hwp` | hwp | no_oracle_pdf |
+| 15 | `samples/86712_regulatory_analysis.hwp` | hwp | no_oracle_pdf |
+| 16 | `samples/basic/calendar_monthly.hwp` | hwp | no_oracle_pdf |
+| 17 | `samples/basic/issue1994_behindtext_table_20200830.hwp` | hwp | no_oracle_pdf |
+| 18 | `samples/basic/pau-004.hwp` | hwp | no_oracle_pdf |
+| 19 | `samples/byeolpyo1.hwp` | hwp | no_oracle_pdf |
+| 20 | `samples/byeolpyo4.hwp` | hwp | no_oracle_pdf |
+| 21 | `samples/el-school-001.hwp` | hwp | no_oracle_pdf |
+| 22 | `samples/eq-002.hwp` | hwp | no_oracle_pdf |
+| 23 | `samples/exam-kor-1p.hwp` | hwp | no_oracle_pdf |
+| 24 | `samples/exam-kor-2p.hwp` | hwp | no_oracle_pdf |
+| 25 | `samples/exam-kor-3p.hwp` | hwp | no_oracle_pdf |
+| 26 | `samples/exam-kor-4p.hwp` | hwp | no_oracle_pdf |
+| 27 | `samples/exam_social-p1.hwp` | hwp | no_oracle_pdf |
+| 28 | `samples/footnote-tbox-01.hwp` | hwp | no_oracle_pdf |
+| 29 | `samples/form-02.hwp` | hwp | no_oracle_pdf |
+| 30 | `samples/hcar-001.hwp` | hwp | no_oracle_pdf |
+| 31 | `samples/honbo-save.hwp` | hwp | no_oracle_pdf |
+| 32 | `samples/hwp-3.0-HWPML.hwp` | hwp | no_oracle_pdf |
+| 33 | `samples/hwp3-curve.hwp` | hwp | no_oracle_pdf |
+| 34 | `samples/hwp3-ellipse-empty-textbox.hwp` | hwp | no_oracle_pdf |
+| 35 | `samples/hwp3-empty-cell.hwp` | hwp | no_oracle_pdf |
+| 36 | `samples/hwp3-pagedef-1915.hwp` | hwp | no_oracle_pdf |
+| 37 | `samples/HWP3-password-123456.hwp` | hwp | no_oracle_pdf |
+| 38 | `samples/hwp3-sample10-hwp5.hwp` | hwp | no_oracle_pdf |
+| 39 | `samples/hwp3-sample10-hwpx.hwpx` | hwpx | no_oracle_pdf |
+| 40 | `samples/hwp3-sample10.hwp` | hwp | no_oracle_pdf |
+| 41 | `samples/hwp3-sample11-hwp5.hwp` | hwp | no_oracle_pdf |
+| 42 | `samples/hwp3-sample11-hwpx.hwpx` | hwpx | no_oracle_pdf |
+| 43 | `samples/hwp3-sample13.hwp` | hwp | no_oracle_pdf |
+| 44 | `samples/hwp3-sample14.hwp` | hwp | no_oracle_pdf |
+| 45 | `samples/hwp3-sample16-hwp5-2024-password-123456.hwp` | hwp | no_oracle_pdf |
+| 46 | `samples/hwp3-sample19-hwpx.hwpx` | hwpx | no_oracle_pdf |
+| 47 | `samples/hwp3-sample19.hwp` | hwp | no_oracle_pdf |
+| 48 | `samples/hwp3-sample5-hwp5-v2018.hwp` | hwp | no_oracle_pdf |
+| 49 | `samples/hwp3-sample5-hwp5-v2024.hwp` | hwp | no_oracle_pdf |
+| 50 | `samples/hwp3-table-caption.hwp` | hwp | no_oracle_pdf |
+| 51 | `samples/hwp3-table-cell-order.hwp` | hwp | no_oracle_pdf |
+| 52 | `samples/hwp3-table-cell-overlap.hwp` | hwp | no_oracle_pdf |
+| 53 | `samples/hwp3-table-grid-gap.hwp` | hwp | no_oracle_pdf |
+| 54 | `samples/HWP5-nopassword-123456.hwp` | hwp | no_oracle_pdf |
+| 55 | `samples/HWP5-nopassword-123456.hwpx` | hwpx | no_oracle_pdf |
+| 56 | `samples/HWP5-password-123456.hwpx` | hwpx | no_oracle_pdf |
+| 57 | `samples/hwp5-tbl-attr-1916.hwp` | hwp | no_oracle_pdf |
+| 58 | `samples/hwp_table_test_saved.hwp` | hwp | no_oracle_pdf |
+| 59 | `samples/hwpers_test4_complex_table.hwp` | hwp | no_oracle_pdf |
+| 60 | `samples/hwpx/143E433F503322BD33.hwpx` | hwpx | no_oracle_pdf |
+| 61 | `samples/hwpx/2026_oss_rst.hwpx` | hwpx | no_oracle_pdf |
+| 62 | `samples/hwpx/[2027] 온새미로 1 본교재.hwpx` | hwpx | no_oracle_pdf |
+| 63 | `samples/hwpx/basic-table-01.hwpx` | hwpx | no_oracle_pdf |
+| 64 | `samples/hwpx/business_overview.hwpx` | hwpx | no_oracle_pdf |
+| 65 | `samples/hwpx/el-school-001.hwpx` | hwpx | no_oracle_pdf |
+| 66 | `samples/hwpx/eq-002.hwpx` | hwpx | no_oracle_pdf |
+| 67 | `samples/hwpx/exam-kor-1p.hwpx` | hwpx | no_oracle_pdf |
+| 68 | `samples/hwpx/exam-kor-2p.hwpx` | hwpx | no_oracle_pdf |
+| 69 | `samples/hwpx/exam-kor-3p.hwpx` | hwpx | no_oracle_pdf |
+| 70 | `samples/hwpx/exam-kor-4p.hwpx` | hwpx | no_oracle_pdf |
+| 71 | `samples/hwpx/exam_kor.hwpx` | hwpx | no_oracle_pdf |
+| 72 | `samples/hwpx/exam_social-p1.hwpx` | hwpx | no_oracle_pdf |
+| 73 | `samples/hwpx/exam_social.hwpx` | hwpx | no_oracle_pdf |
+| 74 | `samples/hwpx/expense_report.hwpx` | hwpx | no_oracle_pdf |
+| 75 | `samples/hwpx/field-multipara-clickhere.hwpx` | hwpx | no_oracle_pdf |
+| 76 | `samples/hwpx/footnote-01.hwpx` | hwpx | no_oracle_pdf |
+| 77 | `samples/hwpx/footnote-tbox-01.hwpx` | hwpx | no_oracle_pdf |
+| 78 | `samples/hwpx/form-01.hwpx` | hwpx | no_oracle_pdf |
+| 79 | `samples/hwpx/form-02.hwpx` | hwpx | no_oracle_pdf |
+| 80 | `samples/hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp` | hwp | no_oracle_pdf |
+| 81 | `samples/hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp` | hwp | no_oracle_pdf |
+| 82 | `samples/hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp` | hwp | no_oracle_pdf |
+| 83 | `samples/hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp` | hwp | no_oracle_pdf |
+| 84 | `samples/hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp` | hwp | no_oracle_pdf |
+| 85 | `samples/hwpx/hancom-hwp/[2027] 온새미로 1 본교재.hwp` | hwp | no_oracle_pdf |
+| 86 | `samples/hwpx/hancom-hwp/activity_report.hwp` | hwp | no_oracle_pdf |
+| 87 | `samples/hwpx/hancom-hwp/blank_hwpx.hwp` | hwp | no_oracle_pdf |
+| 88 | `samples/hwpx/hancom-hwp/business_overview.hwp` | hwp | no_oracle_pdf |
+| 89 | `samples/hwpx/hancom-hwp/expense_report.hwp` | hwp | no_oracle_pdf |
+| 90 | `samples/hwpx/hancom-hwp/form-002.hwp` | hwp | no_oracle_pdf |
+| 91 | `samples/hwpx/hancom-hwp/hang_job_01.hwp` | hwp | no_oracle_pdf |
+| 92 | `samples/hwpx/hancom-hwp/hwpx-01.hwp` | hwp | no_oracle_pdf |
+| 93 | `samples/hwpx/hancom-hwp/hwpx-02.hwp` | hwp | no_oracle_pdf |
+| 94 | `samples/hwpx/hancom-hwp/hwpx-h-01.hwp` | hwp | no_oracle_pdf |
+| 95 | `samples/hwpx/hancom-hwp/hwpx-h-02.hwp` | hwp | no_oracle_pdf |
+| 96 | `samples/hwpx/hancom-hwp/hwpx-h-03.hwp` | hwp | no_oracle_pdf |
+| 97 | `samples/hwpx/hancom-hwp/hy-001.hwp` | hwp | no_oracle_pdf |
+| 98 | `samples/hwpx/hancom-hwp/hy-002.hwp` | hwp | no_oracle_pdf |
+| 99 | `samples/hwpx/hancom-hwp/issue_157.hwp` | hwp | no_oracle_pdf |
+| 100 | `samples/hwpx/hancom-hwp/issue_241.hwp` | hwp | no_oracle_pdf |
+| 101 | `samples/hwpx/hancom-hwp/mel-001.hwp` | hwp | no_oracle_pdf |
+| 102 | `samples/hwpx/hancom-hwp/service_agreement.hwp` | hwp | no_oracle_pdf |
+| 103 | `samples/hwpx/hancom-hwp/tb-org-02.hwp` | hwp | no_oracle_pdf |
+| 104 | `samples/hwpx/hancom-hwp/tbox-v-flow-01.hwp` | hwp | no_oracle_pdf |
+| 105 | `samples/hwpx/hcar-001.hwpx` | hwpx | no_oracle_pdf |
+| 106 | `samples/hwpx/hwpx-centered-cell-vpos-after-tac-shape.hwpx` | hwpx | no_oracle_pdf |
+| 107 | `samples/hwpx/hy-001.hwpx` | hwpx | no_oracle_pdf |
+| 108 | `samples/hwpx/hy-002.hwpx` | hwpx | no_oracle_pdf |
+| 109 | `samples/hwpx/issue1535_coanchored_float_exclusion.hwpx` | hwpx | no_oracle_pdf |
+| 110 | `samples/hwpx/issue1948_cross_para_fieldend.hwpx` | hwpx | no_oracle_pdf |
+| 111 | `samples/hwpx/issue2019_floating_form_74312.hwpx` | hwpx | no_oracle_pdf |
+| 112 | `samples/hwpx/issue2439_page_local_float_exclusion.hwpx` | hwpx | no_oracle_pdf |
+| 113 | `samples/hwpx/issue_1133.hwpx` | hwpx | no_oracle_pdf |
+| 114 | `samples/hwpx/k-water-rfp.hwpx` | hwpx | no_oracle_pdf |
+| 115 | `samples/hwpx/landscape-001.hwpx` | hwpx | no_oracle_pdf |
+| 116 | `samples/hwpx/local-font-nanumsquare-bold.hwpx` | hwpx | no_oracle_pdf |
+| 117 | `samples/hwpx/math-001.hwpx` | hwpx | no_oracle_pdf |
+| 118 | `samples/hwpx/opengov/36382399_결재문서본문_일반지출결의서_기간제 소블록 세척 작업용품 구매.hwpx` | hwpx | no_oracle_pdf |
+| 119 | `samples/hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과.hwpx` | hwpx | no_oracle_pdf |
+| 120 | `samples/hwpx/opengov/36383351_결재문서본문_[관악산] 산악구조대 구급의약품 폐기 계획 보고.hwpx` | hwpx | no_oracle_pdf |
+| 121 | `samples/hwpx/opengov/36383351_결재문서본문_관악산산악구조대급식의약품폐기.hwpx` | hwpx | no_oracle_pdf |
+| 122 | `samples/hwpx/opengov/36384285_결재문서본문_[여의도] 2026년 6월 기본업무수행 급식비 지급.hwpx` | hwpx | no_oracle_pdf |
+| 123 | `samples/hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx` | hwpx | no_oracle_pdf |
+| 124 | `samples/hwpx/opengov/36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고.hwpx` | hwpx | no_oracle_pdf |
+| 125 | `samples/hwpx/opengov/36385445_결재문서본문_화재발생종합보고서(제2026-189호, 2026. 5. 14.).hwpx` | hwpx | no_oracle_pdf |
+| 126 | `samples/hwpx/opengov/36385464_결재문서본문_근무변경(반포수난구조대, 2026-06).hwpx` | hwpx | no_oracle_pdf |
+| 127 | `samples/hwpx/opengov/36386761_백제학연구총서위탁판매의뢰목록.hwpx` | hwpx | no_oracle_pdf |
+| 128 | `samples/hwpx/opengov/36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내.hwpx` | hwpx | no_oracle_pdf |
+| 129 | `samples/hwpx/opengov/36387725_footer_page_bottom.hwpx` | hwpx | no_oracle_pdf |
+| 130 | `samples/hwpx/opengov/36388571_결재문서본문_2026년 6월 생일 축하품 수령증 제출(119항공대).hwpx` | hwpx | no_oracle_pdf |
+| 131 | `samples/hwpx/opengov/36388711_사회보장제도 신설 협의요청서(청년오피스)_260624.hwpx` | hwpx | no_oracle_pdf |
+| 132 | `samples/hwpx/opengov/36388853_결재문서본문_일상감사 의견서 송부.hwpx` | hwpx | no_oracle_pdf |
+| 133 | `samples/hwpx/opengov/36389298_결재문서본문_물품검사(수)조서(라벨테이프 등).hwpx` | hwpx | no_oracle_pdf |
+| 134 | `samples/hwpx/opengov/36389301_결재문서본문_직장훈련계획_덧말.hwpx` | hwpx | no_oracle_pdf |
+| 135 | `samples/hwpx/opengov/36389312_결재문서본문_특정소방대상물 화재발생 알림(화재번호 2026-177).hwpx` | hwpx | no_oracle_pdf |
+| 136 | `samples/hwpx/opengov/36392900_결재문서본문_일일굴착복구공사현황보고.hwpx` | hwpx | no_oracle_pdf |
+| 137 | `samples/hwpx/opengov/36395270_footer_overpush.hwpx` | hwpx | no_oracle_pdf |
+| 138 | `samples/hwpx/opengov/36398366_결재문서본문_PC 셧다운 제외 및 초과근무 인정 요청(데이터전략과).hwpx` | hwpx | no_oracle_pdf |
+| 139 | `samples/hwpx/pagenation-001.hwpx` | hwpx | no_oracle_pdf |
+| 140 | `samples/hwpx/para-001.hwpx` | hwpx | no_oracle_pdf |
+| 141 | `samples/hwpx/para-unit-01.hwpx` | hwpx | no_oracle_pdf |
+| 142 | `samples/hwpx/pr-1674.hwpx` | hwpx | no_oracle_pdf |
+| 143 | `samples/hwpx/shape-001.hwpx` | hwpx | no_oracle_pdf |
+| 144 | `samples/hwpx/ta-pic-001-r.hwpx` | hwpx | no_oracle_pdf |
+| 145 | `samples/hwpx/tb-img-03.hwpx` | hwpx | no_oracle_pdf |
+| 146 | `samples/hwpx/tb-org-02.hwpx` | hwpx | no_oracle_pdf |
+| 147 | `samples/hwpx/water-mark.hwpx` | hwpx | no_oracle_pdf |
+| 148 | `samples/issue-986-receipt.hwp` | hwp | no_oracle_pdf |
+| 149 | `samples/issue1549_empty_host_float_clamp.hwpx` | hwpx | no_oracle_pdf |
+| 150 | `samples/issue1549_multipositive_float_tables.hwpx` | hwpx | no_oracle_pdf |
+| 151 | `samples/issue1639_empty_host_negative_offset_float.hwpx` | hwpx | no_oracle_pdf |
+| 152 | `samples/issue1639_empty_host_positive_only_float.hwpx` | hwpx | no_oracle_pdf |
+| 153 | `samples/issue1842_cell_tac_group_lineheight.hwp` | hwp | no_oracle_pdf |
+| 154 | `samples/issue1858_paper_anchor_float_stack.hwpx` | hwpx | no_oracle_pdf |
+| 155 | `samples/issue1880_anchor_stack_sb_convert.hwpx` | hwpx | no_oracle_pdf |
+| 156 | `samples/issue1880_takeplace_host_before.hwpx` | hwpx | no_oracle_pdf |
+| 157 | `samples/issue1880_takeplace_oracle_p13.hwpx` | hwpx | no_oracle_pdf |
+| 158 | `samples/issue1891/76076_regulatory_analysis.hwpx` | hwpx | no_oracle_pdf |
+| 159 | `samples/issue1891/80168_regulatory_analysis.hwpx` | hwpx | no_oracle_pdf |
+| 160 | `samples/issue1891/80250_regulatory_analysis.hwpx` | hwpx | no_oracle_pdf |
+| 161 | `samples/issue1891/86712_regulatory_analysis.hwpx` | hwpx | no_oracle_pdf |
+| 162 | `samples/issue1891_external_bindata_link.hwpx` | hwpx | no_oracle_pdf |
+| 163 | `samples/issue1892_hwp3_drawing_group_roundtrip.hwp` | hwp | no_oracle_pdf |
+| 164 | `samples/issue1892_hwp3_tab_roundtrip.hwp` | hwp | no_oracle_pdf |
+| 165 | `samples/issue1937_rowbreak_footnote_overpagination.hwp` | hwp | no_oracle_pdf |
+| 166 | `samples/issue2439/issue2439_repeat_table_overlap.hwp` | hwp | no_oracle_pdf |
+| 167 | `samples/issue2439_zero_offset_coanchored_float_exclusion.hwp` | hwp | no_oracle_pdf |
+| 168 | `samples/issue2527_empty_linesegs.hwpx` | hwpx | no_oracle_pdf |
+| 169 | `samples/issue3637/regulatory_impact_nested_table_escape.hwpx` | hwpx | no_oracle_pdf |
+| 170 | `samples/issue3738/tac_sibling_shape_line_advance.hwpx` | hwpx | no_oracle_pdf |
+| 171 | `samples/issue3751/vpos_reset_midparagraph_fit.hwpx` | hwpx | no_oracle_pdf |
+| 172 | `samples/issue3798/page_end_trailing_spill.hwpx` | hwpx | no_oracle_pdf |
+| 173 | `samples/issue3834/flow_with_text_zero.hwpx` | hwpx | no_oracle_pdf |
+| 174 | `samples/issue4090/156492236_규제샌드박스_min.hwpx` | hwpx | no_oracle_pdf |
+| 175 | `samples/issue4490/148720174_111014(인력기획과)민간경력자_5급_일괄채용_필기_합격자_발표.hwp` | hwp | no_oracle_pdf |
+| 176 | `samples/issue4491/30213_1.혼합단지등 제도개선 방안.hwp` | hwp | no_oracle_pdf |
+| 177 | `samples/issue4657/distribute-alignment-sample.hwpx` | hwpx | no_oracle_pdf |
+| 178 | `samples/issue4690/30098_indent_over_stored_cs.hwp` | hwp | no_oracle_pdf |
+| 179 | `samples/issue_1133.hwp` | hwp | no_oracle_pdf |
+| 180 | `samples/issue_2148_degenerate_cell_vpos.hwpx` | hwpx | no_oracle_pdf |
+| 181 | `samples/issues/2809/jubo_20260104.hwp` | hwp | no_oracle_pdf |
+| 182 | `samples/landscape-001.hwp` | hwp | no_oracle_pdf |
+| 183 | `samples/math-001.hwp` | hwp | no_oracle_pdf |
+| 184 | `samples/para-001.hwp` | hwp | no_oracle_pdf |
+| 185 | `samples/para-unit-01.hwp` | hwp | no_oracle_pdf |
+| 186 | `samples/pic-in-table-with-toggle.hwp` | hwp | no_oracle_pdf |
+| 187 | `samples/pic2-2018.hwp` | hwp | no_oracle_pdf |
+| 188 | `samples/pr4093/outline_navigation_panel_demo.hwpx` | hwpx | no_oracle_pdf |
+| 189 | `samples/pr4093/outline_navigation_table_cell_number.hwpx` | hwpx | no_oracle_pdf |
+| 190 | `samples/render-p35-font-native-bitmap.hwpx` | hwpx | no_oracle_pdf |
+| 191 | `samples/shape-001.hwp` | hwp | no_oracle_pdf |
+| 192 | `samples/ta-pic-001-r.hwp` | hwp | no_oracle_pdf |
+| 193 | `samples/ta-pic-cell-center-pos-bottom.hwpx` | hwpx | no_oracle_pdf |
+| 194 | `samples/ta-pic-cell-top-pos-center.hwpx` | hwpx | no_oracle_pdf |
+| 195 | `samples/tac-host-spacing.hwpx` | hwpx | no_oracle_pdf |
+| 196 | `samples/tac-verify/scenario-a-after.hwp` | hwp | no_oracle_pdf |
+| 197 | `samples/tac-verify/scenario-a-before.hwp` | hwp | no_oracle_pdf |
+| 198 | `samples/tac-verify/scenario-b-after.hwp` | hwp | no_oracle_pdf |
+| 199 | `samples/tac-verify/scenario-b-before.hwp` | hwp | no_oracle_pdf |
+| 200 | `samples/tac-verify/scenario-c-after.hwp` | hwp | no_oracle_pdf |
+| 201 | `samples/tac-verify/scenario-c-before.hwp` | hwp | no_oracle_pdf |
+| 202 | `samples/tac-verify/scenario-d-after.hwp` | hwp | no_oracle_pdf |
+| 203 | `samples/tac-verify/scenario-d-before.hwp` | hwp | no_oracle_pdf |
+| 204 | `samples/task1700/byeolpyo1_uujeong_wrap_singlepage.hwp` | hwp | no_oracle_pdf |
+| 205 | `samples/task1700/myeonjeok_wrap_10page.hwp` | hwp | no_oracle_pdf |
+| 206 | `samples/task1705/wrap_empty_para_anchor_page.hwp` | hwp | no_oracle_pdf |
+| 207 | `samples/task1706/empty_para_before_pagebreak.hwpx` | hwpx | no_oracle_pdf |
+| 208 | `samples/task1706/empty_para_between_tac_tables.hwp` | hwp | no_oracle_pdf |
+| 209 | `samples/task1716/table_scattered_header_rowbreak.hwpx` | hwpx | no_oracle_pdf |
+| 210 | `samples/task1718/table_giant_cell_overfill.hwp` | hwp | no_oracle_pdf |
+| 211 | `samples/task1725/text_footnote_tail_overpagination.hwp` | hwp | no_oracle_pdf |
+| 212 | `samples/task1725/text_footnote_tail_overpagination.hwpx` | hwpx | no_oracle_pdf |
+| 213 | `samples/task1745/table_text_anchor_wrap.hwp` | hwp | no_oracle_pdf |
+| 214 | `samples/task1749/saved_bounds_cumulative_page_break.hwp` | hwp | no_oracle_pdf |
+| 215 | `samples/task1749/saved_bounds_cumulative_page_break.hwpx` | hwpx | no_oracle_pdf |
+| 216 | `samples/task1749/saved_bounds_cumulative_vpos.hwp` | hwp | no_oracle_pdf |
+| 217 | `samples/task1749/saved_bounds_cumulative_vpos.hwpx` | hwpx | no_oracle_pdf |
+| 218 | `samples/task1750/split_guard_spacing_before.hwp` | hwp | no_oracle_pdf |
+| 219 | `samples/task1750/split_guard_spacing_before.hwpx` | hwpx | no_oracle_pdf |
+| 220 | `samples/task1753/deferred_takeplace_fill_ahead.hwp` | hwp | no_oracle_pdf |
+| 221 | `samples/task1753/deferred_takeplace_fill_ahead.hwpx` | hwpx | no_oracle_pdf |
+| 222 | `samples/task1763/cell_trailing_ls_expand.hwp` | hwp | no_oracle_pdf |
+| 223 | `samples/task1763/cell_trailing_ls_expand.hwpx` | hwpx | no_oracle_pdf |
+| 224 | `samples/task1765/merged_cell_trailing_ls.hwp` | hwp | no_oracle_pdf |
+| 225 | `samples/task1765/merged_cell_trailing_ls.hwpx` | hwpx | no_oracle_pdf |
+| 226 | `samples/task1768/distribution_doc.hwpx` | hwpx | no_oracle_pdf |
+| 227 | `samples/task1771/nested_group_vectors.hwpx` | hwpx | no_oracle_pdf |
+| 228 | `samples/task1772/table_outer_margin_common_sync.hwpx` | hwpx | no_oracle_pdf |
+| 229 | `samples/task1789/exclusion_probe_line_spacing.hwpx` | hwpx | no_oracle_pdf |
+| 230 | `samples/task2070/hy_ladder3.hwpx` | hwpx | no_oracle_pdf |
+| 231 | `samples/task2070/hy_ladder4.hwpx` | hwpx | no_oracle_pdf |
+| 232 | `samples/task2097/17809123_jawonbongsa.hwpx` | hwpx | no_oracle_pdf |
+| 233 | `samples/task2097/18095317_eogu_geumji.hwp` | hwp | no_oracle_pdf |
+| 234 | `samples/task2097/21217935_simsa_jipyo.hwp` | hwp | no_oracle_pdf |
+| 235 | `samples/task2097/3023771_wichokjang.hwpx` | hwpx | no_oracle_pdf |
+| 236 | `samples/task2097/3248363_upmu_bunjang.hwpx` | hwpx | no_oracle_pdf |
+| 237 | `samples/task2097/rowbreak_midpage_declared_fits.hwpx` | hwpx | no_oracle_pdf |
+| 238 | `samples/task2105/rowbreak_table_declared_fits.hwpx` | hwpx | no_oracle_pdf |
+| 239 | `samples/task2137/156637323_unification_lecture.hwpx` | hwpx | no_oracle_pdf |
+| 240 | `samples/task2156/width_ladder.hwpx` | hwpx | no_oracle_pdf |
+| 241 | `samples/task2169/anchor_ladder.hwpx` | hwpx | no_oracle_pdf |
+| 242 | `samples/task2169/empty_ladder.hwpx` | hwpx | no_oracle_pdf |
+| 243 | `samples/task2279/36353832_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 244 | `samples/task2279/36358528_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 245 | `samples/task2279/36365360_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 246 | `samples/task2279/36376848_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 247 | `samples/task2279/36378128_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 248 | `samples/task2279/36378481_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 249 | `samples/task2279/36394733_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 250 | `samples/task2279/36395825_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 251 | `samples/task2279/36398724_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 252 | `samples/task2279/36404953_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 253 | `samples/task2279/36406174_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 254 | `samples/task2279/36407074_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 255 | `samples/task2279/36410902_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 256 | `samples/task2279/36417406_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 257 | `samples/task2279/36423194_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 258 | `samples/task2279/36423558_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 259 | `samples/task2279/36425476_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 260 | `samples/task2279/36433160_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 261 | `samples/task2279/36434078_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 262 | `samples/task2279/36437313_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 263 | `samples/task2279/36446358_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 264 | `samples/task2279/36455850_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 265 | `samples/task2279/36456688_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 266 | `samples/task2279/36477251_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 267 | `samples/task2279/36477373_gyeoljae.hwpx` | hwpx | no_oracle_pdf |
+| 268 | `samples/task2311/156744475_nano_plan_poster.hwpx` | hwpx | no_oracle_pdf |
+| 269 | `samples/task2319/20544835_jinan_apt_form.hwp` | hwp | no_oracle_pdf |
+| 270 | `samples/task2322/19439117_gokseong_voucher_form.hwp` | hwp | no_oracle_pdf |
+| 271 | `samples/task2322/20862337_cheongyang_voucher_form.hwp` | hwp | no_oracle_pdf |
+| 272 | `samples/task2430/1382000_domestic_violence_survey.hwp` | hwp | no_oracle_pdf |
+| 273 | `samples/task3307/issue3307_outline_number.hwpx` | hwpx | no_oracle_pdf |
+| 274 | `samples/tb-img-03.hwp` | hwp | no_oracle_pdf |
+| 275 | `samples/test-image.hwp` | hwp | no_oracle_pdf |
+| 276 | `samples/test-image.hwpx` | hwpx | no_oracle_pdf |
+| 277 | `samples/test-image2.hwp` | hwp | no_oracle_pdf |
+| 278 | `samples/textbox-under-image.hwp` | hwp | no_oracle_pdf |
+| 279 | `samples/unicode/각 항목에 명시되어 있는_유니코드.hwp` | hwp | no_oracle_pdf |
+| 280 | `samples/valign_fixtures/cell_vbottom_nested_overcount.hwpx` | hwpx | no_oracle_pdf |
+| 281 | `samples/valign_fixtures/cell_vcenter_multi_nested_overcount.hwpx` | hwpx | no_oracle_pdf |
+| 282 | `samples/valign_fixtures/cell_vcenter_nested_undercount.hwpx` | hwpx | no_oracle_pdf |
+| 283 | `samples/valign_fixtures/centered_cell_nested_table.hwpx` | hwpx | no_oracle_pdf |
+| 284 | `samples/water-mark.hwp` | hwp | no_oracle_pdf |
+| 285 | `samples/대각선샘플3.hwp` | hwp | no_oracle_pdf |
+| 286 | `samples/대각선샘플3.hwpx` | hwpx | no_oracle_pdf |
+| 287 | `samples/대각선샘플4.hwp` | hwp | no_oracle_pdf |
+| 288 | `samples/대각선샘플4.hwpx` | hwpx | no_oracle_pdf |
+| 289 | `samples/대각선샘플5.hwp` | hwp | no_oracle_pdf |
+| 290 | `samples/대각선샘플5.hwpx` | hwpx | no_oracle_pdf |
+| 291 | `samples/셀보호.hwp` | hwp | no_oracle_pdf |
+| 292 | `samples/셀보호.hwpx` | hwpx | no_oracle_pdf |
+| 293 | `samples/수식-문자처럼취급-아님.hwp` | hwp | no_oracle_pdf |
+| 294 | `samples/수식-문자처럼취급-아님.hwpx` | hwpx | no_oracle_pdf |
+| 295 | `samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp` | hwp | no_oracle_pdf |
+| 296 | `samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx` | hwpx | no_oracle_pdf |
+| 297 | `samples/종이기준.hwp` | hwp | no_oracle_pdf |
+| 298 | `samples/종이기준.hwpx` | hwpx | no_oracle_pdf |
+| 299 | `samples/쪽기준.hwp` | hwp | no_oracle_pdf |
+| 300 | `samples/쪽기준.hwpx` | hwpx | no_oracle_pdf |
+| 301 | `samples/투명도0-50-2nd그림글차처럼off.hwp` | hwp | no_oracle_pdf |
+| 302 | `samples/투명도0-50-2nd그림글차처럼off.hwpx` | hwpx | no_oracle_pdf |
+| 303 | `samples/투명도0-50.hwp` | hwp | no_oracle_pdf |
+| 304 | `samples/투명도0-50.hwpx` | hwpx | no_oracle_pdf |
+| 305 | `samples/한글문서파일형식_5.0_revision1.3.hwp` | hwp | no_oracle_pdf |

--- a/tools/oracle_public/test_coverage_report.py
+++ b/tools/oracle_public/test_coverage_report.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""coverage_report.py 가드 테스트 — 실 코퍼스 불요.
+
+실행:
+    python -m unittest tools/oracle_public/test_coverage_report.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import coverage_report as cov  # noqa: E402
+
+MINI_REPO = HERE / "fixtures" / "mini_repo"
+SCRIPT = HERE / "coverage_report.py"
+
+
+def _touch(path: Path, body: str = "placeholder\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8", newline="\n")
+
+
+def write_mini_tree(root: Path) -> None:
+    """테스트용 최소 트리. 실 코퍼스와 같은 이름 규칙을 쓴다."""
+    files = [
+        "samples/exam_kor.hwp",
+        "samples/exam_kor.hwpx",
+        "samples/lonely.hwp",
+        "samples/편람.hwp",
+        "samples/편람.hwpx",
+        "samples/hwp3-sample.hwp",
+        "samples/hwp3-sample-hwpx.hwpx",
+        "samples/3-09월_교육_통합_2022.hwp",
+        "samples/basic/calendar_year.hwp",
+        "samples/multi.hwp",
+        "samples/readme.txt",
+        "pdf/exam_kor-2022.pdf",
+        "pdf/편람-hwp-2020.pdf",
+        "pdf/편람-hwpx-2020.pdf",
+        "pdf/hwp3-sample-hwpx-2022.pdf",
+        "pdf/3-09월_교육_통합_2022.pdf",
+        "pdf/basic/calendar_year-2022.pdf",
+        "pdf/multi-2018.pdf",
+        "pdf/multi-2024.pdf",
+        "pdf/unused-2022.pdf",
+        "pdf-2020/exam_kor-2020.pdf",
+        "pdf-large/hwpx/lonely.pdf",
+    ]
+    for rel in files:
+        _touch(root / rel)
+
+
+class ParseSuffixTests(unittest.TestCase):
+    def test_plain_year(self) -> None:
+        info = cov.parse_oracle_suffix("exam_kor", "exam_kor-2022.pdf")
+        self.assertEqual(info, {"year": "2022", "variant": "2022", "fmt": None})
+
+    def test_hwp_variant_does_not_steal_hwpx_stem(self) -> None:
+        stolen = cov.parse_oracle_suffix("hwp3-sample", "hwp3-sample-hwpx-2022.pdf")
+        self.assertIsNotNone(stolen)
+        assert stolen is not None
+        self.assertEqual(stolen["fmt"], "hwpx")
+        own = cov.parse_oracle_suffix(
+            "hwp3-sample-hwpx", "hwp3-sample-hwpx-2022.pdf"
+        )
+        self.assertEqual(own, {"year": "2022", "variant": "2022", "fmt": None})
+
+    def test_hwp_2020_variant(self) -> None:
+        info = cov.parse_oracle_suffix("편람", "편람-hwp-2020.pdf")
+        self.assertEqual(info, {"year": "2020", "variant": "hwp-2020", "fmt": "hwp"})
+
+    def test_exact_stem_with_year(self) -> None:
+        info = cov.parse_oracle_suffix(
+            "3-09월_교육_통합_2022", "3-09월_교육_통합_2022.pdf"
+        )
+        self.assertEqual(info, {"year": "2022", "variant": "exact", "fmt": None})
+
+    def test_exact_stem_without_year_rejected(self) -> None:
+        self.assertIsNone(cov.parse_oracle_suffix("lonely", "lonely.pdf"))
+
+    def test_unrelated_name_rejected(self) -> None:
+        self.assertIsNone(cov.parse_oracle_suffix("exam_kor", "other-2022.pdf"))
+
+    def test_year_2010_is_out_of_scope(self) -> None:
+        self.assertIsNone(cov.parse_oracle_suffix("doc", "doc-2010.pdf"))
+
+    def test_hancom_alt_suffix(self) -> None:
+        info = cov.parse_oracle_suffix("doc", "doc-hancom2020.pdf")
+        self.assertIsNotNone(info)
+        assert info is not None
+        self.assertEqual(info["year"], "2020")
+        self.assertEqual(info["variant"], "hancom2020")
+
+
+class MiniRepoTests(unittest.TestCase):
+    def test_checked_in_fixture_tree_exists(self) -> None:
+        self.assertTrue((MINI_REPO / "samples" / "exam_kor.hwp").is_file())
+        self.assertTrue((MINI_REPO / "pdf" / "exam_kor-2022.pdf").is_file())
+        self.assertTrue((MINI_REPO / "samples" / "lonely.hwp").is_file())
+
+    def test_walk_ignores_non_hwp(self) -> None:
+        docs = cov.walk_samples(MINI_REPO / "samples", MINI_REPO)
+        names = [doc.sample for doc in docs]
+        self.assertNotIn("samples/readme.txt", names)
+        self.assertIn("samples/exam_kor.hwp", names)
+        self.assertIn("samples/exam_kor.hwpx", names)
+
+    def test_mini_unmatched_and_pairs(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        errors = cov.validate_report(report)
+        self.assertEqual(errors, [])
+        samples = {item["sample"] for item in report["pairs"]}
+        self.assertIn("samples/exam_kor.hwp", samples)
+        self.assertIn("samples/편람.hwp", samples)
+        self.assertIn("samples/hwp3-sample-hwpx.hwpx", samples)
+        self.assertIn("samples/3-09월_교육_통합_2022.hwp", samples)
+        unmatched = {item["sample"] for item in report["unmatched"]}
+        self.assertIn("samples/lonely.hwp", unmatched)
+        self.assertIn("samples/hwp3-sample.hwp", unmatched)
+        self.assertNotIn("samples/readme.txt", unmatched)
+        self.assertEqual(report["unmatchedCount"], 2)
+        self.assertEqual(report["sampleCount"], 10)
+        self.assertEqual(report["matchedSampleCount"], 8)
+        self.assertEqual(report["pairCount"], 11)
+
+    def test_format_tag_does_not_cross_hwp_hwpx(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        hwp_pdfs = [
+            item["pdf"]
+            for item in report["pairs"]
+            if item["sample"] == "samples/편람.hwp"
+        ]
+        hwpx_pdfs = [
+            item["pdf"]
+            for item in report["pairs"]
+            if item["sample"] == "samples/편람.hwpx"
+        ]
+        self.assertEqual(hwp_pdfs, ["pdf/편람-hwp-2020.pdf"])
+        self.assertEqual(hwpx_pdfs, ["pdf/편람-hwpx-2020.pdf"])
+
+    def test_hwpx_stem_keeps_full_name(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        hits = [
+            item
+            for item in report["pairs"]
+            if item["sample"] == "samples/hwp3-sample-hwpx.hwpx"
+        ]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["pdf"], "pdf/hwp3-sample-hwpx-2022.pdf")
+        self.assertEqual(hits[0]["hancomVersion"], "2022")
+        self.assertEqual(hits[0]["stem"], "hwp3-sample-hwpx")
+
+    def test_exact_year_in_stem(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        hits = [
+            item
+            for item in report["pairs"]
+            if item["sample"] == "samples/3-09월_교육_통합_2022.hwp"
+        ]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["pdf"], "pdf/3-09월_교육_통합_2022.pdf")
+        self.assertEqual(hits[0]["variant"], "exact")
+        self.assertEqual(hits[0]["hancomVersion"], "2022")
+
+    def test_nested_dir_and_extra_root(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        calendar = [
+            item["pdf"]
+            for item in report["pairs"]
+            if item["sample"] == "samples/basic/calendar_year.hwp"
+        ]
+        self.assertEqual(calendar, ["pdf/basic/calendar_year-2022.pdf"])
+        exam_roots = {
+            item["oracleRoot"]
+            for item in report["pairs"]
+            if item["sample"] == "samples/exam_kor.hwp"
+        }
+        self.assertEqual(exam_roots, {"pdf", "pdf-2020"})
+
+    def test_version_table_counts(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        by_ver = report["byHancomVersion"]
+        self.assertEqual(by_ver["2018"]["pairCount"], 1)
+        self.assertEqual(by_ver["2018"]["sampleCount"], 1)
+        self.assertEqual(by_ver["2020"]["pairCount"], 4)
+        self.assertEqual(by_ver["2020"]["sampleCount"], 4)
+        self.assertEqual(by_ver["2022"]["pairCount"], 5)
+        self.assertEqual(by_ver["2022"]["sampleCount"], 5)
+        self.assertEqual(by_ver["2024"]["pairCount"], 1)
+        self.assertEqual(by_ver["2024"]["sampleCount"], 1)
+
+    def test_unmatched_count_is_measured_not_hardcoded(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotRegex(source, r"unmatchedCount\s*=\s*276")
+        self.assertNotRegex(source, r"UNMATCHED\s*=\s*276")
+        report = cov.build_report(MINI_REPO)
+        self.assertEqual(report["unmatchedCount"], len(report["unmatched"]))
+        self.assertNotEqual(report["unmatchedCount"], 276)
+
+    def test_does_not_import_forbidden_siblings(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        # docstring 에 형제 도구 금지 안내는 있어도 import 는 없어야 한다.
+        self.assertNotIn("import visual_sweep", source)
+        self.assertNotIn("import issue_draft", source)
+        self.assertNotIn("import oracle_resolver", source)
+        self.assertNotIn("from oracle_resolver", source)
+
+
+class TempTreeAndCliTests(unittest.TestCase):
+    def test_temp_tree_matches_checked_in_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_mini_tree(root)
+            built = cov.build_report(root)
+        checked = cov.build_report(MINI_REPO)
+        self.assertEqual(built["unmatchedCount"], checked["unmatchedCount"])
+        self.assertEqual(built["pairCount"], checked["pairCount"])
+        self.assertEqual(
+            [item["sample"] for item in built["unmatched"]],
+            [item["sample"] for item in checked["unmatched"]],
+        )
+
+    def test_validate_rejects_bad_year(self) -> None:
+        data = cov.build_report(MINI_REPO)
+        data["pairs"][0]["hancomVersion"] = "2010"
+        errors = cov.validate_report(data)
+        self.assertTrue(any("hancomVersion" in err for err in errors))
+
+    def test_validate_rejects_count_mismatch(self) -> None:
+        data = cov.build_report(MINI_REPO)
+        data["unmatchedCount"] = 276
+        errors = cov.validate_report(data)
+        self.assertTrue(any("unmatchedCount" in err for err in errors))
+
+    def test_markdown_contains_unmatched_and_years(self) -> None:
+        report = cov.build_report(MINI_REPO)
+        md = cov.render_markdown(report)
+        self.assertIn("짝 없는 샘플 (2건)", md)
+        self.assertIn("`samples/lonely.hwp`", md)
+        self.assertIn("| 2018 |", md)
+        self.assertIn("| 2020 |", md)
+        self.assertIn("| 2022 |", md)
+        self.assertIn("| 2024 |", md)
+        self.assertNotIn("276", md)
+
+    def test_cli_writes_json_and_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_json = Path(tmp) / "coverage.json"
+            out_md = Path(tmp) / "coverage.md"
+            code = cov.main(
+                [
+                    "--repo-root",
+                    str(MINI_REPO),
+                    "--pretty",
+                    "--validate",
+                    "--json-out",
+                    str(out_json),
+                    "--md-out",
+                    str(out_md),
+                ]
+            )
+            self.assertEqual(code, 0)
+            payload = json.loads(out_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["claim"], "M01-3")
+            self.assertEqual(cov.validate_report(payload), [])
+            md = out_md.read_text(encoding="utf-8")
+            self.assertIn("M01-3", md)
+            self.assertIn("짝 없는 샘플", md)
+
+    def test_cli_missing_samples_is_usage_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code = cov.main(["--repo-root", tmp, "--json-out", "-"])
+            self.assertEqual(code, 2)
+
+    def test_does_not_read_visual_sweep(self) -> None:
+        self.assertFalse(hasattr(cov, "visual_sweep"))
+        self.assertNotIn("scripts/visual_sweep.py", os.listdir(str(HERE)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

M01-3 (#5353): samples/ 의 .hwp/.hwpx 와 {stem}-{year}.pdf (2018/2020/2022/2024) 짝을 맞춰 **짝 없는 샘플 목록**과 **한글 버전별 커버리지 표**를 만듭니다. oracle_resolver.py 가 devel 에 없어도 같은 규칙을 이 도구 안에서 직접 씁니다.

전부 tools/oracle_public/ 신규 파일입니다. scripts/visual_sweep.py 와 issue_draft.py(M01-6)는 수정하지 않았습니다.

- coverage_report.py — 같은 상대 경로의 pdf/ · pdf-2020/ · pdf-large/ 에서 {stem}-{year}.pdf (및 -hwp-2020 등 허용 변형)를 맞춘다
- fixtures/mini_repo/ — 짝 있음·없음·형식 태그·중첩 디렉터리·다중 버전 픽스처
- test_coverage_report.py — 접미사 파싱·매칭·집계·CLI 25건 (실 코퍼스 불요)
- reports/coverage.md / reports/coverage.json — devel 실측 표

```
python tools/oracle_public/coverage_report.py --pretty --validate \
  --json-out tools/oracle_public/reports/coverage.json \
  --md-out tools/oracle_public/reports/coverage.md
```

실측 (devel, samples/ 694 · 오라클 PDF 425):

| 항목 | 수 |
| --- | ---: |
| 샘플 | 694 |
| 짝 있는 샘플 | 389 |
| 짝 없는 샘플 | **305** |
| 오라클 링크 | 409 |
| 2018 / 2020 / 2022 / 2024 링크 | 0 / 56 / 294 / 59 |

짝 없는 305는 실측이다. 이슈의 참고값(~276)을 코드에 박지 않았다. 2018 PDF 는 이 규칙으로 맞는 샘플이 없다.

## 관련 이슈

closes #5353

## 테스트

- [x] **cargo fmt --all -- --check 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일)
- [x] node scripts/rust-test-suite-manifest.mjs --check 통과
- [x] node scripts/rust-unit-test-tiers.mjs --check 통과
- [x] python -m unittest tools.oracle_public.test_coverage_report 25건 통과
- [ ] cargo test / cargo clippy — 해당 없음 (Rust 소스 미변경, Python 도구만 추가)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (문서 편집 없음)
- [ ] capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (독립 실행 Python 도구, 기존 코드 미변경)
- 재현·측정: python -m unittest tools.oracle_public.test_coverage_report (약 1초)

## 스크린샷

해당 없음.
