### PR TITLE
fix(parser): 중첩 listParam 깊이 상한 — M03-6 #4436

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5654,6 +5654,30 @@ fn open_param_frame<'a>(
     }
 }
 
+/// [#4436] `<hp:listParam>` 중첩 상한. 루트 `<hp:parameters>` 는 세지 않는다.
+///
+/// OWPML `hp:ParameterList` 는 재귀 `listParam` 을 막지 않아, 손상·적대 HWPX 가
+/// 극단적으로 깊게 중첩할 수 있다. 트리 빌더는 반복 스택이라 네이티브 스택은
+/// 당장 안 넘지만, 만든 `Parameter::List` 트리는 이후 render/Drop 이 재귀한다.
+/// 실문서는 두세 단계를 넘지 않는다. 8 도 넉넉하고, 여기서는 그 위에 여유를 둔다.
+const MAX_LIST_PARAM_DEPTH: usize = 32;
+
+/// 새 `listParam` 을 열기 직전 — 이미 열린 List 프레임(루트 + 조상 listParam)이
+/// 상한에 있으면 파싱 오류. 조용히 자르지 않는다(#4436).
+fn ensure_list_param_depth(stack: &[ParamFrame]) -> Result<(), HwpxError> {
+    let nested = stack
+        .iter()
+        .filter(|frame| matches!(frame, ParamFrame::List { .. }))
+        .count()
+        .saturating_sub(1);
+    if nested >= MAX_LIST_PARAM_DEPTH {
+        return Err(HwpxError::XmlError(format!(
+            "listParam nesting exceeds {MAX_LIST_PARAM_DEPTH} levels"
+        )));
+    }
+    Ok(())
+}
+
 fn parse_field_parameters(
     start: &quick_xml::events::BytesStart,
     reader: &mut Reader<&[u8]>,
@@ -5722,6 +5746,9 @@ fn parse_field_parameters(
                     }
                 }
                 if let Some(frame) = open_param_frame(local, ce.attributes().flatten()) {
+                    if matches!(frame, ParamFrame::List { .. }) {
+                        ensure_list_param_depth(&stack)?;
+                    }
                     stack.push(frame);
                 }
             }
