### PR TITLE
fix(render): CanvasKit verticalText tab-leader/decoration 폴백 해제 (M07-3)

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -1108,6 +1108,35 @@ function runExecutableTextSpecialReplay() {
       positionsComplete: true,
     },
   }, 'screen');
+  renderer.renderOp(canvas, {
+    type: 'tabLeader',
+    bbox: { x: 10, y: 20, width: 40, height: 16 },
+    leaders: [{ startX: 4, endX: 30, fillType: 2 }],
+    color: '#000000',
+    fontSize: 16,
+    baseline: 12,
+    rotation: 0,
+    isVertical: true,
+    leadersComplete: true,
+  }, 'screen');
+  renderer.renderOp(canvas, {
+    type: 'textDecoration',
+    bbox: { x: 10, y: 20, width: 40, height: 16 },
+    decoration: {
+      kind: 'emphasisDot',
+      baseline: 12,
+      rotation: 0,
+      isVertical: true,
+      fontSize: 16,
+      ratio: 1,
+      color: '#000000',
+      shape: 0,
+      underline: 'none',
+      emphasisDot: 1,
+      positions: [0, 12],
+      positionsComplete: true,
+    },
+  }, 'screen');
   const beforeMirror = events.length;
   renderer.renderTextRun(canvas, {
     type: 'textRun',
@@ -2426,6 +2455,11 @@ for (const diagnostic of [
     `malformed text visuals should report ${diagnostic}`,
   );
 }
+assert.equal(
+  textSpecialReplay.unsupportedOps.has('textRun:verticalText'),
+  false,
+  'vertical tab-leader and decoration must not pin the document to a verticalText fallback',
+);
 
 const alternatingGlyphText = 'A'.repeat(4098);
 const alternatingGlyphReplay = runExecutableTextReplay({

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -2702,10 +2702,6 @@ export class CanvasKitLayerRenderer {
   }
 
   private renderTabLeader(canvas: SkCanvas, op: LayerTabLeaderOp): void {
-    if (op.isVertical) {
-      this.unsupportedOps.add('textRun:verticalText');
-      return;
-    }
     if (!Array.isArray(op.leaders)) {
       this.unsupportedOps.add('tabLeader:invalidGeometry');
       return;
@@ -2784,10 +2780,6 @@ export class CanvasKitLayerRenderer {
       || !Array.isArray(decoration.positions)
       || !['underline', 'strikethrough', 'emphasisDot'].includes(decoration.kind)) {
       this.unsupportedOps.add('textDecoration:invalidGeometry');
-      return;
-    }
-    if (decoration.isVertical) {
-      this.unsupportedOps.add('textRun:verticalText');
       return;
     }
     if (decoration.positionsComplete !== true

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -1530,8 +1530,6 @@ impl CanvasKitReplayPlanBuilder {
                     Some("visualItemLimitExceeded")
                 } else if !text_visual_geometry_is_valid(bbox, run, &display_text) {
                     Some("invalidGeometry")
-                } else if run.is_vertical {
-                    Some("verticalText")
                 } else if run.rotation.abs() > f64::EPSILON {
                     Some("rotatedText")
                 } else if run.style.tab_leaders.iter().any(|leader| {
@@ -1562,8 +1560,6 @@ impl CanvasKitReplayPlanBuilder {
                     Some("visualItemLimitExceeded")
                 } else if !text_visual_geometry_is_valid(bbox, run, &display_text) {
                     Some("invalidGeometry")
-                } else if run.is_vertical {
-                    Some("verticalText")
                 } else if run.rotation.abs() > f64::EPSILON {
                     Some("rotatedText")
                 } else if match kind {
@@ -2949,6 +2945,31 @@ mod tests {
                 .iter()
                 .all(|item| item.status == CanvasKitReplayStatus::Direct));
         }
+
+        // 세로 tab-leader/decoration 은 이미 위치 기반 벡터이므로 verticalText 로 폴백하지 않는다.
+        let mut vertical = text_run("AB");
+        vertical.is_vertical = true;
+        vertical
+            .style
+            .tab_leaders
+            .push(crate::renderer::TabLeaderInfo {
+                start_x: 4.0,
+                end_x: 20.0,
+                fill_type: 3,
+            });
+        vertical.style.underline = crate::model::style::UnderlineType::Bottom;
+        let vertical_tree = tree_with_ops(vec![
+            PaintOp::tab_leader(bbox(), vertical.clone()),
+            PaintOp::text_decoration(bbox(), vertical, TextDecorationKind::Underline),
+        ]);
+        let vertical_plan =
+            analyze_canvaskit_replay_plan(&vertical_tree, CanvasKitReplayMode::Default);
+        assert_eq!(vertical_plan.summary.direct_items, 2);
+        assert_eq!(vertical_plan.summary.direct_required_items, 0);
+        assert!(vertical_plan
+            .items
+            .iter()
+            .all(|item| { item.status == CanvasKitReplayStatus::Direct && item.detail.is_none() }));
     }
 
     #[test]

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2505,7 +2505,7 @@
       "id": "src/renderer/canvaskit_policy.rs::tests#1",
       "file": "src/renderer/canvaskit_policy.rs",
       "sourcePath": "src/renderer/canvaskit_policy.rs",
-      "line": 2266,
+      "line": 2262,
       "module": "tests",
       "testAttributes": 43,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M07-3 (◆10 CanvasKit 폴백 소거). verticalText 특수 op 중 tab-leader·decoration 만 CanvasKit 폴백에서 뺀다. 해당 op 는 이미 위치 기반 벡터 재생이 있으므로 `textRun:verticalText` 로 문서 revision 을 Canvas2D 에 고정하지 않는다.

- `src/renderer/canvaskit_policy.rs` 의 TabLeader/TextDecoration `verticalText` 차단을 제거한다.
- 런타임 `renderTabLeader`/`renderTextDecoration` 을 같은 계약으로 맞춘다.
- `charOverlap`·`textControlMark` 세로 폴백, 회전·그라데이션·화살표, boxed-PUA(#5408), showControlCodes(#5418) 는 그대로 둔다.
- CanvasKit 기본 렌더러 전환은 이 CLAIM 밖이다.

## 관련 이슈

closes #5419

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `node rhwp-studio/e2e/renderer-contract.test.mjs` 통과
- [ ] `cargo test --lib -- external_text_special_visuals_are_direct_replay_items malformed_vertical_and_rotated_text_special_visuals_stay_fail_closed` — 로컬 디스크 한도로 미실행. 정책 술어 자체는 기존 Direct 경로에 세로 tab-leader/decoration 만 추가
- [ ] `cargo clippy -- -D warnings` — 해당 범위 밖 (폴백 제거만)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 계약 시험(모의 replay)으로 대체
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음 (폴백 술어만)
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (폴백 판정만, 기본 렌더러 전환 아님)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- boxed-PUA + 장평/효과 폴백 유지 (M07-1 #5408)
- showControlCodes `[표]`/`[그림]` 폴백 유지 (M07-2 #5418)
- charOverlap·textControlMark 세로, 회전·그라데이션·화살표 폴백 유지
- CanvasKit 기본 렌더러 선언 (M07-14)
- gym 미수정
