### PR TITLE
docs(ci): 오라클 공개 비교 CI advisory 잡 설계

### DIFF
--- a/.github/workflows/oracle-public-advisory.yml
+++ b/.github/workflows/oracle-public-advisory.yml
@@ -1,0 +1,407 @@
+# Oracle Public Advisory — 공개 한컴 PDF 오라클 쪽수 비교 (advisory).
+#
+# 설계: tools/oracle_public/ci_advisory.md
+# PR 게이트가 아니다. required check / branch protection 에 등록하지 말 것.
+# scripts/visual_sweep.py 는 호출·수정하지 않는다. --strict 금지.
+#
+# pull_request 트리거는 의도적으로 꺼 두었다. 켜더라도 required 로 올리지 않는다.
+# pull_request:
+#   branches: [devel]
+#   types: [opened, reopened, synchronize]
+#   paths:
+#     - 'src/renderer/**'
+#     - 'src/document_core/**'
+#     - 'src/paint/**'
+#     - 'tools/oracle_public/**'
+#     - '.github/workflows/oracle-public-advisory.yml'
+
+name: Oracle Public Advisory
+
+on:
+  workflow_dispatch:
+    inputs:
+      top_n:
+        description: '아티팩트로 남길 상위 실패 건수 (1–50)'
+        required: false
+        default: '10'
+        type: string
+      limit:
+        description: '비교할 최대 짝 수 (0=전수)'
+        required: false
+        default: '0'
+        type: string
+      include_large:
+        description: 'pdf-large/ LFS 실파일을 받아 비교에 포함한다'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: oracle-public-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  advisory:
+    name: oracle-public-compare-advisory
+    runs-on: ubuntu-latest
+    # [#3284] hang 상한 (성능 목표 아님). 내부 timeout 22m 뒤에 부분 리포트를 남긴다.
+    timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out sparse oracle tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          lfs: ${{ inputs.include_large }}
+          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            src
+            crates
+            tests
+            samples
+            pdf
+            pdf-2020
+            pdf-large
+            tools
+            bindings
+            scripts
+
+      - name: Gate on real oracle PDFs
+        id: pdf
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          roots = [Path("pdf"), Path("pdf-2020")]
+          if os.environ.get("INCLUDE_LARGE") == "true":
+              roots.append(Path("pdf-large"))
+
+          real = 0
+          pointers = 0
+          for root in roots:
+              if not root.is_dir():
+                  continue
+              for path in root.rglob("*"):
+                  if not path.is_file():
+                      continue
+                  try:
+                      head = path.read_bytes()[:80]
+                  except OSError:
+                      continue
+                  if head.startswith(b"%PDF-"):
+                      real += 1
+                  elif head.startswith(b"version https://git-lfs.github.com/spec/v1"):
+                      pointers += 1
+
+          runner = Path("tools/oracle_public/page_smoke.py").is_file()
+          reason = "ok"
+          if not runner:
+              reason = "runner-absent"
+          elif real == 0:
+              reason = "pdf-absent"
+
+          print(f"real_pdfs={real} lfs_pointers={pointers} runner={runner} reason={reason}")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"real_pdfs={real}\n")
+              fh.write(f"lfs_pointers={pointers}\n")
+              fh.write(f"runner={'true' if runner else 'false'}\n")
+              fh.write(f"reason={reason}\n")
+              fh.write(f"should_run={'true' if reason == 'ok' else 'false'}\n")
+          PY
+        env:
+          INCLUDE_LARGE: ${{ inputs.include_large }}
+
+      - name: Skip note
+        if: ${{ steps.pdf.outputs.should_run != 'true' }}
+        shell: bash
+        env:
+          REASON: ${{ steps.pdf.outputs.reason }}
+          REAL_PDFS: ${{ steps.pdf.outputs.real_pdfs }}
+          LFS_POINTERS: ${{ steps.pdf.outputs.lfs_pointers }}
+        run: |
+          set -euo pipefail
+          mkdir -p oracle-advisory
+          {
+            echo '## Oracle public compare (advisory) — skipped'
+            echo
+            echo "| reason | real_pdfs | lfs_pointers |"
+            echo "| --- | ---: | ---: |"
+            echo "| ${REASON} | ${REAL_PDFS} | ${LFS_POINTERS} |"
+            echo
+            echo '비교를 건너뛰었습니다. 이 잡은 advisory 이며 required check 가 아닙니다.'
+          } | tee oracle-advisory/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Install Rust toolchain
+        if: ${{ steps.pdf.outputs.should_run == 'true' }}
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+        with:
+          toolchain: 1.93.1
+
+      - name: Rust build cache (restore-only)
+        if: ${{ steps.pdf.outputs.should_run == 'true' }}
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
+        with:
+          shared-key: oracle-public-advisory
+          save-if: false
+
+      - name: Build rhwp
+        id: build
+        if: ${{ steps.pdf.outputs.should_run == 'true' }}
+        continue-on-error: true
+        shell: bash
+        run: cargo build --release --bin rhwp
+
+      - name: Build-failed note
+        if: ${{ steps.pdf.outputs.should_run == 'true' && steps.build.outcome != 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p oracle-advisory
+          {
+            echo '## Oracle public compare (advisory) — skipped'
+            echo
+            echo 'reason: `rhwp-build-failed`. cargo build --release --bin rhwp 가 실패했습니다.'
+            echo
+            echo '이 잡은 advisory 이며 required check 가 아닙니다.'
+          } | tee oracle-advisory/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Run public oracle compare
+        id: compare
+        if: ${{ steps.pdf.outputs.should_run == 'true' && steps.build.outcome == 'success' }}
+        shell: bash
+        env:
+          TOP_N: ${{ inputs.top_n }}
+          LIMIT: ${{ inputs.limit }}
+          INCLUDE_LARGE: ${{ inputs.include_large }}
+        run: |
+          set -uo pipefail
+          mkdir -p oracle-advisory/top
+          : > oracle-advisory/page-smoke.json
+
+          args=(
+            python3 tools/oracle_public/page_smoke.py
+            --rhwp target/release/rhwp
+            --json
+            --timeout 30
+          )
+          if [[ "${INCLUDE_LARGE}" != "true" ]]; then
+            args+=(--pdf-dirs pdf --pdf-dirs pdf-2020)
+          fi
+          if [[ -f tools/oracle_public/oracle_pairs.json ]]; then
+            args+=(--manifest tools/oracle_public/oracle_pairs.json)
+          fi
+          if [[ "${LIMIT}" =~ ^[1-9][0-9]*$ ]]; then
+            args+=(--limit "${LIMIT}")
+          fi
+
+          printf 'compare command: %s\n' "${args[*]}"
+          # --strict 없음. timeout 비정상 종료도 잡을 실패로 올리지 않는다.
+          set +e
+          timeout 22m "${args[@]}" > oracle-advisory/page-smoke.json
+          cmp_rc=$?
+          set -e
+          printf 'compare_exit=%s\n' "${cmp_rc}" >> "${GITHUB_OUTPUT}"
+          # 벽시계 초과(124)나 비교 비0도 advisory. 아티팩트 추출은 다음 step.
+          exit 0
+
+      - name: Pack top-N failures
+        if: ${{ steps.pdf.outputs.should_run == 'true' && steps.build.outcome == 'success' }}
+        shell: bash
+        env:
+          TOP_N: ${{ inputs.top_n }}
+          COMPARE_EXIT: ${{ steps.compare.outputs.compare_exit }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          out = Path("oracle-advisory")
+          report_path = out / "page-smoke.json"
+          raw = report_path.read_text(encoding="utf-8") if report_path.is_file() else ""
+          data = {}
+          parse_error = ""
+          if raw.strip():
+              try:
+                  data = json.loads(raw)
+              except json.JSONDecodeError as exc:
+                  parse_error = str(exc)
+                  data = {}
+
+          try:
+              top_n = int(os.environ.get("TOP_N") or "10")
+          except ValueError:
+              top_n = 10
+          top_n = max(1, min(top_n, 50))
+
+          rows = list(data.get("rows") or [])
+          summary = data.get("summary") or {}
+          if not summary:
+              summary = {
+                  "pairs": len(rows),
+                  "match": sum(1 for r in rows if str(r.get("verdict", "")).upper() == "MATCH"),
+                  "mismatch": sum(1 for r in rows if str(r.get("verdict", "")).upper() == "MISMATCH"),
+                  "error": sum(1 for r in rows if str(r.get("verdict", "")).upper() == "ERROR"),
+                  "unpaired": len(data.get("unpaired") or []),
+              }
+
+          def rank_key(row: dict) -> tuple:
+              verdict = str(row.get("verdict") or "").upper()
+              group = 0 if verdict == "MISMATCH" else 1 if verdict == "ERROR" else 2
+              delta = row.get("delta")
+              try:
+                  mag = abs(int(delta)) if delta is not None else -1
+              except (TypeError, ValueError):
+                  mag = -1
+              stem = str(row.get("stem") or row.get("doc") or "")
+              return (group, -mag, stem)
+
+          failures = [
+              r for r in rows
+              if str(r.get("verdict") or "").upper() in {"MISMATCH", "ERROR"}
+          ]
+          failures.sort(key=rank_key)
+          top = failures[:top_n]
+
+          slug_re = re.compile(r"[^\w가-힣.-]+", re.UNICODE)
+          packed = []
+          for i, row in enumerate(top, start=1):
+              stem = str(row.get("stem") or f"row-{i}")
+              slug = slug_re.sub("-", stem).strip("-")[:80] or f"row-{i}"
+              name = f"{i:02d}-{slug}.json"
+              (out / "top" / name).write_text(
+                  json.dumps(row, ensure_ascii=False, indent=2) + "\n",
+                  encoding="utf-8",
+              )
+              packed.append({"rank": i, "file": f"top/{name}", "row": row})
+
+          (out / "top-n.json").write_text(
+              json.dumps(
+                  {
+                      "topN": top_n,
+                      "compareExit": os.environ.get("COMPARE_EXIT"),
+                      "parseError": parse_error,
+                      "summary": summary,
+                      "failures": packed,
+                  },
+                  ensure_ascii=False,
+                  indent=2,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+
+          lines = [
+              "## Oracle public compare (advisory)",
+              "",
+              "이 잡은 **advisory** 입니다. required check 가 아니며 PR 게이트를 막지 않습니다.",
+              "`visual_sweep.py` 는 호출하지 않았습니다. `--strict` 는 쓰지 않았습니다.",
+              "",
+              "| pairs | match | mismatch | error | unpaired | compare_exit | top_n |",
+              "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+              (
+                  f"| {summary.get('pairs', 0)} | {summary.get('match', 0)} | "
+                  f"{summary.get('mismatch', 0)} | {summary.get('error', 0)} | "
+                  f"{summary.get('unpaired', 0)} | {os.environ.get('COMPARE_EXIT')} | {top_n} |"
+              ),
+              "",
+          ]
+          if parse_error:
+              lines.extend([f"JSON 파싱 경고: `{parse_error}`", ""])
+          if packed:
+              lines.extend(["### 상위 실패", "", "| rank | verdict | delta | doc | pdf |", "| ---: | --- | ---: | --- | --- |"])
+              for item in packed:
+                  row = item["row"]
+                  lines.append(
+                      f"| {item['rank']} | {row.get('verdict')} | {row.get('delta')} | "
+                      f"`{row.get('doc', '')}` | `{row.get('pdf', '')}` |"
+                  )
+                  repro = row.get("repro") or ""
+                  if repro:
+                      lines.extend(["", "```text", repro, "```"])
+          else:
+              lines.append("상위 실패 없음 (또는 리포트가 비어 있음).")
+          lines.append("")
+          (out / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          print("\n".join(lines))
+
+          drafts = Path("tools/oracle_public/issue_draft.py")
+          if drafts.is_file() and packed:
+              documents = []
+              for item in packed:
+                  row = item["row"]
+                  delta = row.get("delta")
+                  try:
+                      measured = abs(int(delta)) if delta is not None else 1
+                  except (TypeError, ValueError):
+                      measured = 1
+                  documents.append(
+                      {
+                          "id": str(row.get("stem") or item["file"]),
+                          "hwp": str(row.get("doc") or ""),
+                          "pdf": str(row.get("pdf") or ""),
+                          "pages": row.get("pdfPages"),
+                          "exceeds": True,
+                          "metrics": {
+                              "page_delta": delta,
+                              "rhwp_pages": row.get("rhwpPages"),
+                              "pdf_pages": row.get("pdfPages"),
+                          },
+                          "repro": {"command": str(row.get("repro") or "")},
+                          "notes": str(row.get("note") or ""),
+                      }
+                  )
+              report = {
+                  "schema": "oracle_public.failure_report/v1",
+                  "source": "dump-pages-smoke",
+                  "rhwp_bin": "target/release/rhwp",
+                  "threshold": {"metric": "page_delta", "op": ">=", "value": 0},
+                  "documents": documents,
+              }
+              fail_path = out / "failure-report.json"
+              fail_path.write_text(
+                  json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+                  encoding="utf-8",
+              )
+              dest = out / "drafts"
+              dest.mkdir(parents=True, exist_ok=True)
+              proc = subprocess.run(
+                  [
+                      sys.executable,
+                      str(drafts),
+                      "--report",
+                      str(fail_path),
+                      "--out",
+                      str(dest),
+                  ],
+                  check=False,
+              )
+              if proc.returncode != 0:
+                  print(f"issue_draft skipped rc={proc.returncode}", file=sys.stderr)
+          PY
+          cat oracle-advisory/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload advisory artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: oracle-public-advisory-${{ github.run_id }}
+          path: oracle-advisory/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/tools/oracle_public/ci_advisory.md
+++ b/tools/oracle_public/ci_advisory.md
@@ -1,0 +1,252 @@
+# 오라클 공개 비교 CI advisory 잡
+
+MEGA QUEUE M01-7 (#5357). 한컴 라이선스가 없는 기여자가 커밋된 한컴 PDF 오라클로
+269쌍을 1커맨드 비교할 수 있게 된 뒤, 그 비교를 CI 에 **advisory** 잡으로 올리는
+설계다. 이 문서는 제안이다. 병합만으로 PR 게이트를 바꾸지 않는다.
+
+`scripts/visual_sweep.py` 는 읽거나 수정하지 않는다. gym 은 쓰지 않는다.
+
+초안 워크플로: [`.github/workflows/oracle-public-advisory.yml`](../../.github/workflows/oracle-public-advisory.yml).
+트리거는 `workflow_dispatch` 만이다. `pull_request` 블록은 주석으로만 남겨 두었다.
+
+## 1. 목적과 비목표
+
+### 목적
+
+- 커밋된 `pdf/` · `pdf-2020/` (선택 `pdf-large/`) 오라클이 **실제로 있는** 러너에서
+  공개 비교(`tools/oracle_public/page_smoke.py`)를 돌린다.
+- 불일치는 데이터가 된다. 상위 N건을 아티팩트로 올려 사람이 본다.
+- M01-6 `issue_draft.py` 가 있으면 초안 markdown 까지 디스크에 남긴다. `gh issue create`
+  는 호출하지 않는다.
+
+### 비목표
+
+| 하지 않는 일 | 이유 |
+| --- | --- |
+| required check / branch protection 등록 | PR 게이트를 막지 않는다 |
+| `scripts/visual_sweep.py` 호출·수정 | jangster77 금지, 픽셀 전수는 이 잡 범위 밖 |
+| `--strict` | 쪽수 불일치가 있으면 종료 1 이 되어 빨간 엑스처럼 보인다 |
+| gym | 이 클레임 범위 밖 |
+| `issues: write` 로 이슈 자동 제출 | 제출은 사람 |
+| `pdf/` 없는 포크·sparse clone 에서 실패 | 없으면 skip, 종료 0 |
+
+## 2. 왜 advisory 인가
+
+1. 쪽수 불일치는 이미 알려진 회귀일 수 있다. 지금 강제 게이트로 켜면 devel PR 이 한꺼번에 막힌다.
+2. `pdf/` 는 메인 `ci.yml` 이 `paths-ignore` 하는 코퍼스다. 없는 checkout 이 흔하다.
+3. 269쌍 × `dump-pages` 는 렌더보다 가볍지만, hang 이 나면 게이트를 잡아먹으면 안 된다.
+4. 판정은 데이터다. M01-4 `page_smoke.py` 기본 종료 코드는 불일치가 있어도 0 이다.
+
+운영 등급은 [github_operations.md](../../mydocs/manual/github_operations.md) 의 **O2
+(라우팅·비용)** 이다. required check·권한 확대는 O3/O4 이고 이 제안 범위가 아니다.
+
+## 3. 잡 계약
+
+| 항목 | 값 |
+| --- | --- |
+| workflow 파일 | `.github/workflows/oracle-public-advisory.yml` |
+| workflow 이름 | `Oracle Public Advisory` |
+| job id / 이름 | `advisory` / `oracle-public-compare-advisory` |
+| 러너 | `ubuntu-latest` |
+| `timeout-minutes` | 30 (성능 목표 아님. [#3284] hang 상한과 같은 철학) |
+| 내부 벽시계 | `timeout 22m` — 잡 timeout 전에 부분 리포트를 남긴다 |
+| permissions | top-level `contents: read` 만 |
+| concurrency | `oracle-public-advisory-${{ github.ref }}`, cancel-in-progress |
+| `continue-on-error` | `true` (이중 안전장치) |
+| 비교 종료 코드 | 불일치여도 0. `--strict` 금지 |
+| required checks | **등록 금지**. 아래 4.3 |
+
+현재 required context (Lint / Build & Test / CodeQL / Render Diff 등) 와
+이름을 겹치지 않게 `oracle-public-compare-advisory` 를 쓴다.
+
+## 4. 트리거
+
+### 4.1 1단계 (이 PR 이 넣는 것)
+
+`workflow_dispatch` 만. 입력:
+
+| 입력 | 기본 | 의미 |
+| --- | --- | --- |
+| `top_n` | `10` | 아티팩트로 남길 상위 실패 건수 |
+| `limit` | `0` | 비교할 최대 짝. `0` = 전수 |
+| `include_large` | `false` | `pdf-large/` LFS 실파일을 받을지 |
+
+PR synchronize 마다 돌지 않는다. 메인테이너가 Actions 탭에서 켠다.
+
+### 4.2 2단계 (제안, 주석으로만)
+
+워크플로 YAML 에 `pull_request` 블록을 주석으로 남겨 두었다. 풀 조건:
+
+- base `devel`
+- `types: [opened, reopened, synchronize]`
+- `paths` 를 렌더·오라클 도구·이 YAML 로 좁힌다
+- **PDF 존재 게이트를 그대로 둔다** (4.4)
+- 풀어도 required check 로 등록하지 않는다
+- `--strict` 는 여전히 넣지 않는다
+
+`ci.yml` 의 `pdf/**` `paths-ignore` 와 충돌하지 않는다. 이 잡은 별도 workflow 다.
+
+### 4.3 required 로 켜지 않는 방법
+
+1. `on.pull_request` 를 주석 상태로 둔다 (1단계).
+2. 나중에 풀더라도 ruleset / branch protection 의 `required_status_checks` 에
+   `oracle-public-compare-advisory` 를 넣지 않는다. 이 변경은 O4 이고 별도 승인이다.
+3. `ci.yml` `needs:` 에 이 잡을 연결하지 않는다.
+4. 비교 커맨드에 `--strict` 를 넣지 않는다.
+5. 잡 step 은 마지막에 `exit 0` 이다. `continue-on-error: true` 는 백업이다.
+
+### 4.4 PDF 존재 게이트
+
+sparse checkout 직후, 실제 PDF 시그니처(`%PDF-`)가 하나라도 있어야 비교를 시작한다.
+Git LFS 포인터(`version https://git-lfs.github.com/spec/v1`) 만 있으면 **없는 것**으로 본다.
+
+판정:
+
+| 상태 | 동작 | 종료 |
+| --- | --- | --- |
+| `%PDF-` 파일 ≥ 1 | 비교 진행 | 0 (불일치 포함) |
+| 디렉터리만 있거나 LFS 포인터만 | skip, step summary 에 `pdf-absent` | 0 |
+| `page_smoke.py` 없음 (M01-4 미병합) | skip, `runner-absent` | 0 |
+| `cargo build --bin rhwp` 실패 | skip, `rhwp-build-failed`, 부분 로그 업로드 | 0 |
+
+`pdf-large/` 는 기본 비교 루트에서 뺀다. `.gitattributes` 상 LFS 는 `pdf-large/**/*.pdf`
+뿐이다. `pdf/` · `pdf-2020/` 는 일반 blob 이다.
+
+## 5. Sparse checkout
+
+`actions/checkout` cone-mode. 루트 `Cargo.toml` · `Cargo.lock` · `rust-toolchain.toml` 은
+cone 이 자동으로 포함한다.
+
+```text
+src
+crates
+tests
+samples
+pdf
+pdf-2020
+pdf-large
+tools
+bindings
+scripts
+```
+
+근거:
+
+- `pdf/` · `pdf-2020/` 가 공개 오라클이다. `samples/` 가 짝 문서다.
+- workspace members (`crates/*`, `tools/rhwp-subsecond`, `tools/batch-convert`,
+  `bindings/Native`) 가 빠지면 `cargo build --bin rhwp` 가 매니페스트에서 실패한다.
+- `tools/oracle_public/` 는 비교 러너·리포트 변환기다.
+- `pdf-large/` 는 목록에 넣되 `lfs: ${{ inputs.include_large }}` 로 실파일 수신을 끈다.
+  기본은 포인터만 받아서 용량을 줄인다.
+
+로컬 재현은 `tools/sparse_clone_hint.py` 의 `visual-regression` 프리셋과 같다.
+
+```text
+git sparse-checkout add pdf pdf-2020
+python tools/sparse_clone_hint.py --task visual-regression --apply
+```
+
+## 6. 비교 명령
+
+호출 순서:
+
+1. `tools/oracle_public/page_smoke.py` 가 없으면 skip (`runner-absent`).
+2. `cargo build --release --bin rhwp`.
+3. 짝 소스:
+   - `tools/oracle_public/oracle_pairs.json` 이 있으면 `--manifest` (M01-1).
+   - 없으면 글롭 `pdf/{stem}.pdf` · `pdf/{stem}-*.pdf` (M01-4 기본).
+4. `include_large != true` 이면 `--pdf-dirs pdf --pdf-dirs pdf-2020`.
+5. `limit > 0` 이면 `--limit N`.
+6. **`--strict` 없음.** `--json` 만.
+
+```text
+timeout 22m python tools/oracle_public/page_smoke.py \
+  --rhwp target/release/rhwp \
+  --json \
+  --timeout 30 \
+  > oracle-advisory/page-smoke.json
+```
+
+`--timeout 30` 은 짝당 `dump-pages` 상한(초)이다. 기본 180 초 × 269쌍은 잡 30분을 넘길 수 있다.
+
+픽셀 비교·`visual_sweep.py` 는 호출하지 않는다. 쪽수 스모크가 1차 공개 비교다.
+
+## 7. 상위 N 실패 아티팩트
+
+작업 디렉터리 `oracle-advisory/`:
+
+```text
+oracle-advisory/
+  page-smoke.json          # 전체 봉투 (schemaVersion / summary / rows)
+  summary.md               # job summary 와 동일
+  top-n.json               # 상위 N 실패만
+  top/
+    01-<stem>.json
+    02-<stem>.json
+    …
+  drafts/                  # issue_draft.py 가 있을 때만
+    manifest.json
+    *.md
+```
+
+선정:
+
+1. `verdict == MISMATCH` 를 `|delta|` 내림차순, 같으면 `stem` 오름차순.
+2. 자리가 남으면 `verdict == ERROR` 를 같은 키로 채운다.
+3. `N = inputs.top_n` (기본 10, 1..50 으로 clamp).
+
+각 top 파일은 `page_smoke` 행 + `repro` 문자열을 그대로 둔다. 예:
+
+```text
+python tools/oracle_public/page_smoke.py --pair samples/foo.hwp pdf/foo-2022.pdf
+```
+
+M01-6 `issue_draft.py` 가 있으면 `failure_report/v1` 로 변환해 `--out oracle-advisory/drafts`
+만 수행한다. `--submit` / `--gh` 는 넣지 않는다.
+
+업로드:
+
+- `actions/upload-artifact` SHA 핀 (저장소 관례 v7.0.1)
+- name: `oracle-public-advisory-${{ github.run_id }}`
+- `if-no-files-found: ignore` — skip 경로도 잡을 실패시키지 않는다
+- `retention-days: 14`
+
+## 8. 비용·시간
+
+| 구간 | 대략 | 비고 |
+| --- | --- | --- |
+| sparse checkout + `pdf/` blob | 1–5분 | `pdf/` 는 LFS 가 아님 |
+| `cargo build --release --bin rhwp` | 5–15분 | cache hit 시 수 분 |
+| 269쌍 `dump-pages` | 5–15분 | 짝당 30초 상한, 벽시계 22분 |
+| 잡 상한 | 30분 | hang 을 게이트로 승격하지 않음 |
+
+`pdf-large/` 전수는 `include_large=true` 수동 실행으로만 연다.
+
+cache: `Swatinem/rust-cache` 의 `save-if` 는 `devel`/`main` push 가 아니다. 이 잡은
+`workflow_dispatch` 이므로 restore-only 가 맞다. 캐시 키를 CI Lint 와 섞지 않는다.
+
+## 9. 활성화·롤백
+
+### 활성화 (메인테이너)
+
+1. 이 설계 PR 병합.
+2. 제안 이슈에서 M01-4 `page_smoke.py` 병합 여부를 확인.
+3. Actions → **Oracle Public Advisory** → `workflow_dispatch` 1회.
+4. 아티팩트·step summary 의 `summary.match/mismatch/error` 를 본다.
+5. (선택) YAML 의 `pull_request` 주석을 푸는 후속 PR. **required 등록은 하지 않는다.**
+
+### 롤백
+
+- 워크플로 파일 한 개를 지우거나 `on:` 을 빈 주석만 남긴다.
+- required checks 를 건드리지 않았으므로 protection rollback 은 없다.
+
+## 10. 로컬에서 같은 계약
+
+```text
+git sparse-checkout add pdf pdf-2020
+cargo build --release --bin rhwp
+python tools/oracle_public/page_smoke.py --json > page-smoke.json
+# --strict 없음
+```
+
+CI 는 위 커맨드의 상위 N 아티팩트 래퍼다. 새 비교 엔진을 이 잡에 넣지 않는다.


### PR DESCRIPTION
> **PR base 釉뚮옖移섍? `devel` ?몄? ?뺤씤?댁＜?몄슂** (`main` ?꾨떂 ??GitHub 湲곕낯 ?좏깮??main ?????덉뒿?덈떎). > ?묒뾽 釉뚮옖移섎뒗 理쒖떊 `upstream/devel` ?먯꽌 ?앹꽦?⑸땲?? ?곸꽭: [CONTRIBUTING.md](../CONTRIBUTING.md)  ## 蹂寃??붿빟  M01-7 (#5357): 怨듦컻 ?쒖뺨 PDF ?ㅻ씪??鍮꾧탳瑜?CI ??**advisory** ?≪쑝濡??ｋ뒗 ?ㅺ퀎?낅땲?? 蹂묓빀留뚯쑝濡?PR 寃뚯씠?몃? 諛붽씀吏 ?딆뒿?덈떎. `scripts/visual_sweep.py` ???섏젙?섏? ?딆븯?듬땲?? gym ?놁쓬.  - `tools/oracle_public/ci_advisory.md` ????怨꾩빟, ?몃━嫄? PDF 議댁옱 寃뚯씠?? sparse checkout, timeout, ?곸쐞 N ?ㅽ뙣 ?꾪떚?⑺듃, required 濡?耳쒖? ?딅뒗 諛⑸쾿, 濡ㅻ갚 - `.github/workflows/oracle-public-advisory.yml` ??`workflow_dispatch` ?꾩슜 珥덉븞. `pull_request` ??二쇱꽍. `--strict` ?놁쓬. `continue-on-error: true`. PDF/`page_smoke.py` ?놁쑝硫?skip ??醫낅즺 0  鍮꾧탳 ?щ꼫??M01-4 `page_smoke.py` ?낅땲???덉쑝硫?. ?놁쑝硫?`runner-absent` 濡?嫄대꼫?곷땲?? ?쎌? ?꾩닔쨌`visual_sweep.py` ?몄텧? ?섏? ?딆뒿?덈떎.  ## 愿???댁뒋  closes #5357  ## ?뚯뒪?? - [x] **`cargo fmt --all -- --check` ?듦낵** (PR ?앹꽦쨌push 吏곸쟾 ?꾩닔. CI Lint Format check ? ?숈씪. `cargo fmt --check` 留뚯쑝濡쒕뒗 ???? - [x] `node scripts/rust-test-suite-manifest.mjs --check` ?듦낵 - [x] `node scripts/rust-unit-test-tiers.mjs --check` ?듦낵 - [ ] `cargo test` ?듦낵 ??Rust 蹂寃??놁쓬 - [ ] `cargo clippy -- -D warnings` ?듦낵 ??Rust 蹂寃??놁쓬 - [ ] 愿???섑뵆 ?뚯씪濡?SVG ?대낫?닿린 ?뺤씤 ???대떦 ?놁쓬 - [ ] ??WASM) ?뚮뜑留??뺤씤 ???대떦 ?놁쓬 - [ ] rhwp-studio ?몄쭛쨌UI 蹂寃????대떦 ?놁쓬 - [ ] ?묒뾽 利앸튃 罹≪뒓 ???대떦 ?놁쓬 (臾몄꽌쨌珥덉븞 ?뚰겕?뚮줈留? - [ ] capability 移댄깉濡쒓렇 ???대떦 ?놁쓬  ## ?깅뒫 ?곹뼢 諛?痢≪젙 寃곌낵 (?대떦?섎뒗 寃쎌슦)  - ?덉긽 ?곹뼢: ?놁쓬 (?쒗뭹 寃쎈줈 誘몃?寃? 珥덉븞 ?≪? ?섎룞 dispatch 留? - ?ы쁽쨌痢≪젙: 誘몄륫?? ??timeout 30遺? ?대? 踰쎌떆怨?22遺꾩쑝濡?hang ??寃뚯씠?몃줈 ?밴꺽?섏? ?딆쓬  ## ?ㅽ겕由곗꺑  ?대떦 ?놁쓬. 

제안 이슈: #5365
