### PR TITLE
fix(render): CanvasKit showControlCodes [표]/[그림] 폴백 해제 (M07-2)

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -505,10 +505,10 @@ assert.doesNotMatch(
   /viewOption:showParagraphMarks/,
   'Automatic selection should permit directly replayable text marks',
 );
-assert.match(
+assert.doesNotMatch(
   mainSource,
   /viewOption:showControlCodes/,
-  'Automatic selection should reject structural control markers until they have explicit ops',
+  'Automatic selection should permit directly replayable structural control markers',
 );
 requireSnippet(
   embedRpcRouterSource,
@@ -644,6 +644,7 @@ for (const directTextVisualToken of [
   'textRun:engraveTextEffect',
   'textRun:shadeTextEffect',
   'textRun:ratioTextEffect',
+  'viewOption:showControlCodes',
 ]) {
   assert.equal(
     expectedUnsupportedSetBody.includes(`'${directTextVisualToken}'`),
@@ -2365,6 +2366,37 @@ assert.equal(
   true,
   'Hancom boxed-number PUA should preserve the encoded number',
 );
+
+for (const markerText of ['[표]', '[그림]']) {
+  const controlCodeMarkerReplay = runExecutableTextReplay({
+    type: 'textRun',
+    bbox: { x: 0, y: 20, width: 36, height: 20 },
+    text: markerText,
+    baseline: 15,
+    positions: Array.from({ length: Array.from(markerText).length + 1 }, (_, index) => index * 10),
+    style: { fontFamily: 'Prepared', fontSize: 11, color: '#0000FF' },
+  }, { usePreparedTypeface: true });
+  assert.equal(
+    controlCodeMarkerReplay.unsupportedOps.has('viewOption:showControlCodes'),
+    false,
+    `${markerText} must not pin the document to a showControlCodes fallback`,
+  );
+  assert.equal(
+    controlCodeMarkerReplay.unsupportedOps.has('textRun:scriptTextRequiresShaping'),
+    false,
+    `${markerText} must replay as ordinary horizontal text`,
+  );
+  assert.equal(
+    controlCodeMarkerReplay.events.some(event => event.type === 'font.getGlyphIDs' && event.text === markerText),
+    true,
+    `${markerText} should map its producer text to glyphs`,
+  );
+  assert.equal(
+    controlCodeMarkerReplay.events.some(event => event.type === 'canvas.drawGlyphs'),
+    true,
+    `${markerText} should replay through positioned glyph draws`,
+  );
+}
 
 const textSpecialReplay = runExecutableTextSpecialReplay();
 assert.equal(textSpecialReplay.events.some(event => event.type === 'canvas.drawOval'), true);

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -507,7 +507,6 @@ async function initialize(): Promise<void> {
             extensionViewerSettings,
           );
           const blockers = plan.unavailableFonts.map(font => `fontUnavailable:${font}`);
-          if (wasm.getShowControlCodes()) blockers.push('viewOption:showControlCodes');
           return withCanvasKitSurfaceBlockers(
             report,
             blockers,

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -630,9 +630,6 @@ export class CanvasKitLayerRenderer {
       this.glyphRunFonts.registerResources(tree.fontResources, tree.resources);
       this.currentShowParagraphMarks = tree.outputOptions?.showParagraphMarks === true;
       this.currentShowControlCodes = tree.outputOptions?.showControlCodes === true;
-      if (this.currentShowControlCodes) {
-        this.unsupportedOps.add('viewOption:showControlCodes');
-      }
       this.selectedTextVariantOps = new WeakSet<LayerPaintOp>();
       this.selectTextVariants(tree.root);
       let hasPageBackground = false;

--- a/rhwp-studio/src/view/canvaskit/diagnostics.ts
+++ b/rhwp-studio/src/view/canvaskit/diagnostics.ts
@@ -19,7 +19,6 @@ const EXPECTED_CANVASKIT_UNSUPPORTED_OPS = new Set([
   'textRun:layoutPositions',
   'textRun:scriptTextRequiresShaping',
   'textRunFont',
-  'viewOption:showControlCodes',
 ]);
 
 export function isExpectedCanvasKitUnsupportedOp(op: string): boolean {

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -182,10 +182,10 @@ test('CanvasKit text replay uses positioned fallback glyphs and external text vi
   assert.doesNotMatch(source, /case 'charOverlap':[\s\S]{0,200}unsupportedOps\.add\(op\.type\)/);
 });
 
-test('CanvasKit auto preflight permits text marks but blocks missing structural control markers', () => {
+test('CanvasKit auto preflight permits text marks and structural control markers', () => {
   const source = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
   assert.doesNotMatch(source, /viewOption:showParagraphMarks/);
-  assert.match(source, /viewOption:showControlCodes/);
+  assert.doesNotMatch(source, /viewOption:showControlCodes/);
 });
 
 test('CanvasKit contains malformed images and bounds both decode caches', () => {

--- a/rhwp-studio/tests/renderer-session.test.ts
+++ b/rhwp-studio/tests/renderer-session.test.ts
@@ -189,18 +189,14 @@ test('surface preflight transforms stay lazy and document resources prepare befo
   assert.equal(fallback.diagnostics.selectionError, 'font decode failed');
 });
 
-test('auto re-evaluation permits text marks but keeps structural control markers on Canvas2D', async () => {
-  let showControlCodes = false;
+test('auto re-evaluation permits text marks and structural control markers', async () => {
   let createCalls = 0;
   const rendererSession = session('auto', async () => {
     createCalls += 1;
     return fakeRenderer();
   }, {
     transformCanvasKitPreflight(report) {
-      return withCanvasKitSurfaceBlockers(
-        report,
-        showControlCodes ? ['viewOption:showControlCodes'] : [],
-      );
+      return withCanvasKitSurfaceBlockers(report, []);
     },
   });
   const wasm = { getCanvasKitDocumentPreflight: () => preflight('eligible') };
@@ -209,20 +205,14 @@ test('auto re-evaluation permits text marks but keeps structural control markers
   assert.equal((await rendererSession.resolve(wasm)).backend, 'canvaskit');
 
   rendererSession.invalidateDocument({ resetResources: false });
-  assert.equal((await rendererSession.resolve(wasm)).backend, 'canvaskit');
-
-  showControlCodes = true;
-  rendererSession.invalidateDocument({ resetResources: false });
   const controlCodes = await rendererSession.resolve(wasm);
-  assert.equal(controlCodes.backend, 'canvas2d');
+  assert.equal(controlCodes.backend, 'canvaskit');
   assert.equal(
-    controlCodes.diagnostics.preflight?.blockers.at(-1)?.detail,
-    'viewOption:showControlCodes',
+    controlCodes.diagnostics.preflight?.blockers.some(
+      (blocker) => blocker.detail === 'viewOption:showControlCodes',
+    ),
+    false,
   );
-
-  showControlCodes = false;
-  rendererSession.invalidateDocument({ resetResources: false });
-  assert.equal((await rendererSession.resolve(wasm)).backend, 'canvaskit');
   assert.equal(createCalls, 1);
 });
 

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -2914,6 +2914,21 @@ mod tests {
         assert_eq!(mark_plan.items[0].op_type, "textControlMark");
         assert_eq!(mark_plan.items[0].status, CanvasKitReplayStatus::Direct);
         assert_eq!(mark_plan.summary.hidden_overlay_violations, 0);
+
+        // [표]/[그림] 조판부호는 일반 TextRun 이므로 showControlCodes 만으로 폴백하지 않는다.
+        for (index, text) in ["[표]", "[그림]"].into_iter().enumerate() {
+            let mut marker = text_run(text);
+            marker.field_marker = FieldMarkerType::ShapeMarker(index);
+            marker.style.color = 0x0000FF;
+            let tree = tree_with_ops(vec![PaintOp::text_run(bbox(), marker)]);
+            let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+            assert_eq!(
+                plan.items[0].status,
+                CanvasKitReplayStatus::Direct,
+                "text={text}"
+            );
+            assert_eq!(plan.items[0].detail, None, "text={text}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M07-2 (◆10 CanvasKit 폴백 소거). showControlCodes 조판부호 마커(`[표]`/`[그림]`)만 CanvasKit 폴백에서 뺀다. 해당 마커는 이미 일반 `TextRun` 으로 내려가므로 `viewOption:showControlCodes` 로 문서 revision 을 Canvas2D 에 고정하지 않는다.

- 자동 선택 preflight 의 `viewOption:showControlCodes` 차단을 제거한다.
- 런타임 `unsupportedOps` 와 expected-unsupported allowlist 를 같은 계약으로 맞춘다.
- `canvaskit_policy.rs` 는 `[표]`/`[그림]` ShapeMarker TextRun 이 Direct 임을 고정한다.
- boxed-PUA, 세로, 그라데이션, 화살표 등 다른 폴백은 그대로 둔다.
- CanvasKit 기본 렌더러 전환은 이 CLAIM 밖이다.

## 관련 이슈

closes #5410

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `node rhwp-studio/e2e/renderer-contract.test.mjs` 통과
- [x] `node --test rhwp-studio/tests/render-backend.test.ts rhwp-studio/tests/renderer-session.test.ts` 통과
- [ ] `cargo test --lib -- nonvisual_control_metadata_and_opaque_white_shade_keep_text_direct` — 로컬 링크 PDB/디스크 한도로 미실행. 정책 술어 자체는 변경 없음(`[표]`/`[그림]` Direct 회귀 시험만 추가)
- [ ] `cargo clippy -- -D warnings` — 해당 범위 밖 (폴백 제거만)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 계약 시험(모의 replay)으로 대체
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음 (폴백 술어만)
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (폴백 판정만, 기본 렌더러 전환 아님)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- boxed-PUA + 장평/효과 폴백 유지 (M07-1 #5408)
- 세로·그라데이션·화살표 폴백 유지
- CanvasKit 기본 렌더러 선언 (M07-14)
- gym 미수정
