### PR TITLE
test: 수식 명령 골든 31종 (M09-1)

### DIFF
--- a/src/renderer/equation/fixtures/m09_1/bmatrix_1x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/bmatrix_1x2.golden
@@ -1,0 +1,30 @@
+# M09-1 equation golden — current-engine lock
+command: BMATRIX
+script: BMATRIX{x & y}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "x",
+            ),
+            Text(
+                "y",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=20.0000 bl=10.0000
+  row0:
+    Text("x") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("y") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,20.00 L4.20,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,20.00 L54.90,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_1/bmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/bmatrix_2x2.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: BMATRIX
+script: BMATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,46.00 L54.90,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/bmatrix_identity.golden
+++ b/src/renderer/equation/fixtures/m09_1/bmatrix_identity.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: BMATRIX
+script: BMATRIX{1 & 0 # 0 & 1}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=58.0000 h=46.0000 bl=23.0000
+  row0:
+    Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M53.80,0.00 L56.20,0.00 L56.20,46.00 L53.80,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_1/dmatrix_1x1.golden
+++ b/src/renderer/equation/fixtures/m09_1/dmatrix_1x1.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: DMATRIX
+script: DMATRIX{1}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=31.0000 h=20.0000 bl=10.0000
+  row0:
+    Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="28.00" y1="0.00" x2="28.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_1/dmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/dmatrix_2x2.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: DMATRIX
+script: DMATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="56.10" y1="0.00" x2="56.10" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/dmatrix_col.golden
+++ b/src/renderer/equation/fixtures/m09_1/dmatrix_col.golden
@@ -1,0 +1,33 @@
+# M09-1 equation golden — current-engine lock
+command: DMATRIX
+script: DMATRIX{x # y}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "x",
+            ),
+        ],
+        [
+            Text(
+                "y",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=31.5500 h=46.0000 bl=23.0000
+  row0:
+    Text("x") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("y") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="28.55" y1="0.00" x2="28.55" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_1/eqalign_no_amp.golden
+++ b/src/renderer/equation/fixtures/m09_1/eqalign_no_amp.golden
@@ -1,0 +1,66 @@
+# M09-1 equation golden — current-engine lock
+command: EQALIGN
+script: EQALIGN{x = 1 # y = 2}
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Row(
+                [
+                    Text(
+                        "x",
+                    ),
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+            Empty,
+        ),
+        (
+            Row(
+                [
+                    Text(
+                        "y",
+                    ),
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+            Empty,
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Row x=0.0000 y=0.0000 w=38.5500 h=20.0000 bl=16.0000
+      Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=27.5500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Empty x=41.5500 y=16.0000 w=0.0000 h=0.0000 bl=0.0000
+  row1.left:
+    Row x=0.0000 y=26.0000 w=38.5500 h=20.0000 bl=16.0000
+      Text("y") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=27.5500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.right:
+    Empty x=41.5500 y=42.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="19.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="27.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="19.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="27.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_1/eqalign_one.golden
+++ b/src/renderer/equation/fixtures/m09_1/eqalign_one.golden
@@ -1,0 +1,53 @@
+# M09-1 equation golden — current-engine lock
+command: EQALIGN
+script: EQALIGN{a + b &= c}
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Row(
+                [
+                    Text(
+                        "a",
+                    ),
+                    Symbol(
+                        "+",
+                    ),
+                    Text(
+                        "b",
+                    ),
+                ],
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Text(
+                        "c",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=69.6500 h=20.0000 bl=10.0000
+  row0.left:
+    Row x=0.0000 y=0.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=42.1000 y=0.0000 w=27.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("c") x=16.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="19.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="27.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="50.10" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="58.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_1/eqalign_two.golden
+++ b/src/renderer/equation/fixtures/m09_1/eqalign_two.golden
@@ -1,0 +1,62 @@
+# M09-1 equation golden — current-engine lock
+command: EQALIGN
+script: EQALIGN{x &= 1 # y &= 2}
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "y",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Text("y") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=14.5500 y=26.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="22.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="22.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_1/lpile_left.golden
+++ b/src/renderer/equation/fixtures/m09_1/lpile_left.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: PILE
+script: LPILE{a # b}
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Left,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/matrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_2x2.golden
@@ -1,0 +1,41 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/matrix_col.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_col.golden
@@ -1,0 +1,39 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX{1 # 2 # 3}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+        ],
+        [
+            Number(
+                "2",
+            ),
+        ],
+        [
+            Number(
+                "3",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=19.0000 h=72.0000 bl=36.0000
+  row0:
+    Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("2") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Number("3") x=4.0000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_1/matrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_no_brace.golden
@@ -1,0 +1,11 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_1/matrix_row.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_row.golden
@@ -1,0 +1,33 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX{a & b & c}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=74.6500 h=20.0000 bl=10.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=59.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="59.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_1/over_glued_denom.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_glued_denom.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: 7 OVER10
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "7",
+    ),
+    denom: Number(
+        "10",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("7") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="9.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="1.00" y1="24.40" x2="29.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>

--- a/src/renderer/equation/fixtures/m09_1/over_grouped.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_grouped.golden
@@ -1,0 +1,55 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: {a+b} OVER {c-d}
+
+=== ast ===
+Fraction {
+    numer: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+    denom: Row(
+        [
+            Text(
+                "c",
+            ),
+            Symbol(
+                "-",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=47.1000 h=48.8000 bl=29.4000
+  numer:
+    Row x=4.0000 y=4.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  denom:
+    Row x=4.0000 y=24.8000 w=39.1000 h=20.0000 bl=16.0000
+      Text("c") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("-") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("d") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="23.55" y="20.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="31.55" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<line x1="1.00" y1="24.40" x2="46.10" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="23.55" y="40.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="31.55" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/over_in_paren.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_in_paren.golden
@@ -1,0 +1,32 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: LEFT ( x OVER y RIGHT )
+
+=== ast ===
+Paren {
+    left: "(",
+    right: ")",
+    body: Fraction {
+        numer: Text(
+            "x",
+        ),
+        denom: Text(
+            "y",
+        ),
+    },
+}
+
+=== layout ===
+Paren("(",")") x=0.0000 y=0.0000 w=31.5500 h=48.8000 bl=29.4000
+  Fraction x=6.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+    numer:
+      Text("x") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Text("y") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.86,0.00 C0.27,8.78 0.27,40.02 4.86,48.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<line x1="7.00" y1="24.40" x2="24.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<path d="M26.69,0.00 C31.28,8.78 31.28,40.02 26.69,48.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>

--- a/src/renderer/equation/fixtures/m09_1/over_nested.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_nested.golden
@@ -1,0 +1,36 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: {1 OVER 2} OVER 3
+
+=== ast ===
+Fraction {
+    numer: Fraction {
+        numer: Number(
+            "1",
+        ),
+        denom: Number(
+            "2",
+        ),
+    },
+    denom: Number(
+        "3",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=27.0000 h=77.6000 bl=58.2000
+  numer:
+    Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="5.00" y1="28.40" x2="22.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="53.20" x2="26.00" y2="53.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="69.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_1/over_simple.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_simple.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: 1 OVER 2
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_1/pile_center.golden
+++ b/src/renderer/equation/fixtures/m09_1/pile_center.golden
@@ -1,0 +1,30 @@
+# M09-1 equation golden — current-engine lock
+command: PILE
+script: PILE{a # b # c}
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+        Text(
+            "c",
+        ),
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=72.0000 bl=36.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("c") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_1/pmatrix_1x1.golden
+++ b/src/renderer/equation/fixtures/m09_1/pmatrix_1x1.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: PMATRIX
+script: PMATRIX{x}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "x",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=31.5500 h=20.0000 bl=10.0000
+  row0:
+    Text("x") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,3.60 0.30,16.40 5.40,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M26.15,0.00 C31.25,3.60 31.25,16.40 26.15,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/pmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/pmatrix_2x2.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: PMATRIX
+script: PMATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.70,0.00 C58.80,8.28 58.80,37.72 53.70,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/pmatrix_frac.golden
+++ b/src/renderer/equation/fixtures/m09_1/pmatrix_frac.golden
@@ -1,0 +1,54 @@
+# M09-1 equation golden — current-engine lock
+command: PMATRIX
+script: PMATRIX{{1} OVER {2} & 0 # 0 & 1}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=66.0000 h=74.8000 bl=37.4000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=45.0000 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=14.0000 y=54.8000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=45.0000 y=54.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,13.46 0.30,61.34 5.40,74.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M60.60,0.00 C65.70,13.46 65.70,61.34 60.60,74.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="11.00" y1="24.40" x2="28.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="45.00" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="14.00" y="70.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="45.00" y="70.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_1/root_group.golden
+++ b/src/renderer/equation/fixtures/m09_1/root_group.golden
@@ -1,0 +1,35 @@
+# M09-1 equation golden — current-engine lock
+command: ROOT
+script: ROOT {a+b}
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=53.1000 h=24.0000 bl=18.0000
+  body:
+    Row x=13.0000 y=2.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L53.10,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="32.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="40.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/root_ident.golden
+++ b/src/renderer/equation/fixtures/m09_1/root_ident.golden
@@ -1,0 +1,20 @@
+# M09-1 equation golden — current-engine lock
+command: ROOT
+script: ROOT x
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/root_index.golden
+++ b/src/renderer/equation/fixtures/m09_1/root_index.golden
@@ -1,0 +1,27 @@
+# M09-1 equation golden — current-engine lock
+command: ROOT
+script: ROOT(3) of x
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/rpile_right.golden
+++ b/src/renderer/equation/fixtures/m09_1/rpile_right.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: PILE
+script: RPILE{a # b}
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Right,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_group.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_group.golden
@@ -1,0 +1,35 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT {a+b}
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=53.1000 h=24.0000 bl=18.0000
+  body:
+    Row x=13.0000 y=2.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L53.10,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="32.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="40.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_ident.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_ident.golden
@@ -1,0 +1,20 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT x
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_index_brace.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_index_brace.golden
@@ -1,0 +1,27 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT {3} of {x}
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_index_paren.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_index_paren.golden
@@ -1,0 +1,27 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT(3) of x
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/tests/cases/equation_command_goldens.rs
+++ b/tests/cases/equation_command_goldens.rs
@@ -1,0 +1,439 @@
+//! M09-1: 수식 명령 골든 30종.
+//!
+//! OVER/SQRT/ROOT/MATRIX/PMATRIX/BMATRIX/DMATRIX/EQALIGN/PILE 의
+//! 현재 파서·레이아웃·SVG 출력을 잠근다. 엔진을 고치거나 디스패치를
+//! 리팩터하지 않는다(M09-2). 미구현·축약 동작도 현행 그대로 고정한다.
+//!
+//! 골든 갱신: `UPDATE_EQ_GOLDENS=1 cargo test --test <suite> equation_command_goldens`
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use rhwp::renderer::equation::ast::MatrixStyle;
+use rhwp::renderer::equation::layout::{EqLayout, LayoutBox, LayoutKind};
+use rhwp::renderer::equation::parser::parse;
+use rhwp::renderer::equation::svg_render::render_equation_svg;
+
+const FONT_SIZE: f64 = 20.0;
+const COLOR: &str = "#000000";
+const FIXTURE_DIR: &str = "src/renderer/equation/fixtures/m09_1";
+
+struct GoldenCase {
+    id: &'static str,
+    command: &'static str,
+    script: &'static str,
+}
+
+/// 명령별 대표 스크립트. 현행 엔진 동작을 잠그는 입력이지 정답 오라클이 아니다.
+const CASES: &[GoldenCase] = &[
+    // OVER
+    GoldenCase {
+        id: "over_simple",
+        command: "OVER",
+        script: "1 OVER 2",
+    },
+    GoldenCase {
+        id: "over_grouped",
+        command: "OVER",
+        script: "{a+b} OVER {c-d}",
+    },
+    GoldenCase {
+        id: "over_nested",
+        command: "OVER",
+        script: "{1 OVER 2} OVER 3",
+    },
+    GoldenCase {
+        id: "over_glued_denom",
+        command: "OVER",
+        script: "7 OVER10",
+    },
+    GoldenCase {
+        id: "over_in_paren",
+        command: "OVER",
+        script: "LEFT ( x OVER y RIGHT )",
+    },
+    // SQRT
+    GoldenCase {
+        id: "sqrt_ident",
+        command: "SQRT",
+        script: "SQRT x",
+    },
+    GoldenCase {
+        id: "sqrt_group",
+        command: "SQRT",
+        script: "SQRT {a+b}",
+    },
+    GoldenCase {
+        id: "sqrt_index_paren",
+        command: "SQRT",
+        script: "SQRT(3) of x",
+    },
+    GoldenCase {
+        id: "sqrt_index_brace",
+        command: "SQRT",
+        script: "SQRT {3} of {x}",
+    },
+    // ROOT — 현행 파서는 SQRT 와 동일 분기로 처리한다.
+    GoldenCase {
+        id: "root_ident",
+        command: "ROOT",
+        script: "ROOT x",
+    },
+    GoldenCase {
+        id: "root_group",
+        command: "ROOT",
+        script: "ROOT {a+b}",
+    },
+    GoldenCase {
+        id: "root_index",
+        command: "ROOT",
+        script: "ROOT(3) of x",
+    },
+    // MATRIX
+    GoldenCase {
+        id: "matrix_2x2",
+        command: "MATRIX",
+        script: "MATRIX{a & b # c & d}",
+    },
+    GoldenCase {
+        id: "matrix_col",
+        command: "MATRIX",
+        script: "MATRIX{1 # 2 # 3}",
+    },
+    GoldenCase {
+        id: "matrix_row",
+        command: "MATRIX",
+        script: "MATRIX{a & b & c}",
+    },
+    GoldenCase {
+        id: "matrix_no_brace",
+        command: "MATRIX",
+        script: "MATRIX",
+    },
+    // PMATRIX
+    GoldenCase {
+        id: "pmatrix_2x2",
+        command: "PMATRIX",
+        script: "PMATRIX{a & b # c & d}",
+    },
+    GoldenCase {
+        id: "pmatrix_1x1",
+        command: "PMATRIX",
+        script: "PMATRIX{x}",
+    },
+    GoldenCase {
+        id: "pmatrix_frac",
+        command: "PMATRIX",
+        script: "PMATRIX{{1} OVER {2} & 0 # 0 & 1}",
+    },
+    // BMATRIX
+    GoldenCase {
+        id: "bmatrix_2x2",
+        command: "BMATRIX",
+        script: "BMATRIX{a & b # c & d}",
+    },
+    GoldenCase {
+        id: "bmatrix_identity",
+        command: "BMATRIX",
+        script: "BMATRIX{1 & 0 # 0 & 1}",
+    },
+    GoldenCase {
+        id: "bmatrix_1x2",
+        command: "BMATRIX",
+        script: "BMATRIX{x & y}",
+    },
+    // DMATRIX
+    GoldenCase {
+        id: "dmatrix_2x2",
+        command: "DMATRIX",
+        script: "DMATRIX{a & b # c & d}",
+    },
+    GoldenCase {
+        id: "dmatrix_col",
+        command: "DMATRIX",
+        script: "DMATRIX{x # y}",
+    },
+    GoldenCase {
+        id: "dmatrix_1x1",
+        command: "DMATRIX",
+        script: "DMATRIX{1}",
+    },
+    // EQALIGN
+    GoldenCase {
+        id: "eqalign_two",
+        command: "EQALIGN",
+        script: "EQALIGN{x &= 1 # y &= 2}",
+    },
+    GoldenCase {
+        id: "eqalign_one",
+        command: "EQALIGN",
+        script: "EQALIGN{a + b &= c}",
+    },
+    GoldenCase {
+        id: "eqalign_no_amp",
+        command: "EQALIGN",
+        script: "EQALIGN{x = 1 # y = 2}",
+    },
+    // PILE / LPILE / RPILE — 레이아웃은 전용 kind 없이 Row 로 쌓는다.
+    GoldenCase {
+        id: "pile_center",
+        command: "PILE",
+        script: "PILE{a # b # c}",
+    },
+    GoldenCase {
+        id: "lpile_left",
+        command: "PILE",
+        script: "LPILE{a # b}",
+    },
+    GoldenCase {
+        id: "rpile_right",
+        command: "PILE",
+        script: "RPILE{a # b}",
+    },
+];
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_DIR)
+}
+
+fn golden_path(id: &str) -> PathBuf {
+    fixture_dir().join(format!("{id}.golden"))
+}
+
+fn snapshot_of(case: &GoldenCase) -> String {
+    let ast = parse(case.script);
+    let layout = EqLayout::new(FONT_SIZE).layout(&ast);
+    let svg = render_equation_svg(&layout, COLOR, FONT_SIZE);
+    let mut layout_ir = String::new();
+    dump_layout(&mut layout_ir, &layout, 0);
+    format!(
+        "# M09-1 equation golden — current-engine lock\n\
+         command: {}\n\
+         script: {}\n\
+         \n\
+         === ast ===\n\
+         {:#?}\n\
+         \n\
+         === layout ===\n\
+         {}\n\
+         === svg ===\n\
+         {}",
+        case.command, case.script, ast, layout_ir, svg
+    )
+}
+
+fn dump_layout(out: &mut String, lb: &LayoutBox, indent: usize) {
+    let pad = "  ".repeat(indent);
+    let metrics = format!(
+        "x={:.4} y={:.4} w={:.4} h={:.4} bl={:.4}",
+        lb.x, lb.y, lb.width, lb.height, lb.baseline
+    );
+    match &lb.kind {
+        LayoutKind::Row(children) => {
+            let _ = writeln!(out, "{pad}Row {metrics}");
+            for child in children {
+                dump_layout(out, child, indent + 1);
+            }
+        }
+        LayoutKind::Text(text) => {
+            let _ = writeln!(out, "{pad}Text({text:?}) {metrics}");
+        }
+        LayoutKind::Number(text) => {
+            let _ = writeln!(out, "{pad}Number({text:?}) {metrics}");
+        }
+        LayoutKind::Symbol(text) => {
+            let _ = writeln!(out, "{pad}Symbol({text:?}) {metrics}");
+        }
+        LayoutKind::MathSymbol(text) => {
+            let _ = writeln!(out, "{pad}MathSymbol({text:?}) {metrics}");
+        }
+        LayoutKind::Function(text) => {
+            let _ = writeln!(out, "{pad}Function({text:?}) {metrics}");
+        }
+        LayoutKind::Fraction { numer, denom } => {
+            let _ = writeln!(out, "{pad}Fraction {metrics}");
+            let _ = writeln!(out, "{pad}  numer:");
+            dump_layout(out, numer, indent + 2);
+            let _ = writeln!(out, "{pad}  denom:");
+            dump_layout(out, denom, indent + 2);
+        }
+        LayoutKind::Atop { top, bottom } => {
+            let _ = writeln!(out, "{pad}Atop {metrics}");
+            let _ = writeln!(out, "{pad}  top:");
+            dump_layout(out, top, indent + 2);
+            let _ = writeln!(out, "{pad}  bottom:");
+            dump_layout(out, bottom, indent + 2);
+        }
+        LayoutKind::Sqrt { index, body } => {
+            let _ = writeln!(out, "{pad}Sqrt {metrics}");
+            if let Some(index) = index {
+                let _ = writeln!(out, "{pad}  index:");
+                dump_layout(out, index, indent + 2);
+            }
+            let _ = writeln!(out, "{pad}  body:");
+            dump_layout(out, body, indent + 2);
+        }
+        LayoutKind::Superscript { base, sup } => {
+            let _ = writeln!(out, "{pad}Superscript {metrics}");
+            let _ = writeln!(out, "{pad}  base:");
+            dump_layout(out, base, indent + 2);
+            let _ = writeln!(out, "{pad}  sup:");
+            dump_layout(out, sup, indent + 2);
+        }
+        LayoutKind::Subscript { base, sub } => {
+            let _ = writeln!(out, "{pad}Subscript {metrics}");
+            let _ = writeln!(out, "{pad}  base:");
+            dump_layout(out, base, indent + 2);
+            let _ = writeln!(out, "{pad}  sub:");
+            dump_layout(out, sub, indent + 2);
+        }
+        LayoutKind::SubSup { base, sub, sup } => {
+            let _ = writeln!(out, "{pad}SubSup {metrics}");
+            let _ = writeln!(out, "{pad}  base:");
+            dump_layout(out, base, indent + 2);
+            let _ = writeln!(out, "{pad}  sub:");
+            dump_layout(out, sub, indent + 2);
+            let _ = writeln!(out, "{pad}  sup:");
+            dump_layout(out, sup, indent + 2);
+        }
+        LayoutKind::BigOp { symbol, sub, sup } => {
+            let _ = writeln!(out, "{pad}BigOp({symbol:?}) {metrics}");
+            if let Some(sub) = sub {
+                let _ = writeln!(out, "{pad}  sub:");
+                dump_layout(out, sub, indent + 2);
+            }
+            if let Some(sup) = sup {
+                let _ = writeln!(out, "{pad}  sup:");
+                dump_layout(out, sup, indent + 2);
+            }
+        }
+        LayoutKind::Limit { is_upper, sub } => {
+            let _ = writeln!(out, "{pad}Limit(is_upper={is_upper}) {metrics}");
+            if let Some(sub) = sub {
+                let _ = writeln!(out, "{pad}  sub:");
+                dump_layout(out, sub, indent + 2);
+            }
+        }
+        LayoutKind::Matrix { cells, style } => {
+            let style = match style {
+                MatrixStyle::Plain => "Plain",
+                MatrixStyle::Paren => "Paren",
+                MatrixStyle::Bracket => "Bracket",
+                MatrixStyle::Vert => "Vert",
+            };
+            let _ = writeln!(out, "{pad}Matrix({style}) {metrics}");
+            for (row_i, row) in cells.iter().enumerate() {
+                let _ = writeln!(out, "{pad}  row{row_i}:");
+                for cell in row {
+                    dump_layout(out, cell, indent + 2);
+                }
+            }
+        }
+        LayoutKind::Rel { arrow, over, under } => {
+            let _ = writeln!(out, "{pad}Rel {metrics}");
+            let _ = writeln!(out, "{pad}  arrow:");
+            dump_layout(out, arrow, indent + 2);
+            let _ = writeln!(out, "{pad}  over:");
+            dump_layout(out, over, indent + 2);
+            if let Some(under) = under {
+                let _ = writeln!(out, "{pad}  under:");
+                dump_layout(out, under, indent + 2);
+            }
+        }
+        LayoutKind::EqAlign { rows } => {
+            let _ = writeln!(out, "{pad}EqAlign {metrics}");
+            for (row_i, (left, right)) in rows.iter().enumerate() {
+                let _ = writeln!(out, "{pad}  row{row_i}.left:");
+                dump_layout(out, left, indent + 2);
+                let _ = writeln!(out, "{pad}  row{row_i}.right:");
+                dump_layout(out, right, indent + 2);
+            }
+        }
+        LayoutKind::Paren { left, right, body } => {
+            let _ = writeln!(out, "{pad}Paren({left:?},{right:?}) {metrics}");
+            dump_layout(out, body, indent + 1);
+        }
+        LayoutKind::Decoration { kind, body } => {
+            let _ = writeln!(out, "{pad}Decoration({kind:?}) {metrics}");
+            dump_layout(out, body, indent + 1);
+        }
+        LayoutKind::FontStyle { style, body } => {
+            let _ = writeln!(out, "{pad}FontStyle({style:?}) {metrics}");
+            dump_layout(out, body, indent + 1);
+        }
+        LayoutKind::Space(width) => {
+            let _ = writeln!(out, "{pad}Space({width:.4}) {metrics}");
+        }
+        LayoutKind::Newline => {
+            let _ = writeln!(out, "{pad}Newline {metrics}");
+        }
+        LayoutKind::Empty => {
+            let _ = writeln!(out, "{pad}Empty {metrics}");
+        }
+    }
+}
+
+fn update_requested() -> bool {
+    matches!(
+        std::env::var("UPDATE_EQ_GOLDENS").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+#[test]
+fn equation_command_goldens_lock_parse_layout_svg() {
+    // 이슈 본문은 "약 30종". OVER 5 + SQRT 4 + ROOT 3 + MATRIX 4 + PMATRIX 3
+    // + BMATRIX 3 + DMATRIX 3 + EQALIGN 3 + PILE 3 = 31.
+    assert_eq!(CASES.len(), 31, "M09-1 골든 개수가 카탈로그와 어긋난다");
+    let required = [
+        "OVER", "SQRT", "ROOT", "MATRIX", "PMATRIX", "BMATRIX", "DMATRIX", "EQALIGN", "PILE",
+    ];
+    for command in required {
+        assert!(
+            CASES.iter().any(|c| c.command == command),
+            "명령 {command} 골든이 없다"
+        );
+    }
+    let mut ids = CASES.iter().map(|c| c.id).collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), CASES.len(), "골든 id 가 중복된다");
+
+    std::fs::create_dir_all(fixture_dir()).expect("create fixture dir");
+    let update = update_requested();
+    let mut mismatches = Vec::new();
+
+    for case in CASES {
+        let actual = snapshot_of(case);
+        let path = golden_path(case.id);
+        if update || !path.exists() {
+            if !update && !path.exists() {
+                mismatches.push(format!(
+                    "{}: 골든 파일 없음 ({}) — UPDATE_EQ_GOLDENS=1 로 생성",
+                    case.id,
+                    path.display()
+                ));
+                continue;
+            }
+            std::fs::write(&path, actual.as_bytes())
+                .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+            continue;
+        }
+        let expected = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        if expected != actual {
+            mismatches.push(format!(
+                "{} ({})\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
+                case.id,
+                path.display()
+            ));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "수식 골든 불일치 {}건 (현행 엔진 잠금. 의도된 변경이면 UPDATE_EQ_GOLDENS=1):\n\n{}",
+        mismatches.len(),
+        mismatches.join("\n\n")
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

MEGA QUEUE M09-1 (◆10 수식 모듈 인수). 수식 명령 **골든 31종**을 잠근다. 대상은 OVER / SQRT / ROOT / MATRIX / PMATRIX / BMATRIX / DMATRIX / EQALIGN / PILE (LPILE·RPILE 포함).

픽스처는 `src/renderer/equation/fixtures/m09_1/*.golden` 에 두고, 시험은 `tests/cases/equation_command_goldens.rs` 가 파서 AST · 레이아웃 IR · SVG 조각을 한 파일로 대조한다. source-side `#[cfg(test)]` 모듈은 늘리지 않았다.

엔진을 고치거나 디스패치를 리팩터하지 않는다(M09-2). 한컴 정답 오라클이 아니라 **현행 엔진 잠금**이다. 의도된 엔진 변경 시에만 `UPDATE_EQ_GOLDENS=1` 로 갱신한다.

### 현행 동작으로 정직하게 잠근 것

- `ROOT` 는 파서에서 `SQRT` 와 같은 분기라 AST 가 `Sqrt` 이다.
- `PILE`/`LPILE`/`RPILE` 레이아웃은 전용 kind 없이 `Row` 로 세로 쌓는다.
- 중괄호 없는 `MATRIX` 는 `Empty` (현행 `parse_matrix` 가 brace 없으면 Empty).

#4056 · #4865 는 손대지 않았다. gym 없음.

## 관련 이슈

closes #5405

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --test regression_suite_031 equation_command_goldens` 통과 (1)
- [ ] `cargo clippy -- -D warnings` — 엔진 미변경, 시험·픽스처만
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (스크립트 단위 골든)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [x] `.claude/agents/`·스킬 변경 없음

명령 분포: OVER 5, SQRT 4, ROOT 3, MATRIX 4, PMATRIX 3, BMATRIX 3, DMATRIX 3, EQALIGN 3, PILE 3 = 31.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (시험·픽스처만)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- 수식 디스패치 리팩터(M09-2) 없음
- #4056 / #4865 수정 없음
- gym / `scripts/visual_sweep.py` 미수정
- 파서·레이아웃·SVG 렌더러 구현 변경 없음
