### PR TITLE
ci: proptest 왕복 계층 CI 배선 (M04-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,9 @@ jobs:
   # [#5164] archive는 preflight 직후 한 번만 compile/link하고 Lint와 병렬 실행한다.
   # 네 worker는 동일 archive를 slow filter와 regular test-case partition으로 나눠 소비한다.
   # required check 는 집계 job "Build & Test" 로 불변이다.
+  # [#5388] M04-4: tests/cases/prop_*_roundtrip.rs 는 정규 shard 가 archive 에서
+  # 자동 실행한다. 전용 싼 job 은 .github/workflows/proptest-roundtrip.yml
+  # (원본 부재 skip). 5번째 shard 를 넣지 않는다 — 집계는 4 worker 합이다.
   build-test-archive:
     uses: ./.github/workflows/build-nextest-archives.yml
     needs: [preflight]
@@ -939,6 +942,7 @@ jobs:
           python3 -m unittest scripts/tests/test_release_channel_policy_workflow.py
           python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py
           python3 -m unittest scripts/tests/test_gym_release_gate_workflow.py
+          python3 -m unittest scripts/tests/test_proptest_roundtrip_workflow.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 
       - name: Validate gym scorer contracts

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -1,0 +1,54 @@
+name: Proptest roundtrip
+
+# M04-4 / #5388 — fuzz/README 가 범위 밖으로 둔 왕복 정합성(#2740) 계층.
+# nextest archive 정규 shard 도 tests/cases 원본을 돌리지만, 여기 잡은
+# debug + 이름 필터로 싸고 명시적으로 돌린다. 10분 퍼지가 아니다.
+#
+# M04-2 `prop_hwpx_roundtrip` · M04-3 `prop_hwp5_roundtrip` 원본이 없으면
+# skip (본체가 아직 안 들어와도 실패하지 않는다). 배선 확인용
+# `prop_roundtrip_ci` 는 항상 돈다.
+
+on:
+  pull_request:
+    branches: [main, devel]
+  push:
+    branches: [main, devel]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: proptest-roundtrip-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  proptest-roundtrip:
+    name: prop roundtrip
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+        with:
+          toolchain: 1.93.1
+
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
+        with:
+          shared-key: proptest-roundtrip
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
+
+      - name: Check property runner contract
+        run: node --test scripts/tests/run-prop-roundtrip.test.mjs
+
+      - name: Prepare derived Rust test suites
+        run: node scripts/rust-test-suite-manifest.mjs --prepare
+
+      - name: Run property roundtrip cases
+        run: node scripts/run-prop-roundtrip.mjs --cargo-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,12 +215,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -873,6 +888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1044,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1030,7 +1063,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasm-bindgen",
 ]
 
