### PR TITLE
feat: render_backend native-skia 어댑터 (M06-2)

### DIFF
--- a/src/render_backend/mod.rs
+++ b/src/render_backend/mod.rs
@@ -21,6 +21,8 @@
 //!
 //! 이 모듈은 그 공통 계약을 **기존 백엔드를 고치지 않고** 신설한다.
 //! 어댑터는 기존 코드를 호출만 하며, `src/renderer/**` 는 이 PR 에서 바뀌지 않는다.
+//! 구체 어댑터는 `SvgBackend` 와 `SkiaBackend` 이다. PNG 바이트열 어댑터
+//! (`PngBackend` / `SkiaLayerRenderer::render_png`) 는 M06-1 범위이며 여기 없다.
 //!
 //! # 기존 trait 들과의 관계
 //!
@@ -67,12 +69,14 @@
 
 pub mod backends;
 pub mod caps;
+pub mod skia_adapter;
 pub mod svg_adapter;
 pub mod traits;
 pub mod util;
 
 pub use backends::{DrawStats, NullBackend, TraceBackend};
 pub use caps::{BackendCapabilities, BackendFeature};
+pub use skia_adapter::SkiaBackend;
 pub use svg_adapter::SvgBackend;
 pub use traits::{PageSize, RenderBackend, RenderBackendError};
 pub use util::{paint_op_kind, replay_page, PageState};
@@ -172,6 +176,11 @@ mod tests {
         let mut svg = SvgBackend::new();
         assert_eq!(
             svg.draw(&rect_op(0.0, 0.0)).unwrap_err(),
+            RenderBackendError::NoOpenPage { call: "draw" }
+        );
+        let mut skia = SkiaBackend::new();
+        assert_eq!(
+            skia.draw(&rect_op(0.0, 0.0)).unwrap_err(),
             RenderBackendError::NoOpenPage { call: "draw" }
         );
     }
