### PR TITLE
fix(hwpx): synam-001 HWPX 왕복 쪽수 35 유지 (#3521)

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2258,7 +2258,14 @@ fn materialize_hwpx_table_attrs(table: &mut Table, table_record_flags: u32) {
     // table.attr bit0 for some inline-table decisions. Only mirror the minimum
     // renderer compatibility bit here; the HWP5 storage attr is packed later by
     // the HWP adapter.
-    table.attr = if table.common.treat_as_char && table.common.flow_with_text {
+    //
+    // 순수 HWPX 의 TAC 판정은 `treatAsChar && flowWithText` (#3930) 다. HWP5 원본은
+    // CTRL_HEADER bit0 = treatAsChar 만으로 TAC 이다. HWP5-origin HWPX 가 후자
+    // 계약을 잃으면 synam-001 문단 237 같은 flowWithText=0 TAC 표가 블록
+    // RowBreak 로 쪼개져 35→36 이 된다 (#3521).
+    table.attr = if table.common.treat_as_char
+        && (table.common.flow_with_text || HWPX_HWP5_ORIGIN_SOURCE.with(|c| c.get()))
+    {
         0x01
     } else {
         0

--- a/tests/cases/issue_3521_synam001_page_roundtrip.rs
+++ b/tests/cases/issue_3521_synam001_page_roundtrip.rs
@@ -1,0 +1,72 @@
+//! [#3521] synam-001 HWPX 내보내기 전후 쪽수가 같아야 한다.
+//!
+//! 35→36 은 문단 237 TAC 표(treatAsChar, flowWithText=0, wrap=Square)가
+//! HWPX 재파싱에서 `table.attr` bit0 을 잃어 블록 RowBreak 로 쪼개지기 때문이다.
+//! HWP5-origin HWPX 는 원본 HWP5 와 같이 treatAsChar 만으로 bit0 을 켠다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::wasm_api::HwpDocument;
+
+const SAMPLE: &str = "samples/synam-001.hwp";
+
+#[test]
+fn synam001_export_hwpx_preserves_page_count() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let data = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let src = HwpDocument::from_bytes(&data).expect("parse source");
+    let src_pages = src.page_count();
+    assert_eq!(src_pages, 35, "#3521 전제: synam-001 원본 35쪽");
+
+    let bytes = src.export_hwpx_native().expect("export hwpx");
+    assert!(
+        bytes.len() > 4 && &bytes[0..4] == b"PK\x03\x04",
+        "산출물이 ZIP(HWPX) 매직으로 시작해야 한다"
+    );
+
+    let rt_ir = rhwp::parse_document(&bytes).expect("parse exported ir");
+    assert!(
+        rt_ir
+            .hwpx_aux_entry(rhwp::model::document::HWP5_ORIGIN_HWPX_MARKER_PATH)
+            .is_some(),
+        "HWP5→HWPX 마커가 있어야 한다"
+    );
+
+    let src_ir = rhwp::parse_document(&data).expect("parse source ir");
+    let p237s = &src_ir.sections[0].paragraphs[237];
+    let p237r = &rt_ir.sections[0].paragraphs[237];
+    let src_table = p237s
+        .controls
+        .iter()
+        .find_map(|c| match c {
+            rhwp::model::control::Control::Table(t) => Some(t),
+            _ => None,
+        })
+        .expect("문단 237 표");
+    let rt_table = p237r
+        .controls
+        .iter()
+        .find_map(|c| match c {
+            rhwp::model::control::Control::Table(t) => Some(t),
+            _ => None,
+        })
+        .expect("왕복 문단 237 표");
+    assert!(src_table.common.treat_as_char, "샘플 전제: 문단 237 TAC");
+    assert!(
+        !src_table.common.flow_with_text,
+        "샘플 전제: 문단 237 flowWithText=0"
+    );
+    assert_eq!(
+        rt_table.attr & 0x01,
+        0x01,
+        "HWP5-origin HWPX 는 treatAsChar 표의 attr bit0 을 켜야 한다"
+    );
+
+    let round = HwpDocument::from_bytes(&bytes).expect("reparse exported hwpx");
+    assert_eq!(
+        src_pages,
+        round.page_count(),
+        "#3521: HWP5→HWPX 왕복 후 페이지 수가 달라졌다"
+    );
+}

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -13,11 +13,12 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-/// 쪽수 축만 실패하는 표본 — 35→36쪽.
+/// 쪽수 축만 실패하는 표본 — 151→152쪽.
 ///
-/// [#4677] `synam-001.hwp`의 이전 IR 차이는 책갈피 위치 보정으로 해소되었지만, 저장 HWPX의
-/// 쪽수 차이는 여전히 남아 있다.
-const PAGE_FAIL_SAMPLE: &str = "samples/synam-001.hwp";
+/// [#3521] `synam-001.hwp` 쪽수 왕복이 정상화되면 이 축의 실패 표본으로 쓰지 않는다
+/// (#3820·#4916 때 교체와 같은 관례). `hwp3-sample11.hwp`(#3737) 는 IR 차이 0,
+/// 쪽수만 어긋난다.
+const PAGE_FAIL_SAMPLE: &str = "samples/hwp3-sample11.hwp";
 /// IR 축만 실패하고 쪽수는 안정적인 표본 — 16쪽 유지, IR 차이 1건(선두
 /// char_shapes 경계 시프트 — 본 PR 의 말미 경계 수정(#3532)으로도 남는 별개 클래스).
 ///

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2349,7 +2349,7 @@
       "id": "src/parser/hwpx/section.rs::tests#1",
       "file": "src/parser/hwpx/section.rs",
       "sourcePath": "src/parser/hwpx/section.rs",
-      "line": 7203,
+      "line": 7210,
       "module": "tests",
       "testAttributes": 94,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

`samples/synam-001.hwp` 를 HWPX 로 내보낸 뒤 다시 읽으면 쪽수가 35→36 으로 늘어나던 [#3521](https://github.com/edwardkim/rhwp/issues/3521) 을 고칩니다. 새 편집 API 가 아니라 HWPX 재파싱의 TAC `table.attr` bit0 계약이 원본 HWP5 와 어긋난 것이 원인입니다.

원본 문단 237 표는 `treatAsChar=true`, `flowWithText=false`, wrap=Square, 선언 높이 994.4px 입니다. HWP5 는 CTRL_HEADER bit0 = treatAsChar 만으로 TAC 로 보고 한 쪽에 통째로 둡니다. HWPX 재파싱은 `treatAsChar && flowWithText` 일 때만 bit0 을 켜서 이 표가 블록 RowBreak 로 빠지고, 5행 표가 0..2 / 2..5 로 쪼개져 +1 쪽이 났습니다.

HWP5-origin 마커가 있는 HWPX 만 treatAsChar 로 bit0 을 켭니다. 순수 HWPX 의 TAC 판정은 계속 `treatAsChar && flowWithText` (#3930) 입니다.

## 관련 이슈

Closes [#5417](https://github.com/edwardkim/rhwp/issues/5417)
Closes [#3521](https://github.com/edwardkim/rhwp/issues/3521)

## 범위

- `materialize_hwpx_table_attrs`: HWP5-origin 이면 treatAsChar 만으로 `table.attr` bit0
- 회귀 시험 `tests/cases/issue_3521_synam001_page_roundtrip.rs`
- `#3915` 쪽수 실패 표본을 `hwp3-sample11.hwp`(#3737) 로 교체 (정상화된 문서를 실패 표본으로 두지 않음)

## 하지 않은 것

- 새 편집 API / gym
- [#3518](https://github.com/edwardkim/rhwp/issues/3518) hwp3-sample16 (PR #5416)
- [#3737](https://github.com/edwardkim/rhwp/issues/3737) [#4056](https://github.com/edwardkim/rhwp/issues/4056) [#4882](https://github.com/edwardkim/rhwp/issues/4882) [#5128](https://github.com/edwardkim/rhwp/issues/5128)

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (4225)
- [x] `cargo test --test regression_suite_015 synam001_export_hwpx` 통과 (35==35)
- [x] `cargo test --test regression_suite_012 issue_3915` 통과 (3)
- [ ] `cargo clippy -- -D warnings` — 디스크 여유 부족으로 전체 clippy 는 생략
- [x] 관련 샘플 파일로 쪽수 확인 — `export-hwpx --verify-pages` 35쪽
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음

## 1커맨드 스모크

```
cargo test --test regression_suite_015 synam001_export_hwpx
rhwp export-hwpx samples/synam-001.hwp /tmp/synam-001.hwpx --verify-pages
```

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (HWP5-origin HWPX 표 attr bit0 만 맞춤)
- 재현·측정: `samples/synam-001.hwp` 원본 35쪽, export-hwpx 재파싱 35쪽
