### PR TITLE
feat(harness): 페이지 수 왕복 공통 하네스

### DIFF
--- a/tools/page_roundtrip/README.md
+++ b/tools/page_roundtrip/README.md
@@ -1,0 +1,99 @@
+# page_roundtrip — 페이지 수 왕복 공통 하네스 (M05-1)
+
+판정 도구. `pages(원본) == pages(export → reimport)` 를 문서마다 기록한다.
+
+- `scripts/visual_sweep.py` · `gym/` 는 건드리지 않는다.
+- DocumentCore / serializer 구현을 바꾸지 않는다. 기존 CLI (`export-hwpx` / `convert --verify-pages`) 만 부른다.
+- `#3518` `#3521` `#3737` `#4056` `#4882` `#5128` 은 고치지 않는다. 카탈로그 expected-fail 로 남긴다.
+- 판정은 데이터다. 기본 종료 코드는 불일치가 있어도 0. `--strict` 만 신규 위반·ERROR 에서 1.
+
+## 1커맨드 (CI 부분집합)
+
+저장소 루트에서:
+
+```text
+python tools/page_roundtrip/harness.py --ci
+python tools/page_roundtrip/harness.py --ci --json
+python tools/page_roundtrip/harness.py --ci --strict
+```
+
+`--ci` 는 `tools/page_roundtrip/fixtures/ci-subset.json` 을 읽는다. samples/ 전수가 아니다.
+
+단위 시험 (가짜 rhwp, 실문서 불필요):
+
+```text
+python -m unittest tools.page_roundtrip.test_harness
+python -m unittest tools/page_roundtrip/test_harness.py
+```
+
+## samples/ + --limit
+
+```text
+python tools/page_roundtrip/harness.py --docs samples --limit 20
+python tools/page_roundtrip/harness.py --file samples/foo.hwp --route hwpx
+```
+
+`--limit N` 은 문서 N개다. 경로는 `--route` 로 펼친다.
+
+## Full sweep (로컬, 무거움)
+
+`samples/` 아래 `.hwp` / `.hwpx` 전수. 카탈로그 항목은 빠지지 않고 리포트 `catalog` 절에 남는다.
+
+```text
+cargo build --release --bin rhwp
+python tools/page_roundtrip/harness.py --docs samples
+python tools/page_roundtrip/harness.py --docs samples --json > page-roundtrip.json
+python tools/page_roundtrip/harness.py --docs samples --route both
+python tools/page_roundtrip/harness.py --docs samples --strict
+```
+
+매니페스트로 목록을 고정하려면:
+
+```text
+python tools/page_roundtrip/harness.py --docs samples --write-manifest tools/page_roundtrip/fixtures/full.json
+python tools/page_roundtrip/harness.py --manifest tools/page_roundtrip/fixtures/full.json
+```
+
+## 경로 (route)
+
+| route | 명령 | 기본 |
+| --- | --- | --- |
+| `hwpx` | `rhwp export-hwpx <입력> <tmp.hwpx> --verify-pages --json` | 기본. 이슈 가족(#3518 등)과 같다 |
+| `hwp` | `rhwp convert <입력> <tmp.hwp> --verify-pages --json` | HWP5 저장 왕복 |
+| `both` | 위 둘을 문서마다 한 행씩 | 전수 매트릭스 |
+
+기존 CLI 가 원본 쪽수 → 내보내기 → 재파싱 쪽수를 잰다. 하네스는 그 봉투의 `verifyPages.before/after/identical` 을 읽어 판정한다.
+
+## expected-fail 카탈로그
+
+`tools/page_roundtrip/catalog.json`. 알려진 위반을 숨기지 않는다.
+
+| 판정 | 뜻 |
+| --- | --- |
+| `MATCH` | 쪽수 동일, 카탈로그 밖 |
+| `MISMATCH` | 쪽수 불일치, 카탈로그 밖 — **신규 위반** |
+| `EXPECTED_FAIL` | 쪽수 불일치, 카탈로그에 있음 |
+| `UNEXPECTED_PASS` | 쪽수 동일, 카탈로그에 있음 — 카탈로그가 낡음 |
+| `ERROR` | 로드/내보내기/재파싱 실패 |
+| `CATALOG_MISSING` | 카탈로그 경로의 파일이 디스크에 없음 |
+
+`--limit` / `--manifest` / `--file` 때문에 이번 실행에 안 들어간 카탈로그 항목은 `catalog[].state=held` 로 남는다. 건너뛴 것처럼 지우지 않는다.
+
+## 불일치 재현
+
+리포트 `repro` 열을 그대로 실행한다.
+
+```text
+python tools/page_roundtrip/harness.py --file samples/hwp3-sample16.hwp --route hwpx
+rhwp export-hwpx samples/hwp3-sample16.hwp /tmp/rt.hwpx --verify-pages --json
+```
+
+## 종료 코드
+
+| 코드 | 조건 |
+| --- | --- |
+| 0 | 기본. MATCH/MISMATCH/EXPECTED_FAIL 도 데이터 |
+| 1 | `--strict` 이고 MISMATCH · ERROR · UNEXPECTED_PASS · CATALOG_MISSING ≥ 1 |
+| 2 | 인자/매니페스트/카탈로그 사용법 오류 |
+
+`EXPECTED_FAIL` 은 `--strict` 에서도 통과다 (이미 이슈로 추적 중).

--- a/tools/page_roundtrip/__init__.py
+++ b/tools/page_roundtrip/__init__.py
@@ -1,0 +1,1 @@
+"""페이지 수 왕복 공통 하네스 (M05-1). pages(원본)==pages(export→reimport)."""

--- a/tools/page_roundtrip/catalog.json
+++ b/tools/page_roundtrip/catalog.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "kind": "pageRoundtripCatalog",
+  "notes": [
+    "M05-1 판정 도구의 expected-fail 목록이다. 침묵 스킵 금지 — 항목은 항상 리포트에 남는다.",
+    "이슈 수정(#3518 #3521 #3737 #4056 #4882 #5128)은 M05-2~ 의 몫이다. 고치면 이 목록에서 뺀다."
+  ],
+  "entries": [
+    {
+      "doc": "samples/hwp3-sample16.hwp",
+      "route": "hwpx",
+      "issue": 3518,
+      "reason": "HWPX 내보내기 전후 쪽수 불일치 (64→65)"
+    },
+    {
+      "doc": "samples/synam-001.hwp",
+      "route": "hwpx",
+      "issue": 3521,
+      "reason": "HWPX 내보내기 전후 쪽수 불일치 (35→36)"
+    },
+    {
+      "doc": "samples/hwp3-sample11.hwp",
+      "route": "hwpx",
+      "issue": 3737,
+      "reason": "HWPX 내보내기 전후 쪽수 불일치 (151→152)"
+    },
+    {
+      "doc": "samples/issue-505-equations.hwp",
+      "route": "hwpx",
+      "issue": 4056,
+      "reason": "HWPX 내보내기 전후 쪽수 불일치 (4→1)"
+    },
+    {
+      "doc": "samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp",
+      "route": "hwpx",
+      "issue": 4882,
+      "reason": "HWPX 내보내기 전후 쪽수 불일치 (215→223)"
+    },
+    {
+      "doc": "samples/한글문서파일형식_5.0_revision1.3.hwp",
+      "route": "hwpx",
+      "issue": 5128,
+      "reason": "HWPX 내보내기 전후 쪽수 불일치 (69→68)"
+    }
+  ]
+}

