### PR TITLE
fix(render): CanvasKit rotatedText char-overlap 폴백 해제 (M07-4)

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -1065,6 +1065,18 @@ function runExecutableTextSpecialReplay() {
     charOverlap: { borderType: 1, innerCharSize: 80 },
   }, 'screen');
   renderer.renderOp(canvas, {
+    type: 'charOverlap',
+    bbox: { x: 50, y: 20, width: 16, height: 16 },
+    text: '①',
+    baseline: 12,
+    rotation: 15,
+    isVertical: false,
+    style: { fontSize: 16, color: '#112233' },
+    positions: [0, 16],
+    positionsComplete: true,
+    charOverlap: { borderType: 1, innerCharSize: 80 },
+  }, 'screen');
+  renderer.renderOp(canvas, {
     type: 'textControlMark',
     bbox: { x: 10, y: 20, width: 40, height: 16 },
     fieldMarker: 'none',
@@ -1321,18 +1333,6 @@ function runExecutableTextSpecialReplay() {
       positions: [0, 10],
       positionsComplete: true,
     },
-  }, 'screen');
-  renderer.renderOp(canvas, {
-    type: 'charOverlap',
-    bbox: { x: 0, y: 0, width: 10, height: 10 },
-    text: 'A',
-    baseline: 8,
-    rotation: 15,
-    isVertical: false,
-    style: { fontSize: 10 },
-    positions: [0, 10],
-    positionsComplete: true,
-    charOverlap: { borderType: 1, innerCharSize: 100 },
   }, 'screen');
   renderer.renderOp(canvas, {
     type: 'textControlMark',
@@ -2415,7 +2415,6 @@ for (const diagnostic of [
   'tabLeader:visualItemLimitExceeded',
   'textDecoration:invalidGeometry',
   'textDecoration:visualItemLimitExceeded',
-  'charOverlap:rotatedText',
   'textControlMark:rotatedText',
   'tabLeader:rotatedText',
   'textDecoration:rotatedText',
@@ -2426,6 +2425,16 @@ for (const diagnostic of [
     `malformed text visuals should report ${diagnostic}`,
   );
 }
+assert.equal(
+  textSpecialReplay.unsupportedOps.has('charOverlap:rotatedText'),
+  false,
+  'rotated char-overlap markers must not pin the document to a rotatedText fallback',
+);
+assert.equal(
+  textSpecialReplay.events.some(event => event.type === 'canvas.rotate' && event.rotation === 15),
+  true,
+  'rotated char-overlap markers should replay under the producer rotation',
+);
 
 const alternatingGlyphText = 'A'.repeat(4098);
 const alternatingGlyphReplay = runExecutableTextReplay({

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -2939,7 +2939,17 @@ export class CanvasKitLayerRenderer {
       return;
     }
     if (rotation !== 0) {
-      this.unsupportedOps.add(`${opType}:rotatedText`);
+      if (opType !== 'charOverlap') {
+        this.unsupportedOps.add(`${opType}:rotatedText`);
+        return;
+      }
+      canvas.save();
+      try {
+        canvas.rotate(rotation, bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
+        draw(bbox.x, bbox.y);
+      } finally {
+        canvas.restore();
+      }
       return;
     }
     draw(bbox.x, bbox.y);

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -1462,8 +1462,6 @@ impl CanvasKitReplayPlanBuilder {
                     Some("invalidGeometry")
                 } else if run.is_vertical {
                     Some("verticalText")
-                } else if run.rotation.abs() > f64::EPSILON {
-                    Some("rotatedText")
                 } else if run
                     .char_overlap
                     .as_ref()
@@ -2949,6 +2947,23 @@ mod tests {
                 .iter()
                 .all(|item| item.status == CanvasKitReplayStatus::Direct));
         }
+
+        // 회전 char-overlap 마커는 이미 위치 기반 벡터이므로 rotatedText 로 폴백하지 않는다.
+        let mut rotated = text_run("AB");
+        rotated.rotation = 15.0;
+        rotated.char_overlap = Some(CharOverlapInfo {
+            border_type: 1,
+            inner_char_size: 100,
+        });
+        let rotated_tree = tree_with_ops(vec![PaintOp::char_overlap(bbox(), rotated)]);
+        let rotated_plan =
+            analyze_canvaskit_replay_plan(&rotated_tree, CanvasKitReplayMode::Default);
+        assert_eq!(rotated_plan.summary.direct_items, 1);
+        assert_eq!(rotated_plan.summary.direct_required_items, 0);
+        assert!(rotated_plan
+            .items
+            .iter()
+            .all(|item| { item.status == CanvasKitReplayStatus::Direct && item.detail.is_none() }));
     }
 
     #[test]
@@ -2971,10 +2986,6 @@ mod tests {
         vertical_mark.is_vertical = true;
         let mut rotated = text_run("A");
         rotated.rotation = 15.0;
-        rotated.char_overlap = Some(CharOverlapInfo {
-            border_type: 1,
-            inner_char_size: 100,
-        });
         rotated
             .style
             .tab_leaders
@@ -2987,14 +2998,13 @@ mod tests {
             PaintOp::char_overlap(bbox(), invalid_overlap),
             PaintOp::tab_leader(bbox(), invalid_leader),
             PaintOp::text_control_mark(bbox(), vertical_mark),
-            PaintOp::char_overlap(bbox(), rotated.clone()),
             PaintOp::text_control_mark(bbox(), rotated.clone()),
             PaintOp::tab_leader(bbox(), rotated.clone()),
             PaintOp::text_decoration(bbox(), rotated, TextDecorationKind::Underline),
         ]);
 
         let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
-        assert_eq!(plan.summary.direct_required_items, 7);
+        assert_eq!(plan.summary.direct_required_items, 6);
         assert_eq!(plan.items[0].detail.as_deref(), Some("invalidCharOverlap"));
         assert_eq!(plan.items[1].detail.as_deref(), Some("invalidTabLeader"));
         assert_eq!(plan.items[2].detail.as_deref(), Some("verticalText"));

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2505,7 +2505,7 @@
       "id": "src/renderer/canvaskit_policy.rs::tests#1",
       "file": "src/renderer/canvaskit_policy.rs",
       "sourcePath": "src/renderer/canvaskit_policy.rs",
-      "line": 2266,
+      "line": 2264,
       "module": "tests",
       "testAttributes": 43,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M07-4 (◆10 CanvasKit 폴백 소거). rotatedText 특수 op 중 char-overlap 마커 replay 만 CanvasKit 폴백에서 뺀다. 해당 마커는 이미 위치 기반 벡터 재생이 있으므로 `charOverlap:rotatedText` 로 문서 revision 을 Canvas2D 에 고정하지 않는다.

- `src/renderer/canvaskit_policy.rs` 의 CharOverlap `rotatedText` 차단을 제거한다.
- 런타임 `renderCharOverlap` 을 같은 계약으로 맞춘다(회전은 bbox 중심으로 replay).
- `textControlMark`·`tabLeader`·`textDecoration` 회전 폴백, verticalText(#5426), showControlCodes, 그라데이션·화살표는 그대로 둔다.
- CanvasKit 기본 렌더러 전환은 이 CLAIM 밖이다.

## 관련 이슈

closes #5428

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `node rhwp-studio/e2e/renderer-contract.test.mjs` 통과
- [ ] `cargo test --lib -- external_text_special_visuals_are_direct_replay_items malformed_vertical_and_rotated_text_special_visuals_stay_fail_closed` — 로컬 디스크 한도로 미실행. 정책 술어 자체는 기존 Direct 경로에 회전 char-overlap 만 추가
- [ ] `cargo clippy -- -D warnings` — 해당 범위 밖 (폴백 제거만)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 계약 시험(모의 replay)으로 대체
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음 (폴백 술어만)
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (폴백 판정만, 기본 렌더러 전환 아님)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- verticalText tab-leader/decoration 폴백 (M07-3 #5426) — 이 CLAIM 에서 손대지 않음
- showControlCodes `[표]`/`[그림]` 폴백 유지 (M07-2 #5418)
- boxed-PUA + 장평/효과 폴백 유지 (M07-1 #5408)
- textControlMark·tabLeader·textDecoration 회전, 그라데이션·화살표 폴백 유지
- CanvasKit 기본 렌더러 선언 (M07-14)
- gym 미수정