@@ -275,10 +284,30 @@ mod tests {
         assert!(!null.supports(BackendFeature::VectorText));
         assert!(null.supports(BackendFeature::Deterministic));
 
+        // Skia 어댑터는 실제로 지원하는 능력만 선언한다 (210b3ee37 정직성 보정과 같은 결).
+        // 얇은 어댑터는 클립·다중 페이지를 보존하지 못하고, native-skia 가 없으면
+        // 이미지·그라디언트도 산출물에 남지 않는다. M06-3 이 전 백엔드 정직성 스윕이다.
+        let skia = SkiaBackend::new().capabilities();
+        assert_eq!(skia.name, "skia");
+        assert!(skia.raster_only);
+        assert!(!skia.supports(BackendFeature::VectorText));
+        assert!(!skia.supports(BackendFeature::EmbeddedFonts));
+        assert!(!skia.supports(BackendFeature::Clipping));
+        assert!(!skia.supports(BackendFeature::MultiPage));
+        assert!(!skia.supports(BackendFeature::Deterministic));
+        let live = SkiaBackend::raster_available();
+        assert_eq!(skia.supports(BackendFeature::Images), live);
+        assert_eq!(skia.supports(BackendFeature::Gradients), live);
+        assert_eq!(
+            live,
+            cfg!(all(not(target_arch = "wasm32"), feature = "native-skia"))
+        );
+
         // 자기모순 선언(래스터 전용인데 벡터 텍스트)은 불변식 위반이다.
         for caps in [
             svg,
             null,
+            skia,
             TraceBackend::new().capabilities(),
             BackendCapabilities::raster("skia"),
         ] {
@@ -324,6 +353,27 @@ mod tests {
         assert!(svg.starts_with("<svg"), "{svg}");
         assert!(svg.contains("viewBox=\"0 0 400 300\""), "{svg}");
         assert!(svg.trim_end().ends_with("</svg>"), "{svg}");
+
+        // Skia 어댑터: native-skia 가 있으면 래스터 문서, 없으면 빈 문서.
+        let mut skia_backend = SkiaBackend::new();
+        replay_page(&mut skia_backend, &sample_tree()).unwrap();
+        assert_eq!(skia_backend.pages().len(), 1);
+        let raster = skia_backend.finish().unwrap();
+        if SkiaBackend::raster_available() {
+            assert!(raster.width > 0, "width={}", raster.width);
+            assert!(raster.height > 0, "height={}", raster.height);
+            assert!(
+                raster
+                    .bytes
+                    .starts_with(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]),
+                "expected raster document payload, got {} bytes",
+                raster.bytes.len()
+            );
+        } else {
+            assert!(raster.bytes.is_empty());
+            assert_eq!(raster.width, 0);
+            assert_eq!(raster.height, 0);
+        }
     }
 
     // 10. 페이지별 SVG 문서를 이어 붙여 유효하지 않은 단일 SVG를 만들지 않는다.
@@ -336,6 +386,14 @@ mod tests {
         assert_eq!(
             backend.begin_page(PageSize::new(400.0, 300.0)).unwrap_err(),
             RenderBackendError::MultiplePagesUnsupported { backend: "svg" }
+        );
+
+        let mut skia = SkiaBackend::new();
+        skia.begin_page(PageSize::new(400.0, 300.0)).unwrap();
+        skia.end_page().unwrap();
+        assert_eq!(
+            skia.begin_page(PageSize::new(400.0, 300.0)).unwrap_err(),
+            RenderBackendError::MultiplePagesUnsupported { backend: "skia" }
         );
     }
 

--- a/src/render_backend/skia_adapter.rs
+++ b/src/render_backend/skia_adapter.rs
@@ -1,0 +1,189 @@
+//! native-skia 어댑터 — 기존 레이어 래스터 경로를 `RenderBackend` 뒤에 세운다.
+//!
+//! 이 파일은 `src/renderer/**` 를 **한 줄도 고치지 않는다**. `native-skia` 가 켜져 있고
+//! wasm 이 아니면 기존 공개 API (`SkiaLayerRenderer::new` /
+//! `LayerRasterRenderer::render_raster`) 를 호출만 한다. `render_png` /
+//! `render_png_with_options` 는 쓰지 않는다 — PNG 바이트열만 내는 어댑터는
+//! M06-1 `PngBackend` 의 몫이다. 이 어댑터의 산출물은 레이어 래스터 문서
+//! (`RasterRenderOutput`: 바이트 + 폭·높이·dpi·색공간·형식)다.
+//!
+//! 그 피처가 없으면 어댑터는 그대로 컴파일되고 생명주기는 지키지만 래스터는
+//! **건너뛴다** (`finish` 산출물은 빈 문서 — 바이트 없음, 0×0). 능력 선언은 그
+//! 사실을 숨기지 않는다.
+//!
+//! # 얇음의 대가 (알려진 한계)
+//!
+//! 어댑터는 받은 op 들을 `LayerNode::leaf` 하나로 묶어 기존 렌더러에 넘긴다.
+//! 따라서 원본 트리의 그룹·클립 구조는 이 경로에서 평탄해진다. SVG 어댑터와
+//! 같은 대가이며, `capabilities().clipping` 을 켜지 않는다.
+
+use crate::paint::{PaintOp, RenderProfile};
+use crate::renderer::layer_renderer::{
+    RasterColorSpace, RasterOutputFormat, RasterRenderOptions, RasterRenderOutput,
+};
+
+use super::caps::BackendCapabilities;
+use super::traits::{PageSize, RenderBackend, RenderBackendError};
+use super::util::PageState;
+
+/// 기존 native-skia 레이어 래스터 경로를 `RenderBackend` 계약으로 감싼 어댑터.
+///
+/// 산출물은 [`RasterRenderOutput`] 한 장이다. 래스터 문서 여러 장을 한 값으로
+/// 이어 붙일 형식이 없으므로, 이 어댑터는 두 번째 페이지를 거절한다. 여러
+/// 페이지를 내려면 페이지마다 새 `SkiaBackend` 를 만든다.
+#[derive(Debug)]
+pub struct SkiaBackend {
+    state: PageState,
+    profile: RenderProfile,
+    options: RasterRenderOptions,
+    pending: Vec<PaintOp>,
+    pages: Vec<RasterRenderOutput>,
+}
+
+impl SkiaBackend {
+    /// 화면 프로파일과 기본 래스터 옵션으로 어댑터를 만든다.
+    pub fn new() -> Self {
+        Self::with_options(RenderProfile::Screen, RasterRenderOptions::default())
+    }
+
+    /// 렌더 프로파일을 지정해 어댑터를 만든다.
+    pub fn with_profile(profile: RenderProfile) -> Self {
+        Self::with_options(profile, RasterRenderOptions::default())
+    }
+
+    /// 래스터 옵션만 지정해 어댑터를 만든다.
+    ///
+    /// 옵션은 페이지마다 바뀌지 않고 생성자에 고정된다. 기존
+    /// `LayerRasterRenderer::render_raster` 가 받는 값과 같다.
+    pub fn with_raster_options(options: RasterRenderOptions) -> Self {
+        Self::with_options(RenderProfile::Screen, options)
+    }
+
+    /// 렌더 프로파일과 래스터 옵션을 지정해 어댑터를 만든다.
+    ///
+    /// `native-skia` 가 꺼져 있으면 이 옵션은 쓰이지 않는다.
+    pub fn with_options(profile: RenderProfile, options: RasterRenderOptions) -> Self {
+        Self {
+            state: PageState::new(),
+            profile,
+            options,
+            pending: Vec::new(),
+            pages: Vec::new(),
+        }
+    }
+
+    /// 지금까지 완성된 페이지별 래스터 문서.
+    ///
+    /// 래스터를 건너뛴 페이지는 빈 문서(0×0, 바이트 없음)다.
+    pub fn pages(&self) -> &[RasterRenderOutput] {
+        &self.pages
+    }
+
+    /// 이 빌드가 실제 native-skia 래스터를 돌릴 수 있는가.
+    ///
+    /// `native-skia` 피처가 켜진 네이티브 빌드에서만 `true` 다. wasm 과
+    /// 기본 CI 빌드에서는 `false` 이며, 그때 능력 선언도 그에 맞춘다.
+    pub const fn raster_available() -> bool {
+        cfg!(all(not(target_arch = "wasm32"), feature = "native-skia"))
+    }
+}
+
+impl Default for SkiaBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderBackend for SkiaBackend {
+    type Output = RasterRenderOutput;
+    type Error = RenderBackendError;
+
+    fn capabilities(&self) -> BackendCapabilities {
+        // 래스터 전용 산출물이므로 vector_text 는 끈다 (`raster("skia")` 기본값).
+        // 얇은 어댑터는 PaintOp 만 받아 새 leaf 로 평탄화하므로 클립을 보존하지 못한다.
+        // RasterRenderOutput 한 장은 한 페이지 — 여러 장을 한 산출물로 묶을 형식이 없다.
+        // 실제 래스터가 없으면 이미지·그라디언트도 산출물에 남지 않는다.
+        let live = Self::raster_available();
+        BackendCapabilities {
+            gradients: live,
+            clipping: false,
+            images: live,
+            multi_page: false,
+            ..BackendCapabilities::raster("skia")
+        }
+    }
+
+    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error> {
+        if !self.pages.is_empty() {
+            return Err(RenderBackendError::MultiplePagesUnsupported { backend: "skia" });
+        }
+        self.state.begin(size)?;
+        self.pending.clear();
+        Ok(())
+    }
+
+    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error> {
+        self.state.record_draw()?;
+        self.pending.push(op.clone());
+        Ok(())
+    }
+
+    fn end_page(&mut self) -> Result<(), Self::Error> {
+        let (size, _) = self.state.end()?;
+        let document = raster_document(
+            size,
+            self.profile,
+            self.options,
+            std::mem::take(&mut self.pending),
+        )?;
+        self.pages.push(document);
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Self::Output, Self::Error> {
+        self.state.assert_finished()?;
+        Ok(self.pages.into_iter().next().unwrap_or_else(empty_document))
+    }
+
+    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error> {
+        (*self).finish()
+    }
+}
+
+fn empty_document() -> RasterRenderOutput {
+    RasterRenderOutput {
+        bytes: Vec::new(),
+        format: RasterOutputFormat::Png,
+        width: 0,
+        height: 0,
+        dpi: None,
+        color_space: RasterColorSpace::Srgb,
+    }
+}
+
+fn raster_document(
+    size: PageSize,
+    profile: RenderProfile,
+    options: RasterRenderOptions,
+    pending: Vec<PaintOp>,
+) -> Result<RasterRenderOutput, RenderBackendError> {
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    {
+        use crate::paint::{LayerNode, PageLayerTree};
+        use crate::renderer::layer_renderer::LayerRasterRenderer;
+        use crate::renderer::render_tree::BoundingBox;
+        use crate::renderer::skia::SkiaLayerRenderer;
+
+        let bounds = BoundingBox::new(0.0, 0.0, size.width, size.height);
+        let root = LayerNode::leaf(bounds, None, pending);
+        let tree = PageLayerTree::with_profile(size.width, size.height, root, profile);
+        SkiaLayerRenderer::new()
+            .render_raster(&tree, options)
+            .map_err(RenderBackendError::from)
+    }
+    #[cfg(not(all(not(target_arch = "wasm32"), feature = "native-skia")))]
+    {
+        let _ = (size, profile, options, pending);
+        Ok(empty_document())
+    }
+}

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2479,7 +2479,7 @@
       "id": "src/render_backend/mod.rs::tests#1",
       "file": "src/render_backend/mod.rs",
       "sourcePath": "src/render_backend/mod.rs",
-      "line": 80,
+      "line": 84,
       "module": "tests",
       "testAttributes": 15,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M06-2 (◆10 render_backend 계층 인수). 세 번째 구체 어댑터 **native-skia** 를 얹는다. `SvgBackend` 만 있던 `src/render_backend/` 에 `skia_adapter.rs` 를 추가하고 등록한다. 기존 `SkiaLayerRenderer` / `LayerRasterRenderer::render_raster` 를 호출만 한다. `render_png` / `render_png_with_options` 는 쓰지 않는다 — 그 경로는 M06-1 `PngBackend`(PR #5377) 의 몫이다. `src/renderer/**` 는 한 줄도 바꾸지 않는다.

산출물은 PNG 바이트열이 아니라 레이어 래스터 문서 `RasterRenderOutput`(바이트 + 폭·높이·dpi·색공간·형식)이다. `native-skia` 피처가 켜진 네이티브 빌드에서만 실제 래스터를 낸다. 꺼져 있으면(기본 CI) 어댑터는 그대로 컴파일되고 생명주기(`begin_page`/`draw`/`end_page`/`finish`)는 지키지만 래스터는 건너뛴다. `finish` 산출물은 빈 문서(0×0, 바이트 없음)다. `SkiaBackend::raster_available()` 과 `capabilities()` 가 그 사실을 숨기지 않는다.

얇은 어댑터는 SVG 와 같이 op 를 `LayerNode::leaf` 로 평탄화하므로 클립을 보존하지 못한다. 래스터 문서 한 장은 한 페이지라 두 번째 페이지는 `MultiplePagesUnsupported` 로 거절한다. 전 백엔드 정직성 스윕은 M06-3 이다. PNG 어댑터(`PngBackend`)는 M06-1 범위이며 여기 없다.

## 관련 이슈

closes #5378

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --lib render_backend::` 통과 (15)
- [x] `cargo clippy --lib -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (어댑터 래퍼만)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (wasm 에서는 래스터 skip)
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] `.claude/agents/`·스킬 변경 없음

계약 시험은 기존 `render_backend` 단위 시험에 접었다(source-side `#[test]` 증가 금지).

- `capabilities_are_queryable_and_consistent` — Skia 가 선언하는 능력이 실제 지원과 같다 (`clipping`/`multi_page` 끔, `images`/`gradients` 는 `raster_available()` 과 동기)
- `svg_backend_rejects_a_second_page` — Skia 도 두 번째 페이지를 거절
- `svg_backend_emits_real_svg_document` — 피처 있으면 래스터 문서(폭·높이·시그니처), 없으면 빈 문서
- `draw_without_begin_page_is_error` — Skia 도 같은 생명주기 오류

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (호출 경로만 감쌈, 기본 빌드는 래스터 skip)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- `src/renderer/**` 미수정
- PNG 어댑터(M06-1 `PngBackend` / `render_png`) 미추가·미복제
- gym / `scripts/visual_sweep.py` 미수정
- DocumentCore 신설 없음