@@ -5747,6 +5774,9 @@ fn parse_field_parameters(
                 }
                 // 자기닫힘(빈 값) — 여닫 없이 즉시 부모에 붙인다.
                 if let Some(frame) = open_param_frame(local, ce.attributes().flatten()) {
+                    if matches!(frame, ParamFrame::List { .. }) {
+                        ensure_list_param_depth(&stack)?;
+                    }
                     if let Some(ParamFrame::List { items, .. }) = stack.last_mut() {
                         items.push(frame.finish());
                     }
@@ -8736,6 +8766,67 @@ mod tests {
             "바깥 </hp:listParam> 누락(중첩 불균형): {raw}"
         );
         assert!(raw.ends_with("</hp:parameters>"), "params close: {raw}");
+
+        // [#4436] 상한 안쪽은 성공, 초과는 조용히 자르지 않고 XmlError.
+        let at_limit = parse_parameters_xml(&nested_list_param_xml(MAX_LIST_PARAM_DEPTH))
+            .expect("정상 깊이 listParam 이 거부됐다 — 가드가 과잉 차단");
+        assert_eq!(
+            list_param_tree_depth(&at_limit.parameters),
+            MAX_LIST_PARAM_DEPTH
+        );
+        match parse_parameters_xml(&nested_list_param_xml(MAX_LIST_PARAM_DEPTH + 1)) {
+            Err(HwpxError::XmlError(msg)) => {
+                assert!(
+                    msg.contains("listParam nesting exceeds"),
+                    "XmlError 메시지에 `listParam nesting exceeds` 가 없다: {msg}"
+                );
+            }
+            other => panic!("상한 초과 listParam 이 XmlError 로 거부되지 않았다: {other:?}"),
+        }
+    }
+
+    fn nested_list_param_xml(depth: usize) -> String {
+        let mut xml = String::from(
+            r#"<hp:parameters xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" cnt="1" name="">"#,
+        );
+        for i in 0..depth {
+            xml.push_str(&format!(r#"<hp:listParam cnt="1" name="L{i}">"#));
+        }
+        xml.push_str(r#"<hp:stringParam name="A">x</hp:stringParam>"#);
+        for _ in 0..depth {
+            xml.push_str("</hp:listParam>");
+        }
+        xml.push_str("</hp:parameters>");
+        xml
+    }
+
+    fn parse_parameters_xml(xml: &str) -> Result<Field, HwpxError> {
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let mut field = Field::default();
+        loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"parameters" => {
+                    let start = e.to_owned();
+                    parse_field_parameters(&start, &mut reader, &mut field)?;
+                    return Ok(field);
+                }
+                Event::Eof => panic!("parameters not found"),
+                _ => {}
+            }
+            buf.clear();
+        }
+    }
+
+    fn list_param_tree_depth(list: &ParameterList) -> usize {
+        list.items
+            .iter()
+            .filter_map(|param| match param {
+                Parameter::List(inner) => Some(1 + list_param_tree_depth(inner)),
+                _ => None,
+            })
+            .max()
+            .unwrap_or(0)
     }
 
     #[test]

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2349,7 +2349,7 @@
       "id": "src/parser/hwpx/section.rs::tests#1",
       "file": "src/parser/hwpx/section.rs",
       "sourcePath": "src/parser/hwpx/section.rs",
-      "line": 7203,
+      "line": 7233,
       "module": "tests",
       "testAttributes": 94,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 devel 인지 확인해주세요** (main 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 upstream/devel 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

#5407 / M03-6. #4436 — HWPX parse_field_parameters 가 중첩 <hp:listParam> 을 깊이 제한 없이 트리로 쌓던 경로만 고칩니다.

MAX_LIST_PARAM_DEPTH(32, 루트 <hp:parameters> 는 제외)를 넘으면 트리를 더 쌓지 않고 XmlError 로 거절합니다. 조용히 자르지 않습니다. 정상 깊이(상한 이하) 중첩은 그대로 파싱됩니다.

OWPML hp:ParameterList 스키마가 무한 중첩을 막지 않아, 손상·적대 HWPX 가 극단적으로 깊은 listParam 을 담을 수 있습니다. 트리 빌더는 반복 스택이라 당장 네이티브 스택은 안 넘지만, 만든 Parameter::List 트리는 이후 render/Drop 이 재귀합니다. 실문서는 두세 단계를 넘지 않으므로 32 는 여유 있는 상한입니다.

## 관련 이슈

closes #5407
closes #4436

## 테스트

- [x] **cargo fmt --all -- --check 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. cargo fmt --check 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 cargo fmt --all 후 다시 --check)
- [x] 
ode scripts/rust-test-suite-manifest.mjs --check 통과 (--prepare 후)
- [x] 
ode scripts/rust-unit-test-tiers.mjs --check 통과
- [x] cargo test --lib -- parse_field_parameters_reassembles_nested_params_balanced 통과 (상한 안쪽 성공 + 상한 초과 XmlError)
- [ ] cargo clippy -- -D warnings — 디스크 부족으로 전체 clippy 는 생략. 변경은 깊이 가드와 회귀 단언뿐
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (파서 깊이 가드)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] .claude/agents/·스킬 변경 없음

## 하지 않은 것

- layout / pagination (planet6897 활동 구간)
- gym
- M08
- ParameterList::parse_xml (HWP5 CTRL_DATA 내부 코덱, #4436 HWPX 파서 범위 밖)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 정상 문서는 영향 없음 (상한 분기는 32단 초과에서만)
- 재현·측정: 32단 중첩은 파싱 성공, 33단은 listParam nesting exceeds 32 levels 로 거절
