### PR TITLE
feat: render_backend PNG raster 어댑터 (M06-1)

### DIFF
--- a/src/render_backend/mod.rs
+++ b/src/render_backend/mod.rs
@@ -21,6 +21,7 @@
 //!
 //! 이 모듈은 그 공통 계약을 **기존 백엔드를 고치지 않고** 신설한다.
 //! 어댑터는 기존 코드를 호출만 하며, `src/renderer/**` 는 이 PR 에서 바뀌지 않는다.
+//! 구체 어댑터는 `SvgBackend` 와 `PngBackend` 둘이다. native-skia 어댑터는 여기 없다.
 //!
 //! # 기존 trait 들과의 관계
 //!
@@ -67,12 +68,14 @@
 
 pub mod backends;
 pub mod caps;
+pub mod png_adapter;
 pub mod svg_adapter;
 pub mod traits;
 pub mod util;
 
 pub use backends::{DrawStats, NullBackend, TraceBackend};
 pub use caps::{BackendCapabilities, BackendFeature};
+pub use png_adapter::PngBackend;
 pub use svg_adapter::SvgBackend;
 pub use traits::{PageSize, RenderBackend, RenderBackendError};
 pub use util::{paint_op_kind, replay_page, PageState};
@@ -172,6 +175,11 @@ mod tests {
         let mut svg = SvgBackend::new();
         assert_eq!(
             svg.draw(&rect_op(0.0, 0.0)).unwrap_err(),
+            RenderBackendError::NoOpenPage { call: "draw" }
+        );
+        let mut png = PngBackend::new();
+        assert_eq!(
+            png.draw(&rect_op(0.0, 0.0)).unwrap_err(),
             RenderBackendError::NoOpenPage { call: "draw" }
         );
     }
