### PR TITLE
feat(fuzz): nightly 스모크 CI — 기존 6타깃×60초 + 크래시 아티팩트

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -1,0 +1,85 @@
+name: Fuzz smoke
+
+# M03-1 / #5359 — #3141 1단계 스모크 배선.
+# 기존 cargo-fuzz 타깃 6개(parse_hwp / parse_hwp3 / parse_hwpx / parse_hml /
+# parse_wmf / parse_ooxml_chart)를 각 60초 돌리고, 크래시·타임아웃·OOM 산출물을
+# 실패 시 아티팩트로 올린다.
+#
+# PR required check 가 아니다. pull_request 트리거를 두지 않는다.
+# DoS 수정은 M03-3 이후. OSS-Fuzz 등재는 M10. 왕복 정합성은 M04.
+
+on:
+  schedule:
+    # 다른 nightly(cache-generation-sweep 18:23, CodeQL 월 06:00)와 시각을 겹치지 않게 한다.
+    - cron: "41 2 * * *"
+  workflow_dispatch:
+    inputs:
+      max_total_time:
+        description: 타깃당 libFuzzer 실행 초 (nightly 기본 60)
+        required: false
+        default: "60"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-smoke
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz-smoke:
+    name: fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    # 컴파일(sanitizer) + 60초 런. hang 상한이지 성능 목표가 아니다.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - parse_hwp
+          - parse_hwp3
+          - parse_hwpx
+          - parse_hml
+          - parse_wmf
+          - parse_ooxml_chart
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+        with:
+          toolchain: nightly
+
+      - name: Cache cargo-fuzz + sanitizer build
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
+        with:
+          workspaces: fuzz
+          shared-key: fuzz-smoke-${{ matrix.target }}
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Smoke-run ${{ matrix.target }} (60s)
+        env:
+          TARGET: ${{ matrix.target }}
+          MAX_TOTAL_TIME: ${{ github.event_name == 'workflow_dispatch' && inputs.max_total_time || '60' }}
+        run: |
+          set -euo pipefail
+          cargo +nightly fuzz run "${TARGET}" -- \
+            -max_total_time="${MAX_TOTAL_TIME}" \
+            -rss_limit_mb=2048 \
+            -timeout=30 \
+            -print_final_stats=1
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crash-${{ matrix.target }}-${{ github.run_id }}
+          path: |
+            fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: warn
+          retention-days: 14

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -55,6 +55,18 @@ cargo +nightly fuzz run parse_ooxml_chart -- -rss_limit_mb=2048 -timeout=30
   타임아웃으로 검출합니다. 기본값(1200초)은 이 용도에 너무 깁니다.
 - 병렬 실행이 필요하면 `-jobs=N -workers=N` 을 추가합니다.
 
+## Nightly 스모크 CI
+
+`.github/workflows/fuzz-smoke.yml` 이 **nightly(`02:41 UTC`) + `workflow_dispatch`** 로
+위 기존 타깃 6개를 각 60초 돌립니다. 플래그는 위와 같습니다
+(`-rss_limit_mb=2048 -timeout=30` + `-max_total_time=60`).
+크래시·타임아웃·OOM 이 나면 job 이 실패하고 `fuzz/artifacts/<타깃>/` 을
+아티팩트로 올립니다.
+
+이 잡은 PR required check 가 아닙니다 (`pull_request` 트리거 없음).
+왕복 정합성(#2740, M04)과 OSS-Fuzz 등재(M10)는 이 잡의 범위가 아닙니다.
+발견된 DoS 를 이 단계에서 고치지 않습니다(M03-3 이후).
+
 ### Windows 참고
 
 MSVC 링크 단계에서 `dbghelp.lib` 관련 오류가 나면 rust-lld로 우회합니다:
@@ -107,5 +119,5 @@ CFB/ZIP처럼 구조 제약이 강한 컨테이너 포맷은 시드 없이는 �
 
 - 2순위 하네스: `parse_body_text_section` / `parse_doc_info` / `parse_control` /
   EMF 등 나머지 임베드 포맷·컨테이너를 우회하는 내부 파서 직접 하네스
-- CI 통합: PR당 짧은 스모크 퍼징 또는 회귀 코퍼스 재생
-- OSS-Fuzz 등재 (메인테이너 판단)
+- nightly 스모크는 위 CI 절. PR 게이트·왕복 정합성(M04)은 여기 넣지 않습니다
+- OSS-Fuzz 등재 (M10, 메인테이너 판단)


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

#3141 1단계 스모크를 nightly 로 배선합니다. 기존 cargo-fuzz 타깃 **6개**를 각 60초 돌리고, 크래시·타임아웃·OOM 산출물을 실패 시 아티팩트로 올립니다.

스텁 타깃은 추가하지 않았습니다. devel 에 이미 있는 하네스만 씁니다.

| 타깃 | 진입점 |
|---|---|
| `parse_hwp` | `rhwp::parser::parse_hwp` |
| `parse_hwp3` | `rhwp::parser::hwp3::parse_hwp3` |
| `parse_hwpx` | `rhwp::parser::hwpx::parse_hwpx` |
| `parse_hml` | `rhwp::parser::hml::parse_hml` |
| `parse_wmf` | `WMFConverter::new(...).run()` |
| `parse_ooxml_chart` | `rhwp::ooxml_chart::parser::parse_chart_xml` |

## 관련 이슈

closes #5359

## 범위

- `.github/workflows/fuzz-smoke.yml` — `schedule` nightly(`02:41 UTC`) + `workflow_dispatch`. `pull_request` 트리거 없음 (PR required check 가 아님)
- 타깃당 `-max_total_time=60 -rss_limit_mb=2048 -timeout=30`
- 실패 시 `fuzz/artifacts/<타깃>/` 업로드
- `fuzz/README.md` 에 스모크 잡만 설명

## 하지 않은 것

- DoS 수정 (M03-3 이후)
- OSS-Fuzz 등재 (M10)
- 왕복 정합성 (M04 / #2740)
- gym / `visual_sweep.py` / DocumentCore 편집

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (generated harness `--prepare` 후)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 러스트 원본 미변경
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — `src/` 미변경
- [ ] `cargo test` — 러스트 미변경
- [ ] `cargo clippy -- -D warnings` — 러스트 미변경
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (제품 경로 미변경, nightly 전용)
- 재현·측정: 미측정