### PR TITLE
test: proptest 편집 계획 시퀀스 생성기 (M04-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,12 +215,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -873,6 +888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1044,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1030,7 +1063,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasm-bindgen",
 ]
 
@@ -1231,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -1584,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
@@ -1908,6 +1941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,10 +1981,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -1970,9 +2037,35 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_core"
@@ -1982,9 +2075,27 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "range-alloc"
@@ -2165,7 +2276,7 @@ dependencies = [
  "embedded-io",
  "encoding_rs",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "hmac",
  "image",
  "js-sys",
@@ -2176,6 +2287,7 @@ dependencies = [
  "pcx",
  "pdf-writer",
  "pollster",
+ "proptest",
  "quick-xml",
  "rand_core 0.10.1",
  "resvg 0.46.0",
@@ -2240,7 +2352,7 @@ dependencies = [
  "crc32fast",
  "des",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "hmac",
  "pbkdf2",
  "quick-xml",
@@ -2311,6 +2423,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -2765,6 +2889,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2939,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.5.15",
 ]
@@ -2933,6 +3070,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -3160,6 +3303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3319,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3338,8 +3499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
@@ -3400,7 +3561,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "block2",
  "bytemuck",
@@ -3611,6 +3772,12 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write-fonts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,6 +323,8 @@ zip = { version = "8.5", default-features = false, features = ["deflate"] }
 # [#4378] CAS 계약 테스트가 기대 해시를 스스로 계산한다 — 위 [dependencies] 와
 # 같은 버전이라 의존성 그래프도 산출물도 그대로다(zip 선례와 동일).
 sha2 = "0.11"
+# [#5363] M04-1 편집 계획 시퀀스 생성기. 왕복 property 본체는 M04-2/3.
+proptest = "1.6"
 
 # ── Clippy 린트 정책 ──
 # 리팩토링(타스크 142) 각 단계 완료 시 allow → warn → deny 전환

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -109,3 +109,17 @@ CFB/ZIP처럼 구조 제약이 강한 컨테이너 포맷은 시드 없이는 �
   EMF 등 나머지 임베드 포맷·컨테이너를 우회하는 내부 파서 직접 하네스
 - CI 통합: PR당 짧은 스모크 퍼징 또는 회귀 코퍼스 재생
 - OSS-Fuzz 등재 (메인테이너 판단)
+
+## 왕복 정합성은 여기가 아니다 (M04)
+
+위 서두가 비워 둔 **정상 입력의 왕복 정합성(#2740, IrDiff-0)** 은 cargo-fuzz
+범위 밖이다. 그 공백을 메우는 계층이 M04 다 — 퍼저 타깃을 늘리지 않는다.
+
+- **M04-1** (`tests/cases/prop_edit_plan.rs`, #5363): `proptest` 의존 +
+  기존 `rhwp run` step(`fill_fields` · `replace_text` · `set_cell` ·
+  `set_checkbox`)만 조합하는 편집 시퀀스 생성기. 생성 계획은 JSON
+  직렬화/역직렬화와 `export-plan-schema` 정적 검증을 통과하고, 처음부터
+  잘못된 계획은 거부된다. DocumentCore 변이를 직접 실행하지 않는다.
+- **M04-2/3**: 실제 HWPX/HWP5 IrDiff-0 왕복 property. 이 생성기를 쓰되
+  본 단계는 여기 구현하지 않는다.
+- **M04-4**: 그 property 의 CI 배선.

--- a/tests/cases/prop_edit_plan.rs
+++ b/tests/cases/prop_edit_plan.rs
@@ -1,0 +1,625 @@
+//! [#5363] M04-1: proptest 편집 계획 시퀀스 생성기.
+//!
+//! `rhwp run` 이 이미 받는 step 4종(`fill_fields` · `replace_text` · `set_cell` ·
+//! `set_checkbox`)만 조합한다. DocumentCore 편집 로직을 발명하지 않고, 생성된
+//! 계획서는 JSON 왕복과 `export-plan-schema` 정적 검증만 본다.
+//! HWPX/HWP5 IrDiff-0 왕복 property 본체는 M04-2/3.
+#![cfg(not(target_arch = "wasm32"))]
+
+use proptest::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+const PLAN_VERSION: &str = "1.0";
+const ACTIONS: [&str; 4] = ["fill_fields", "replace_text", "set_cell", "set_checkbox"];
+const PATHS: &[&str] = &[
+    "in.hwp",
+    "in.hwpx",
+    "form.hml",
+    "samples/field-01.hwp",
+    "out.hwpx",
+];
+const FIELD_NAMES: &[&str] = &["이름", "주소", "신청인", "피규제집단명", "title", "name"];
+const FIND_NEEDLES: &[&str] = &["한글", "기관명", "2024", "TODO", "example"];
+const CELL_TEXTS: &[&str] = &["", "서울", "완료", "1,000", "n/a"];
+const REPLACE_TEXTS: &[&str] = &["", "한국", "2026", "DONE"];
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EditPlan {
+    plan_version: String,
+    input: String,
+    output: String,
+    steps: Vec<EditStep>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assertions: Option<Assertions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dry_run: Option<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct Assertions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_found_empty: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verify: Option<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum EditStep {
+    FillFields {
+        data: Map<String, Value>,
+        #[serde(rename = "if", skip_serializing_if = "Option::is_none")]
+        cond: Option<StepCondition>,
+    },
+    ReplaceText {
+        find: String,
+        replace: String,
+        #[serde(rename = "caseSensitive", skip_serializing_if = "Option::is_none")]
+        case_sensitive: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        occurrence: Option<u32>,
+        #[serde(rename = "if", skip_serializing_if = "Option::is_none")]
+        cond: Option<StepCondition>,
+    },
+    SetCell {
+        table: u32,
+        row: u16,
+        col: u16,
+        text: String,
+        #[serde(rename = "keepStyle", skip_serializing_if = "Option::is_none")]
+        keep_style: Option<bool>,
+        #[serde(rename = "if", skip_serializing_if = "Option::is_none")]
+        cond: Option<StepCondition>,
+    },
+    SetCheckbox {
+        occurrence: u32,
+        #[serde(rename = "if", skip_serializing_if = "Option::is_none")]
+        cond: Option<StepCondition>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum StepCondition {
+    FieldExists(String),
+    FieldEquals { name: String, value: String },
+    TextFound(String),
+}
+
+fn arb_path() -> impl Strategy<Value = String> {
+    prop::sample::select(PATHS).prop_map(str::to_string)
+}
+
+fn arb_field_key() -> impl Strategy<Value = String> {
+    (
+        prop::sample::select(FIELD_NAMES),
+        proptest::option::of(0u32..4),
+    )
+        .prop_map(|(name, occ)| match occ {
+            Some(n) => format!("{name}[{n}]"),
+            None => (*name).to_string(),
+        })
+}
+
+fn arb_field_value() -> impl Strategy<Value = Value> {
+    prop_oneof![
+        prop::sample::select(REPLACE_TEXTS).prop_map(|s| Value::String((*s).to_string())),
+        (0i64..10_000).prop_map(|n| json!(n)),
+        any::<bool>().prop_map(Value::Bool),
+    ]
+}
+
+fn arb_condition() -> impl Strategy<Value = StepCondition> {
+    prop_oneof![
+        arb_field_key().prop_map(StepCondition::FieldExists),
+        (arb_field_key(), prop::sample::select(REPLACE_TEXTS)).prop_map(|(name, value)| {
+            StepCondition::FieldEquals {
+                name,
+                value: (*value).to_string(),
+            }
+        }),
+        prop::sample::select(FIND_NEEDLES).prop_map(|s| StepCondition::TextFound((*s).to_string())),
+    ]
+}
+
+fn arb_fill_fields() -> impl Strategy<Value = EditStep> {
+    (
+        proptest::collection::btree_map(arb_field_key(), arb_field_value(), 1..4),
+        proptest::option::of(arb_condition()),
+    )
+        .prop_map(|(data, cond)| EditStep::FillFields {
+            data: data.into_iter().collect(),
+            cond,
+        })
+}
+
+fn arb_replace_text() -> impl Strategy<Value = EditStep> {
+    (
+        prop::sample::select(FIND_NEEDLES),
+        prop::sample::select(REPLACE_TEXTS),
+        proptest::option::of(any::<bool>()),
+        proptest::option::of(0u32..8),
+        proptest::option::of(arb_condition()),
+    )
+        .prop_map(
+            |(find, replace, case_sensitive, occurrence, cond)| EditStep::ReplaceText {
+                find: (*find).to_string(),
+                replace: (*replace).to_string(),
+                case_sensitive,
+                occurrence,
+                cond,
+            },
+        )
+}
+
+fn arb_set_cell() -> impl Strategy<Value = EditStep> {
+    (
+        0u32..8,
+        0u16..64,
+        0u16..32,
+        prop::sample::select(CELL_TEXTS),
+        proptest::option::of(any::<bool>()),
+        proptest::option::of(arb_condition()),
+    )
+        .prop_map(
+            |(table, row, col, text, keep_style, cond)| EditStep::SetCell {
+                table,
+                row,
+                col,
+                text: (*text).to_string(),
+                keep_style,
+                cond,
+            },
+        )
+}
+
+fn arb_set_checkbox() -> impl Strategy<Value = EditStep> {
+    (0u32..8, proptest::option::of(arb_condition()))
+        .prop_map(|(occurrence, cond)| EditStep::SetCheckbox { occurrence, cond })
+}
+
+fn arb_step() -> impl Strategy<Value = EditStep> {
+    prop_oneof![
+        arb_fill_fields(),
+        arb_replace_text(),
+        arb_set_cell(),
+        arb_set_checkbox(),
+    ]
+}
+
+fn arb_assertions() -> impl Strategy<Value = Assertions> {
+    (
+        proptest::option::of(any::<bool>()),
+        proptest::option::of(any::<bool>()),
+    )
+        .prop_map(|(not_found_empty, verify)| Assertions {
+            not_found_empty,
+            verify,
+        })
+}
+
+fn arb_valid_plan() -> impl Strategy<Value = EditPlan> {
+    (
+        arb_path(),
+        arb_path(),
+        proptest::collection::vec(arb_step(), 1..5),
+        proptest::option::of(arb_assertions()),
+        proptest::option::of(any::<bool>()),
+    )
+        .prop_map(|(input, output, steps, assertions, dry_run)| EditPlan {
+            plan_version: PLAN_VERSION.to_string(),
+            input,
+            output,
+            steps,
+            assertions,
+            dry_run,
+        })
+}
+
+fn valid_seed_plan() -> EditPlan {
+    EditPlan {
+        plan_version: PLAN_VERSION.to_string(),
+        input: "in.hwp".into(),
+        output: "out.hwpx".into(),
+        steps: vec![
+            EditStep::FillFields {
+                data: Map::from_iter([("이름".into(), json!("홍길동"))]),
+                cond: None,
+            },
+            EditStep::ReplaceText {
+                find: "기관명".into(),
+                replace: "한국".into(),
+                case_sensitive: Some(true),
+                occurrence: None,
+                cond: Some(StepCondition::TextFound("기관명".into())),
+            },
+            EditStep::SetCell {
+                table: 0,
+                row: 1,
+                col: 2,
+                text: "서울".into(),
+                keep_style: Some(false),
+                cond: None,
+            },
+            EditStep::SetCheckbox {
+                occurrence: 0,
+                cond: Some(StepCondition::FieldExists("신청인".into())),
+            },
+        ],
+        assertions: Some(Assertions {
+            not_found_empty: Some(true),
+            verify: Some(false),
+        }),
+        dry_run: Some(true),
+    }
+}
+
+fn arb_invalid_plan() -> impl Strategy<Value = Value> {
+    let seed = serde_json::to_value(valid_seed_plan()).expect("seed");
+    prop_oneof![
+        Just(json!({
+            "planVersion": "0.9",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "fill_fields", "data": {"이름": "x"}}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "output": "out.hwp",
+            "steps": [{"action": "fill_fields", "data": {"이름": "x"}}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "explode", "data": {}}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "replace_text", "find": "", "replace": "x"}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "set_cell", "table": 0, "row": 0, "col": 0, "text": "a\nb"}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "set_cell", "table": 0, "row": -1, "col": 0, "text": "x"}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "set_checkbox"}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{"action": "fill_fields"}],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{
+                "action": "fill_fields",
+                "data": {"이름": "x"},
+                "if": {"fieldExists": "이름", "textFound": "한글"}
+            }],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "output": "out.hwp",
+            "steps": [{
+                "action": "replace_text",
+                "find": "한글",
+                "replace": "x",
+                "if": {}
+            }],
+        })),
+        Just(json!({
+            "planVersion": "1.0",
+            "input": "in.hwp",
+            "steps": "not-an-array",
+        })),
+        Just(seed.clone()).prop_map(|mut plan| {
+            plan["planVersion"] = json!("2.0");
+            plan
+        }),
+        Just(seed).prop_map(|mut plan| {
+            plan["steps"] = json!([]);
+            plan
+        }),
+    ]
+}
+
+fn schema_actions(schema: &Value) -> Vec<String> {
+    let variants = schema["$defs"]["Step"]["oneOf"]
+        .as_array()
+        .expect("Step.oneOf");
+    let mut actions = Vec::new();
+    for variant in variants {
+        let name = variant["$ref"]
+            .as_str()
+            .and_then(|p| p.strip_prefix("#/$defs/"))
+            .expect("oneOf $ref");
+        let action = schema["$defs"][name]["properties"]["action"]["const"]
+            .as_str()
+            .expect("action const")
+            .to_string();
+        actions.push(action);
+    }
+    actions.sort();
+    actions
+}
+
+fn resolve_ref<'a>(root: &'a Value, pointer: &str, path: &str) -> Result<&'a Value, String> {
+    let trimmed = pointer
+        .strip_prefix("#/")
+        .ok_or_else(|| format!("{path}: 지원하지 않는 $ref {pointer}"))?;
+    let mut cur = root;
+    for part in trimmed.split('/') {
+        cur = cur
+            .get(part)
+            .ok_or_else(|| format!("{path}: $ref {pointer} 를 풀 수 없습니다"))?;
+    }
+    Ok(cur)
+}
+
+fn type_matches(ty: &str, instance: &Value) -> bool {
+    match ty {
+        "object" => instance.is_object(),
+        "array" => instance.is_array(),
+        "string" => instance.is_string(),
+        "integer" => instance
+            .as_i64()
+            .map(|_| true)
+            .or_else(|| instance.as_u64().map(|_| true))
+            .unwrap_or(false),
+        "number" => instance.is_number(),
+        "boolean" => instance.is_boolean(),
+        "null" => instance.is_null(),
+        _ => false,
+    }
+}
+
+/// `export-plan-schema` 가 실제로 쓰는 키워드만 검사한다.
+fn validate_against(
+    root: &Value,
+    schema: &Value,
+    instance: &Value,
+    path: &str,
+) -> Result<(), String> {
+    if let Some(pointer) = schema.get("$ref").and_then(Value::as_str) {
+        let resolved = resolve_ref(root, pointer, path)?;
+        validate_against(root, resolved, instance, path)?;
+    }
+
+    if let Some(ty) = schema.get("type") {
+        let ok = match ty {
+            Value::String(name) => type_matches(name, instance),
+            Value::Array(names) => names.iter().any(|name| {
+                name.as_str()
+                    .is_some_and(|name| type_matches(name, instance))
+            }),
+            _ => true,
+        };
+        if !ok {
+            return Err(format!("{path}: type {ty} 불일치 ({instance})"));
+        }
+    }
+
+    if let Some(expected) = schema.get("const") {
+        if instance != expected {
+            return Err(format!("{path}: const {expected} 불일치 ({instance})"));
+        }
+    }
+
+    if let Some(opts) = schema.get("oneOf").and_then(Value::as_array) {
+        let mut matched = 0usize;
+        let mut last_err = None;
+        for opt in opts {
+            match validate_against(root, opt, instance, path) {
+                Ok(()) => matched += 1,
+                Err(err) => last_err = Some(err),
+            }
+        }
+        if matched != 1 {
+            return Err(format!(
+                "{path}: oneOf 일치 {matched}개 (마지막 거부: {})",
+                last_err.unwrap_or_else(|| "없음".into())
+            ));
+        }
+    }
+
+    if let Some(obj) = instance.as_object() {
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for key in required {
+                let key = key.as_str().expect("required 키");
+                if !obj.contains_key(key) {
+                    return Err(format!("{path}: 필수 필드 {key} 없음"));
+                }
+            }
+        }
+        if let Some(props) = schema.get("properties").and_then(Value::as_object) {
+            for (key, sub) in props {
+                if let Some(value) = obj.get(key) {
+                    validate_against(root, sub, value, &format!("{path}.{key}"))?;
+                }
+            }
+        }
+        let declared = schema.get("properties").and_then(Value::as_object);
+        match schema.get("additionalProperties") {
+            Some(Value::Bool(false)) => {
+                if let Some(declared) = declared {
+                    for key in obj.keys() {
+                        if !declared.contains_key(key) {
+                            return Err(format!("{path}: 추가 필드 {key} 거부"));
+                        }
+                    }
+                }
+            }
+            Some(sub) if sub.is_object() => {
+                for (key, value) in obj {
+                    if declared.is_none_or(|declared| !declared.contains_key(key)) {
+                        validate_against(root, sub, value, &format!("{path}.{key}"))?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        if let Some(min) = schema.get("minProperties").and_then(Value::as_u64) {
+            if (obj.len() as u64) < min {
+                return Err(format!("{path}: minProperties {min} (실제 {})", obj.len()));
+            }
+        }
+        if let Some(max) = schema.get("maxProperties").and_then(Value::as_u64) {
+            if (obj.len() as u64) > max {
+                return Err(format!("{path}: maxProperties {max} (실제 {})", obj.len()));
+            }
+        }
+    }
+
+    if let Some(items) = schema.get("items") {
+        let arr = instance
+            .as_array()
+            .ok_or_else(|| format!("{path}: 배열이어야 합니다"))?;
+        if let Some(min) = schema.get("minItems").and_then(Value::as_u64) {
+            if (arr.len() as u64) < min {
+                return Err(format!("{path}: minItems {min} (실제 {})", arr.len()));
+            }
+        }
+        for (idx, item) in arr.iter().enumerate() {
+            validate_against(root, items, item, &format!("{path}[{idx}]"))?;
+        }
+    }
+
+    if let Some(s) = instance.as_str() {
+        if let Some(min) = schema.get("minLength").and_then(Value::as_u64) {
+            if (s.chars().count() as u64) < min {
+                return Err(format!("{path}: minLength {min}"));
+            }
+        }
+        if let Some(pat) = schema.get("pattern").and_then(Value::as_str) {
+            let ok = match pat {
+                "^[^\r\n\t]*$" => !s.chars().any(|ch| matches!(ch, '\r' | '\n' | '\t')),
+                other => {
+                    return Err(format!("{path}: 지원하지 않는 pattern {other}"));
+                }
+            };
+            if !ok {
+                return Err(format!("{path}: pattern {pat} 불일치"));
+            }
+        }
+    }
+
+    if instance.is_number() {
+        let n = instance.as_f64().expect("number");
+        if let Some(min) = schema.get("minimum").and_then(Value::as_f64) {
+            if n < min {
+                return Err(format!("{path}: minimum {min} (실제 {n})"));
+            }
+        }
+        if let Some(max) = schema.get("maximum").and_then(Value::as_f64) {
+            if n > max {
+                return Err(format!("{path}: maximum {max} (실제 {n})"));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_plan_schema(plan: &Value) -> Result<(), String> {
+    let schema = rhwp::plan_schema::plan_schema();
+    validate_against(&schema, &schema, plan, "$")
+}
+
+fn prop_config() -> ProptestConfig {
+    ProptestConfig {
+        cases: 32,
+        max_shrink_iters: 64,
+        ..ProptestConfig::default()
+    }
+}
+
+#[test]
+fn generator_actions_match_export_plan_schema() {
+    let schema = rhwp::plan_schema::plan_schema();
+    assert_eq!(schema["$ref"], "#/$defs/Plan");
+    assert_eq!(schema_actions(&schema), ACTIONS);
+}
+
+#[test]
+fn seed_plan_roundtrips_and_matches_schema() {
+    let plan = valid_seed_plan();
+    let text = serde_json::to_string_pretty(&plan).expect("serialize");
+    let back: EditPlan = serde_json::from_str(&text).expect("deserialize");
+    assert_eq!(plan, back);
+    let value: Value = serde_json::from_str(&text).expect("value");
+    assert_eq!(value["planVersion"], PLAN_VERSION);
+    validate_plan_schema(&value).expect("schema");
+}
+
+#[test]
+fn handwritten_invalid_plans_are_rejected() {
+    let cases = [
+        json!({"planVersion": "1.0", "input": "a.hwp", "output": "b.hwp", "steps": []}),
+        json!({"planVersion": "9.9", "input": "a.hwp", "output": "b.hwp",
+            "steps": [{"action": "fill_fields", "data": {"이름": "x"}}]}),
+        json!({"planVersion": "1.0", "input": "a.hwp", "output": "b.hwp",
+            "steps": [{"action": "nope"}]}),
+        json!({"planVersion": "1.0", "input": "a.hwp", "output": "b.hwp",
+            "steps": [{"action": "replace_text", "find": "", "replace": "x"}]}),
+        json!({"planVersion": "1.0", "input": "a.hwp", "output": "b.hwp",
+            "steps": [{"action": "set_cell", "table": 0, "row": 0, "col": 0, "text": "x\t"}]}),
+    ];
+    for case in cases {
+        assert!(
+            validate_plan_schema(&case).is_err(),
+            "통과하면 안 됨: {case}"
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(prop_config())]
+
+    #[test]
+    fn generated_plans_serialize_and_match_schema(plan in arb_valid_plan()) {
+        let text = serde_json::to_string(&plan).expect("serialize");
+        let back: EditPlan = serde_json::from_str(&text).expect("deserialize");
+        prop_assert_eq!(&plan, &back);
+        let value: Value = serde_json::from_str(&text).expect("value");
+        let again: EditPlan = serde_json::from_value(value.clone()).expect("from_value");
+        prop_assert_eq!(plan, again);
+        if let Err(err) = validate_plan_schema(&value) {
+            return Err(TestCaseError::fail(format!("{err}\n{value}")));
+        }
+    }
+
+    #[test]
+    fn invalid_plans_are_rejected_not_executed(plan in arb_invalid_plan()) {
+        prop_assert!(
+            validate_plan_schema(&plan).is_err(),
+            "무효 계획이 스키마를 통과함: {plan}"
+        );
+    }
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M04-1 (◆10 proptest 왕복 불변식 계층)의 **1단계**입니다. 저장소에 없던 property 계층을 엽니다. 왕복 property 본체는 M04-2/3, CI 배선은 M04-4입니다.

- `proptest` 를 루트 크레이트 dev-dependency 로 추가합니다.
- `tests/cases/prop_edit_plan.rs` 에 기존 `rhwp run` step 4종(`fill_fields` · `replace_text` · `set_cell` · `set_checkbox`)만 조합하는 구조화 Strategy 를 둡니다. DocumentCore 편집 로직을 발명하지 않습니다.
- 생성 계획서는 JSON 직렬화/역직렬화 왕복과 `export-plan-schema` 정적 검증을 통과합니다.
- 처음부터 잘못된 계획(빈 steps, 알 수 없는 action, 빈 find, 칸 줄바꿈 등)은 거부됩니다. 문서를 열어 실행하지 않습니다.
- `fuzz/README.md` 에 퍼저가 비워 둔 "왕복 정합성은 범위 밖" 공백을 M04 가 메운다는 점을 적습니다. 실제 IrDiff-0 왕복은 M04-2/3 입니다.

## 관련 이슈

closes #5363

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (로컬 `--prepare` 뒤. 파생 harness/manifest 는 커밋하지 않음)
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --test regression_suite_013 prop_edit_plan::` 5 passed
- [ ] `cargo clippy -- -D warnings` — 해당 없음에 가깝습니다. src/ 미변경, 통합 시험·dev-dep 만 추가
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (문서 편집 없음)
- [ ] capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (dev-dependency + 통합 시험, 런타임 경로 미변경)
- 재현·측정: `cargo test --test regression_suite_013 prop_edit_plan::` 5 passed, 약 0.07s

## 스크린샷

해당 없음.

## 하지 않은 것

- HWPX/HWP5 IrDiff-0 왕복 property (M04-2/3)
- property CI 배선 (M04-4)
- DocumentCore 편집 로직 발명
- gym/ 미수정
- `scripts/visual_sweep.py` 미수정