@@ -275,10 +283,30 @@ mod tests {
         assert!(!null.supports(BackendFeature::VectorText));
         assert!(null.supports(BackendFeature::Deterministic));
 
+        // PNG 어댑터는 실제로 지원하는 능력만 선언한다 (210b3ee37 정직성 보정과 같은 결).
+        // 얇은 어댑터는 클립·다중 페이지를 보존하지 못하고, native-skia 가 없으면
+        // 이미지·그라디언트도 산출물에 남지 않는다. M06-3 이 전 백엔드 정직성 스윕이다.
+        let png = PngBackend::new().capabilities();
+        assert_eq!(png.name, "png");
+        assert!(png.raster_only);
+        assert!(!png.supports(BackendFeature::VectorText));
+        assert!(!png.supports(BackendFeature::EmbeddedFonts));
+        assert!(!png.supports(BackendFeature::Clipping));
+        assert!(!png.supports(BackendFeature::MultiPage));
+        assert!(!png.supports(BackendFeature::Deterministic));
+        let live = PngBackend::raster_available();
+        assert_eq!(png.supports(BackendFeature::Images), live);
+        assert_eq!(png.supports(BackendFeature::Gradients), live);
+        assert_eq!(
+            live,
+            cfg!(all(not(target_arch = "wasm32"), feature = "native-skia"))
+        );
+
         // 자기모순 선언(래스터 전용인데 벡터 텍스트)은 불변식 위반이다.
         for caps in [
             svg,
             null,
+            png,
             TraceBackend::new().capabilities(),
             BackendCapabilities::raster("skia"),
         ] {
@@ -324,6 +352,21 @@ mod tests {
         assert!(svg.starts_with("<svg"), "{svg}");
         assert!(svg.contains("viewBox=\"0 0 400 300\""), "{svg}");
         assert!(svg.trim_end().ends_with("</svg>"), "{svg}");
+
+        // PNG 어댑터: native-skia 가 있으면 진짜 시그니처, 없으면 래스터를 건너뛴다.
+        let mut png_backend = PngBackend::new();
+        replay_page(&mut png_backend, &sample_tree()).unwrap();
+        assert_eq!(png_backend.pages().len(), 1);
+        let png = png_backend.finish().unwrap();
+        if PngBackend::raster_available() {
+            assert!(
+                png.starts_with(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]),
+                "expected PNG signature, got {} bytes",
+                png.len()
+            );
+        } else {
+            assert!(png.is_empty());
+        }
     }
 
     // 10. 페이지별 SVG 문서를 이어 붙여 유효하지 않은 단일 SVG를 만들지 않는다.
@@ -336,6 +379,14 @@ mod tests {
         assert_eq!(
             backend.begin_page(PageSize::new(400.0, 300.0)).unwrap_err(),
             RenderBackendError::MultiplePagesUnsupported { backend: "svg" }
+        );
+
+        let mut png = PngBackend::new();
+        png.begin_page(PageSize::new(400.0, 300.0)).unwrap();
+        png.end_page().unwrap();
+        assert_eq!(
+            png.begin_page(PageSize::new(400.0, 300.0)).unwrap_err(),
+            RenderBackendError::MultiplePagesUnsupported { backend: "png" }
         );
     }
 

--- a/src/render_backend/png_adapter.rs
+++ b/src/render_backend/png_adapter.rs
@@ -1,0 +1,168 @@
+//! PNG raster 어댑터 — 기존 래스터 PNG 내보내기 경로를 `RenderBackend` 뒤에 세운다.
+//!
+//! 이 파일은 `src/renderer/**` 를 **한 줄도 고치지 않는다**. `native-skia` 가 켜져 있고
+//! wasm 이 아니면 기존 공개 API (`SkiaLayerRenderer::new` /
+//! `LayerRasterRenderer::render_png_with_options`) 를 호출만 한다. 그 피처가 없으면
+//! 어댑터는 그대로 컴파일되고 생명주기는 지키지만 래스터는 **건너뛴다**
+//! (`finish` 산출물은 빈 바이트열). 능력 선언은 그 사실을 숨기지 않는다.
+//!
+//! native-skia 어댑터 자체(`SkiaBackend`)는 M06-2 범위이며 여기 없다.
+//!
+//! # 얇음의 대가 (알려진 한계)
+//!
+//! 어댑터는 받은 op 들을 `LayerNode::leaf` 하나로 묶어 기존 렌더러에 넘긴다.
+//! 따라서 원본 트리의 그룹·클립 구조는 이 경로에서 평탄해진다. SVG 어댑터와
+//! 같은 대가이며, `capabilities().clipping` 을 켜지 않는다.
+
+use crate::paint::{PaintOp, RenderProfile};
+use crate::renderer::layer_renderer::RasterRenderOptions;
+
+use super::caps::BackendCapabilities;
+use super::traits::{PageSize, RenderBackend, RenderBackendError};
+use super::util::PageState;
+
+/// 기존 래스터 PNG 경로를 `RenderBackend` 계약으로 감싼 어댑터.
+///
+/// 산출물은 PNG 바이트열 한 장이다. PNG 파일 여러 개를 이어 붙이면 유효한
+/// PNG 가 아니므로, 이 어댑터는 두 번째 페이지를 거절한다. 여러 페이지를
+/// 내려면 페이지마다 새 `PngBackend` 를 만든다.
+#[derive(Debug)]
+pub struct PngBackend {
+    state: PageState,
+    profile: RenderProfile,
+    options: RasterRenderOptions,
+    pending: Vec<PaintOp>,
+    pages: Vec<Vec<u8>>,
+}
+
+impl PngBackend {
+    /// 화면 프로파일과 기본 래스터 옵션으로 어댑터를 만든다.
+    pub fn new() -> Self {
+        Self::with_options(RenderProfile::Screen, RasterRenderOptions::default())
+    }
+
+    /// 렌더 프로파일을 지정해 어댑터를 만든다.
+    pub fn with_profile(profile: RenderProfile) -> Self {
+        Self::with_options(profile, RasterRenderOptions::default())
+    }
+
+    /// 렌더 프로파일과 래스터 옵션을 지정해 어댑터를 만든다.
+    ///
+    /// `options` 는 기존 `LayerRasterRenderer::render_png_with_options` 가 받는
+    /// 값과 같다. `native-skia` 가 꺼져 있으면 이 옵션은 쓰이지 않는다.
+    pub fn with_options(profile: RenderProfile, options: RasterRenderOptions) -> Self {
+        Self {
+            state: PageState::new(),
+            profile,
+            options,
+            pending: Vec::new(),
+            pages: Vec::new(),
+        }
+    }
+
+    /// 지금까지 완성된 페이지별 PNG 바이트열.
+    ///
+    /// 래스터를 건너뛴 페이지는 빈 슬라이스다.
+    pub fn pages(&self) -> &[Vec<u8>] {
+        &self.pages
+    }
+
+    /// 이 빌드가 실제 PNG 래스터를 돌릴 수 있는가.
+    ///
+    /// `native-skia` 피처가 켜진 네이티브 빌드에서만 `true` 다. wasm 과
+    /// 기본 CI 빌드에서는 `false` 이며, 그때 능력 선언도 그에 맞춘다.
+    pub const fn raster_available() -> bool {
+        cfg!(all(not(target_arch = "wasm32"), feature = "native-skia"))
+    }
+}
+
+impl Default for PngBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderBackend for PngBackend {
+    type Output = Vec<u8>;
+    type Error = RenderBackendError;
+
+    fn capabilities(&self) -> BackendCapabilities {
+        // 래스터 전용 산출물이므로 vector_text 는 끈다.
+        // 얇은 어댑터는 PaintOp 만 받아 새 leaf 로 평탄화하므로 클립을 보존하지 못한다.
+        // PNG 한 장은 한 페이지 — 여러 장을 이어 붙인 바이트열은 유효한 PNG 가 아니다.
+        // 실제 래스터가 없으면 이미지·그라디언트도 산출물에 남지 않는다.
+        let live = Self::raster_available();
+        BackendCapabilities {
+            gradients: live,
+            clipping: false,
+            images: live,
+            multi_page: false,
+            ..BackendCapabilities::raster("png")
+        }
+    }
+
+    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error> {
+        if !self.pages.is_empty() {
+            return Err(RenderBackendError::MultiplePagesUnsupported { backend: "png" });
+        }
+        self.state.begin(size)?;
+        self.pending.clear();
+        Ok(())
+    }
+
+    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error> {
+        self.state.record_draw()?;
+        self.pending.push(op.clone());
+        Ok(())
+    }
+
+    fn end_page(&mut self) -> Result<(), Self::Error> {
+        let (size, _) = self.state.end()?;
+        let bytes = raster_page(
+            size,
+            self.profile,
+            self.options,
+            std::mem::take(&mut self.pending),
+        )?;
+        self.pages.push(bytes);
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Self::Output, Self::Error> {
+        self.state.assert_finished()?;
+        Ok(self.pages.into_iter().next().unwrap_or_default())
+    }
+
+    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error> {
+        (*self).finish()
+    }
+}
+
+fn raster_page(
+    size: PageSize,
+    profile: RenderProfile,
+    options: RasterRenderOptions,
+    pending: Vec<PaintOp>,
+) -> Result<Vec<u8>, RenderBackendError> {
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    {
+        use crate::paint::{LayerNode, PageLayerTree};
+        use crate::renderer::layer_renderer::{LayerRasterRenderer, RasterOutputFormat};
+        use crate::renderer::render_tree::BoundingBox;
+        use crate::renderer::skia::SkiaLayerRenderer;
+
+        let bounds = BoundingBox::new(0.0, 0.0, size.width, size.height);
+        let root = LayerNode::leaf(bounds, None, pending);
+        let tree = PageLayerTree::with_profile(size.width, size.height, root, profile);
+        let mut options = options;
+        options.format = RasterOutputFormat::Png;
+        SkiaLayerRenderer::new()
+            .render_png_with_options(&tree, options)
+            .map_err(RenderBackendError::from)
+    }
+    #[cfg(not(all(not(target_arch = "wasm32"), feature = "native-skia")))]
+    {
+        let _ = (size, profile, options, pending);
+        Ok(Vec::new())
+    }
+}

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2479,7 +2479,7 @@
       "id": "src/render_backend/mod.rs::tests#1",
       "file": "src/render_backend/mod.rs",
       "sourcePath": "src/render_backend/mod.rs",
-      "line": 80,
+      "line": 83,
       "module": "tests",
       "testAttributes": 15,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M06-1 (◆10 render_backend 계층 인수). 두 번째 구체 어댑터 **PNG raster** 를 얹는다. `SvgBackend` 만 있던 `src/render_backend/` 에 `png_adapter.rs` 를 추가하고 등록한다. 기존 `SkiaLayerRenderer` / `LayerRasterRenderer::render_png_with_options` 를 호출만 한다. `src/renderer/**` 는 한 줄도 바꾸지 않는다.

`native-skia` 피처가 켜진 네이티브 빌드에서만 실제 PNG 를 낸다. 꺼져 있으면(기본 CI) 어댑터는 그대로 컴파일되고 생명주기(`begin_page`/`draw`/`end_page`/`finish`)는 지키지만 래스터는 건너뛴다. `finish` 산출물은 빈 바이트열이다. `PngBackend::raster_available()` 과 `capabilities()` 가 그 사실을 숨기지 않는다.

얇은 어댑터는 SVG 와 같이 op 를 `LayerNode::leaf` 로 평탄화하므로 클립을 보존하지 못한다. PNG 한 장은 한 페이지라 두 번째 페이지는 `MultiplePagesUnsupported` 로 거절한다. 전 백엔드 정직성 스윕은 M06-3 이다. native-skia 어댑터(`SkiaBackend`)는 M06-2 범위이며 여기 없다.

## 관련 이슈

closes #5370

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --lib render_backend::` 통과 (15)
- [x] `cargo clippy --lib -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (어댑터 래퍼만)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (wasm 에서는 래스터 skip)
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] `.claude/agents/`·스킬 변경 없음

계약 시험은 기존 `render_backend` 단위 시험에 접었다(source-side `#[test]` 증가 금지).

- `capabilities_are_queryable_and_consistent` — PNG 가 선언하는 능력이 실제 지원과 같다 (`clipping`/`multi_page` 끔, `images`/`gradients` 는 `raster_available()` 과 동기)
- `svg_backend_rejects_a_second_page` — PNG 도 두 번째 페이지를 거절
- `svg_backend_emits_real_svg_document` — 피처 있으면 PNG 시그니처, 없으면 빈 바이트
- `draw_without_begin_page_is_error` — PNG 도 같은 생명주기 오류

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (호출 경로만 감쌈, 기본 빌드는 래스터 skip)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- `src/renderer/**` 미수정
- native-skia 어댑터(M06-2) 미추가
- gym / `scripts/visual_sweep.py` 미수정
- DocumentCore 신설 없음