@@ -1231,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -1584,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
@@ -1908,6 +1941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,10 +1981,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -1970,9 +2037,35 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_core"
@@ -1982,9 +2075,27 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "range-alloc"
@@ -2165,7 +2276,7 @@ dependencies = [
  "embedded-io",
  "encoding_rs",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "hmac",
  "image",
  "js-sys",
@@ -2176,6 +2287,7 @@ dependencies = [
  "pcx",
  "pdf-writer",
  "pollster",
+ "proptest",
  "quick-xml",
  "rand_core 0.10.1",
  "resvg 0.46.0",
@@ -2240,7 +2352,7 @@ dependencies = [
  "crc32fast",
  "des",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "hmac",
  "pbkdf2",
  "quick-xml",
@@ -2311,6 +2423,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -2765,6 +2889,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2939,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.5.15",
 ]
@@ -2933,6 +3070,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -3160,6 +3303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3319,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3338,8 +3499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
@@ -3400,7 +3561,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "block2",
  "bytemuck",
@@ -3611,6 +3772,12 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write-fonts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,6 +323,8 @@ zip = { version = "8.5", default-features = false, features = ["deflate"] }
 # [#4378] CAS 계약 테스트가 기대 해시를 스스로 계산한다 — 위 [dependencies] 와
 # 같은 버전이라 의존성 그래프도 산출물도 그대로다(zip 선례와 동일).
 sha2 = "0.11"
+# [#5388] M04-4 왕복 property CI 배선. 문서 IrDiff-0 본체는 M04-2/3.
+proptest = "1.6"
 
 # ── Clippy 린트 정책 ──
 # 리팩토링(타스크 142) 각 단계 완료 시 allow → warn → deny 전환

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -107,5 +107,23 @@ CFB/ZIP처럼 구조 제약이 강한 컨테이너 포맷은 시드 없이는 �
 
 - 2순위 하네스: `parse_body_text_section` / `parse_doc_info` / `parse_control` /
   EMF 등 나머지 임베드 포맷·컨테이너를 우회하는 내부 파서 직접 하네스
-- CI 통합: PR당 짧은 스모크 퍼징 또는 회귀 코퍼스 재생
+- CI 통합: PR당 짧은 스모크 퍼징 또는 회귀 코퍼스 재생 (왕복 정합성은 아래 M04)
 - OSS-Fuzz 등재 (메인테이너 판단)
+
+## 왕복 정합성은 여기가 아니다 (M04)
+
+위 서두가 비워 둔 **정상 입력의 왕복 정합성(#2740, IrDiff-0)** 은 cargo-fuzz
+범위 밖이다. 그 공백을 메우는 계층이 M04 다 — 퍼저 타깃을 늘리지 않는다.
+왕복은 property 계층이지 퍼지가 아니다.
+
+- **CI** (`.github/workflows/proptest-roundtrip.yml`,
+  `scripts/run-prop-roundtrip.mjs`): debug 프로필, 기본 8 cases. 10분 퍼지가
+  아니다. `tests/cases/prop_hwpx_roundtrip.rs`(M04-2, #5381) 와
+  `tests/cases/prop_hwp5_roundtrip.rs`(M04-3, #5387) 가 있으면 돌리고, 없으면
+  skip 한다. 배선 확인용 `tests/cases/prop_roundtrip_ci.rs` 는 항상 돈다.
+  nextest archive 정규 shard 도 같은 `tests/cases/` 원본을 자동 실행한다.
+- **본체**: 작은 픽스처에 기존 `rhwp run` step 만 적용한 뒤
+  parse→serialize→reparse 가
+  [`diff_documents`](../src/serializer/hwpx/roundtrip.rs) IrDiff 0.
+  전체 화력은 `PROPTEST_CASES` (예:
+  `PROPTEST_CASES=256 cargo test --test regression_suite_* prop_hwpx_roundtrip::`).

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -86,6 +86,19 @@ base 대비 module·support item·총 테스트 수 또는 최대값 증가를 �
 실행한다. 따라서 새 일반 test source는 integration binary 수를 늘리지 않고, private white-box test는
 production crate 경계와 함께 독립 binary로 점진 분리할 수 있다.
 
+정상 입력의 parse→serialize→reparse (IrDiff-0, #2740) 는 cargo-fuzz 범위가 아니다.
+그 공백은 M04 property 계층이다. CI 전용 싼 job 은
+`.github/workflows/proptest-roundtrip.yml` 이고, 로컬은 다음으로 같은 필터를 돌린다.
+
+~~~bash
+node scripts/rust-test-suite-manifest.mjs --prepare
+node scripts/run-prop-roundtrip.mjs --cargo-test
+~~~
+
+`prop_roundtrip_ci` 는 항상 돈다. `prop_hwpx_roundtrip` / `prop_hwp5_roundtrip` 원본이
+`tests/cases/` 에 없으면 skip 하고, 있으면 집는다. 기본 8 cases. 전체 화력은
+`PROPTEST_CASES`. 정규 nextest archive 도 같은 원본을 자동 실행한다.
+
 ### 시각 대조용 최신 바이너리 준비는 별도다
 
 renderer/layout 변경을 한컴 기준 PDF와 비교할 때는 비교 하네스가 수정 후 바이너리를 실행하도록 다음

--- a/scripts/run-prop-roundtrip.mjs
+++ b/scripts/run-prop-roundtrip.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  cargoTestArguments,
+  nextestArguments,
+  resolveCasePlan,
+} from './run-rust-test.mjs';
+import { ROOT } from './rust-test-suite-manifest.mjs';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+
+/** 배선 확인용. 이 원본이 없으면 job 이 실패한다. */
+export const REQUIRED_CASES = ['prop_roundtrip_ci'];
+
+/**
+ * M04-2 / M04-3 본체. 원본이 아직 없으면 skip — CI 를 실패시키지 않는다.
+ * nextest archive 정규 shard 도 tests/cases 원본을 자동 실행한다.
+ */
+export const OPTIONAL_CASES = ['prop_hwpx_roundtrip', 'prop_hwp5_roundtrip'];
+
+export function caseSourcePath(caseName, root = ROOT) {
+  return path.join(root, 'tests', 'cases', `${caseName}.rs`);
+}
+
+export function planPropRoundtrip(root = ROOT) {
+  const run = [];
+  const skipped = [];
+  for (const caseName of REQUIRED_CASES) {
+    if (!existsSync(caseSourcePath(caseName, root))) {
+      throw new Error(`필수 property case 가 없습니다: ${caseName}`);
+    }
+    run.push(caseName);
+  }
+  for (const caseName of OPTIONAL_CASES) {
+    if (existsSync(caseSourcePath(caseName, root))) {
+      run.push(caseName);
+    } else {
+      skipped.push(caseName);
+    }
+  }
+  return { run, skipped };
+}
+
+function usage() {
+  return (
+    '사용법: node scripts/run-prop-roundtrip.mjs [--print] [--cargo-test]\n'
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
+  try {
+    const arguments_ = process.argv.slice(2);
+    let printOnly = false;
+    let cargoTest = false;
+    while (arguments_[0] === '--print' || arguments_[0] === '--cargo-test') {
+      const option = arguments_.shift();
+      printOnly ||= option === '--print';
+      cargoTest ||= option === '--cargo-test';
+    }
+    if (arguments_.length > 0) {
+      throw new Error(usage().trim());
+    }
+
+    const plan = planPropRoundtrip();
+    for (const caseName of plan.skipped) {
+      process.stdout.write(
+        `[PropRoundtrip] skip ${caseName} (tests/cases/${caseName}.rs 없음)\n`,
+      );
+    }
+
+    for (const caseName of plan.run) {
+      const casePlan = resolveCasePlan(caseName);
+      const cargoArguments = cargoTest
+        ? cargoTestArguments(casePlan)
+        : nextestArguments(casePlan);
+      process.stdout.write(
+        `[PropRoundtrip] ${caseName} -> ${casePlan.target}` +
+          `${casePlan.grouped ? `::${caseName}` : ''}\n` +
+          `[PropRoundtrip] cargo ${cargoArguments.join(' ')}\n`,
+      );
+      if (printOnly) {
+        continue;
+      }
+      const result = spawnSync('cargo', cargoArguments, {
+        cwd: ROOT,
+        stdio: 'inherit',
+        shell: false,
+      });
+      if (result.error) {
+        throw result.error;
+      }
+      if ((result.status ?? 1) !== 0) {
+        process.exitCode = result.status ?? 1;
+        break;
+      }
+    }
+  } catch (error) {
+    process.stderr.write(
+      `[PropRoundtrip] 오류: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/run-prop-roundtrip.test.mjs
+++ b/scripts/tests/run-prop-roundtrip.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  OPTIONAL_CASES,
+  REQUIRED_CASES,
+  caseSourcePath,
+  planPropRoundtrip,
+} from '../run-prop-roundtrip.mjs';
+
+function withTempRoot(run) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'prop-roundtrip-'));
+  try {
+    mkdirSync(path.join(root, 'tests', 'cases'), { recursive: true });
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('required wiring case is prop_roundtrip_ci', () => {
+  assert.deepEqual(REQUIRED_CASES, ['prop_roundtrip_ci']);
+  assert.deepEqual(OPTIONAL_CASES, [
+    'prop_hwpx_roundtrip',
+    'prop_hwp5_roundtrip',
+  ]);
+});
+
+test('optional M04-2/M04-3 cases are skipped when source files are absent', () => {
+  withTempRoot((root) => {
+    writeFileSync(caseSourcePath('prop_roundtrip_ci', root), '');
+    const plan = planPropRoundtrip(root);
+    assert.deepEqual(plan.run, ['prop_roundtrip_ci']);
+    assert.deepEqual(plan.skipped, OPTIONAL_CASES);
+  });
+});
+
+test('optional cases are picked up when tests/cases sources exist', () => {
+  withTempRoot((root) => {
+    for (const caseName of [...REQUIRED_CASES, ...OPTIONAL_CASES]) {
+      writeFileSync(caseSourcePath(caseName, root), '');
+    }
+    const plan = planPropRoundtrip(root);
+    assert.deepEqual(plan.run, [
+      'prop_roundtrip_ci',
+      'prop_hwpx_roundtrip',
+      'prop_hwp5_roundtrip',
+    ]);
+    assert.deepEqual(plan.skipped, []);
+  });
+});
+
+test('hwpx only is picked up without requiring hwp5', () => {
+  withTempRoot((root) => {
+    writeFileSync(caseSourcePath('prop_roundtrip_ci', root), '');
+    writeFileSync(caseSourcePath('prop_hwpx_roundtrip', root), '');
+    const plan = planPropRoundtrip(root);
+    assert.deepEqual(plan.run, ['prop_roundtrip_ci', 'prop_hwpx_roundtrip']);
+    assert.deepEqual(plan.skipped, ['prop_hwp5_roundtrip']);
+  });
+});
+
+test('missing required wiring case fails instead of skipping', () => {
+  withTempRoot((root) => {
+    assert.throws(
+      () => planPropRoundtrip(root),
+      /필수 property case 가 없습니다: prop_roundtrip_ci/,
+    );
+  });
+});

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -1,0 +1,65 @@
+"""[#5388] M04-4 proptest-roundtrip.yml 계약 — 싼 왕복 property job.
+
+이 파일명은 `test_*workflow*.py` 패턴이라 test_workflow_contract_wiring.py 가
+ci.yml 배선을 강제한다(#4080). 배선을 잊으면 그 테스트가 실패한다.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WF = REPO_ROOT / ".github/workflows/proptest-roundtrip.yml"
+RUNNER = REPO_ROOT / "scripts/run-prop-roundtrip.mjs"
+CI_WF = REPO_ROOT / ".github/workflows/ci.yml"
+RUN_ARCHIVE = REPO_ROOT / ".github/workflows/run-nextest-archives.yml"
+
+
+class ProptestRoundtripWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.wf = WF.read_text(encoding="utf-8")
+        cls.ci = CI_WF.read_text(encoding="utf-8")
+
+    def test_workflow_and_runner_exist(self) -> None:
+        self.assertTrue(WF.is_file(), "proptest-roundtrip.yml 이 없다")
+        self.assertTrue(RUNNER.is_file(), "run-prop-roundtrip.mjs 가 없다")
+
+    def test_runs_on_pull_request(self) -> None:
+        """PR 마다 도는 always-on job. nightly 전용 퍼지가 아니다."""
+        self.assertIn("pull_request:", self.wf)
+        self.assertIn("branches: [main, devel]", self.wf)
+
+    def test_is_not_a_long_fuzz(self) -> None:
+        self.assertNotIn("cargo-fuzz", self.wf)
+        self.assertNotIn("fuzz run", self.wf)
+        self.assertNotIn("max_total_time", self.wf)
+        self.assertNotIn("nightly", self.wf)
+        self.assertIn("timeout-minutes: 20", self.wf)
+
+    def test_uses_debug_cargo_test_not_release_archive(self) -> None:
+        self.assertIn("run-prop-roundtrip.mjs --cargo-test", self.wf)
+        self.assertNotIn("--release", self.wf)
+        self.assertNotIn("release-test", self.wf)
+        self.assertNotIn("cargo nextest archive", self.wf)
+        self.assertNotIn("--archive-file", self.wf)
+
+    def test_prepares_suites_before_running(self) -> None:
+        prepare_at = self.wf.index("rust-test-suite-manifest.mjs --prepare")
+        run_at = self.wf.index("run-prop-roundtrip.mjs --cargo-test")
+        self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
+
+    def test_does_not_add_a_fifth_nextest_shard(self) -> None:
+        """정규 archive 집계는 shard 4개 합 = runnable. 5번째 worker 는 깨진다."""
+        self.assertNotRegex(self.ci, r"(?m)^  proptest-roundtrip:")
+        self.assertNotIn("prop_hwpx_roundtrip", RUN_ARCHIVE.read_text(encoding="utf-8"))
+        self.assertIn("expected 4 shard count files", self.ci)
+
+    def test_read_only_permissions(self) -> None:
+        self.assertIn("contents: read", self.wf)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cases/prop_roundtrip_ci.rs
+++ b/tests/cases/prop_roundtrip_ci.rs
@@ -1,0 +1,28 @@
+//! [#5388] M04-4: 왕복 property CI 배선.
+//!
+//! `prop_hwpx_roundtrip`(M04-2) · `prop_hwp5_roundtrip`(M04-3) 가 아직 없어도
+//! 이 파일은 항상 있다. `.github/workflows/proptest-roundtrip.yml` 이 같은
+//! 러너로 셋을 돌리고, 없는 원본은 skip 한다.
+//!
+//! 문서 IrDiff-0 왕복은 M04-2/3 본체다. 여기는 proptest 가 CI 에서 실제로
+//! 돈다는 최소 불변식만 본다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use proptest::prelude::*;
+
+/// CI 기본. `PROPTEST_CASES` 가 있으면 proptest 가 덮어쓴다.
+const CI_CASES: u32 = 8;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: CI_CASES,
+        max_shrink_iters: 16,
+        ..ProptestConfig::default()
+    })]
+    #[test]
+    fn prop_roundtrip_ci_utf8_identity(s in "\\PC{0,32}") {
+        let bytes = s.as_bytes().to_vec();
+        let back = String::from_utf8(bytes).expect("UTF-8");
+        prop_assert_eq!(s, back);
+    }
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M04-4 (◆10 proptest 왕복 불변식 계층)의 **CI 배선** 입니다. 본체는 M04-2 (#5381) · M04-3 (#5387) 이고, 이 PR 은 그 시험이 아직 없어도 CI 가 실패하지 않게 집습니다.

- nextest archive 는 `tests/cases/` 원본을 네 정규 shard 로 이미 실행합니다. 5번째 shard 를 넣지 않습니다 (집계는 worker 4개 합 = runnable).
- 전용 싼 job (`.github/workflows/proptest-roundtrip.yml`): debug + `cargo test` 이름 필터. 10분 퍼지가 아닙니다.
- `prop_hwpx_roundtrip` / `prop_hwp5_roundtrip` 원본이 없으면 skip, 있으면 집습니다.
- 배선 확인용 `tests/cases/prop_roundtrip_ci.rs` (UTF-8 identity, 8 cases) 는 항상 돕니다.
- `fuzz/README.md` · `local_validation.md` 에 왕복 정합성(#2740) 은 property 계층이지 퍼지가 아니라고 명시합니다.

## 관련 이슈

closes #5388

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (로컬 `--prepare` 뒤. 파생 harness/manifest 는 커밋하지 않음)
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `node --test scripts/tests/run-prop-roundtrip.test.mjs` 5 passed
- [x] `python -m unittest scripts.tests.test_proptest_roundtrip_workflow` 7 passed
- [x] `node scripts/run-prop-roundtrip.mjs --print --cargo-test` — hwpx/hwp5 skip, `prop_roundtrip_ci` → `regression_suite_015`
- [ ] `cargo clippy -- -D warnings` — 해당 없음에 가깝습니다. src/ 미변경, 배선·dev-dep·문서
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (문서 편집 없음)
- [ ] capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (dev-dependency + 싼 CI job, 런타임 경로 미변경)
- 재현·측정: 러너 계약 테스트 5+7 passed. rust 본체는 CI debug job 이 8 cases 로 실행

## 스크린샷

해당 없음.

## 하지 않은 것

- HWPX/HWP5 IrDiff-0 왕복 property 본체 (M04-2 #5381, M04-3 #5387)
- nextest archive 5번째 shard (집계 계약을 깨뜨림)
- 10분 sanitizer 퍼지
- gym/ 미수정
- `scripts/visual_sweep.py` 미수정
