### PR TITLE
fix(render): CanvasKit boxed-PUA·장평 폴백 해제 (M07-1)

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -2366,6 +2366,35 @@ assert.equal(
   'Hancom boxed-number PUA should preserve the encoded number',
 );
 
+const boxedPuaRatioReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 20, height: 20 },
+  text: '\u{F02B1}',
+  baseline: 15,
+  positions: [0, 18],
+  style: { fontFamily: 'Prepared', fontSize: 20, ratio: 0.8, shadowType: 1 },
+}, {
+  glyphIds: [0],
+  fallbackGlyphIds: [0],
+  symbolGlyphIds: [0],
+  usePreparedTypeface: true,
+});
+assert.equal(
+  boxedPuaRatioReplay.unsupportedOps.has('textRun:scriptTextRequiresShaping'),
+  false,
+  'boxed-PUA with 장평 must not fail closed as a shaping gap',
+);
+assert.equal(
+  boxedPuaRatioReplay.events.some(event => event.type === 'font.scaleX' && event.scale === 0.8),
+  true,
+  'boxed-PUA 장평 should apply setScaleX on the digit font',
+);
+assert.equal(
+  boxedPuaRatioReplay.events.some(event => event.type === 'canvas.drawRect'),
+  true,
+  'boxed-PUA with 장평 should keep the bounded vector box',
+);
+
 const textSpecialReplay = runExecutableTextSpecialReplay();
 assert.equal(textSpecialReplay.events.some(event => event.type === 'canvas.drawOval'), true);
 assert.equal(

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -1955,12 +1955,8 @@ export class CanvasKitLayerRenderer {
         || (codePoint >= 0xa960 && codePoint <= 0xa97f)
         || (codePoint >= 0xd7b0 && codePoint <= 0xd7ff);
     });
-    const hasBoxedPua = codePoints.some((character) => {
-      const codePoint = character.codePointAt(0) ?? 0;
-      return codePoint >= 0xf02b1 && codePoint <= 0xf02c4;
-    });
     const requiresUnsupportedShaping = textRequiresComplexShaping(replayText)
-      || (textRunHasPaintEffects(style) && (hasOldHangul || hasBoxedPua));
+      || (textRunHasPaintEffects(style) && hasOldHangul);
     if (requiresUnsupportedShaping) {
       this.unsupportedOps.add('textRun:scriptTextRequiresShaping');
     }

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -2065,13 +2065,8 @@ fn text_run_transition_detail(
             0x1100..=0x11ff | 0xa960..=0xa97f | 0xd7b0..=0xd7ff
         )
     });
-    let has_boxed_pua = run
-        .display_or_text()
-        .chars()
-        .any(|ch| matches!(ch as u32, 0xf02b1..=0xf02c4));
-    if text_requires_complex_shaping(&display_text)
-        || (has_paint_effects && (has_old_hangul || has_boxed_pua))
-    {
+    // Boxed-PUA + 장평/effects already replay as a vector box; old Hangul does not.
+    if text_requires_complex_shaping(&display_text) || (has_paint_effects && has_old_hangul) {
         return Some("scriptTextRequiresShaping");
     }
     None
@@ -3157,7 +3152,7 @@ mod tests {
             );
         }
 
-        for text in ["\u{1112}\u{119e}\u{11ab}", "\u{f02b1}"] {
+        for text in ["\u{1112}\u{119e}\u{11ab}"] {
             let mut effected = text_run(text);
             effected.style.shadow_type = 1;
             let tree = tree_with_ops(vec![PaintOp::text_run(bbox(), effected)]);
@@ -3169,6 +3164,14 @@ mod tests {
                 "text={text:?}"
             );
         }
+
+        let mut boxed_pua_ratio = text_run("\u{f02b1}");
+        boxed_pua_ratio.style.shadow_type = 1;
+        boxed_pua_ratio.style.ratio = 0.8;
+        let tree = tree_with_ops(vec![PaintOp::text_run(bbox(), boxed_pua_ratio)]);
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(plan.items[0].detail, None);
 
         let mut positioned_effect = text_run("가");
         positioned_effect.style.superscript = true;

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2505,7 +2505,7 @@
       "id": "src/renderer/canvaskit_policy.rs::tests#1",
       "file": "src/renderer/canvaskit_policy.rs",
       "sourcePath": "src/renderer/canvaskit_policy.rs",
-      "line": 2266,
+      "line": 2261,
       "module": "tests",
       "testAttributes": 43,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M07-1 (◆10 CanvasKit 폴백 소거). boxed-PUA(U+F02B1..F02C4)와 장평(ratio) 조합만 CanvasKit 폴백에서 뺀다. 해당 글리프는 이미 벡터 박스+숫자 재생과 `setScaleX` 가 있으므로 `scriptTextRequiresShaping` 으로 문서 revision 을 Canvas2D 에 고정하지 않는다.

- `src/renderer/canvaskit_policy.rs` 술어에서 boxed-PUA + 효과 조합 폴백을 제거한다.
- 런타임 `recordTextRunCoverageGaps` 를 같은 계약으로 맞춘다.
- 옛한글+장평/그림자/외곽선 등, 복합 shaping, `showControlCodes`, 세로·그라데이션 폴백은 그대로 둔다.
- CanvasKit 기본 렌더러 전환은 이 CLAIM 밖이다.

## 관련 이슈

closes #5403

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --lib -- shaped_script_text_fails_closed_without_positioned_cluster_authority horizontal_text_effects_and_ratio_are_direct` 통과
- [x] `node rhwp-studio/e2e/renderer-contract.test.mjs` 통과
- [ ] `cargo clippy -- -D warnings` — 해당 범위 밖 (정책 술어만)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 계약 시험(모의 replay)으로 대체
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음 (폴백 술어만)
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (폴백 판정만, 기본 렌더러 전환 아님)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- 옛한글 + 장평/페인트 효과 폴백 유지
- 복합 shaping·showControlCodes·세로·그라데이션 폴백 유지
- CanvasKit 기본 렌더러 선언 (M07-14)
- gym 미수정
