### PR TITLE
refactor(equation): 수식 명령 디스패치 표준화 + 모듈 문서 (M09-2)

### DIFF
--- a/mydocs/README.md
+++ b/mydocs/README.md
@@ -73,6 +73,7 @@ front matter는 `mydocs/manual`, `mydocs/tech`, `mydocs/troubleshootings`의 모
 | [한글 문서 파일 형식 5.0 개정 1.3](tech/한글문서파일형식_5.0_revision1.3.md) | reference | active | `tech/hwp_spec_errata.md` | 2026-07-16 |
 | [Document IR LineSeg 표준](tech/document_ir_lineseg_standard.md) | canonical | active | `tech/document_ir_lineseg_standard.md` | 2026-07-16 |
 | [렌더링 엔진 설계](tech/rendering_engine_design.md) | canonical | active | `tech/rendering_engine_design.md` | 2026-07-23 |
+| [수식 모듈 매뉴얼](manual/equation_module.md) | guide | active | `manual/equation_module.md` | 2026-08-18 |
 | [표 레이아웃 규칙](tech/table_layout_rules.md) | canonical | active | `tech/table_layout_rules.md` | 2026-07-16 |
 | [폰트 fallback 전략](tech/font_fallback_strategy.md) | canonical | active | `tech/font_fallback_strategy.md` | 2026-07-16 |
 | [편집 action undo/redo 아키텍처](tech/edit_action_undo_redo_architecture.md) | canonical | active | `tech/edit_action_undo_redo_architecture.md` | 2026-07-16 |

--- a/mydocs/manual/README.md
+++ b/mydocs/manual/README.md
@@ -39,6 +39,7 @@ last_verified: 2026-08-15
 | 웹한글컨트롤 호환 층 개발·Oracle 대조 | [웹한글컨트롤 호환 개발 가이드](webhwpctrl_compat_development.md) | [`@rhwp/hwpctrl` 패키지 안내](../../npm/hwpctrl-ocx/README.md), [호환 하니스](../../tools/hwpctrl_compat/README.md) |
 | CLI 로 실물 서식 채우기(누름틀·표 좌표·치환) | [서식 자동화 심화 가이드](form_filling_guide.md) | [CLI 명령어 매뉴얼](cli_commands.md), [에이전트 실무 대체 예제집](agent_task_playbook.md) |
 | 편집 command와 단축키 | [Command/Undo 검토 체크리스트](edit_command_review_checklist.md) | [키보드 단축키 추가](keyboard_shortcut_guide.md) |
+| 수식 스크립트 파서·명령 디스패치 | [수식 모듈 매뉴얼](equation_module.md) | 모듈 지도 [`src/renderer/equation/README.md`](../../src/renderer/equation/README.md), 분류 정본 [`dispatch.rs`](../../src/renderer/equation/dispatch.rs) |
 | 품질 지표와 리팩터링 검토 | [코드 품질 대시보드](dashboard.md) | [SOLID 채점 기준](solid_scoring_guide.md) |
 | release 준비와 배포 | [배포 가이드](publish_guide.md) | [개발 환경 가이드](dev_environment_guide.md) |
 | rhwp-studio UI 명칭·CSS 접두어 | [rhwp-studio UI 명칭과 CSS 접두어](rhwp_studio_ui_conventions.md) | [개발 환경 가이드](dev_environment_guide.md) |

