### PR TITLE
test: HWP5 편집 왕복 IrDiff-0 property (M04-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,12 +215,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -873,6 +888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1044,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1030,7 +1063,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasm-bindgen",
 ]
 
@@ -1231,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -1584,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
@@ -1908,6 +1941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,10 +1981,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -1970,9 +2037,35 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_core"
@@ -1982,9 +2075,27 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "range-alloc"
@@ -2165,7 +2276,7 @@ dependencies = [
  "embedded-io",
  "encoding_rs",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "hmac",
  "image",
  "js-sys",
@@ -2176,6 +2287,7 @@ dependencies = [
  "pcx",
  "pdf-writer",
  "pollster",
+ "proptest",
  "quick-xml",
  "rand_core 0.10.1",
  "resvg 0.46.0",
@@ -2240,7 +2352,7 @@ dependencies = [
  "crc32fast",
  "des",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "hmac",
  "pbkdf2",
  "quick-xml",
@@ -2311,6 +2423,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -2765,6 +2889,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2939,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.5.15",
 ]
@@ -2933,6 +3070,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -3160,6 +3303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3319,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3338,8 +3499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
@@ -3400,7 +3561,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "block2",
  "bytemuck",
@@ -3611,6 +3772,12 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write-fonts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,6 +323,8 @@ zip = { version = "8.5", default-features = false, features = ["deflate"] }
 # [#4378] CAS 계약 테스트가 기대 해시를 스스로 계산한다 — 위 [dependencies] 와
 # 같은 버전이라 의존성 그래프도 산출물도 그대로다(zip 선례와 동일).
 sha2 = "0.11"
+# [#5382] M04-3 HWP5 왕복 property. 기존 run step 만 조합한다. 왕복 본체는 통합 시험.
+proptest = "1.6"
 
 # ── Clippy 린트 정책 ──
 # 리팩토링(타스크 142) 각 단계 완료 시 allow → warn → deny 전환

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -109,3 +109,16 @@ CFB/ZIP처럼 구조 제약이 강한 컨테이너 포맷은 시드 없이는 �
   EMF 등 나머지 임베드 포맷·컨테이너를 우회하는 내부 파서 직접 하네스
 - CI 통합: PR당 짧은 스모크 퍼징 또는 회귀 코퍼스 재생
 - OSS-Fuzz 등재 (메인테이너 판단)
+
+## 왕복 정합성은 여기가 아니다 (M04)
+
+위 서두가 비워 둔 **정상 입력의 왕복 정합성(#2740, IrDiff-0)** 은 cargo-fuzz
+범위 밖이다. 그 공백을 메우는 계층이 M04 다 — 퍼저 타깃을 늘리지 않는다.
+
+- **M04-3** (`tests/cases/prop_hwp5_roundtrip.rs`, #5382): 작은 HWP5 픽스처에
+  기존 `rhwp run` step 만 적용한 뒤 parse→serialize→reparse 가
+  [`diff_documents`](../src/serializer/hwpx/roundtrip.rs) IrDiff 0.
+  CI 기본은 8 cases / 0..3 steps. 전체 화력은 `PROPTEST_CASES`
+  (예: `PROPTEST_CASES=256 cargo test --test regression_suite_* prop_hwp5_roundtrip::`).
+  픽스처가 표현하지 못하는 step(누름틀/표/□ 없음)은 skip. DocumentCore
+  편집 API 발명 금지. HWPX 는 M04-2.

--- a/tests/cases/prop_hwp5_roundtrip.rs
+++ b/tests/cases/prop_hwp5_roundtrip.rs
@@ -1,0 +1,362 @@
+//! [#5382] M04-3: HWP5 편집 후 parse→serialize→reparse 왕복 property (IrDiff 0).
+//!
+//! 작은 픽스처에 **이미 있는** `rhwp run` step 4종(`fill_fields` · `replace_text` ·
+//! `set_cell` · `set_checkbox`)만 적용한다. DocumentCore 편집 API 를 발명하지 않고,
+//! 이 픽스처가 표현하지 못하는 step 은 skip 한다 (누름틀/표/□ 없음 등).
+//!
+//! 비교는 기존 [`diff_documents`] 이다. HWPX 왕복은 M04-2.
+//!
+//! CI 는 싼 기본값(`CI_CASES`). 전체 화력은 `PROPTEST_CASES` (proptest 표준).
+#![cfg(not(target_arch = "wasm32"))]
+
+use proptest::prelude::*;
+
+use rhwp::document_core::queries::table_extract::extract_tables;
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::parser::parse_hwp;
+use rhwp::serializer::hwpx::roundtrip::diff_documents;
+use rhwp::serializer::serialize_hwp;
+
+/// 표·누름틀 없는 일반 HWP5. `hwp5_roundtrip_baseline` A등급이라 무편집 왕복은 IrDiff 0.
+const FIXTURE_TEXT: &[u8] = include_bytes!("../../samples/para-001.hwp");
+/// 19×9 표, 중첩 없음. baseline 등급이라 무편집 왕복은 IrDiff 0.
+const FIXTURE_TABLE: &[u8] = include_bytes!("../../samples/table-001.hwp");
+
+/// CI 기본. `PROPTEST_CASES` 가 있으면 proptest 가 덮어쓴다.
+const CI_CASES: u32 = 8;
+const CI_MAX_SHRINK_ITERS: u32 = 32;
+
+const FIND_NEEDLES: &[&str] = &["오호라", "乾坤", "구궁산"];
+const TABLE_FIND_NEEDLES: &[&str] = &["품질", "5월", "평가"];
+const REPLACE_TEXTS: &[&str] = &["", "한국", "X", "2026"];
+const CELL_TEXTS: &[&str] = &["", "서울", "완료", "1"];
+const FIELD_NAMES: &[&str] = &["이름", "myMsg01", "title"];
+
+/// 기존 `rhwp run` step. 스키마 4종과 1:1 이고, 실행은 엔진이 이미 쓰는 함수만 호출한다.
+#[derive(Clone, Debug)]
+enum ExistingRunStep {
+    FillFields {
+        name: String,
+        value: String,
+    },
+    ReplaceText {
+        find: String,
+        replace: String,
+        occurrence: Option<u32>,
+    },
+    SetCell {
+        table: u32,
+        row: u16,
+        col: u16,
+        text: String,
+    },
+    SetCheckbox {
+        occurrence: u32,
+    },
+}
+
+fn prop_config() -> ProptestConfig {
+    ProptestConfig {
+        cases: CI_CASES,
+        max_shrink_iters: CI_MAX_SHRINK_ITERS,
+        ..ProptestConfig::default()
+    }
+}
+
+fn arb_replace_text(needles: &'static [&'static str]) -> impl Strategy<Value = ExistingRunStep> {
+    (
+        prop::sample::select(needles),
+        prop::sample::select(REPLACE_TEXTS),
+        proptest::option::of(Just(0u32)),
+    )
+        .prop_map(|(find, replace, occurrence)| ExistingRunStep::ReplaceText {
+            find: (*find).to_string(),
+            replace: (*replace).to_string(),
+            occurrence,
+        })
+}
+
+fn arb_set_cell() -> impl Strategy<Value = ExistingRunStep> {
+    (
+        Just(0u32),
+        0u16..3,
+        0u16..3,
+        prop::sample::select(CELL_TEXTS),
+    )
+        .prop_map(|(table, row, col, text)| ExistingRunStep::SetCell {
+            table,
+            row,
+            col,
+            text: (*text).to_string(),
+        })
+}
+
+fn arb_fill_fields() -> impl Strategy<Value = ExistingRunStep> {
+    (
+        prop::sample::select(FIELD_NAMES),
+        prop::sample::select(REPLACE_TEXTS),
+    )
+        .prop_map(|(name, value)| ExistingRunStep::FillFields {
+            name: (*name).to_string(),
+            value: (*value).to_string(),
+        })
+}
+
+fn arb_set_checkbox() -> impl Strategy<Value = ExistingRunStep> {
+    (0u32..2).prop_map(|occurrence| ExistingRunStep::SetCheckbox { occurrence })
+}
+
+/// 4종을 모두 생성하되, 이 픽스처에서 실제로 먹을 수 있는 replace_text 에 무게를 둔다.
+fn arb_step_for_text_fixture() -> impl Strategy<Value = ExistingRunStep> {
+    prop_oneof![
+        6 => arb_replace_text(FIND_NEEDLES),
+        1 => arb_set_cell(),
+        1 => arb_fill_fields(),
+        1 => arb_set_checkbox(),
+    ]
+}
+
+fn arb_step_for_table_fixture() -> impl Strategy<Value = ExistingRunStep> {
+    prop_oneof![
+        6 => arb_set_cell(),
+        1 => arb_replace_text(TABLE_FIND_NEEDLES),
+        1 => arb_fill_fields(),
+        1 => arb_set_checkbox(),
+    ]
+}
+
+fn format_ir_diff(diff: &rhwp::serializer::hwpx::roundtrip::IrDiff) -> String {
+    diff.differences
+        .iter()
+        .map(|d| d.to_string())
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// 기존 엔진이 이 step 을 이 문서에 표현할 수 있으면 적용, 아니면 skip.
+/// 새 mutation API 를 만들지 않는다.
+fn apply_existing_step(core: &mut DocumentCore, step: &ExistingRunStep) -> Result<bool, String> {
+    match step {
+        ExistingRunStep::FillFields { name, value } => {
+            match core.set_field_value_by_name_at(name, 0, value) {
+                Ok(_) => Ok(true),
+                Err(_) => Ok(false),
+            }
+        }
+        ExistingRunStep::ReplaceText {
+            find,
+            replace,
+            occurrence,
+        } => {
+            if find.is_empty() {
+                return Ok(false);
+            }
+            let hits = core.grep(find, true, None);
+            if hits.is_empty() {
+                return Ok(false);
+            }
+            let result = match occurrence {
+                Some(n) => {
+                    if (*n as usize) >= hits.len() {
+                        return Ok(false);
+                    }
+                    core.replace_nth_native(find, replace, true, *n as usize)
+                }
+                None => core.replace_all_native(find, replace, true),
+            };
+            result.map(|_| true).map_err(|e| e.to_string())
+        }
+        ExistingRunStep::SetCell {
+            table,
+            row,
+            col,
+            text,
+        } => apply_set_cell(core, *table, *row, *col, text),
+        ExistingRunStep::SetCheckbox { occurrence } => {
+            let hits = core.grep("□", true, None);
+            if (*occurrence as usize) >= hits.len() {
+                return Ok(false);
+            }
+            core.replace_nth_native("□", "☑", true, *occurrence as usize)
+                .map(|_| true)
+                .map_err(|e| e.to_string())
+        }
+    }
+}
+
+/// `run_plan_engine` 의 set_cell 과 같은 기존 셀 비우기→쓰기 경로.
+fn apply_set_cell(
+    core: &mut DocumentCore,
+    table: u32,
+    row: u16,
+    col: u16,
+    text: &str,
+) -> Result<bool, String> {
+    if text.chars().any(|ch| matches!(ch, '\r' | '\n' | '\t')) {
+        return Ok(false);
+    }
+    let grids = extract_tables(core.document());
+    let Some(grid) = grids.get(table as usize) else {
+        return Ok(false);
+    };
+    if !grid.container_path.is_empty() {
+        return Ok(false);
+    }
+    let section = grid.section;
+    let paragraph = grid.paragraph;
+    let control = grid.control;
+    let Control::Table(tbl) =
+        &core.document().sections[section].paragraphs[paragraph].controls[control]
+    else {
+        return Ok(false);
+    };
+    let Some(cell_idx) = tbl
+        .cells
+        .iter()
+        .position(|cell| cell.row == row && cell.col == col)
+    else {
+        return Ok(false);
+    };
+    let para_lens: Vec<usize> = tbl.cells[cell_idx]
+        .paragraphs
+        .iter()
+        .map(|para| para.text.chars().count())
+        .collect();
+
+    for (pi, len) in para_lens.iter().enumerate() {
+        if *len == 0 {
+            continue;
+        }
+        core.delete_text_in_cell_native(section, paragraph, control, cell_idx, pi, 0, *len)
+            .map_err(|e| e.to_string())?;
+    }
+    if !text.is_empty() {
+        core.insert_text_in_cell_native(section, paragraph, control, cell_idx, 0, 0, text)
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(true)
+}
+
+fn assert_edit_serialize_reparse(bytes: &[u8], steps: &[ExistingRunStep]) -> Result<(), String> {
+    let mut core = DocumentCore::from_bytes(bytes).map_err(|e| format!("parse: {e}"))?;
+    let mut applied = 0usize;
+    for step in steps {
+        if apply_existing_step(&mut core, step)? {
+            applied += 1;
+        }
+    }
+    if !steps.is_empty() && applied == 0 {
+        return Err("skip".into());
+    }
+
+    let edited = core.document().clone();
+    let out = serialize_hwp(&edited).map_err(|e| format!("serialize: {e}"))?;
+    let reparsed = parse_hwp(&out).map_err(|e| format!("reparse: {e}"))?;
+    let diff = diff_documents(&edited, &reparsed);
+    if !diff.is_empty() {
+        return Err(format!(
+            "IrDiff {}건 (applied {applied}/{ }): {}",
+            diff.differences.len(),
+            steps.len(),
+            format_ir_diff(&diff)
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn fixture_identity_ir_diff_is_zero() {
+    for (label, bytes) in [("para-001", FIXTURE_TEXT), ("table-001", FIXTURE_TABLE)] {
+        assert_edit_serialize_reparse(bytes, &[]).unwrap_or_else(|e| panic!("{label}: {e}"));
+    }
+}
+
+#[test]
+fn handwritten_replace_text_roundtrips() {
+    let steps = [ExistingRunStep::ReplaceText {
+        find: "오호라".into(),
+        replace: "한국".into(),
+        occurrence: None,
+    }];
+    assert_edit_serialize_reparse(FIXTURE_TEXT, &steps).expect("replace_text 왕복");
+}
+
+#[test]
+fn handwritten_set_cell_roundtrips() {
+    let steps = [ExistingRunStep::SetCell {
+        table: 0,
+        row: 2,
+        col: 1,
+        text: "서울".into(),
+    }];
+    assert_edit_serialize_reparse(FIXTURE_TABLE, &steps).expect("set_cell 왕복");
+}
+
+#[test]
+fn inexpressible_steps_are_skipped_not_invented() {
+    let mut core = DocumentCore::from_bytes(FIXTURE_TEXT).expect("parse");
+    assert!(
+        !apply_existing_step(
+            &mut core,
+            &ExistingRunStep::FillFields {
+                name: "이름".into(),
+                value: "홍길동".into(),
+            },
+        )
+        .expect("fill_fields"),
+        "para-001 은 누름틀이 없어 fill_fields 를 skip 해야 한다"
+    );
+    assert!(
+        !apply_existing_step(
+            &mut core,
+            &ExistingRunStep::SetCell {
+                table: 0,
+                row: 0,
+                col: 0,
+                text: "x".into(),
+            },
+        )
+        .expect("set_cell"),
+        "para-001 은 표가 없어 set_cell 을 skip 해야 한다"
+    );
+    assert!(
+        !apply_existing_step(&mut core, &ExistingRunStep::SetCheckbox { occurrence: 0 },)
+            .expect("set_checkbox"),
+        "para-001 은 □ 가 없어 set_checkbox 를 skip 해야 한다"
+    );
+}
+
+proptest! {
+    #![proptest_config(prop_config())]
+
+    #[test]
+    fn edited_para001_hwp5_roundtrips_with_zero_ir_diff(
+        steps in proptest::collection::vec(arb_step_for_text_fixture(), 0..3)
+    ) {
+        match assert_edit_serialize_reparse(FIXTURE_TEXT, &steps) {
+            Ok(()) => {}
+            Err(err) if err == "skip" => {
+                return Err(TestCaseError::reject(
+                    "이 픽스처가 표현할 수 없는 step 만 나옴",
+                ));
+            }
+            Err(err) => return Err(TestCaseError::fail(err)),
+        }
+    }
+
+    #[test]
+    fn edited_table001_hwp5_roundtrips_with_zero_ir_diff(
+        steps in proptest::collection::vec(arb_step_for_table_fixture(), 0..3)
+    ) {
+        match assert_edit_serialize_reparse(FIXTURE_TABLE, &steps) {
+            Ok(()) => {}
+            Err(err) if err == "skip" => {
+                return Err(TestCaseError::reject(
+                    "이 픽스처가 표현할 수 없는 step 만 나옴",
+                ));
+            }
+            Err(err) => return Err(TestCaseError::fail(err)),
+        }
+    }
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M04-3 (◆10 proptest 왕복 불변식 계층)의 **HWP5 왕복 property** 입니다. M04-2 (#5381) 와 같은 성질이고, 포맷만 HWP5 입니다. 생성기 PR #5375 를 기다리지 않고, 기존 `rhwp run` step 4종만 조합하는 얇은 생성기를 시험 안에 둡니다.

- 작은 픽스처(`samples/para-001.hwp`, `samples/table-001.hwp`)에서 시작한다. 둘 다 `hwp5_roundtrip_baseline` A등급이다.
- `fill_fields` · `replace_text` · `set_cell` · `set_checkbox` 만 적용한다. DocumentCore 편집 API 를 발명하지 않는다.
- 이 픽스처가 표현하지 못하는 step(누름틀/표/□ 없음, 병합에 가린 셀)은 skip 한다.
- 적용 후 `serialize_hwp` → `parse_hwp` → 기존 `diff_documents` IrDiff 0.
- 실패는 proptest 가 shrink 한다.
- CI 기본은 8 cases / 0..3 steps. 전체 화력은 `PROPTEST_CASES` (예: `PROPTEST_CASES=256`).

## 관련 이슈

closes #5382

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (로컬 `--prepare` 뒤. 파생 harness/manifest 는 커밋하지 않음)
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --test regression_suite_007 prop_hwp5_roundtrip::` 6 passed (3.22s)
- [ ] `cargo clippy -- -D warnings` — 해당 없음에 가깝습니다. src/ 미변경, 통합 시험·dev-dep 만 추가
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (문서 편집 없음)
- [ ] capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (dev-dependency + 통합 시험, 런타임 경로 미변경)
- 재현·측정: `cargo test --test regression_suite_007 prop_hwp5_roundtrip::` 6 passed, 약 3.22s

## 스크린샷

해당 없음.

## 하지 않은 것

- HWPX IrDiff-0 왕복 property (M04-2)
- property CI 배선 (M04-4)
- DocumentCore 편집 로직 발명
- gym/ 미수정
- `scripts/visual_sweep.py` 미수정
