### PR TITLE
fix(parser/hwpx): HWPX 섹션 파서 재귀 깊이 가드 — 기본 스택 DoS (#4730)

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -428,8 +428,10 @@ fn parse_page_margin(e: &quick_xml::events::BytesStart, page: &mut PageDef) {
 /// `parse_paragraph` 를 경유**하므로, 그 진입 깊이를 스레드-로컬 카운터로 세어 한
 /// 곳에서 전 경로를 막는다(파라미터를 여러 호출부에 관통시키지 않는다). 그룹
 /// (`<hp:container>`) 자기재귀는 별도로 `MAX_HWPX_CONTAINER_DEPTH` 가 막는다.
-/// 상한 64 는 그 형제 가드와 같은 값이다(실문서의 표 중첩은 이에 한참 못 미친다).
-const MAX_HWPX_SECTION_DEPTH: u32 = 64;
+/// 상한은 컨테이너(64)보다 작다. 한 겹마다 `parse_paragraph`·`parse_table`·
+/// `parse_table_cell` 큰 프레임이 겹쳐, 64 로 두면 기본/WASM 스택에서 가드보다
+/// SIGSEGV 가 앞선다. 실문서의 표 중첩은 이에 한참 못 미친다.
+const MAX_HWPX_SECTION_DEPTH: u32 = 16;
 
 thread_local! {
     // 완전 경로 — 이 모듈의 `Cell` 은 이미 `crate::model::table::Cell`(표 셀)이다.
@@ -517,7 +519,17 @@ fn parse_paragraph(
     reader: &mut Reader<&[u8]>,
 ) -> Result<(Paragraph, Option<SectionDef>), HwpxError> {
     // [#4759] 문단-경유 상호재귀(표·글상자·서브리스트) 깊이 상한 — 위 가드 참고.
+    // 가드는 큰 본문 프레임을 쌓기 전에 실행한다. 상한 초과 호출이
+    // `Paragraph`·`SectionDef` 지역 상태를 먼저 잡으면 기본 스택에서
+    // 가드보다 SIGSEGV 가 앞설 수 있다.
     let _depth_guard = SectionDepthGuard::enter()?;
+    parse_paragraph_body(e, reader)
+}
+
+fn parse_paragraph_body(
+    e: &quick_xml::events::BytesStart,
+    reader: &mut Reader<&[u8]>,
+) -> Result<(Paragraph, Option<SectionDef>), HwpxError> {
     let mut para = Paragraph::default();
     let mut sec_def: Option<SectionDef> = None;
 
@@ -4556,6 +4568,10 @@ const MAX_HWPX_CONTAINER_DEPTH: u32 = 64;
 /// `depth` 는 중첩 그룹의 현재 깊이다(최상위 호출은 0). 최대 64개 그룹을
 /// 허용하며, 그 다음 그룹은 스택을 고갈시키기 전에 오류로 거부한다 — 위
 /// `MAX_HWPX_CONTAINER_DEPTH` 참고.
+///
+/// 가드는 큰 지역 상태를 가진 본문보다 먼저 실행돼야 한다. 상한 검사를
+/// 본문과 같은 프레임에서 하면 거절하는 65번째 호출도 큰 프레임을 먼저
+/// 쌓아, 기본/WASM 스택에서 가드보다 SIGSEGV 가 앞설 수 있다.
 fn parse_container(
     e: &quick_xml::events::BytesStart,
     reader: &mut Reader<&[u8]>,
@@ -4567,6 +4583,14 @@ fn parse_container(
             MAX_HWPX_CONTAINER_DEPTH
         )));
     }
+    parse_container_body(e, reader, depth)
+}
+
+fn parse_container_body(
+    e: &quick_xml::events::BytesStart,
+    reader: &mut Reader<&[u8]>,
+    depth: u32,
+) -> Result<Control, HwpxError> {
     let mut common = CommonObjAttr::default();
     let mut shape_attr = ShapeComponentAttr::default();
     let mut has_pos = false;
@@ -7270,6 +7294,18 @@ mod tests {
         );
     }
 
+    fn assert_section_nesting_xml_error(result: Result<Section, HwpxError>, needle: &str) {
+        match result {
+            Err(HwpxError::XmlError(msg)) => {
+                assert!(
+                    msg.contains(needle),
+                    "XmlError 메시지에 `{needle}` 가 없다: {msg}"
+                );
+            }
+            other => panic!("상한 초과가 XmlError 로 거부되지 않았다: {other:?}"),
+        }
+    }
+
     // ---------- [#4730] <hp:container> 무한 중첩 → 스택 오버플로 DoS 가드 ----------
 
     fn nested_container_section_xml(depth: usize) -> String {
@@ -7294,11 +7330,7 @@ mod tests {
         // 기본 테스트 스레드에서 실행해, 실제 호출자가 흔히 쓰는 스택에서도 가드가
         // 재귀 프레임 고갈보다 먼저 동작함을 검증한다.
         let xml = nested_container_section_xml(MAX_HWPX_CONTAINER_DEPTH as usize + 1);
-        let rejected = parse_hwpx_section(&xml).is_err();
-        assert!(
-            rejected,
-            "상한 초과 container 중첩이 거부되지 않았다 — 재귀 깊이 가드 회귀"
-        );
+        assert_section_nesting_xml_error(parse_hwpx_section(&xml), "container nesting exceeds");
     }
 
     #[test]

--- a/tests/cases/issue_4730_hwpx_section_depth.rs
+++ b/tests/cases/issue_4730_hwpx_section_depth.rs
@@ -1,0 +1,73 @@
+//! [#4730] HWPX 섹션 파서 재귀 깊이 가드 — 기본 스택에서 XmlError 로 거부.
+//!
+//! `parse_container` 자기재귀와 문단↔표↔셀 상호재귀에 상한이 없으면 악성
+//! `.hwpx` 하나가 SIGSEGV(catch_unwind 로 못 잡는 하드 크래시)를 낸다.
+//! 가드는 큰 본문 프레임을 쌓기 전에 동작해야 한다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::parser::hwpx::section::parse_hwpx_section;
+use rhwp::parser::hwpx::HwpxError;
+
+fn nested_table_section_xml(depth: usize) -> String {
+    let mut xml = String::from(
+        r#"<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"><hp:p paraPrIDRef="0" styleIDRef="0">"#,
+    );
+    for _ in 0..depth {
+        xml.push_str("<hp:tbl><hp:tr><hp:tc><hp:p>");
+    }
+    for _ in 0..depth {
+        xml.push_str("</hp:p></hp:tc></hp:tr></hp:tbl>");
+    }
+    xml.push_str("</hp:p></hs:sec>");
+    xml
+}
+
+fn nested_container_section_xml(depth: usize) -> String {
+    let mut xml = String::from(
+        r#"<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"><hp:p paraPrIDRef="0" styleIDRef="0">"#,
+    );
+    for _ in 0..depth {
+        xml.push_str("<hp:container>");
+    }
+    for _ in 0..depth {
+        xml.push_str("</hp:container>");
+    }
+    xml.push_str("</hp:p></hs:sec>");
+    xml
+}
+
+fn assert_xml_nesting_error(
+    result: Result<rhwp::model::document::Section, HwpxError>,
+    needle: &str,
+) {
+    match result {
+        Err(HwpxError::XmlError(msg)) => {
+            assert!(
+                msg.contains(needle),
+                "XmlError 메시지에 `{needle}` 가 없다: {msg}"
+            );
+        }
+        other => panic!("상한 초과가 XmlError 로 거부되지 않았다: {other:?}"),
+    }
+}
+
+#[test]
+fn table_nesting_beyond_limit_is_rejected_on_default_stack() {
+    // 한 겹마다 문단·표·셀 큰 프레임이 겹친다. 상한(16)을 넘긴 입력이
+    // 기본 테스트 스레드에서 크래시하지 않고 XmlError 여야 한다.
+    assert_xml_nesting_error(
+        parse_hwpx_section(&nested_table_section_xml(17)),
+        "section nesting exceeds",
+    );
+}
+
+#[test]
+fn container_nesting_hostile_depth_is_xml_error_on_default_stack() {
+    // 여는 태그 ~14바이트라 수만 겹도 입력 상한에 안 걸린다.
+    // 가드 없이 parse_hwpx_section 에 넣으면 SIGSEGV. 가드 후엔 XmlError.
+    assert_xml_nesting_error(
+        parse_hwpx_section(&nested_container_section_xml(10_000)),
+        "container nesting exceeds",
+    );
+}

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2349,7 +2349,7 @@
       "id": "src/parser/hwpx/section.rs::tests#1",
       "file": "src/parser/hwpx/section.rs",
       "sourcePath": "src/parser/hwpx/section.rs",
-      "line": 7203,
+      "line": 7227,
       "module": "tests",
       "testAttributes": 94,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

#5396 / M03-5. `#4730` — HWPX 섹션 파서 재귀 깊이 가드가 기본 스레드 스택에서 큰 프레임보다 먼저 동작하도록 고칩니다.

`parse_container`·`parse_paragraph` 를 얇은 가드 래퍼와 본문으로 나눕니다. 상한 초과 호출이 `Paragraph`/`SectionDef`/그룹 지역 상태를 먼저 쌓지 않습니다.

문단↔표↔셀 한 겹마다 큰 프레임이 세 겹이라, `MAX_HWPX_SECTION_DEPTH` 를 64에서 16으로 낮춥니다. 64는 기본 스택에서 가드보다 `STATUS_STACK_OVERFLOW`(0xC00000FD) 가 앞섰습니다. 정상 깊이 표 중첩은 그대로입니다.

`#4827`(HWP5 본문 상호재귀)은 이미 닫혀 손대지 않았습니다. HWP5 묶음 개체 경로도 이 PR 범위가 아닙니다.

## 관련 이슈

closes #5396
closes #4730

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (`--prepare` 후)
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --lib -- container_nesting table_nesting` 통과
- [x] `cargo test --test regression_suite_025 -- table_nesting container_nesting` 통과
- [ ] `cargo clippy -- -D warnings` — 디스크 부족으로 전체 clippy 는 생략. 변경은 가드 래퍼와 상한 값뿐
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (악성 중첩은 파싱 단계에서 거부)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] `.claude/agents/`·스킬 변경 없음

## 하지 않은 것

- `#4827` HWP5 문단↔표↔셀 가드 (이미 닫힘)
- HWP5 `parse_container_children` (`#4761`)
- gym / DocumentCore 신설

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 정상 문서의 얕은 표·그룹 중첩은 영향 없음 (상한 분기는 16겹 초과에서만)
- 재현·측정: 표 17겹·컨테이너 10,000겹을 기본 스택에서 `XmlError` 로 거부. 64겹 표는 가드 전에 스택 오버플로를 재현함