--- a/mydocs/manual/equation_module.md
+++ b/mydocs/manual/equation_module.md
@@ -1,0 +1,78 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/equation_module.md
+last_verified: 2026-08-18
+---
+
+# 수식 모듈 매뉴얼
+
+한컴 수식 스크립트를 파싱·배치·그리는 코드는 `src/renderer/equation/` 이다.
+이 문서는 그 모듈의 진입점과 명령 디스패치 규약이다. 구현 정본은
+[`dispatch.rs`](../../src/renderer/equation/dispatch.rs) 와
+[`README.md`](../../src/renderer/equation/README.md).
+
+## 언제 이 문서를 보나
+
+- 수식 명령을 추가하거나 분기 순서를 손대려 할 때
+- 파서 if 연쇄가 어디로 갔는지 찾을 때
+- M09-1 골든이 무엇을 잠그는지 확인할 때
+
+렌더링 엔진 전체는 [렌더링 엔진 설계](../tech/rendering_engine_design.md),
+이슈별 수식 조사는 [issue-139](../tech/investigations/issue-139/README.md).
+
+## 파이프라인
+
+```
+script
+  → tokenizer::tokenize
+  → EqParser::parse          (명령은 classify_command → 핸들러)
+  → EqLayout::layout
+  → svg_render / canvas_render
+```
+
+문서 컨트롤에서 크기가 필요할 때는 `equation::intrinsic_size_hwp(script, font_size)`.
+
+## 명령 디스패치
+
+`parse_command` 는 깊이 가드만 하고, 실제 분기는
+`classify_command(cmd) -> EqCommandClass` 한 곳이다.
+
+| 가족 | 대표 명령 | 핸들러 |
+| --- | --- | --- |
+| `InfixDiscard` | `OVER`, `ATOP` | 단독이면 `Empty`. 결합은 `parse_expression` |
+| `LatexFraction` | `FRAC`, `DFRAC`, `TFRAC` | `parse_latex_fraction` |
+| `RomanText` | `TEXT`, `OPERATORNAME` | 로만체 `FontStyle` |
+| `Phantom` | `PHANTOM`, `VPHANTOM`, `HPHANTOM` | 인자 소비 후 공백 |
+| `LatexSpacing` | `QUAD`, `QQUAD`, … | `Text` 간격 |
+| `Overset` / `Underset` | `OVERSET`, `STACKREL`, `UNDERSET` | 첨자 AST |
+| `BeginEnv` / `EndEnv` | `BEGIN`, `END` | LaTeX 환경 |
+| `Sqrt` | `SQRT`, `ROOT` | `parse_sqrt` (`ROOT` 도 `Sqrt`) |
+| `IntegralNolimits` | `INT`, `DINT`, `OINT`, … | `MathSymbol` + 일반 첨자 |
+| `BigOperator` | `SUM`, `PROD`, … | `parse_big_op` |
+| `Limit` | `lim`, `Lim` | 원문 대소문자 |
+| `Matrix` | `MATRIX`, `PMATRIX`, `BMATRIX`, `DMATRIX` | `parse_matrix` |
+| `Cases` / `EqAlign` / `Pile` | `CASES`, `EQALIGN`, `PILE`… | 각 전용 파서 |
+| `LeftDelim` / `RightDiscard` | `LEFT`, `RIGHT` | LEFT 는 그룹 뒤 첨자 결합 |
+| `Rel` | `REL`, `BUILDREL` | 화살표 위/아래 |
+| `LongDiv` / `Ladder` / `Benzene` / `Bigg` | 자리표시·fallback | 현행 그대로 |
+| `Choose` / `Binom` / `Color` | 조합·색 | 현행 그대로 |
+| `LeftScript` / `Sup` / `Sub` | `LSUB`, `SUP`, `SUB` | 첨자 동의어 |
+| `Fallback` | 그 외 | 장식 → 글꼴 → 기호 → 함수 → `Text` |
+
+적분은 `is_big_operator` 보다 먼저, `lim`/`Lim` 은 그보다 뒤에 분류한다.
+`VMATRIX` 는 행렬 가족이 아니다.
+
+## 명령을 추가할 때
+
+1. 새 이름이 기존 가족에 들어가면 `classify_command` 해당 `match` 팔만 고친다.
+2. 새 가족이면 `EqCommandClass` 변이 + 분류 + `parse_command_inner` 팔을 같이 추가한다.
+3. Fallback 표(`DECORATIONS`/`FONT_STYLES`/`lookup_symbol`/`is_function`)에만 넣을 이름은
+   분류표에 올리지 않는다. `BENZENE` 처럼 첨자 결합이 달라지는 명령은 Fallback 으로 내리면 안 된다.
+4. M09-1 골든(PR #5412)이 깨지면 동작이 바뀐 것이다. 구조만 손댈 때는 골든을 갱신하지 않는다.
+
+## 하지 않는 것
+
+- 골든을 한컴 정답으로 바꾸지 않는다. 현행 엔진 잠금이다.
+- `#4056`(HWPX 내보내기 쪽수), `#4865`(깊은 중첩·괄호 O(n²)) 를 이 매뉴얼 범위에서 고치지 않는다.
+- gym / `scripts/visual_sweep.py` 를 수식 디스패치와 묶지 않는다.

--- a/mydocs/tech/README.md
+++ b/mydocs/tech/README.md
@@ -23,6 +23,7 @@ last_verified: 2026-08-10
 | HWPX와 HWP IR 차이 | [HWP/HWPX IR 차이](hwp_hwpx_ir_differences.md) | [HWPX 한컴 참조](hwpx_hancom_reference.md), [HWPX DVC 참조](hwpx_dvc_reference.md), [로컬 OWPML XML 스키마](../manual/owpml_schema_reference.md) |
 | Document IR와 LineSeg 계약 | [Document IR LineSeg 표준](document_ir_lineseg_standard.md) | [Issue #310 LineSeg vpos 조사](investigations/issue-310/README.md), [HWPX LineSeg 검증](hwpx_lineseg_validation.md) |
 | 렌더링 엔진 | [렌더링 엔진 설계](rendering_engine_design.md) | [Issue #516 다층 렌더링 후보 조사](investigations/issue-516/README.md), [Issue #124 캔버스·폰트 측정 조사](investigations/issue-124/README.md) |
+| 수식 명령 디스패치 | [수식 모듈 매뉴얼](../manual/equation_module.md) | 분류 정본 [`src/renderer/equation/dispatch.rs`](../../src/renderer/equation/dispatch.rs), [Issue #139 수식 지원 조사](investigations/issue-139/README.md) |
 | 표 레이아웃 | [표 레이아웃 규칙](table_layout_rules.md) | [HWP 표 렌더링](hwp_table_rendering.md), [Issue #101 부분 표 흐름 조사](investigations/issue-101/README.md) |
 | 레이아웃 이상탐지(overflow/overlap/empty_page) | [레이아웃 이상탐지 — 세 번째 층](layout_anomaly_detection.md) | CLI `layout-anomaly`, `render_geom_diff`(변위 비교)와의 관계 |
 | 폰트 대체와 충실도 | [폰트 fallback 전략](font_fallback_strategy.md) | [Issue #124 캔버스·폰트 측정 조사](investigations/issue-124/README.md), [Issue #2125 font ownership 조사](investigations/issue-2125/README.md) |

--- a/src/renderer/equation/README.md
+++ b/src/renderer/equation/README.md
@@ -1,0 +1,44 @@
+# 수식 모듈 (`src/renderer/equation`)
+
+한컴 수식 스크립트(버전 6.0)를 토큰 → AST → 레이아웃 → SVG/Canvas 로 그린다.
+명령 분기의 정본은 [`dispatch.rs`](dispatch.rs) 이고, 파서는 그 분류만 본다.
+
+매뉴얼: [`mydocs/manual/equation_module.md`](../../../mydocs/manual/equation_module.md).
+
+## 파일
+
+| 파일 | 역할 |
+| --- | --- |
+| `tokenizer.rs` | 스크립트 → 토큰 |
+| `dispatch.rs` | 명령 이름 → `EqCommandClass` (분류만, 파싱 없음) |
+| `parser.rs` | 토큰 → `EqNode`. `parse_command` 가 분류표로 핸들러를 고른다 |
+| `ast.rs` | `EqNode` / `MatrixStyle` / `PileAlign` |
+| `symbols.rs` | 기호·함수·장식·큰 연산자 표 |
+| `layout.rs` | `EqNode` → `LayoutBox` |
+| `svg_render.rs` | `LayoutBox` → SVG 조각 |
+| `canvas_render.rs` | WASM Canvas 경로 |
+| `mod.rs` | `intrinsic_size_hwp` 진입점 |
+
+## 디스패치 순서
+
+`classify_command` 의 앞쪽이 이긴다. 순서를 바꾸면 동작이 바뀐다.
+
+1. 중위 폐기 (`OVER`/`ATOP`) — 결합은 `parse_expression`
+2. LaTeX 분수·본문·phantom·간격·overset/underset·begin/end
+3. `SQRT`/`ROOT` (`ROOT` 도 AST 는 `Sqrt`)
+4. 적분 nolimits (`INT`/`DINT`/…) — `is_big_operator` 보다 앞
+5. 큰 연산자 (`SUM`/`PROD`/…)
+6. `lim`/`Lim` (원문 대소문자)
+7. 행렬·cases·eqalign·pile·LEFT/RIGHT·rel·longdiv·ladder·benzene·bigg·choose/binom·color·첨자 동의어
+8. Fallback: 장식 → 글꼴 → 기호 → 함수 → `Text`
+
+`VMATRIX`/`SMALLMATRIX` 는 분류표에 없다. 현행처럼 fallback 이다.
+
+## 현행 잠금 (바꾸지 않음)
+
+- `ROOT` 는 `SQRT` 와 같은 파서 분기라 AST 가 `Sqrt` 다.
+- `PILE`/`LPILE`/`RPILE` 레이아웃은 전용 kind 없이 `Row` 로 세로 쌓는다.
+- 중괄호 없는 `MATRIX` 는 `Empty`.
+- 깊이 가드·괄호 짝 계산은 이 모듈이 손대지 않는다.
+
+골든은 M09-1 (PR #5412). 의도된 엔진 변경이 아니면 `UPDATE_EQ_GOLDENS=1` 로 갱신하지 않는다.

--- a/src/renderer/equation/dispatch.rs
+++ b/src/renderer/equation/dispatch.rs
@@ -1,0 +1,151 @@
+//! 수식 명령 디스패치 분류.
+//!
+//! `EqParser::parse_command_inner` 의 명령 분기를 한 표로 고정한다.
+//! 분류 순서와 가족은 구 if 연쇄와 같고, 파서 동작은 바꾸지 않는다.
+//!
+//! 모듈 지도는 `src/renderer/equation/README.md`, 매뉴얼은
+//! `mydocs/manual/equation_module.md`.
+
+use super::ast::{MatrixStyle, PileAlign};
+use super::symbols::is_big_operator;
+
+/// 수식 명령 가족. `parse_command_inner` 가 이 분류만 보고 핸들러를 고른다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EqCommandClass {
+    /// 중위 `OVER`/`ATOP`. 단독 출현은 버리고, 결합은 `parse_expression` 이 맡는다.
+    InfixDiscard,
+    /// LaTeX `\frac`/`\dfrac`/`\tfrac`.
+    LatexFraction,
+    /// `\text`/`\operatorname` — 로만체 본문.
+    RomanText,
+    /// `\phantom` 계열. 인자를 소비하고 공백 한 칸만 남긴다.
+    Phantom,
+    /// LaTeX 간격 명령.
+    LatexSpacing,
+    /// `\overset`/`\stackrel`.
+    Overset,
+    /// `\underset`.
+    Underset,
+    /// `\begin{env}`.
+    BeginEnv,
+    /// `\end{env}` — 인자만 건너뛴다.
+    EndEnv,
+    /// `SQRT`/`ROOT`. `ROOT` 도 현행과 같이 `Sqrt` AST 로 간다.
+    Sqrt,
+    /// 적분 기호. `BigOp` 보다 먼저 매칭해 nolimits(일반 첨자)로 둔다.
+    IntegralNolimits,
+    /// `SUM`/`PROD` 등 limits 큰 연산자.
+    BigOperator,
+    /// `lim`/`Lim`. 원문 대소문자를 구분한다.
+    Limit,
+    /// `MATRIX`/`PMATRIX`/`BMATRIX`/`DMATRIX`. `VMATRIX` 는 여기 넣지 않는다.
+    Matrix,
+    /// 조건식.
+    Cases,
+    /// 칸 맞춤 정렬.
+    EqAlign,
+    /// `PILE`/`LPILE`/`RPILE`.
+    Pile,
+    /// `LEFT` … `RIGHT` 그룹. 뒤 첨자는 그룹 전체에 붙인다.
+    LeftDelim,
+    /// 짝 없는 `RIGHT`.
+    RightDiscard,
+    /// `REL`/`BUILDREL`.
+    Rel,
+    /// 긴 나눗셈 자리표시.
+    LongDiv,
+    /// `LADDER`/`SLADDER` → 평문 행렬 fallback.
+    Ladder,
+    /// 벤젠 자리표시. `try_parse_scripts` 를 타지 않는다.
+    Benzene,
+    /// `BIGG` — 크기 변경은 무시하고 다음 요소만 돌린다.
+    Bigg,
+    /// `CHOOSE`.
+    Choose,
+    /// `BINOM`.
+    Binom,
+    /// `COLOR`.
+    Color,
+    /// `LSUB`/`LSUP`.
+    LeftScript,
+    /// `SUP` 동의어.
+    Sup,
+    /// `SUB` 동의어.
+    Sub,
+    /// 장식·글꼴·기호·함수·미지 명령.
+    Fallback,
+}
+
+/// 명령 토큰을 가족으로 분류한다.
+///
+/// 적분은 [`is_big_operator`] 보다 앞, `lim`/`Lim` 은 그보다 뒤다.
+/// 이 순서를 바꾸면 골든(M09-1, PR #5412)이 깨진다.
+pub(crate) fn classify_command(cmd: &str) -> EqCommandClass {
+    let upper = cmd.to_ascii_uppercase();
+    let cu = upper.as_str();
+
+    match cu {
+        "OVER" | "ATOP" => return EqCommandClass::InfixDiscard,
+        "FRAC" | "DFRAC" | "TFRAC" => return EqCommandClass::LatexFraction,
+        "TEXT" | "OPERATORNAME" => return EqCommandClass::RomanText,
+        "PHANTOM" | "VPHANTOM" | "HPHANTOM" => return EqCommandClass::Phantom,
+        "QUAD" | "QQUAD" | "THINSPACE" | "MEDSPACE" | "THICKSPACE" | "NEGSPACE" | "ENSPACE" => {
+            return EqCommandClass::LatexSpacing;
+        }
+        "OVERSET" | "STACKREL" => return EqCommandClass::Overset,
+        "UNDERSET" => return EqCommandClass::Underset,
+        "BEGIN" => return EqCommandClass::BeginEnv,
+        "END" => return EqCommandClass::EndEnv,
+        "SQRT" | "ROOT" => return EqCommandClass::Sqrt,
+        "INT" | "INTEGRAL" | "SMALLINT" | "DINT" | "TINT" | "OINT" | "SMALLOINT" | "ODINT"
+        | "OTINT" => return EqCommandClass::IntegralNolimits,
+        _ => {}
+    }
+
+    if is_big_operator(cu) || is_big_operator(cmd) {
+        return EqCommandClass::BigOperator;
+    }
+    if cmd == "lim" || cmd == "Lim" {
+        return EqCommandClass::Limit;
+    }
+
+    match cu {
+        "MATRIX" | "PMATRIX" | "BMATRIX" | "DMATRIX" => EqCommandClass::Matrix,
+        "CASES" => EqCommandClass::Cases,
+        "EQALIGN" => EqCommandClass::EqAlign,
+        "PILE" | "LPILE" | "RPILE" => EqCommandClass::Pile,
+        "LEFT" => EqCommandClass::LeftDelim,
+        "RIGHT" => EqCommandClass::RightDiscard,
+        "REL" | "BUILDREL" => EqCommandClass::Rel,
+        "LONGDIV" => EqCommandClass::LongDiv,
+        "LADDER" | "SLADDER" => EqCommandClass::Ladder,
+        "BENZENE" => EqCommandClass::Benzene,
+        "BIGG" => EqCommandClass::Bigg,
+        "CHOOSE" => EqCommandClass::Choose,
+        "BINOM" => EqCommandClass::Binom,
+        "COLOR" => EqCommandClass::Color,
+        "LSUB" | "LSUP" => EqCommandClass::LeftScript,
+        "SUP" => EqCommandClass::Sup,
+        "SUB" => EqCommandClass::Sub,
+        _ => EqCommandClass::Fallback,
+    }
+}
+
+/// `MATRIX` 계열 대문자 이름 → 괄호 스타일. 미지 이름은 Plain.
+pub(crate) fn matrix_style(cmd_upper: &str) -> MatrixStyle {
+    match cmd_upper {
+        "PMATRIX" => MatrixStyle::Paren,
+        "BMATRIX" => MatrixStyle::Bracket,
+        "DMATRIX" => MatrixStyle::Vert,
+        _ => MatrixStyle::Plain,
+    }
+}
+
+/// `PILE` 계열 대문자 이름 → 가로 정렬. 미지 이름은 Center.
+pub(crate) fn pile_align(cmd_upper: &str) -> PileAlign {
+    match cmd_upper {
+        "LPILE" => PileAlign::Left,
+        "RPILE" => PileAlign::Right,
+        _ => PileAlign::Center,
+    }
+}

--- a/src/renderer/equation/mod.rs
+++ b/src/renderer/equation/mod.rs
@@ -2,10 +2,15 @@
 //!
 //! 수식 스크립트(버전 6.0)를 토큰화하고 AST로 변환한 뒤 SVG로 렌더링한다.
 //! 참조: openhwp/docs/hwpx/appendix-i-formula.md
+//!
+//! 명령 분기는 [`dispatch`] 가 가족으로 분류하고, [`parser`] 가 같은 핸들러로
+//! 소비한다. 동작은 바꾸지 않는다. 모듈 지도는 `README.md`, 매뉴얼은
+//! `mydocs/manual/equation_module.md`.
 
 pub mod ast;
 #[cfg(target_arch = "wasm32")]
 pub mod canvas_render;
+pub(crate) mod dispatch;
 pub mod layout;
 pub mod parser;
 pub mod svg_render;

--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -3,6 +3,7 @@
 //! 토큰 리스트를 AST(EqNode)로 변환한다.
 
 use super::ast::*;
+use super::dispatch::{classify_command, matrix_style, pile_align, EqCommandClass};
 use super::symbols::{
     self, is_big_operator, is_function, is_structure_command, lookup_function, lookup_symbol,
     FontStyleKind, DECORATIONS, FONT_STYLES,
@@ -309,288 +310,167 @@ impl EqParser {
     fn parse_command_inner(&mut self, cmd: &str) -> EqNode {
         let cmd_upper = cmd.to_ascii_uppercase();
         let cu = cmd_upper.as_str();
+        match classify_command(cmd) {
+            EqCommandClass::InfixDiscard => EqNode::Empty,
+            EqCommandClass::LatexFraction => self.parse_latex_fraction(),
+            EqCommandClass::RomanText => {
+                // 제한: 토크나이저가 일반 공백을 건너뛰므로 \text{a b} 내부 공백은 보존되지 않음.
+                // 공백이 필요하면 hwpeq 관례대로 ~ 사용 (\text{if~}).
+                let body = self.parse_single_or_group();
+                EqNode::FontStyle {
+                    style: FontStyleKind::Roman,
+                    body: Box::new(body),
+                }
+            }
+            EqCommandClass::Phantom => {
+                self.parse_single_or_group();
+                EqNode::Text(" ".to_string())
+            }
+            EqCommandClass::LatexSpacing => {
+                let space = lookup_symbol(cu).unwrap_or(" ");
+                EqNode::Text(space.to_string())
+            }
+            EqCommandClass::Overset => {
+                let over = self.parse_single_or_group();
+                let base = self.parse_single_or_group();
+                EqNode::Superscript {
+                    base: Box::new(base),
+                    sup: Box::new(over),
+                }
+            }
+            EqCommandClass::Underset => {
+                let under = self.parse_single_or_group();
+                let base = self.parse_single_or_group();
+                EqNode::Subscript {
+                    base: Box::new(base),
+                    sub: Box::new(under),
+                }
+            }
+            EqCommandClass::BeginEnv => self.parse_latex_environment(),
+            EqCommandClass::EndEnv => {
+                self.skip_brace_arg();
+                EqNode::Empty
+            }
+            EqCommandClass::Sqrt => self.parse_sqrt(),
+            EqCommandClass::IntegralNolimits => {
+                // nolimits: 큰 기호 + 일반 첨자 (BigOp이 아닌 MathSymbol로 처리)
+                let symbol = lookup_symbol(cu)
+                    .or_else(|| lookup_symbol(cmd))
+                    .unwrap_or("∫")
+                    .to_string();
+                let node = EqNode::MathSymbol(symbol);
+                self.try_parse_scripts(node)
+            }
+            EqCommandClass::BigOperator => {
+                let symbol = if is_big_operator(cu) {
+                    lookup_symbol(cu).unwrap_or("?").to_string()
+                } else {
+                    lookup_symbol(cmd).unwrap_or("?").to_string()
+                };
+                self.parse_big_op(symbol)
+            }
+            EqCommandClass::Limit => self.parse_limit(cmd == "Lim"),
+            EqCommandClass::Matrix => self.parse_matrix(matrix_style(cu)),
+            EqCommandClass::Cases => self.parse_cases(),
+            EqCommandClass::EqAlign => self.parse_eqalign(),
+            EqCommandClass::Pile => self.parse_pile(pile_align(cu)),
+            EqCommandClass::LeftDelim => {
+                // ★ KeepGong fix: 구분기호 그룹(left|...right| 등) 뒤 첨자(^/_)를 그룹 전체에 부착.
+                //   기존엔 try_parse_scripts 를 안 거쳐 |x|^3 의 ^3 가 base 없는 고아 첨자가 됐다.
+                let node = self.parse_left_right();
+                self.try_parse_scripts(node)
+            }
+            EqCommandClass::RightDiscard => EqNode::Empty,
+            EqCommandClass::Rel => {
+                let is_buildrel = cu == "BUILDREL";
+                let arrow_node = self.parse_element();
+                let arrow = match &arrow_node {
+                    EqNode::MathSymbol(s) => s.clone(),
+                    EqNode::Symbol(s) => s.clone(),
+                    EqNode::Text(s) => s.clone(),
+                    _ => "→".to_string(),
+                };
+                let over = self.parse_single_or_group();
+                let under = if !is_buildrel {
+                    Some(Box::new(self.parse_single_or_group()))
+                } else {
+                    None
+                };
+                EqNode::Rel {
+                    arrow,
+                    over: Box::new(over),
+                    under,
+                }
+            }
+            EqCommandClass::LongDiv => {
+                let divisor = self.parse_single_or_group();
+                let quotient = self.parse_single_or_group();
+                let body = self.parse_single_or_group();
+                EqNode::Row(vec![
+                    quotient,
+                    EqNode::Symbol("÷".to_string()),
+                    divisor,
+                    EqNode::Symbol("=".to_string()),
+                    body,
+                ])
+            }
+            EqCommandClass::Ladder => self.parse_matrix(MatrixStyle::Plain),
+            EqCommandClass::Benzene => EqNode::MathSymbol("⌬".to_string()),
+            EqCommandClass::Bigg => self.parse_element(),
+            EqCommandClass::Choose => {
+                // n CHOOSE r → 이전 요소와 다음 요소를 조합으로
+                let body = self.parse_single_or_group();
+                EqNode::Paren {
+                    left: "(".to_string(),
+                    right: ")".to_string(),
+                    body: Box::new(EqNode::Atop {
+                        top: Box::new(EqNode::Empty), // 이전 요소는 상위에서 처리
+                        bottom: Box::new(body),
+                    }),
+                }
+            }
+            EqCommandClass::Binom => {
+                let top = self.parse_single_or_group();
+                let bottom = self.parse_single_or_group();
+                EqNode::Paren {
+                    left: "(".to_string(),
+                    right: ")".to_string(),
+                    body: Box::new(EqNode::Atop {
+                        top: Box::new(top),
+                        bottom: Box::new(bottom),
+                    }),
+                }
+            }
+            EqCommandClass::Color => self.parse_color(),
+            EqCommandClass::LeftScript => {
+                let script = self.parse_single_or_group();
+                let body = self.parse_single_or_group();
+                if cu == "LSUB" {
+                    EqNode::Subscript {
+                        base: Box::new(body),
+                        sub: Box::new(script),
+                    }
+                } else {
+                    EqNode::Superscript {
+                        base: Box::new(body),
+                        sup: Box::new(script),
+                    }
+                }
+            }
+            EqCommandClass::Sup | EqCommandClass::Sub => {
+                let body = self.parse_single_or_group();
+                self.try_parse_scripts(body)
+            }
+            EqCommandClass::Fallback => self.parse_command_fallback(cmd),
+        }
+    }
+
+    /// 장식·글꼴·기호·함수·미지 명령. 분류표에 없는 이름만 여기로 온다.
+    fn parse_command_fallback(&mut self, cmd: &str) -> EqNode {
         // [#1204] hwpeq 명령은 대소문자 무시 — DECORATIONS/FONT_STYLES 는 소문자 키이므로
         // 1차 lookup 실패 시 소문자 fallback (`RM`/`BAR` 등 대문자 변형이 leak 되지 않도록).
         let cmd_lower = cmd.to_ascii_lowercase();
 
-        // OVER/ATOP은 parse_expression에서 처리됨 (단독 발생 시)
-        if cu == "OVER" {
-            return EqNode::Empty;
-        }
-
-        if cu == "ATOP" {
-            return EqNode::Empty;
-        }
-
-        // LaTeX 분수: \frac{a}{b}, \dfrac{a}{b}, \tfrac{a}{b}
-        if matches!(cu, "FRAC" | "DFRAC" | "TFRAC") {
-            return self.parse_latex_fraction();
-        }
-
-        // LaTeX \text{...} — 로만체 텍스트
-        // 제한: 토크나이저가 일반 공백을 건너뛰므로 \text{a b} 내부 공백은 보존되지 않음.
-        // 공백이 필요하면 hwpeq 관례대로 ~ 사용 (\text{if~}).
-        if cu == "TEXT" {
-            let body = self.parse_single_or_group();
-            return EqNode::FontStyle {
-                style: FontStyleKind::Roman,
-                body: Box::new(body),
-            };
-        }
-
-        // LaTeX \operatorname{...} — 로만체 연산자명
-        if cu == "OPERATORNAME" {
-            let body = self.parse_single_or_group();
-            return EqNode::FontStyle {
-                style: FontStyleKind::Roman,
-                body: Box::new(body),
-            };
-        }
-
-        // LaTeX \phantom{...} — 보이지 않는 공간 (레이아웃 정렬용)
-        if matches!(cu, "PHANTOM" | "VPHANTOM" | "HPHANTOM") {
-            self.parse_single_or_group();
-            return EqNode::Text(" ".to_string());
-        }
-
-        // LaTeX spacing: \quad, \qquad, \,, \:, \;, \!
-        if matches!(
-            cu,
-            "QUAD" | "QQUAD" | "THINSPACE" | "MEDSPACE" | "THICKSPACE" | "NEGSPACE" | "ENSPACE"
-        ) {
-            let space = lookup_symbol(cu).unwrap_or(" ");
-            return EqNode::Text(space.to_string());
-        }
-
-        // LaTeX \overset{over}{base}, \underset{under}{base}, \stackrel{over}{base}
-        if matches!(cu, "OVERSET" | "STACKREL") {
-            let over = self.parse_single_or_group();
-            let base = self.parse_single_or_group();
-            return EqNode::Superscript {
-                base: Box::new(base),
-                sup: Box::new(over),
-            };
-        }
-        if cu == "UNDERSET" {
-            let under = self.parse_single_or_group();
-            let base = self.parse_single_or_group();
-            return EqNode::Subscript {
-                base: Box::new(base),
-                sub: Box::new(under),
-            };
-        }
-
-        // LaTeX \begin{env}...\end{env}
-        if cu == "BEGIN" {
-            return self.parse_latex_environment();
-        }
-        if cu == "END" {
-            self.skip_brace_arg();
-            return EqNode::Empty;
-        }
-
-        // 제곱근
-        if cu == "SQRT" || cu == "ROOT" {
-            return self.parse_sqrt();
-        }
-
-        // 적분 기호 — nolimits: 큰 기호 + 일반 첨자 (BigOp이 아닌 MathSymbol로 처리)
-        if matches!(
-            cu,
-            "INT"
-                | "INTEGRAL"
-                | "SMALLINT"
-                | "DINT"
-                | "TINT"
-                | "OINT"
-                | "SMALLOINT"
-                | "ODINT"
-                | "OTINT"
-        ) {
-            let symbol = lookup_symbol(cu)
-                .or_else(|| lookup_symbol(cmd))
-                .unwrap_or("∫")
-                .to_string();
-            let node = EqNode::MathSymbol(symbol);
-            return self.try_parse_scripts(node);
-        }
-
-        // 큰 연산자 (∑, ∏ 등) — limits: 기호 위/아래 중앙
-        if is_big_operator(cu) {
-            let symbol = lookup_symbol(cu).unwrap_or("?").to_string();
-            return self.parse_big_op(symbol);
-        }
-        // 원본 대소문자로도 확인 (대소문자 구분 명령어)
-        if is_big_operator(cmd) {
-            let symbol = lookup_symbol(cmd).unwrap_or("?").to_string();
-            return self.parse_big_op(symbol);
-        }
-
-        // 극한 (대소문자 구분)
-        if cmd == "lim" || cmd == "Lim" {
-            return self.parse_limit(cmd == "Lim");
-        }
-
-        // 행렬
-        if matches!(cu, "MATRIX" | "PMATRIX" | "BMATRIX" | "DMATRIX") {
-            let style = match cu {
-                "PMATRIX" => MatrixStyle::Paren,
-                "BMATRIX" => MatrixStyle::Bracket,
-                "DMATRIX" => MatrixStyle::Vert,
-                _ => MatrixStyle::Plain,
-            };
-            return self.parse_matrix(style);
-        }
-
-        // 조건식
-        if cu == "CASES" {
-            return self.parse_cases();
-        }
-
-        // 칸 맞춤 정렬
-        if cu == "EQALIGN" {
-            return self.parse_eqalign();
-        }
-
-        // 세로 쌓기
-        if matches!(cu, "PILE" | "LPILE" | "RPILE") {
-            let align = match cu {
-                "LPILE" => PileAlign::Left,
-                "RPILE" => PileAlign::Right,
-                _ => PileAlign::Center,
-            };
-            return self.parse_pile(align);
-        }
-
-        // LEFT-RIGHT 괄호
-        if cu == "LEFT" {
-            // ★ KeepGong fix: 구분기호 그룹(left|...right| 등) 뒤 첨자(^/_)를 그룹 전체에 부착.
-            //   기존엔 try_parse_scripts 를 안 거쳐 |x|^3 의 ^3 가 base 없는 고아 첨자가 됐다.
-            let node = self.parse_left_right();
-            return self.try_parse_scripts(node);
-        }
-
-        if cu == "RIGHT" {
-            return EqNode::Empty;
-        }
-
-        // REL / BUILDREL
-        if cu == "REL" || cu == "BUILDREL" {
-            let is_buildrel = cu == "BUILDREL";
-            // 화살표 기호 읽기 (다음 요소를 파싱하여 화살표로 사용)
-            let arrow_node = self.parse_element();
-            let arrow = match &arrow_node {
-                EqNode::MathSymbol(s) => s.clone(),
-                EqNode::Symbol(s) => s.clone(),
-                EqNode::Text(s) => s.clone(),
-                _ => "→".to_string(),
-            };
-            // {위 내용}
-            let over = self.parse_single_or_group();
-            // {아래 내용} (REL만)
-            let under = if !is_buildrel {
-                Some(Box::new(self.parse_single_or_group()))
-            } else {
-                None
-            };
-            return EqNode::Rel {
-                arrow,
-                over: Box::new(over),
-                under,
-            };
-        }
-
-        // LONGDIV: LONGDIV {제수}{몫}{피제수#나머지...}
-        if cu == "LONGDIV" {
-            let divisor = self.parse_single_or_group();
-            let quotient = self.parse_single_or_group();
-            let body = self.parse_single_or_group();
-            // 간이 표현: 몫 위에 줄, 제수)피제수 형태
-            return EqNode::Row(vec![
-                quotient,
-                EqNode::Symbol("÷".to_string()),
-                divisor,
-                EqNode::Symbol("=".to_string()),
-                body,
-            ]);
-        }
-
-        // LADDER / SLADDER: 사다리꼴 레이아웃 → Matrix로 fallback
-        if cu == "LADDER" || cu == "SLADDER" {
-            return self.parse_matrix(MatrixStyle::Plain);
-        }
-
-        // BENZENE: 벤젠 분자 구조 → 텍스트 placeholder
-        if cu == "BENZENE" {
-            return EqNode::MathSymbol("⌬".to_string());
-        }
-
-        // BIGG: 크기 확대 (현재 크기 변경 무시, 내부 요소만 반환)
-        if cu == "BIGG" {
-            let inner = self.parse_element();
-            return inner;
-        }
-
-        // CHOOSE / BINOM
-        if cu == "CHOOSE" {
-            // n CHOOSE r → 이전 요소와 다음 요소를 조합으로
-            let body = self.parse_single_or_group();
-            return EqNode::Paren {
-                left: "(".to_string(),
-                right: ")".to_string(),
-                body: Box::new(EqNode::Atop {
-                    top: Box::new(EqNode::Empty), // 이전 요소는 상위에서 처리
-                    bottom: Box::new(body),
-                }),
-            };
-        }
-
-        if cu == "BINOM" {
-            let top = self.parse_single_or_group();
-            let bottom = self.parse_single_or_group();
-            return EqNode::Paren {
-                left: "(".to_string(),
-                right: ")".to_string(),
-                body: Box::new(EqNode::Atop {
-                    top: Box::new(top),
-                    bottom: Box::new(bottom),
-                }),
-            };
-        }
-
-        // 색상
-        if cu == "COLOR" {
-            return self.parse_color();
-        }
-
-        // 왼쪽 첨자
-        if cu == "LSUB" || cu == "LSUP" {
-            let script = self.parse_single_or_group();
-            let body = self.parse_single_or_group();
-            if cu == "LSUB" {
-                return EqNode::Subscript {
-                    base: Box::new(body),
-                    sub: Box::new(script),
-                };
-            } else {
-                return EqNode::Superscript {
-                    base: Box::new(body),
-                    sup: Box::new(script),
-                };
-            }
-        }
-
-        // SUP/SUB 동의어
-        if cu == "SUP" {
-            let body = self.parse_single_or_group();
-            return self.try_parse_scripts(body);
-        }
-        if cu == "SUB" {
-            let body = self.parse_single_or_group();
-            return self.try_parse_scripts(body);
-        }
-
-        // 글자 장식
         if let Some(&deco) = DECORATIONS
             .get(cmd)
             .or_else(|| DECORATIONS.get(cmd_lower.as_str()))
@@ -602,7 +482,6 @@ impl EqParser {
             };
         }
 
-        // 글꼴 스타일
         if let Some(&style) = FONT_STYLES
             .get(cmd)
             .or_else(|| FONT_STYLES.get(cmd_lower.as_str()))
@@ -628,7 +507,6 @@ impl EqParser {
             return self.try_parse_scripts(node);
         }
 
-        // 함수 (sin, cos, log 등)
         if is_function(cmd) {
             let func_name = lookup_function(cmd).unwrap_or(cmd).to_string();
             if self.current_type() == TokenType::Whitespace && self.current_value() == "`" {
@@ -638,7 +516,6 @@ impl EqParser {
             return self.try_parse_scripts(node);
         }
 
-        // 알 수 없는 명령어 → 텍스트로 처리
         let node = EqNode::Text(cmd.to_string());
         self.try_parse_scripts(node)
     }

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2635,7 +2635,7 @@
       "id": "src/renderer/equation/parser.rs::latex_compat_tests#1",
       "file": "src/renderer/equation/parser.rs",
       "sourcePath": "src/renderer/equation/parser.rs",
-      "line": 2199,
+      "line": 2076,
       "module": "latex_compat_tests",
       "testAttributes": 50,
       "tier": "white_box",
@@ -2648,7 +2648,7 @@
       "id": "src/renderer/equation/parser.rs::tests#1",
       "file": "src/renderer/equation/parser.rs",
       "sourcePath": "src/renderer/equation/parser.rs",
-      "line": 1774,
+      "line": 1651,
       "module": "tests",
       "testAttributes": 25,
       "tier": "white_box",
@@ -4027,28 +4027,28 @@
     {
       "id": "src/renderer/equation/parser.rs::cfg-fn#1",
       "file": "src/renderer/equation/parser.rs",
-      "line": 2145,
+      "line": 2022,
       "kind": "fn",
       "testAttributes": 1
     },
     {
       "id": "src/renderer/equation/parser.rs::cfg-fn#2",
       "file": "src/renderer/equation/parser.rs",
-      "line": 2162,
+      "line": 2039,
       "kind": "fn",
       "testAttributes": 1
     },
     {
       "id": "src/renderer/equation/parser.rs::cfg-fn#3",
       "file": "src/renderer/equation/parser.rs",
-      "line": 2177,
+      "line": 2054,
       "kind": "fn",
       "testAttributes": 1
     },
     {
       "id": "src/renderer/equation/parser.rs::cfg-fn#4",
       "file": "src/renderer/equation/parser.rs",
-      "line": 2187,
+      "line": 2064,
       "kind": "fn",
       "testAttributes": 1
     },


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

MEGA QUEUE M09-2 (◆10 수식 모듈 인수). 수식 명령 디스패치를 표준화하고 모듈 문서를 신설한다. 골든은 M09-1 [#5412](https://github.com/edwardkim/rhwp/pull/5412). **동작 변경 없이 구조만.**

- `src/renderer/equation/dispatch.rs` — `classify_command` 분류표. 적분은 `is_big_operator` 보다 앞, `lim`/`Lim` 은 그보다 뒤.
- `parser.rs` — `parse_command_inner` 가 가족 `match` 로 기존 핸들러를 호출. 장식·글꼴·기호·함수는 `parse_command_fallback`.
- 모듈 지도 [`src/renderer/equation/README.md`](src/renderer/equation/README.md)
- 매뉴얼 [`mydocs/manual/equation_module.md`](mydocs/manual/equation_module.md)

현행으로 잠근 것: `ROOT` 는 AST `Sqrt`, `VMATRIX` 는 행렬 가족이 아님, `BENZENE` 은 `try_parse_scripts` 를 타지 않음.

[#4056](https://github.com/edwardkim/rhwp/issues/4056) · [#4865](https://github.com/edwardkim/rhwp/issues/4865) 는 손대지 않았다. gym 없음.

## 관련 이슈

closes #5413

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (`parser.rs` `#[cfg(test)]` 줄 이동만)
- [x] `cargo test --lib renderer::equation` 통과 (148)
- [ ] `cargo clippy -- -D warnings` — 구조 리팩터, 동작 미변경
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (엔진 출력 동일)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [x] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (분류 한 번 + 기존 핸들러)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- 파서·레이아웃·SVG 출력 변경 없음
- M09-1 골든 파일 미포함·미갱신
- #4056 / #4865 수정 없음
- gym / `scripts/visual_sweep.py` 미수정
