### PR TITLE
docs(ci): layout-anomaly CI advisory 잡 설계

### DIFF
--- a/.github/workflows/layout-anomaly-advisory.yml
+++ b/.github/workflows/layout-anomaly-advisory.yml
@@ -1,0 +1,194 @@
+# Layout Anomaly Advisory — 소표본 layout-anomaly 스윕 (advisory).
+#
+# 설계: tools/layout_anomaly/ci_advisory.md
+# PR 게이트가 아니다. required check / branch protection 에 등록하지 말 것.
+# scripts/visual_sweep.py 는 호출·수정하지 않는다. --strict 금지. gym 금지.
+#
+# pull_request 트리거는 의도적으로 꺼 두었다. 켜더라도 required 로 올리지 않는다.
+# pull_request:
+#   branches: [devel]
+#   types: [opened, reopened, synchronize]
+#   paths:
+#     - 'src/renderer/**'
+#     - 'src/diagnostics/layout_anomaly*'
+#     - 'tools/layout_anomaly/**'
+#     - '.github/workflows/layout-anomaly-advisory.yml'
+
+name: Layout Anomaly Advisory
+
+on:
+  schedule:
+    # fuzz-smoke 02:41, cache-generation-sweep 18:23 과 시각을 겹치지 않게 한다.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "스캔할 최대 표본 수 (0=목록 전수)"
+        required: false
+        default: "0"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: layout-anomaly-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  advisory:
+    name: layout-anomaly-advisory
+    runs-on: ubuntu-latest
+    # hang 상한 (성능 목표 아님). 내부 timeout 18m 뒤에 부분 리포트를 남긴다.
+    timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out sparse tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            src
+            crates
+            tests
+            samples
+            tools
+            bindings
+            scripts
+
+      - name: Gate on runner + samples
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          runner = Path("tools/layout_anomaly/advisory_run.py").is_file()
+          listed = Path("tools/layout_anomaly/advisory_samples.txt").is_file()
+          batch = Path("tools/layout_anomaly/batch_report.py").is_file()
+          present = 0
+          if listed:
+              for raw in Path("tools/layout_anomaly/advisory_samples.txt").read_text(
+                  encoding="utf-8"
+              ).splitlines():
+                  line = raw.strip()
+                  if line and not line.startswith("#") and Path(line).is_file():
+                      present += 1
+
+          reason = "ok"
+          if not runner:
+              reason = "runner-absent"
+          elif not batch and present == 0:
+              reason = "samples-absent"
+
+          print(
+              f"runner={runner} batch={batch} present={present} reason={reason}"
+          )
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"reason={reason}\n")
+              fh.write(f"present={present}\n")
+              fh.write(f"batch={'true' if batch else 'false'}\n")
+              fh.write(f"should_run={'true' if reason == 'ok' else 'false'}\n")
+          PY
+
+      - name: Skip note
+        if: ${{ steps.gate.outputs.should_run != 'true' }}
+        shell: bash
+        env:
+          REASON: ${{ steps.gate.outputs.reason }}
+          PRESENT: ${{ steps.gate.outputs.present }}
+        run: |
+          set -euo pipefail
+          mkdir -p layout-anomaly-advisory
+          {
+            echo '## layout-anomaly (advisory) — skipped'
+            echo
+            echo "| reason | present_samples |"
+            echo "| --- | ---: |"
+            echo "| ${REASON} | ${PRESENT} |"
+            echo
+            echo '스캔을 건너뛰었습니다. 이 잡은 advisory 이며 required check 가 아닙니다.'
+          } | tee layout-anomaly-advisory/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Install Rust toolchain
+        if: ${{ steps.gate.outputs.should_run == 'true' }}
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+        with:
+          toolchain: 1.93.1
+
+      - name: Rust build cache
+        if: ${{ steps.gate.outputs.should_run == 'true' }}
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
+        with:
+          shared-key: layout-anomaly-advisory
+          save-if: ${{ github.ref == 'refs/heads/devel' && github.event_name == 'schedule' }}
+
+      - name: Build rhwp
+        id: build
+        if: ${{ steps.gate.outputs.should_run == 'true' }}
+        continue-on-error: true
+        shell: bash
+        run: cargo build --release --bin rhwp
+
+      - name: Build-failed note
+        if: ${{ steps.gate.outputs.should_run == 'true' && steps.build.outcome != 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p layout-anomaly-advisory
+          {
+            echo '## layout-anomaly (advisory) — skipped'
+            echo
+            echo 'reason: `rhwp-build-failed`. cargo build --release --bin rhwp 가 실패했습니다.'
+            echo
+            echo '이 잡은 advisory 이며 required check 가 아닙니다.'
+          } | tee layout-anomaly-advisory/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Run layout-anomaly sample set
+        id: scan
+        if: ${{ steps.gate.outputs.should_run == 'true' && steps.build.outcome == 'success' }}
+        shell: bash
+        env:
+          LIMIT: ${{ inputs.limit || '0' }}
+        run: |
+          set -uo pipefail
+          mkdir -p layout-anomaly-advisory
+          args=(
+            python3 tools/layout_anomaly/advisory_run.py
+            --rhwp target/release/rhwp
+            --out layout-anomaly-advisory
+          )
+          if [[ "${LIMIT}" =~ ^[1-9][0-9]*$ ]]; then
+            args+=(--limit "${LIMIT}")
+          fi
+          printf 'scan command: %s\n' "${args[*]}"
+          # --strict 없음. timeout 비정상 종료도 잡을 실패로 올리지 않는다.
+          set +e
+          timeout 18m "${args[@]}"
+          scan_rc=$?
+          set -e
+          printf 'scan_exit=%s\n' "${scan_rc}" >> "${GITHUB_OUTPUT}"
+          exit 0
+
+      - name: Job summary
+        if: ${{ always() && hashFiles('layout-anomaly-advisory/summary.md') != '' }}
+        shell: bash
+        run: cat layout-anomaly-advisory/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload advisory artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: layout-anomaly-advisory-${{ github.run_id }}
+          path: layout-anomaly-advisory/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/tools/layout_anomaly/advisory_run.py
+++ b/tools/layout_anomaly/advisory_run.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""layout-anomaly advisory sample runner.
+
+Never passes --strict. Always exits 0 so CI cannot become a merge gate.
+If tools/layout_anomaly/batch_report.py exists, that script is preferred.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+BATCH_REPORT = Path("tools/layout_anomaly/batch_report.py")
+DEFAULT_LIST = Path("tools/layout_anomaly/advisory_samples.txt")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--rhwp", required=True, help="rhwp binary path")
+    p.add_argument("--out", required=True, help="output directory")
+    p.add_argument("--list", default=str(DEFAULT_LIST), help="sample list file")
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="max samples (0 = all listed)",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="per-document timeout seconds",
+    )
+    return p.parse_args()
+
+
+def _read_list(path: Path, limit: int) -> list[str]:
+    if not path.is_file():
+        return []
+    rows: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        rows.append(line)
+        if limit > 0 and len(rows) >= limit:
+            break
+    return rows
+
+
+def _unwrap(payload: object) -> dict:
+    if not isinstance(payload, dict):
+        return {}
+    inner = payload.get("untrustedContent")
+    if isinstance(inner, dict):
+        return inner
+    return payload
+
+
+def _try_batch_report(args: argparse.Namespace, out: Path) -> bool:
+    if not BATCH_REPORT.is_file():
+        return False
+    cmd = [
+        sys.executable,
+        str(BATCH_REPORT),
+        "--rhwp",
+        args.rhwp,
+        "--json",
+        "--out",
+        str(out),
+    ]
+    if args.limit > 0:
+        cmd.extend(["--limit", str(args.limit)])
+    print("batch report command:", " ".join(cmd), flush=True)
+    proc = subprocess.run(cmd, check=False)
+    print(f"batch_report_exit={proc.returncode}", flush=True)
+    return proc.returncode == 0 and (out / "summary.md").is_file()
+
+
+def _run_one(rhwp: str, doc: Path, timeout: int) -> dict:
+    cmd = [rhwp, "layout-anomaly", "--json", str(doc)]
+    print("scan:", " ".join(cmd), flush=True)
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "doc": str(doc),
+            "verdict": "ERROR",
+            "note": f"timeout>{timeout}s",
+            "exit": 124,
+        }
+    except OSError as exc:
+        return {
+            "doc": str(doc),
+            "verdict": "ERROR",
+            "note": str(exc),
+            "exit": 1,
+        }
+
+    envelope: dict = {}
+    parse_error = ""
+    raw = (proc.stdout or "").strip()
+    if raw:
+        try:
+            envelope = _unwrap(json.loads(raw))
+        except json.JSONDecodeError as exc:
+            parse_error = str(exc)
+
+    overflow = int(envelope.get("overflowCount") or 0)
+    overlap = int(envelope.get("overlapCount") or 0)
+    empty_page = int(envelope.get("emptyPageCount") or 0)
+    has_signal = bool(envelope.get("hasSignal"))
+    if proc.returncode not in (0, 3):
+        verdict = "ERROR"
+    elif has_signal or overflow or overlap:
+        verdict = "ANOMALY"
+    else:
+        verdict = "CLEAN"
+
+    return {
+        "doc": str(doc).replace("\\", "/"),
+        "verdict": verdict,
+        "exit": proc.returncode,
+        "overflowCount": overflow,
+        "overlapCount": overlap,
+        "emptyPageCount": empty_page,
+        "pageCount": envelope.get("pageCount"),
+        "hasSignal": has_signal,
+        "parseError": parse_error,
+        "stderr": (proc.stderr or "").strip()[:500],
+        "repro": f"rhwp layout-anomaly --json {doc}",
+    }
+
+
+def _write_report(out: Path, rows: list[dict], skipped: list[str], mode: str) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "rows").mkdir(exist_ok=True)
+    summary = {
+        "docs": len(rows),
+        "clean": sum(1 for r in rows if r.get("verdict") == "CLEAN"),
+        "anomaly": sum(1 for r in rows if r.get("verdict") == "ANOMALY"),
+        "error": sum(1 for r in rows if r.get("verdict") == "ERROR"),
+        "skipped": len(skipped),
+    }
+    report = {
+        "schema": "layout_anomaly.advisory_report/v1",
+        "mode": mode,
+        "strict": False,
+        "summary": summary,
+        "skipped": skipped,
+        "rows": rows,
+    }
+    (out / "report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    for i, row in enumerate(rows, start=1):
+        stem = Path(str(row.get("doc") or f"row-{i}")).name
+        (out / "rows" / f"{i:02d}-{stem}.json").write_text(
+            json.dumps(row, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    lines = [
+        "## layout-anomaly (advisory)",
+        "",
+        "이 잡은 **advisory** 입니다. required check 가 아니며 PR 게이트를 막지 않습니다.",
+        "`visual_sweep.py` 는 호출하지 않았습니다. `--strict` 는 쓰지 않았습니다.",
+        "",
+        f"mode: `{mode}`",
+        "",
+        "| docs | clean | anomaly | error | skipped |",
+        "| ---: | ---: | ---: | ---: | ---: |",
+        (
+            f"| {summary['docs']} | {summary['clean']} | {summary['anomaly']} | "
+            f"{summary['error']} | {summary['skipped']} |"
+        ),
+        "",
+    ]
+    if rows:
+        lines.extend(
+            [
+                "| verdict | overflow | overlap | empty | doc |",
+                "| --- | ---: | ---: | ---: | --- |",
+            ]
+        )
+        for row in rows:
+            lines.append(
+                f"| {row.get('verdict')} | {row.get('overflowCount', 0)} | "
+                f"{row.get('overlapCount', 0)} | {row.get('emptyPageCount', 0)} | "
+                f"`{row.get('doc', '')}` |"
+            )
+        lines.append("")
+    if skipped:
+        lines.append("건너뛴 경로: " + ", ".join(f"`{s}`" for s in skipped))
+        lines.append("")
+    (out / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print("\n".join(lines), flush=True)
+
+
+def main() -> int:
+    args = _parse_args()
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    if _try_batch_report(args, out):
+        print("used batch_report.py", flush=True)
+        return 0
+
+    samples = _read_list(Path(args.list), args.limit)
+    if not samples:
+        reason = "samples-absent"
+        (out / "summary.md").write_text(
+            "## layout-anomaly (advisory) — skipped\n\n"
+            f"reason: `{reason}`\n\n"
+            "이 잡은 advisory 이며 required check 가 아닙니다.\n",
+            encoding="utf-8",
+        )
+        print(f"reason={reason}", flush=True)
+        return 0
+
+    rows: list[dict] = []
+    skipped: list[str] = []
+    for rel in samples:
+        path = Path(rel)
+        if not path.is_file():
+            skipped.append(rel)
+            continue
+        rows.append(_run_one(args.rhwp, path, args.timeout))
+
+    _write_report(out, rows, skipped, mode="sample-list")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 — advisory must not fail CI
+        print(f"advisory_run caught: {exc}", file=sys.stderr)
+        out = Path(os.environ.get("ADVISORY_OUT") or "layout-anomaly-advisory")
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "summary.md").write_text(
+            "## layout-anomaly (advisory) — skipped\n\n"
+            f"reason: `runner-exception`\n\n`{exc}`\n",
+            encoding="utf-8",
+        )
+        sys.exit(0)

--- a/tools/layout_anomaly/advisory_samples.txt
+++ b/tools/layout_anomaly/advisory_samples.txt
@@ -1,0 +1,10 @@
+# Layout-anomaly CI advisory 소표본. 한 줄에 경로 하나.
+# 커밋된 작은 HWP/HWPX 만. LFS·대형 시험지·pdf-large 금지.
+samples/lseg-01-basic.hwp
+samples/para-001.hwp
+samples/form-01.hwp
+samples/basic/english.hwp
+samples/footnote-01.hwp
+samples/hwpx/blank_hwpx.hwpx
+samples/hwpx/basic-table-01.hwpx
+samples/hwpx/form-01.hwpx

--- a/tools/layout_anomaly/ci_advisory.md
+++ b/tools/layout_anomaly/ci_advisory.md
@@ -1,0 +1,99 @@
+# layout-anomaly CI advisory 잡
+
+MEGA QUEUE M02-7 (#5397). `rhwp layout-anomaly` 를 CI 에 **advisory** 잡으로
+올리는 설계다. 이 문서는 제안이다. 병합만으로 PR 게이트를 바꾸지 않는다.
+
+`scripts/visual_sweep.py` 는 읽거나 수정하지 않는다. gym 은 쓰지 않는다.
+`--strict` 금지 — 이상 신호가 종료 3 이 되어 빨간 엑스처럼 보이면 안 된다.
+
+초안 워크플로: [`.github/workflows/layout-anomaly-advisory.yml`](../../.github/workflows/layout-anomaly-advisory.yml).
+트리거는 `workflow_dispatch` 와 nightly (`17 3 * * *`) 이다. `pull_request`
+블록은 주석으로만 남겨 두었다.
+
+## 1. 목적과 비목표
+
+### 목적
+
+- 커밋된 소표본(`tools/layout_anomaly/advisory_samples.txt`)에
+  `rhwp layout-anomaly --json` 을 돌린다.
+- M02-8 배치 리포트 스크립트(`tools/layout_anomaly/batch_report.py`)가 있으면
+  그걸 우선한다. 없으면 소표본 CLI 루프다.
+- 이상 신호는 데이터가 된다. 요약·행 JSON 을 아티팩트로 올려 사람이 본다.
+
+### 비목표
+
+| 하지 않는 일 | 이유 |
+| --- | --- |
+| required check / branch protection 등록 | PR 게이트를 막지 않는다 |
+| `scripts/visual_sweep.py` 호출·수정 | jangster77 금지, 픽셀 전수는 이 잡 범위 밖 |
+| `--strict` | overflow·overlap 이 있으면 종료 3 |
+| gym | 이 클레임 범위 밖 |
+| `samples/` 전수 | 그건 M02-8. 이 잡은 소표본 |
+| `local_validation.md` 수정 | 등록은 후속 제안 이슈 |
+
+## 2. 왜 advisory 인가
+
+1. 소표본에도 이미 알려진 overflow/overlap 이 있을 수 있다. 지금 강제 게이트로
+   켜면 devel PR 이 한꺼번에 막힌다.
+2. 판정은 데이터다. `layout-anomaly` 기본(비 `--strict`)은 신호가 있어도 종료 0.
+3. 렌더 트리 스캔은 dump-pages 보다 무겁다. hang 이 게이트를 잡아먹으면 안 된다.
+
+운영 등급은 [github_operations.md](../../mydocs/manual/github_operations.md) 의
+**O2 (라우팅·비용)** 이다. required check 변경은 O4 이고 이 제안 범위가 아니다.
+
+## 3. 잡 계약
+
+| 항목 | 값 |
+| --- | --- |
+| workflow 파일 | `.github/workflows/layout-anomaly-advisory.yml` |
+| workflow 이름 | `Layout Anomaly Advisory` |
+| job id / 이름 | `advisory` / `layout-anomaly-advisory` |
+| 러너 | `ubuntu-latest` |
+| `timeout-minutes` | 30 (성능 목표 아님. hang 상한) |
+| 내부 벽시계 | `timeout 18m` — 잡 timeout 전에 부분 리포트를 남긴다 |
+| permissions | top-level `contents: read` 만 |
+| concurrency | `layout-anomaly-advisory-${{ github.ref }}`, cancel-in-progress |
+| `continue-on-error` | `true` (이중 안전장치) |
+| 비교 종료 코드 | 신호여도 0. `--strict` 금지 |
+| required checks | **등록 금지** |
+
+현재 required context (Lint / Build & Test / CodeQL / Render Diff 등) 와
+이름을 겹치지 않게 `layout-anomaly-advisory` 를 쓴다.
+
+## 4. 트리거
+
+1단계: `workflow_dispatch` + nightly. `limit` 입력(기본 `0` = 목록 전수).
+PR synchronize 마다 돌지 않는다.
+
+2단계(주석): `pull_request` 를 풀어도 **required 등록은 하지 않는다**.
+`--strict` 는 여전히 넣지 않는다. `ci.yml` `needs:` 에 연결하지 않는다.
+
+## 5. 소표본
+
+`advisory_samples.txt` — 커밋된 작은 HWP/HWPX 8개(본문·서식·표·각주·빈 HWPX).
+없는 파일은 skip. 목록이 비면 `samples-absent` 로 종료 0.
+
+## 6. 실행 명령
+
+```text
+timeout 18m python3 tools/layout_anomaly/advisory_run.py \
+  --rhwp target/release/rhwp \
+  --out layout-anomaly-advisory
+# --strict 없음
+```
+
+`advisory_run.py` 는 배치 리포트가 있으면 그걸 호출하고, 없으면 소표본마다
+`rhwp layout-anomaly --json <파일>` 을 돌린다. 러너 종료는 항상 0 이다.
+
+## 7. 활성화·롤백
+
+활성화: 이 PR 병합 → Actions 에서 1회 수동 실행 → 요약을 본다.
+롤백: 워크플로 파일 한 개를 지운다. required checks 를 건드리지 않았으므로
+protection rollback 은 없다.
+
+로컬:
+
+```text
+cargo build --release --bin rhwp
+python tools/layout_anomaly/advisory_run.py --rhwp target/release/rhwp --out /tmp/la
+```


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

M02-7 (#5397): `rhwp layout-anomaly` 를 CI 에 **advisory** 잡으로 올리는 설계입니다. 병합만으로 PR 게이트를 바꾸지 않습니다. `scripts/visual_sweep.py` 는 수정하지 않았습니다. gym 없음.

- `tools/layout_anomaly/ci_advisory.md` — 잡 계약, 트리거, 소표본, required 로 켜지 않는 방법, 롤백
- `.github/workflows/layout-anomaly-advisory.yml` — `workflow_dispatch` + nightly. `pull_request` 는 주석. `--strict` 없음. `continue-on-error: true`
- `tools/layout_anomaly/advisory_run.py` + `advisory_samples.txt` — 커밋된 작은 HWP/HWPX 8개. M02-8 `batch_report.py` 가 있으면 그걸 우선

이상 신호는 데이터가 됩니다. 이 잡은 required check 가 아닙니다. `local_validation.md` 등록은 후속 제안 이슈로 엽니다.

## 관련 이슈

closes #5397

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [ ] `cargo test` 통과 — Rust 변경 없음
- [ ] `cargo clippy -- -D warnings` 통과 — Rust 변경 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (문서·초안 워크플로만)
- [ ] capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (제품 경로 미변경). advisory 잡은 수동 dispatch 또는 nightly 만
- 재현·측정: 미측정 — timeout 30분, 내부 벽시계 18분으로 hang 을 게이트로 승격하지 않음

## 스크린샷

해당 없음.

제안 이슈: #5400