--- a/tools/page_roundtrip/fixtures/ci-subset.json
+++ b/tools/page_roundtrip/fixtures/ci-subset.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "kind": "pageRoundtripManifest",
+  "notes": [
+    "CI 용 픽스처 부분집합. samples/ 전수가 아니다.",
+    "issue-505-equations.hwp 는 catalog expected-fail (#4056) — 침묵 스킵하지 않는다."
+  ],
+  "docs": [
+    "samples/hwp3-ellipse-empty-textbox.hwp",
+    "samples/hwp3-pagedef-1915.hwp",
+    "samples/issue-505-equations.hwp"
+  ]
+}

--- a/tools/page_roundtrip/harness.py
+++ b/tools/page_roundtrip/harness.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""페이지 수 왕복 공통 하네스 — pages(원본)==pages(export→reimport).
+
+MEGA QUEUE M05-1 (#5367). 판정 도구만. #3518 #3521 #3737 #4056 #4882 #5128
+은 고치지 않는다. `scripts/visual_sweep.py` · gym · DocumentCore/serializer
+구현을 건드리지 않는다.
+
+기존 CLI 가 쪽수를 잰다:
+
+    rhwp export-hwpx <입력> <tmp.hwpx> --verify-pages --json
+    rhwp convert     <입력> <tmp.hwp>  --verify-pages --json
+
+판정은 데이터다. 기본 종료 코드는 불일치가 있어도 0. `--strict` 만
+MISMATCH/ERROR/UNEXPECTED_PASS/CATALOG_MISSING 에서 1 을 낸다.
+카탈로그 expected-fail 은 침묵 스킵하지 않는다.
+
+사용:
+    python tools/page_roundtrip/harness.py --ci
+    python tools/page_roundtrip/harness.py --docs samples --limit 20
+    python tools/page_roundtrip/harness.py --file samples/foo.hwp --route hwpx
+    python tools/page_roundtrip/harness.py --docs samples --json
+
+전수 스윕은 README Full sweep 절. CI 는
+`python -m unittest tools.page_roundtrip.test_harness` (가짜 rhwp).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+SCHEMA_VERSION = 1
+KIND = "pageRoundtripReport"
+CATALOG_KIND = "pageRoundtripCatalog"
+MANIFEST_KIND = "pageRoundtripManifest"
+DOC_SUFFIXES = {".hwp", ".hwpx"}
+ROUTES = ("hwpx", "hwp")
+DEFAULT_DOCS = ("samples",)
+VERIFY_FAIL_RE = re.compile(
+    r"검증 실패\(--verify-pages\):\s*변환 전\s*(\d+)\s*쪽,\s*재파싱 후\s*(\d+)\s*쪽"
+)
+VERIFY_PASS_RE = re.compile(r"검증 통과\(--verify-pages\):\s*(\d+)\s*쪽")
+
+HERE = Path(__file__).resolve().parent
+REPO_DEFAULT = HERE.parents[1]
+DEFAULT_CATALOG = HERE / "catalog.json"
+DEFAULT_CI_MANIFEST = HERE / "fixtures" / "ci-subset.json"
+
+
+class PageRoundtripError(Exception):
+    """하네스 사용법·카탈로그 오류. 종료 코드 2."""
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    doc: str
+    route: str
+    issue: int | None = None
+    reason: str = ""
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (norm_rel(self.doc), self.route)
+
+
+@dataclass(frozen=True)
+class Job:
+    doc: Path
+    route: str
+    rel: str = ""
+
+
+@dataclass
+class Row:
+    doc: str
+    route: str
+    pages_before: int | None
+    pages_after: int | None
+    equal: bool | None
+    verdict: str
+    issue: int | None = None
+    note: str = ""
+    repro: str = ""
+    rhwp_rc: int | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "doc": self.doc,
+            "route": self.route,
+            "pagesBefore": self.pages_before,
+            "pagesAfter": self.pages_after,
+            "equal": self.equal,
+            "verdict": self.verdict,
+            "issue": self.issue,
+            "note": self.note,
+            "repro": self.repro,
+            "rhwpRc": self.rhwp_rc,
+        }
+
+
+@dataclass
+class CatalogStatus:
+    doc: str
+    route: str
+    issue: int | None
+    reason: str
+    state: str
+    verdict: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "doc": self.doc,
+            "route": self.route,
+            "issue": self.issue,
+            "reason": self.reason,
+            "state": self.state,
+            "verdict": self.verdict,
+        }
+
+
+@dataclass
+class Report:
+    schema_version: int = SCHEMA_VERSION
+    kind: str = KIND
+    strict: bool = False
+    rhwp: str = ""
+    route: str = "hwpx"
+    source: str = "glob"
+    rows: list[Row] = field(default_factory=list)
+    catalog: list[CatalogStatus] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def summary(self) -> dict[str, int]:
+        counts = {
+            "jobs": 0,
+            "match": 0,
+            "mismatch": 0,
+            "expected_fail": 0,
+            "unexpected_pass": 0,
+            "error": 0,
+            "catalog_missing": 0,
+            "catalog_held": 0,
+        }
+        for row in self.rows:
+            counts["jobs"] += 1
+            key = row.verdict.lower()
+            if key in counts:
+                counts[key] += 1
+        for item in self.catalog:
+            if item.state == "held":
+                counts["catalog_held"] += 1
+            elif item.state == "missing" and item.verdict == "CATALOG_MISSING":
+                # 행으로도 세었으면 jobs 쪽에 이미 있다. held/missing 만 별도.
+                pass
+        return counts
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "schemaVersion": self.schema_version,
+            "kind": self.kind,
+            "strict": self.strict,
+            "rhwp": self.rhwp,
+            "route": self.route,
+            "source": self.source,
+            "summary": self.summary,
+            "rows": [r.to_json() for r in self.rows],
+            "mismatches": [r.to_json() for r in self.rows if r.verdict == "MISMATCH"],
+            "expectedFails": [r.to_json() for r in self.rows if r.verdict == "EXPECTED_FAIL"],
+            "unexpectedPasses": [r.to_json() for r in self.rows if r.verdict == "UNEXPECTED_PASS"],
+            "errors": [r.to_json() for r in self.rows if r.verdict == "ERROR"],
+            "catalog": [c.to_json() for c in self.catalog],
+            "notes": list(self.notes),
+        }
+
+
+def norm_rel(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./")
+
+
+def relpath(path: Path, repo: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix().replace("\\", "/")
+
+
+def find_rhwp(explicit: str | None = None, repo: Path | None = None) -> Path | None:
+    if explicit:
+        cand = Path(explicit)
+        return cand if cand.is_file() else None
+    env = os.environ.get("RHWP")
+    if env:
+        cand = Path(env)
+        if cand.is_file():
+            return cand
+    which = shutil.which("rhwp") or shutil.which("rhwp.exe")
+    if which:
+        return Path(which)
+    root = repo or REPO_DEFAULT
+    for rel in (
+        Path("target") / "release" / "rhwp.exe",
+        Path("target") / "release" / "rhwp",
+        Path("target") / "debug" / "rhwp.exe",
+        Path("target") / "debug" / "rhwp",
+    ):
+        cand = root / rel
+        if cand.is_file():
+            return cand
+    return None
+
+
+def expand_routes(route: str) -> list[str]:
+    if route == "both":
+        return list(ROUTES)
+    if route in ROUTES:
+        return [route]
+    raise PageRoundtripError(f"알 수 없는 --route: {route} (hwpx|hwp|both)")
+
+
+def repro_command(doc: str, route: str) -> str:
+    return f"python tools/page_roundtrip/harness.py --file {doc} --route {route}"
+
+
+def classify(
+    equal: bool | None,
+    *,
+    cataloged: bool,
+    error: bool = False,
+    missing: bool = False,
+) -> str:
+    """쪽수 비교 + 카탈로그 → 기계 판정. 침묵 스킵 없음."""
+    if missing:
+        return "CATALOG_MISSING"
+    if error or equal is None:
+        return "ERROR"
+    if cataloged and equal:
+        return "UNEXPECTED_PASS"
+    if cataloged and not equal:
+        return "EXPECTED_FAIL"
+    if equal:
+        return "MATCH"
+    return "MISMATCH"
+
+
+def parse_verify_pages(stdout: str, stderr: str) -> tuple[int, int] | None:
+    """export-hwpx/convert --verify-pages --json 봉투 또는 텍스트에서 쪽수를 읽는다."""
+    text = (stdout or "").strip()
+    blob = text
+    if blob and not blob.startswith("{"):
+        brace = blob.find("{")
+        if brace >= 0:
+            blob = blob[brace:]
+    if blob.startswith("{"):
+        try:
+            obj = json.loads(blob)
+        except json.JSONDecodeError:
+            obj = None
+        if isinstance(obj, dict):
+            vp = obj.get("verifyPages")
+            if isinstance(vp, dict) and "before" in vp and "after" in vp:
+                try:
+                    return int(vp["before"]), int(vp["after"])
+                except (TypeError, ValueError):
+                    pass
+
+    combined = "\n".join(part for part in (stdout, stderr) if part)
+    fail = VERIFY_FAIL_RE.search(combined)
+    if fail:
+        return int(fail.group(1)), int(fail.group(2))
+    passed = VERIFY_PASS_RE.search(combined)
+    if passed:
+        n = int(passed.group(1))
+        return n, n
+    return None
+
+
+def load_catalog(path: Path) -> list[CatalogEntry]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise PageRoundtripError(f"카탈로그가 객체가 아니다: {path}")
+    items = raw.get("entries") or raw.get("expectedFail") or raw.get("items") or []
+    if not isinstance(items, list):
+        raise PageRoundtripError(f"카탈로그 entries 가 배열이 아니다: {path}")
+    entries: list[CatalogEntry] = []
+    seen: set[tuple[str, str]] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        doc = item.get("doc") or item.get("sample") or item.get("path")
+        if not doc:
+            continue
+        route = str(item.get("route") or "hwpx").lower()
+        if route not in ROUTES:
+            raise PageRoundtripError(f"카탈로그 route 가 잘못됐다: {route} ({doc})")
+        issue_raw = item.get("issue")
+        issue: int | None
+        try:
+            issue = int(issue_raw) if issue_raw is not None else None
+        except (TypeError, ValueError) as exc:
+            raise PageRoundtripError(f"카탈로그 issue 가 숫자가 아니다: {issue_raw}") from exc
+        entry = CatalogEntry(
+            doc=norm_rel(str(doc)),
+            route=route,
+            issue=issue,
+            reason=str(item.get("reason") or ""),
+        )
+        if entry.key in seen:
+            continue
+        seen.add(entry.key)
+        entries.append(entry)
+    return entries
+
+
+def load_manifest(path: Path, repo: Path) -> list[Path]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    items: Iterable[Any]
+    if isinstance(raw, list):
+        items = raw
+    elif isinstance(raw, dict):
+        items = raw.get("docs") or raw.get("files") or raw.get("items") or []
+    else:
+        raise PageRoundtripError(f"매니페스트 형식이 아니다: {path}")
+    docs: list[Path] = []
+    seen: set[str] = set()
+    for item in items:
+        if isinstance(item, str):
+            rel = item
+        elif isinstance(item, dict):
+            rel = item.get("doc") or item.get("sample") or item.get("path")
+        else:
+            continue
+        if not rel:
+            continue
+        doc = Path(str(rel))
+        if not doc.is_absolute():
+            doc = repo / doc
+        key = str(doc.resolve()).casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        docs.append(doc)
+    return docs
+
+
+def write_manifest(path: Path, docs: Sequence[Path], repo: Path) -> None:
+    payload = {
+        "schemaVersion": SCHEMA_VERSION,
+        "kind": MANIFEST_KIND,
+        "docs": [relpath(d, repo) for d in docs],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def iter_docs(roots: Sequence[Path]) -> list[Path]:
+    docs: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        if root.is_file() and root.suffix.lower() in DOC_SUFFIXES:
+            key = str(root.resolve()).casefold()
+            if key not in seen:
+                seen.add(key)
+                docs.append(root)
+            continue
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in DOC_SUFFIXES:
+                continue
+            key = str(path.resolve()).casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            docs.append(path)
+    return docs
+
+
+def catalog_lookup(catalog: Sequence[CatalogEntry]) -> dict[tuple[str, str], CatalogEntry]:
+    return {entry.key: entry for entry in catalog}
+
+
+def run_job(
+    job: Job,
+    *,
+    repo: Path,
+    rhwp: Path | str | None,
+    catalog: dict[tuple[str, str], CatalogEntry],
+    out_dir: Path,
+    timeout: float,
+    runner: Any = None,
+) -> Row:
+    rel = job.rel or relpath(job.doc, repo)
+    repro = repro_command(rel, job.route)
+    cat = catalog.get((norm_rel(rel), job.route))
+    issue = cat.issue if cat else None
+    if not job.doc.is_file():
+        return Row(
+            doc=rel,
+            route=job.route,
+            pages_before=None,
+            pages_after=None,
+            equal=None,
+            verdict=classify(None, cataloged=cat is not None, missing=True),
+            issue=issue,
+            note="파일을 찾을 수 없다",
+            repro=repro,
+        )
+    if rhwp is None:
+        return Row(
+            doc=rel,
+            route=job.route,
+            pages_before=None,
+            pages_after=None,
+            equal=None,
+            verdict=classify(None, cataloged=cat is not None, error=True),
+            issue=issue,
+            note="rhwp 바이너리를 찾지 못했다 (RHWP/--rhwp/target/release)",
+            repro=repro,
+        )
+
+    ext = ".hwpx" if job.route == "hwpx" else ".hwp"
+    out_path = out_dir / f"{job.doc.stem}.{job.route}.rt{ext}"
+    if job.route == "hwpx":
+        cmd = [str(rhwp), "export-hwpx", str(job.doc), str(out_path), "--verify-pages", "--json"]
+    else:
+        cmd = [str(rhwp), "convert", str(job.doc), str(out_path), "--verify-pages", "--json"]
+
+    run = runner or subprocess.run
+    try:
+        proc = run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return Row(
+            doc=rel,
+            route=job.route,
+            pages_before=None,
+            pages_after=None,
+            equal=None,
+            verdict=classify(None, cataloged=cat is not None, error=True),
+            issue=issue,
+            note=f"timeout {timeout}s",
+            repro=repro,
+        )
+    except OSError as exc:
+        return Row(
+            doc=rel,
+            route=job.route,
+            pages_before=None,
+            pages_after=None,
+            equal=None,
+            verdict=classify(None, cataloged=cat is not None, error=True),
+            issue=issue,
+            note=f"실행 실패: {exc}",
+            repro=repro,
+        )
+
+    rc = getattr(proc, "returncode", 1)
+    parsed = parse_verify_pages(getattr(proc, "stdout", "") or "", getattr(proc, "stderr", "") or "")
+    if parsed is None:
+        err = (getattr(proc, "stderr", "") or "").strip().splitlines()
+        tail = err[-1] if err else f"rc={rc}"
+        return Row(
+            doc=rel,
+            route=job.route,
+            pages_before=None,
+            pages_after=None,
+            equal=None,
+            verdict=classify(None, cataloged=cat is not None, error=True),
+            issue=issue,
+            note=f"verify-pages 파싱 실패 rc={rc}: {tail}",
+            repro=repro,
+            rhwp_rc=rc,
+        )
+
+    before, after = parsed
+    equal = before == after
+    verdict = classify(equal, cataloged=cat is not None)
+    note = ""
+    if verdict != "MATCH":
+        note = f"before={before} after={after}"
+        if cat and cat.reason:
+            note = f"{note}; {cat.reason}"
+    return Row(
+        doc=rel,
+        route=job.route,
+        pages_before=before,
+        pages_after=after,
+        equal=equal,
+        verdict=verdict,
+        issue=issue,
+        note=note,
+        repro=repro,
+        rhwp_rc=rc,
+    )
+
+
+def build_jobs(
+    docs: Sequence[Path],
+    repo: Path,
+    routes: Sequence[str],
+) -> list[Job]:
+    jobs: list[Job] = []
+    for doc in docs:
+        rel = relpath(doc, repo)
+        for route in routes:
+            jobs.append(Job(doc=doc, route=route, rel=rel))
+    return jobs
+
+
+def attach_catalog_status(
+    report: Report,
+    catalog: Sequence[CatalogEntry],
+    ran_keys: set[tuple[str, str]],
+    repo: Path,
+    *,
+    require_missing_rows: bool = False,
+) -> None:
+    """카탈로그 전항을 리포트에 남긴다. 실행 밖은 held, 파일 없음은 missing.
+
+    전수 스윕(`require_missing_rows`)에서만 빠진 카탈로그 파일을 행으로 올린다.
+    --limit/--ci 는 catalog[].state=held|missing 으로만 남기고 침묵 삭제는 하지 않는다.
+    """
+    row_by_key = {(norm_rel(r.doc), r.route): r for r in report.rows}
+    for entry in catalog:
+        key = entry.key
+        if key in ran_keys:
+            row = row_by_key.get(key)
+            report.catalog.append(
+                CatalogStatus(
+                    doc=entry.doc,
+                    route=entry.route,
+                    issue=entry.issue,
+                    reason=entry.reason,
+                    state="run",
+                    verdict=row.verdict if row else "",
+                )
+            )
+            continue
+        disk = repo / entry.doc
+        if not disk.is_file():
+            report.catalog.append(
+                CatalogStatus(
+                    doc=entry.doc,
+                    route=entry.route,
+                    issue=entry.issue,
+                    reason=entry.reason,
+                    state="missing",
+                    verdict="CATALOG_MISSING",
+                )
+            )
+            if require_missing_rows and key not in row_by_key:
+                report.rows.append(
+                    Row(
+                        doc=entry.doc,
+                        route=entry.route,
+                        pages_before=None,
+                        pages_after=None,
+                        equal=None,
+                        verdict="CATALOG_MISSING",
+                        issue=entry.issue,
+                        note="카탈로그 경로의 파일이 없다 (침묵 스킵 금지)",
+                        repro=repro_command(entry.doc, entry.route),
+                    )
+                )
+            continue
+        report.catalog.append(
+            CatalogStatus(
+                doc=entry.doc,
+                route=entry.route,
+                issue=entry.issue,
+                reason=entry.reason,
+                state="held",
+                verdict="",
+            )
+        )
+
+
+def run_harness(
+    *,
+    repo: Path,
+    docs: Sequence[Path],
+    routes: Sequence[str],
+    catalog: Sequence[CatalogEntry],
+    rhwp: Path | str | None,
+    strict: bool,
+    source: str,
+    timeout: float = 180.0,
+    out_dir: Path | None = None,
+    runner: Any = None,
+    notes: Sequence[str] | None = None,
+    emit_missing_catalog: bool = True,
+    require_missing_rows: bool | None = None,
+) -> Report:
+    report = Report(
+        strict=strict,
+        rhwp=str(rhwp) if rhwp else "",
+        route=",".join(routes),
+        source=source,
+        notes=list(notes or ()),
+    )
+    cat_map = catalog_lookup(catalog)
+    jobs = build_jobs(docs, repo, routes)
+    ran_keys: set[tuple[str, str]] = set()
+
+    tmp_owned = None
+    work_dir = out_dir
+    if work_dir is None:
+        tmp_owned = tempfile.TemporaryDirectory(prefix="rhwp-page-rt-")
+        work_dir = Path(tmp_owned.name)
+    else:
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        for job in jobs:
+            ran_keys.add((norm_rel(job.rel or relpath(job.doc, repo)), job.route))
+            report.rows.append(
+                run_job(
+                    job,
+                    repo=repo,
+                    rhwp=rhwp,
+                    catalog=cat_map,
+                    out_dir=work_dir,
+                    timeout=timeout,
+                    runner=runner,
+                )
+            )
+    finally:
+        if tmp_owned is not None:
+            tmp_owned.cleanup()
+
+    if emit_missing_catalog:
+        if require_missing_rows is None:
+            require_missing_rows = source.startswith("glob")
+        attach_catalog_status(
+            report,
+            catalog,
+            ran_keys,
+            repo,
+            require_missing_rows=require_missing_rows,
+        )
+    return report
+
+
+def format_human(report: Report) -> str:
+    summary = report.summary
+    lines = [
+        f"# page-roundtrip jobs={summary['jobs']} match={summary['match']} "
+        f"mismatch={summary['mismatch']} expected_fail={summary['expected_fail']} "
+        f"unexpected_pass={summary['unexpected_pass']} error={summary['error']} "
+        f"catalog_missing={summary['catalog_missing']} catalog_held={summary['catalog_held']}",
+        "# 판정은 데이터다. 기본 종료 코드 0. --strict 이면 신규 위반/ERROR/UNEXPECTED_PASS/CATALOG_MISSING 시 1.",
+        "doc\troute\tbefore\tafter\tequal\tverdict\tissue\trepro",
+    ]
+    for row in report.rows:
+        before = "" if row.pages_before is None else str(row.pages_before)
+        after = "" if row.pages_after is None else str(row.pages_after)
+        equal = "" if row.equal is None else ("yes" if row.equal else "no")
+        issue = "" if row.issue is None else f"#{row.issue}"
+        lines.append(
+            f"{row.doc}\t{row.route}\t{before}\t{after}\t{equal}\t{row.verdict}\t{issue}\t{row.repro}"
+        )
+    new_violations = [r for r in report.rows if r.verdict == "MISMATCH"]
+    if new_violations:
+        lines.append("# new-violations")
+        for row in new_violations:
+            lines.append(f"# REPRO {row.repro}")
+            lines.append(f"#   {row.note}")
+    if report.catalog:
+        lines.append("# catalog")
+        for item in report.catalog:
+            issue = "" if item.issue is None else f"#{item.issue}"
+            extra = item.verdict or item.state
+            lines.append(f"# CATALOG {item.state}\t{item.doc}\t{item.route}\t{issue}\t{extra}")
+    for note in report.notes:
+        lines.append(f"# note: {note}")
+    return "\n".join(lines) + "\n"
+
+
+def exit_code(report: Report) -> int:
+    if not report.strict:
+        return 0
+    summary = report.summary
+    if (
+        summary["mismatch"]
+        or summary["error"]
+        or summary["unexpected_pass"]
+        or summary["catalog_missing"]
+    ):
+        return 1
+    return 0
+
+
+def _configure_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        reconf = getattr(stream, "reconfigure", None)
+        if callable(reconf):
+            try:
+                reconf(encoding="utf-8")
+            except (OSError, ValueError):
+                pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--repo", type=Path, default=None, help="저장소 루트 (기본: 이 파일 기준)")
+    p.add_argument("--rhwp", default=None, help="rhwp 바이너리. 없으면 RHWP / PATH / target/release")
+    p.add_argument("--docs", action="append", default=None, help="문서 루트 또는 파일. 반복 가능. 기본 samples/")
+    p.add_argument("--file", action="append", default=None, help="단건 재현. 반복 가능")
+    p.add_argument("--manifest", type=Path, default=None, help="문서 목록 JSON (CI 부분집합)")
+    p.add_argument("--ci", action="store_true", help="fixtures/ci-subset.json 으로 돌린다")
+    p.add_argument("--catalog", type=Path, default=None, help="expected-fail 카탈로그 JSON")
+    p.add_argument("--no-catalog", action="store_true", help="카탈로그를 비운다 (시험용)")
+    p.add_argument(
+        "--route",
+        default="hwpx",
+        choices=("hwpx", "hwp", "both"),
+        help="내보내기 경로. 기본 hwpx (이슈 가족과 동일)",
+    )
+    p.add_argument("--limit", type=int, default=None, help="앞에서 N 문서만 (전수 부담 줄이기)")
+    p.add_argument("--timeout", type=float, default=180.0, help="문서 하나 초")
+    p.add_argument("--out-dir", type=Path, default=None, help="왕복 산출물을 남길 폴더")
+    p.add_argument("--write-manifest", type=Path, default=None, help="선택한 문서 목록을 JSON 으로 저장")
+    p.add_argument("--strict", action="store_true", help="신규 위반/ERROR/UNEXPECTED_PASS/CATALOG_MISSING 이면 종료 1")
+    p.add_argument("--json", action="store_true", dest="as_json", help="stdout 에 JSON 봉투")
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    _configure_stdio()
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    repo = (args.repo or REPO_DEFAULT).resolve()
+
+    notes: list[str] = []
+    source = "glob"
+    docs: list[Path] = []
+
+    try:
+        routes = expand_routes(args.route)
+        if args.no_catalog:
+            catalog: list[CatalogEntry] = []
+        else:
+            catalog_path = args.catalog or DEFAULT_CATALOG
+            if not catalog_path.is_absolute():
+                catalog_path = (repo / catalog_path) if (repo / catalog_path).is_file() else catalog_path
+            if not catalog_path.is_file():
+                raise PageRoundtripError(f"카탈로그가 없다: {catalog_path}")
+            catalog = load_catalog(catalog_path)
+            notes.append(f"catalog={relpath(catalog_path, repo)} entries={len(catalog)}")
+
+        if args.file:
+            for item in args.file:
+                path = Path(item)
+                if not path.is_absolute():
+                    path = repo / path
+                docs.append(path)
+            source = "file"
+        elif args.ci:
+            man = DEFAULT_CI_MANIFEST
+            docs = load_manifest(man, repo)
+            source = f"ci:{relpath(man, repo)}"
+        elif args.manifest:
+            man = args.manifest
+            if not man.is_absolute():
+                man = repo / man
+            docs = load_manifest(man, repo)
+            source = f"manifest:{relpath(man, repo)}"
+        else:
+            roots = [repo / Path(d) if not Path(d).is_absolute() else Path(d) for d in (args.docs or DEFAULT_DOCS)]
+            docs = iter_docs(roots)
+            source = "glob:" + ",".join(relpath(r, repo) for r in roots)
+    except (OSError, json.JSONDecodeError, PageRoundtripError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.limit is not None:
+        docs = list(docs)[: max(0, args.limit)]
+
+    if args.write_manifest:
+        write_manifest(args.write_manifest, docs, repo)
+        notes.append(f"manifest written: {relpath(args.write_manifest, repo)}")
+
+    rhwp = find_rhwp(args.rhwp, repo)
+    if rhwp is None:
+        notes.append("rhwp 없음 — 행은 ERROR 로 남긴다")
+    if not docs:
+        notes.append("비교할 문서가 없다. --ci / --manifest / --file / --docs 를 확인")
+
+    report = run_harness(
+        repo=repo,
+        docs=docs,
+        routes=routes,
+        catalog=catalog,
+        rhwp=rhwp,
+        strict=bool(args.strict),
+        source=source,
+        timeout=float(args.timeout),
+        out_dir=args.out_dir,
+        notes=notes,
+    )
+
+    if args.as_json:
+        print(json.dumps(report.to_json(), ensure_ascii=False, indent=2))
+    else:
+        sys.stdout.write(format_human(report))
+    return exit_code(report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/page_roundtrip/test_harness.py
+++ b/tools/page_roundtrip/test_harness.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""page_roundtrip 하네스 단위 시험 — 가짜 rhwp, 실문서 전수 불필요.
+
+실행 (저장소 루트):
+    python -m unittest tools.page_roundtrip.test_harness
+    python -m unittest tools/page_roundtrip/test_harness.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import harness as prt  # noqa: E402
+
+
+def _touch(path: Path, text: str = "x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class FakeRhwp:
+    """export-hwpx/convert --verify-pages --json 을 흉내 낸다."""
+
+    def __init__(self, mapping: dict[str, tuple[int, int]] | tuple[int, int], rc: int | None = None) -> None:
+        self.mapping = mapping
+        self.rc = rc
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **_: object) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(cmd))
+        # [rhwp, export-hwpx|convert, input, output, --verify-pages, --json]
+        name = Path(cmd[2]).name
+        if isinstance(self.mapping, tuple):
+            before, after = self.mapping
+        else:
+            before, after = self.mapping[name]
+        identical = before == after
+        payload = {
+            "schemaVersion": 1,
+            "verifyPages": {"before": before, "after": after, "identical": identical},
+            "untrustedContent": False,
+        }
+        if self.rc is not None:
+            rc = self.rc
+        else:
+            rc = 0 if identical else 4
+        return subprocess.CompletedProcess(cmd, rc, json.dumps(payload), "")
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_four_way_verdict(self) -> None:
+        self.assertEqual(prt.classify(True, cataloged=False), "MATCH")
+        self.assertEqual(prt.classify(False, cataloged=False), "MISMATCH")
+        self.assertEqual(prt.classify(False, cataloged=True), "EXPECTED_FAIL")
+        self.assertEqual(prt.classify(True, cataloged=True), "UNEXPECTED_PASS")
+
+    def test_error_and_missing_are_not_skips(self) -> None:
+        self.assertEqual(prt.classify(None, cataloged=True, error=True), "ERROR")
+        self.assertEqual(prt.classify(None, cataloged=True, missing=True), "CATALOG_MISSING")
+
+
+class ParseTests(unittest.TestCase):
+    def test_json_envelope(self) -> None:
+        blob = json.dumps({"verifyPages": {"before": 64, "after": 65, "identical": False}})
+        self.assertEqual(prt.parse_verify_pages(blob, ""), (64, 65))
+
+    def test_json_with_noise_prefix(self) -> None:
+        blob = '저장 완료\n{"verifyPages": {"before": 4, "after": 4, "identical": true}}'
+        self.assertEqual(prt.parse_verify_pages(blob, ""), (4, 4))
+
+    def test_text_fail_on_stderr(self) -> None:
+        err = "검증 실패(--verify-pages): 변환 전 35쪽, 재파싱 후 36쪽"
+        self.assertEqual(prt.parse_verify_pages("", err), (35, 36))
+
+    def test_text_pass(self) -> None:
+        self.assertEqual(prt.parse_verify_pages("검증 통과(--verify-pages): 2쪽", ""), (2, 2))
+
+    def test_empty(self) -> None:
+        self.assertIsNone(prt.parse_verify_pages("", ""))
+
+
+class CatalogTests(unittest.TestCase):
+    def test_shipped_catalog_lists_m05_issues(self) -> None:
+        entries = prt.load_catalog(HERE / "catalog.json")
+        issues = {e.issue for e in entries}
+        self.assertEqual(issues, {3518, 3521, 3737, 4056, 4882, 5128})
+        self.assertTrue(all(e.route == "hwpx" for e in entries))
+        docs = {e.doc for e in entries}
+        self.assertIn("samples/hwp3-sample16.hwp", docs)
+        self.assertIn("samples/issue-505-equations.hwp", docs)
+        self.assertTrue(any("중간진도보고서" in e.doc for e in entries))
+        self.assertTrue(any("revision1.3" in e.doc for e in entries))
+
+    def test_ci_subset_includes_cataloged_fixture(self) -> None:
+        docs = prt.load_manifest(HERE / "fixtures" / "ci-subset.json", HERE.parents[1])
+        rels = [p.as_posix().replace("\\", "/") for p in docs]
+        joined = "\n".join(rels)
+        self.assertIn("issue-505-equations.hwp", joined)
+        self.assertGreaterEqual(len(docs), 2)
+
+
+class RunTests(unittest.TestCase):
+    def test_match_mismatch_expected_fail_unexpected_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            ok = _touch(repo / "samples" / "ok.hwp")
+            bad = _touch(repo / "samples" / "bad.hwp")
+            known = _touch(repo / "samples" / "known.hwp")
+            stale = _touch(repo / "samples" / "stale.hwp")
+            catalog = [
+                prt.CatalogEntry("samples/known.hwp", "hwpx", 3518, "known"),
+                prt.CatalogEntry("samples/stale.hwp", "hwpx", 4056, "stale"),
+            ]
+            fake = FakeRhwp({"ok.hwp": (1, 1), "bad.hwp": (2, 3), "known.hwp": (4, 1), "stale.hwp": (5, 5)})
+            report = prt.run_harness(
+                repo=repo,
+                docs=[ok, bad, known, stale],
+                routes=["hwpx"],
+                catalog=catalog,
+                rhwp=Path("rhwp-fake"),
+                strict=False,
+                source="test",
+                runner=fake,
+            )
+            by_doc = {r.doc: r.verdict for r in report.rows}
+            self.assertEqual(by_doc["samples/ok.hwp"], "MATCH")
+            self.assertEqual(by_doc["samples/bad.hwp"], "MISMATCH")
+            self.assertEqual(by_doc["samples/known.hwp"], "EXPECTED_FAIL")
+            self.assertEqual(by_doc["samples/stale.hwp"], "UNEXPECTED_PASS")
+            self.assertEqual(report.rows[1].equal, False)
+            self.assertEqual(report.rows[2].issue, 3518)
+            self.assertIn("harness.py --file", report.rows[1].repro)
+            self.assertEqual(prt.exit_code(report), 0)
+            states = {c.doc: c.state for c in report.catalog}
+            self.assertEqual(states["samples/known.hwp"], "run")
+            self.assertEqual(states["samples/stale.hwp"], "run")
+
+    def test_catalog_not_silently_skipped_on_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            first = _touch(repo / "samples" / "a.hwp")
+            _touch(repo / "samples" / "known.hwp")
+            catalog = [prt.CatalogEntry("samples/known.hwp", "hwpx", 3518, "known")]
+            fake = FakeRhwp((1, 1))
+            report = prt.run_harness(
+                repo=repo,
+                docs=[first],
+                routes=["hwpx"],
+                catalog=catalog,
+                rhwp=Path("rhwp-fake"),
+                strict=False,
+                source="limit",
+                runner=fake,
+            )
+            self.assertEqual(len(report.rows), 1)
+            self.assertEqual(report.rows[0].doc, "samples/a.hwp")
+            self.assertEqual(report.catalog[0].state, "held")
+            self.assertEqual(report.catalog[0].doc, "samples/known.hwp")
+            self.assertEqual(report.summary["catalog_held"], 1)
+
+    def test_full_sweep_missing_catalog_is_a_row(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            present = _touch(repo / "samples" / "ok.hwp")
+            catalog = [prt.CatalogEntry("samples/ghost.hwp", "hwpx", 3518, "ghost")]
+            fake = FakeRhwp((1, 1))
+            report = prt.run_harness(
+                repo=repo,
+                docs=[present],
+                routes=["hwpx"],
+                catalog=catalog,
+                rhwp=Path("rhwp-fake"),
+                strict=True,
+                source="glob:samples",
+                runner=fake,
+                require_missing_rows=True,
+            )
+            verdicts = [r.verdict for r in report.rows]
+            self.assertIn("CATALOG_MISSING", verdicts)
+            self.assertEqual(prt.exit_code(report), 1)
+
+    def test_strict_fails_on_new_violation_not_expected_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            known = _touch(repo / "samples" / "known.hwp")
+            catalog = [prt.CatalogEntry("samples/known.hwp", "hwpx", 3518, "known")]
+            fake = FakeRhwp((10, 11))
+            report = prt.run_harness(
+                repo=repo,
+                docs=[known],
+                routes=["hwpx"],
+                catalog=catalog,
+                rhwp=Path("rhwp-fake"),
+                strict=True,
+                source="test",
+                runner=fake,
+            )
+            self.assertEqual(report.rows[0].verdict, "EXPECTED_FAIL")
+            self.assertEqual(prt.exit_code(report), 0)
+
+            newbie = _touch(repo / "samples" / "new.hwp")
+            report2 = prt.run_harness(
+                repo=repo,
+                docs=[newbie],
+                routes=["hwpx"],
+                catalog=catalog,
+                rhwp=Path("rhwp-fake"),
+                strict=True,
+                source="test",
+                runner=FakeRhwp((1, 2)),
+            )
+            self.assertEqual(report2.rows[0].verdict, "MISMATCH")
+            self.assertEqual(prt.exit_code(report2), 1)
+
+    def test_both_routes_emit_two_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            doc = _touch(repo / "samples" / "x.hwpx")
+            fake = FakeRhwp((3, 3))
+            report = prt.run_harness(
+                repo=repo,
+                docs=[doc],
+                routes=["hwpx", "hwp"],
+                catalog=[],
+                rhwp=Path("rhwp-fake"),
+                strict=False,
+                source="test",
+                runner=fake,
+            )
+            self.assertEqual([r.route for r in report.rows], ["hwpx", "hwp"])
+            self.assertEqual(len(fake.calls), 2)
+            self.assertEqual(fake.calls[0][1], "export-hwpx")
+            self.assertEqual(fake.calls[1][1], "convert")
+
+    def test_missing_rhwp_is_error_row_default_exit_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            doc = _touch(repo / "samples" / "x.hwp")
+            report = prt.run_harness(
+                repo=repo,
+                docs=[doc],
+                routes=["hwpx"],
+                catalog=[],
+                rhwp=None,
+                strict=False,
+                source="test",
+            )
+            self.assertEqual(report.rows[0].verdict, "ERROR")
+            self.assertIn("rhwp", report.rows[0].note)
+            self.assertEqual(prt.exit_code(report), 0)
+
+
+class CliTests(unittest.TestCase):
+    def test_file_json_default_zero_on_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            doc = _touch(repo / "samples" / "z.hwp")
+            cat = repo / "cat.json"
+            cat.write_text(json.dumps({"entries": []}), encoding="utf-8")
+            fake = FakeRhwp((1, 2))
+            with patch.object(prt, "find_rhwp", return_value=Path("rhwp-fake")):
+                with patch.object(prt.subprocess, "run", fake):
+                    with patch.object(sys, "stdout"):
+                        rc = prt.main(
+                            [
+                                "--repo",
+                                str(repo),
+                                "--catalog",
+                                str(cat),
+                                "--file",
+                                "samples/z.hwp",
+                                "--json",
+                            ]
+                        )
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(fake.calls), 1)
+
+    def test_strict_cli_nonzero_on_new_violation(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            _touch(repo / "samples" / "z.hwp")
+            cat = repo / "cat.json"
+            cat.write_text(json.dumps({"entries": []}), encoding="utf-8")
+            fake = FakeRhwp((1, 2))
+            buf: list[str] = []
+
+            def capture(text: str) -> None:
+                buf.append(text)
+
+            with patch.object(prt, "find_rhwp", return_value=Path("rhwp-fake")):
+                with patch.object(prt.subprocess, "run", fake):
+                    with patch.object(sys, "stdout") as stdout:
+                        stdout.write = capture
+                        rc = prt.main(
+                            [
+                                "--repo",
+                                str(repo),
+                                "--catalog",
+                                str(cat),
+                                "--file",
+                                "samples/z.hwp",
+                                "--strict",
+                            ]
+                        )
+            self.assertEqual(rc, 1)
+            joined = "".join(buf)
+            self.assertIn("MISMATCH", joined)
+            self.assertIn("harness.py --file", joined)
+
+    def test_limit_does_not_drop_catalog_section(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            _touch(repo / "samples" / "a.hwp")
+            _touch(repo / "samples" / "b.hwp")
+            _touch(repo / "samples" / "known.hwp")
+            cat = repo / "cat.json"
+            cat.write_text(
+                json.dumps(
+                    {
+                        "entries": [
+                            {"doc": "samples/known.hwp", "route": "hwpx", "issue": 3518}
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            fake = FakeRhwp((1, 1))
+            with patch.object(prt, "find_rhwp", return_value=Path("rhwp-fake")):
+                with patch.object(prt.subprocess, "run", fake):
+                    with patch.object(sys, "stdout"):
+                        rc = prt.main(
+                            [
+                                "--repo",
+                                str(repo),
+                                "--catalog",
+                                str(cat),
+                                "--docs",
+                                "samples",
+                                "--limit",
+                                "1",
+                                "--json",
+                            ]
+                        )
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(fake.calls), 1)
+
+    def test_human_report_lists_repro_and_catalog(self) -> None:
+        row = prt.Row(
+            doc="samples/foo.hwp",
+            route="hwpx",
+            pages_before=4,
+            pages_after=5,
+            equal=False,
+            verdict="MISMATCH",
+            note="before=4 after=5",
+            repro=prt.repro_command("samples/foo.hwp", "hwpx"),
+        )
+        report = prt.Report(
+            rows=[row],
+            catalog=[
+                prt.CatalogStatus(
+                    "samples/known.hwp", "hwpx", 3518, "known", "held", ""
+                )
+            ],
+        )
+        text = prt.format_human(report)
+        self.assertIn("# REPRO python tools/page_roundtrip/harness.py --file samples/foo.hwp --route hwpx", text)
+        self.assertIn("# CATALOG held\tsamples/known.hwp\thwpx\t#3518", text)
+        self.assertIn("판정은 데이터다", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

페이지 수 왕복 공통 하네스를 신설합니다. 문서마다 `pages(원본)` 과 `pages(export → reimport)` 를 재고 equal/not 을 기계 판정으로 남깁니다.

판정은 데이터입니다. 기본 종료 코드는 불일치가 있어도 0 이고, `--strict` 일 때만 신규 위반(MISMATCH)·ERROR·UNEXPECTED_PASS·CATALOG_MISSING 이 1 입니다.

이슈 수정(#3518 #3521 #3737 #4056 #4882 #5128)은 M05-2~ 의 몫입니다. 이 PR 은 판정 도구만 추가합니다.

## 관련 이슈

Closes #5367

## 범위

- 신규 `tools/page_roundtrip/harness.py` 러너·리포트
- expected-fail 카탈로그 `tools/page_roundtrip/catalog.json` (침묵 스킵 금지)
- CI 픽스처 부분집합 `tools/page_roundtrip/fixtures/ci-subset.json` (`--ci`, `--limit`)
- tiny fixture 단위 시험 `tools/page_roundtrip/test_harness.py` (실문서 전수 불필요)
- 사용법·전수 스윕 안내 `tools/page_roundtrip/README.md`

## 판정

기존 CLI 만 부릅니다. DocumentCore / serializer 로직을 발명하지 않습니다.

- `rhwp export-hwpx <입력> <tmp.hwpx> --verify-pages --json` (기본 route)
- `rhwp convert <입력> <tmp.hwp> --verify-pages --json` (`--route hwp` / `both`)

| 판정 | 뜻 |
| --- | --- |
| MATCH | 쪽수 동일, 카탈로그 밖 |
| MISMATCH | 쪽수 불일치, 카탈로그 밖 — 신규 위반 |
| EXPECTED_FAIL | 쪽수 불일치, 카탈로그에 있음 |
| UNEXPECTED_PASS | 쪽수 동일, 카탈로그에 있음 |
| ERROR | 로드/내보내기/재파싱 실패 |
| CATALOG_MISSING | 카탈로그 경로의 파일이 없음 |

`--limit` / `--ci` 로 이번 실행에 안 들어간 카탈로그 항목은 `catalog[].state=held` 로 남습니다.

## 하지 않은 것

- `scripts/visual_sweep.py` 수정
- gym / DocumentCore / serializer / 신규 CLI
- #3518 #3521 #3737 #4056 #4882 #5128 수정

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `python -m unittest tools.page_roundtrip.test_harness` 통과 (19)
- [x] `python -m unittest tools/page_roundtrip/test_harness.py` 통과 (19)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` — 러스트 테스트 원본 없음
- [x] `node scripts/rust-unit-test-tiers.mjs --check` — `src/` 미변경
- [ ] `cargo test` — 러스트 미변경
- [ ] `cargo clippy -- -D warnings` — 러스트 미변경
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (렌더 없음)

## 1커맨드 스모크

```
python tools/page_roundtrip/harness.py --ci
python tools/page_roundtrip/harness.py --docs samples --limit 20
python tools/page_roundtrip/harness.py --file samples/hwp3-sample16.hwp --route hwpx
```

전수 스윕: `cargo build --release --bin rhwp` 후 `python tools/page_roundtrip/harness.py --docs samples`. CI 는 unittest 와 `--ci` 부분집합.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (도구 전용, 제품 경로 미변경)
- 재현·측정: 미측정
