### PR TITLE
fix(render): CanvasKit gradientFill 폴백 해제 (M07-5)

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -15,6 +15,7 @@ const repoRoot = path.resolve(studioRoot, '..');
 const canvaskitPath = path.join(studioRoot, 'src/view/canvaskit-renderer.ts');
 const canvaskitDirectory = path.join(studioRoot, 'src/view/canvaskit');
 const canvaskitDiagnosticsPath = path.join(canvaskitDirectory, 'diagnostics.ts');
+const canvaskitPolicyPath = path.join(repoRoot, 'src/renderer/canvaskit_policy.rs');
 const layerTypesPath = path.join(studioRoot, 'src/core/types.ts');
 const textIrV2DocPath = path.join(repoRoot, 'docs/text-ir-v2.md');
 const canvaskitParityPlanDocPath = path.join(repoRoot, 'docs/canvaskit-parity-implementation.md');
@@ -42,6 +43,7 @@ const fullRendererSweepWorkflowPath = path.join(
 
 const canvaskitSource = fs.readFileSync(canvaskitPath, 'utf8');
 const canvaskitDiagnosticsSource = fs.readFileSync(canvaskitDiagnosticsPath, 'utf8');
+const canvaskitPolicySource = fs.readFileSync(canvaskitPolicyPath, 'utf8');
 const layerTypesSource = fs.readFileSync(layerTypesPath, 'utf8');
 const textIrV2DocSource = fs.readFileSync(textIrV2DocPath, 'utf8');
 const canvaskitParityPlanDocSource = fs.readFileSync(canvaskitParityPlanDocPath, 'utf8');
@@ -96,6 +98,12 @@ function extractMethodBody(source, methodName) {
   assert.notEqual(signatureIndex, -1, `missing method ${methodName}`);
 
   return extractBlockBody(source, signatureIndex, methodName);
+}
+
+function extractRustFnBody(source, fnName) {
+  const signatureIndex = source.indexOf(`fn ${fnName}(`);
+  assert.notEqual(signatureIndex, -1, `missing rust fn ${fnName}`);
+  return extractBlockBody(source, signatureIndex, fnName);
 }
 
 function extractSwitchCaseClusterBody(methodBody, caseLabel) {
@@ -630,6 +638,13 @@ for (const expectedUnsupportedToken of [
     `CanvasKit expected unsupported set should include ${expectedUnsupportedToken}`,
   );
 }
+assert.equal(
+  expectedUnsupportedSetBody.includes("'gradientFill'")
+    || expectedUnsupportedSetBody.includes("'pageBackground:gradientFill'")
+    || expectedUnsupportedSetBody.includes("'rectangle:gradientFill'"),
+  false,
+  'gradientFill must not stay on the expected-unsupported allowlist',
+);
 for (const directTextVisualToken of [
   'charOverlap',
   'tabLeader',
@@ -689,9 +704,17 @@ const renderRectangleBody = extractMethodBody(canvaskitSource, 'renderRectangle'
 const renderEllipseBody = extractMethodBody(canvaskitSource, 'renderEllipse');
 const renderEquationBody = extractMethodBody(canvaskitSource, 'renderEquation');
 const renderEquationBoxBody = extractMethodBody(canvaskitSource, 'renderEquationBox');
+const renderPageBackgroundBody = extractMethodBody(canvaskitSource, 'renderPageBackground');
 const renderPathBody = extractMethodBody(canvaskitSource, 'renderPath');
 const renderLineBody = extractMethodBody(canvaskitSource, 'renderLine');
 const drawStrokeWithDashBody = extractMethodBody(canvaskitSource, 'drawStrokeWithDash');
+const drawStyledShapeBody = extractMethodBody(canvaskitSource, 'drawStyledShape');
+const drawStyledPathBody = extractMethodBody(canvaskitSource, 'drawStyledPath');
+const makeShapeGradientShaderBody = extractMethodBody(canvaskitSource, 'makeShapeGradientShader');
+const pageBackgroundItemBody = extractRustFnBody(canvaskitPolicySource, 'page_background_item');
+const rectangleTransitionDetailBody = extractRustFnBody(canvaskitPolicySource, 'rectangle_transition_detail');
+const ellipseTransitionDetailBody = extractRustFnBody(canvaskitPolicySource, 'ellipse_transition_detail');
+const pathTransitionDetailBody = extractRustFnBody(canvaskitPolicySource, 'path_transition_detail');
 const renderFormObjectBody = extractMethodBody(canvaskitSource, 'renderFormObject');
 const renderPlaceholderBody = extractMethodBody(canvaskitSource, 'renderPlaceholder');
 const renderTextRunBody = extractMethodBody(canvaskitSource, 'renderTextRun');
@@ -974,6 +997,105 @@ function runExecutableStrokeDashReplay() {
   });
 
   return { events, renderer, drawCountBeforeInvalid };
+}
+
+function runExecutableGradientFillReplay() {
+  const events = [];
+  class FakePaint {
+    setAntiAlias() {}
+    setStyle() {}
+    setColor(color) { this.color = color; }
+    setShader(shader) {
+      this.shader = shader;
+      events.push({ type: 'paint.setShader' });
+    }
+    delete() { events.push({ type: 'paint.delete' }); }
+  }
+  class FakePath {
+    moveTo() {}
+    lineTo() {}
+    delete() { events.push({ type: 'path.delete' }); }
+  }
+  const renderer = new CanvasKitLayerRendererRuntime({
+    Paint: FakePaint,
+    Path: FakePath,
+    PaintStyle: { Fill: 0, Stroke: 1 },
+    TileMode: { Clamp: 0 },
+    Shader: {
+      MakeLinearGradient(start, end, colors, positions) {
+        events.push({
+          type: 'shader.linear',
+          start: [...start],
+          end: [...end],
+          colors,
+          positions,
+        });
+        return { delete() { events.push({ type: 'shader.delete' }); } };
+      },
+      MakeRadialGradient(center, radius, colors, positions) {
+        events.push({
+          type: 'shader.radial',
+          center: [...center],
+          radius,
+          colors,
+          positions,
+        });
+        return { delete() { events.push({ type: 'shader.delete' }); } };
+      },
+    },
+    Color: (r, g, b, a) => [r, g, b, a],
+    XYWHRect: (x, y, width, height) => ({ x, y, width, height }),
+    RRectXY: (rect, rx, ry) => ({ ...rect, rx, ry }),
+  }, 'default', {}, {});
+  const canvas = {
+    drawRect(_rect, paint) {
+      events.push({ type: 'canvas.drawRect', shader: Boolean(paint.shader) });
+    },
+    drawOval(_rect, paint) {
+      events.push({ type: 'canvas.drawOval', shader: Boolean(paint.shader) });
+    },
+    drawPath(_path, paint) {
+      events.push({ type: 'canvas.drawPath', shader: Boolean(paint.shader) });
+    },
+  };
+  renderer.unsupportedOps = new Set();
+  const linear = {
+    gradientType: 1,
+    angle: 0,
+    colors: ['#000000', '#ffffff'],
+    positions: [0, 1],
+  };
+  const radial = {
+    gradientType: 2,
+    centerX: 50,
+    centerY: 50,
+    colors: ['#ff0000', '#0000ff'],
+    positions: [0, 1],
+  };
+  renderer.renderPageBackground(canvas, {
+    type: 'pageBackground',
+    bbox: { x: 0, y: 0, width: 10, height: 20 },
+    gradient: linear,
+  });
+  renderer.renderRectangle(canvas, {
+    type: 'rectangle',
+    bbox: { x: 0, y: 0, width: 10, height: 10 },
+    style: { fillColor: '#123456' },
+    gradient: linear,
+  });
+  renderer.renderEllipse(canvas, {
+    type: 'ellipse',
+    bbox: { x: 0, y: 0, width: 10, height: 10 },
+    gradient: radial,
+  });
+  renderer.renderPath(canvas, {
+    type: 'path',
+    bbox: { x: 0, y: 0, width: 10, height: 10 },
+    commands: [{ type: 'moveTo', x: 0, y: 0 }, { type: 'lineTo', x: 10, y: 10 }],
+    style: { fillColor: null, strokeWidth: 0 },
+    gradient: linear,
+  });
+  return { events, renderer };
 }
 
 function runExecutableTextSpecialReplay() {
@@ -1713,6 +1835,47 @@ assert.equal(
   'unknown dash styles must fail closed before drawing',
 );
 assert.ok(strokeDashReplay.renderer.unsupportedOps.has('strokeDash:zigzag'));
+const gradientFillReplay = runExecutableGradientFillReplay();
+assert.equal(
+  [...gradientFillReplay.renderer.unsupportedOps].some((op) => op.includes('gradientFill')),
+  false,
+  'gradientFill must not pin the document to a Canvas2D fallback',
+);
+assert.deepEqual(
+  gradientFillReplay.events.filter((event) => event.type === 'shader.linear').map((event) => event.start),
+  [[0, 0], [0, 0], [0, 0]],
+  'linear gradientFill replay should keep the producer angle-0 start',
+);
+assert.deepEqual(
+  gradientFillReplay.events.filter((event) => event.type === 'shader.linear').map((event) => event.end),
+  [[0, 20], [0, 10], [0, 10]],
+  'linear gradientFill replay should keep the producer angle-0 end',
+);
+assert.equal(
+  gradientFillReplay.events.filter((event) => event.type === 'shader.radial').length,
+  1,
+  'radial gradientFill replay should use a CanvasKit radial shader',
+);
+assert.equal(
+  gradientFillReplay.events.filter((event) => event.type === 'shader.delete').length,
+  gradientFillReplay.events.filter((event) => event.type === 'shader.linear' || event.type === 'shader.radial').length,
+  'each CanvasKit gradient shader should be released after drawing',
+);
+assert.equal(
+  gradientFillReplay.events.filter((event) => event.type === 'canvas.drawRect' && event.shader).length,
+  2,
+  'page background and rectangle gradientFill should draw with a shader',
+);
+assert.equal(
+  gradientFillReplay.events.some((event) => event.type === 'canvas.drawOval' && event.shader),
+  true,
+  'ellipse gradientFill should draw with a shader',
+);
+assert.equal(
+  gradientFillReplay.events.some((event) => event.type === 'canvas.drawPath' && event.shader),
+  true,
+  'path gradientFill should draw with a shader',
+);
 runExecutableEquationFallback();
 
 requireSnippet(
@@ -1726,10 +1889,42 @@ requireSnippet(
   'equation layout replay should bound recursion and reject non-finite geometry',
 );
 
+for (const [label, body] of [
+  ['pageBackground', pageBackgroundItemBody],
+  ['rectangle', rectangleTransitionDetailBody],
+  ['ellipse', ellipseTransitionDetailBody],
+  ['path', pathTransitionDetailBody],
+]) {
+  assert.doesNotMatch(
+    body,
+    /gradientFill/,
+    `${label} must not pin the document to a gradientFill fallback`,
+  );
+}
+requireSnippet(
+  renderPageBackgroundBody,
+  /this\.makeShapeGradientShader\(op\.gradient, op\.bbox\)[\s\S]*?setShader[\s\S]*?canvas\.drawRect/,
+  'page background gradientFill should replay through a CanvasKit shader',
+);
 requireSnippet(
   renderRectangleBody,
-  /this\.drawStyledShape\(canvas, op\.bbox, op\.style,[\s\S]*?drawRRect[\s\S]*?drawRect/,
+  /this\.drawStyledShape\(canvas, op\.bbox, op\.style,[\s\S]*?drawRRect[\s\S]*?drawRect[\s\S]*?op\.gradient/,
   'rectangle replay should stay on drawStyledShape and handle rounded and plain rectangles',
+);
+requireSnippet(
+  drawStyledShapeBody,
+  /this\.makeShapeGradientShader\(gradient, bounds\)[\s\S]*?setShader/,
+  'shape gradientFill should apply a CanvasKit shader before the solid fill fallback',
+);
+requireSnippet(
+  drawStyledPathBody,
+  /this\.makeShapeGradientShader\(gradient, bounds\)[\s\S]*?setShader/,
+  'path gradientFill should apply a CanvasKit shader before the solid fill fallback',
+);
+requireSnippet(
+  makeShapeGradientShaderBody,
+  /gradientType >= 2 && gradientType <= 4[\s\S]*?MakeRadialGradient[\s\S]*?MakeLinearGradient/,
+  'shape gradientFill should keep the Canvas2D linear/radial type split',
 );
 requireSnippet(
   renderEllipseBody,

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -1093,6 +1093,7 @@ export interface LayerPageBackgroundOp {
   backgroundColor?: string;
   borderColor?: string;
   borderWidth?: number;
+  gradient?: LayerGradientFill;
 }
 
 export interface LayerTextStyle {
@@ -1204,6 +1205,16 @@ export interface LayerShapeStyle {
   opacity?: number;
 }
 
+/** HWP 도형/페이지 배경 그라데이션. paint JSON `gradient` 필드와 동일. */
+export interface LayerGradientFill {
+  gradientType?: number;
+  angle?: number;
+  centerX?: number;
+  centerY?: number;
+  colors?: string[];
+  positions?: number[];
+}
+
 export interface LayerLineOp {
   type: 'line';
   bbox: LayerBounds;
@@ -1219,12 +1230,14 @@ export interface LayerRectangleOp {
   bbox: LayerBounds;
   cornerRadius?: number;
   style?: LayerShapeStyle;
+  gradient?: LayerGradientFill;
 }
 
 export interface LayerEllipseOp {
   type: 'ellipse';
   bbox: LayerBounds;
   style?: LayerShapeStyle;
+  gradient?: LayerGradientFill;
 }
 
 export type LayerPathCommand =
@@ -1256,6 +1269,7 @@ export interface LayerPathOp {
   style?: LayerShapeStyle;
   lineStyle?: LayerLineStyle;
   transform?: LayerPathTransform;
+  gradient?: LayerGradientFill;
 }
 
 export interface LayerImageOp {

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -23,6 +23,7 @@ import type {
   LayerEquationLayoutBox,
   LayerEquationOp,
   LayerFormObjectOp,
+  LayerGradientFill,
   LayerAffineTransform,
   LayerGlyphOutlineOp,
   LayerGlyphRunOp,
@@ -1314,6 +1315,17 @@ export class CanvasKitLayerRenderer {
       canvas.drawRect(this.rect(op.bbox), paint);
       paint.delete?.();
     }
+    const gradientShader = this.makeShapeGradientShader(op.gradient, op.bbox);
+    if (gradientShader) {
+      const paint = this.makeFillPaint('#000000');
+      try {
+        (paint as unknown as { setShader: (shader: unknown) => void }).setShader(gradientShader);
+        canvas.drawRect(this.rect(op.bbox), paint);
+      } finally {
+        (gradientShader as { delete?: () => void }).delete?.();
+        paint.delete?.();
+      }
+    }
     if (op.borderColor && (op.borderWidth ?? 0) > 0) {
       const paint = this.makeStrokePaint(op.borderColor, op.borderWidth ?? 1);
       canvas.drawRect(this.rect(op.bbox), paint);
@@ -1329,13 +1341,13 @@ export class CanvasKitLayerRenderer {
       } else {
         canvas.drawRect(this.rect(op.bbox), paint);
       }
-    });
+    }, op.gradient);
   }
 
   private renderEllipse(canvas: SkCanvas, op: LayerEllipseOp): void {
     this.drawStyledShape(canvas, op.bbox, op.style, (paint) => {
       canvas.drawOval(this.rect(op.bbox), paint);
-    });
+    }, op.gradient);
   }
 
   private renderLine(canvas: SkCanvas, op: LayerLineOp): void {
@@ -1390,7 +1402,7 @@ export class CanvasKitLayerRenderer {
         canvas.rotate(rotation, cx, cy);
       }
     }
-    this.drawStyledPath(canvas, path, replayStyle);
+    this.drawStyledPath(canvas, path, replayStyle, op.bbox, op.gradient);
     if (needsTransform) {
       canvas.restore();
     }
@@ -3605,8 +3617,19 @@ export class CanvasKitLayerRenderer {
     bounds: LayerBounds,
     style: LayerShapeStyle | undefined,
     draw: (paint: SkPaint) => void,
+    gradient?: LayerGradientFill,
   ): void {
-    if (style?.fillColor) {
+    const fillShader = this.makeShapeGradientShader(gradient, bounds);
+    if (fillShader) {
+      const paint = this.makeFillPaint(style?.fillColor ?? '#000000', style?.opacity);
+      try {
+        (paint as unknown as { setShader: (shader: unknown) => void }).setShader(fillShader);
+        draw(paint);
+      } finally {
+        (fillShader as { delete?: () => void }).delete?.();
+        paint.delete?.();
+      }
+    } else if (style?.fillColor) {
       const paint = this.makeFillPaint(style.fillColor, style.opacity);
       draw(paint);
       paint.delete?.();
@@ -3619,16 +3642,33 @@ export class CanvasKitLayerRenderer {
         paint.delete?.();
       }
     }
-    if (!style?.fillColor && !style?.strokeColor) {
+    if (!fillShader && !style?.fillColor && !style?.strokeColor) {
       const paint = this.makeStrokePaint('#000000', 1);
       draw(paint);
       paint.delete?.();
     }
   }
 
-  private drawStyledPath(canvas: SkCanvas, path: Path, style: LayerShapeStyle): void {
+  private drawStyledPath(
+    canvas: SkCanvas,
+    path: Path,
+    style: LayerShapeStyle,
+    bounds?: LayerBounds,
+    gradient?: LayerGradientFill,
+  ): void {
     let drawn = false;
-    if (style.fillColor) {
+    const fillShader = bounds ? this.makeShapeGradientShader(gradient, bounds) : null;
+    if (fillShader) {
+      const paint = this.makeFillPaint(style.fillColor ?? '#000000', style.opacity);
+      try {
+        (paint as unknown as { setShader: (shader: unknown) => void }).setShader(fillShader);
+        canvas.drawPath(path, paint);
+      } finally {
+        (fillShader as { delete?: () => void }).delete?.();
+        paint.delete?.();
+      }
+      drawn = true;
+    } else if (style.fillColor) {
       const paint = this.makeFillPaint(style.fillColor, style.opacity);
       canvas.drawPath(path, paint);
       paint.delete?.();
@@ -3648,6 +3688,52 @@ export class CanvasKitLayerRenderer {
       canvas.drawPath(path, paint);
       paint.delete?.();
     }
+  }
+
+  private makeShapeGradientShader(
+    gradient: LayerGradientFill | undefined,
+    bounds: LayerBounds,
+  ): unknown | null {
+    const colors = gradient?.colors;
+    if (!gradient || !Array.isArray(colors) || colors.length < 2) {
+      return null;
+    }
+    const lastIndex = Math.max(1, colors.length - 1);
+    const shaderColors = colors.map((css) => {
+      const { r, g, b, a } = parseCssColor(css);
+      return [r / 255, g / 255, b / 255, a];
+    });
+    const positions = colors.map((_, index) => {
+      const raw = index < (gradient.positions?.length ?? 0)
+        ? gradient.positions?.[index]
+        : index / lastIndex;
+      return Math.max(0, Math.min(1, Number.isFinite(raw) ? (raw as number) : index / lastIndex));
+    });
+    const shaderApi = this.canvasKit.Shader as unknown as {
+      MakeLinearGradient?: (...args: unknown[]) => unknown;
+      MakeRadialGradient?: (...args: unknown[]) => unknown;
+    };
+    const gradientType = gradient.gradientType ?? 1;
+    if (gradientType >= 2 && gradientType <= 4) {
+      const cx = bounds.x + bounds.width * ((gradient.centerX ?? 50) / 100);
+      const cy = bounds.y + bounds.height * ((gradient.centerY ?? 50) / 100);
+      const radius = Math.max(bounds.width, bounds.height) / 2;
+      return shaderApi.MakeRadialGradient?.(
+        [cx, cy],
+        radius,
+        shaderColors,
+        positions,
+        this.canvasKit.TileMode.Clamp,
+      ) ?? null;
+    }
+    const [x0, y0, x1, y1] = shapeGradientLinearCoords(gradient.angle ?? 0, bounds);
+    return shaderApi.MakeLinearGradient?.(
+      [x0, y0],
+      [x1, y1],
+      shaderColors,
+      positions,
+      this.canvasKit.TileMode.Clamp,
+    ) ?? null;
   }
 
   private drawStrokeWithDash(
@@ -3895,6 +3981,43 @@ function parseCssColor(value: string): { r: number; g: number; b: number; a: num
 
 function clampUnit(value: number | undefined): number {
   return Math.max(0, Math.min(1, Number.isFinite(value) ? value ?? 0 : 0));
+}
+
+function shapeGradientLinearCoords(
+  angle: number,
+  bounds: LayerBounds,
+): [number, number, number, number] {
+  const { x, y, width: w, height: h } = bounds;
+  const normalized = ((angle % 360) + 360) % 360;
+  switch (normalized) {
+    case 0:
+      return [x, y, x, y + h];
+    case 45:
+      return [x, y, x + w, y + h];
+    case 90:
+      return [x, y, x + w, y];
+    case 135:
+      return [x, y + h, x + w, y];
+    case 180:
+      return [x, y + h, x, y];
+    case 225:
+      return [x + w, y + h, x, y];
+    case 270:
+      return [x + w, y, x, y];
+    case 315:
+      return [x + w, y, x, y + h];
+    default: {
+      const rad = (normalized * Math.PI) / 180;
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+      return [
+        cx - Math.sin(rad) * w / 2,
+        cy - Math.cos(rad) * h / 2,
+        cx + Math.sin(rad) * w / 2,
+        cy + Math.cos(rad) * h / 2,
+      ];
+    }
+  }
 }
 
 function gradientColors(stops: Array<{ color?: { rgba?: number[] } }> | undefined): number[][] {

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -1623,14 +1623,6 @@ impl CanvasKitReplayPlanBuilder {
             );
             item.detail = Some("imageFill".to_string());
             item
-        } else if background.gradient.is_some() {
-            let mut item = self.transition_overlay_item(
-                path,
-                "pageBackground",
-                CanvasKitReplayFeature::PageBackground,
-            );
-            item.detail = Some("gradientFill".to_string());
-            item
         } else {
             direct_item(
                 path,
@@ -1992,9 +1984,6 @@ fn line_transition_detail(line: &LineNode) -> Option<&'static str> {
 }
 
 fn rectangle_transition_detail(rect: &RectangleNode) -> Option<&'static str> {
-    if rect.gradient.is_some() {
-        return Some("gradientFill");
-    }
     if rect.transform.has_transform() {
         return Some("shapeTransform");
     }
@@ -2002,9 +1991,6 @@ fn rectangle_transition_detail(rect: &RectangleNode) -> Option<&'static str> {
 }
 
 fn ellipse_transition_detail(ellipse: &EllipseNode) -> Option<&'static str> {
-    if ellipse.gradient.is_some() {
-        return Some("gradientFill");
-    }
     if ellipse.transform.has_transform() {
         return Some("shapeTransform");
     }
@@ -2012,9 +1998,6 @@ fn ellipse_transition_detail(ellipse: &EllipseNode) -> Option<&'static str> {
 }
 
 fn path_transition_detail(path: &PathNode) -> Option<&'static str> {
-    if path.gradient.is_some() {
-        return Some("gradientFill");
-    }
     if let Some(detail) = shape_style_transition_detail(&path.style) {
         return Some(detail);
     }
@@ -2272,8 +2255,9 @@ mod tests {
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
     use crate::renderer::render_tree::{
-        BoundingBox, EquationNode, FieldMarkerType, FootnoteMarkerNode, FormObjectNode, ImageNode,
-        PageBackgroundImage, PathNode, PlaceholderNode, RawSvgNode, RectangleNode, RenderLayerInfo,
+        BoundingBox, EllipseNode, EquationNode, FieldMarkerType, FootnoteMarkerNode,
+        FormObjectNode, ImageNode, PageBackgroundImage, PathNode, PlaceholderNode, RawSvgNode,
+        RectangleNode, RenderLayerInfo,
     };
     use crate::renderer::{GradientFillInfo, PathCommand, ShapeStyle, TextStyle};
     use image::ImageFormat;
@@ -2779,7 +2763,8 @@ mod tests {
         ]);
 
         let default_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
-        assert_eq!(default_plan.summary.direct_required_items, 2);
+        assert_eq!(default_plan.summary.direct_items, 1);
+        assert_eq!(default_plan.summary.direct_required_items, 1);
         assert_eq!(
             default_plan.items[0].feature,
             CanvasKitReplayFeature::RasterImage
@@ -2789,16 +2774,78 @@ mod tests {
             default_plan.items[1].feature,
             CanvasKitReplayFeature::PageBackground
         );
-        assert_eq!(
-            default_plan.items[1].detail.as_deref(),
-            Some("gradientFill")
-        );
+        assert_eq!(default_plan.items[1].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(default_plan.items[1].detail, None);
 
         let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
         assert!(!compat_plan.hidden_canvas2d_overlay_allowed);
         assert!(compat_plan.direct_replay_required);
-        assert_eq!(compat_plan.summary.direct_required_items, 2);
+        assert_eq!(compat_plan.summary.direct_required_items, 1);
         assert_eq!(compat_plan.summary.compat_overlay_items, 0);
+
+        // gradientFill 은 4지점 모두 직접 재생한다. 그림자 폴백은 그대로 둔다.
+        let gradient = || {
+            Box::new(GradientFillInfo {
+                gradient_type: 1,
+                angle: 0,
+                center_x: 50,
+                center_y: 50,
+                colors: vec![0x0000_0000, 0x00FF_FFFF],
+                positions: vec![0.0, 1.0],
+            })
+        };
+        let gradient_tree = tree_with_ops(vec![
+            PaintOp::page_background(bbox(), page_background(None, Some(gradient()))),
+            PaintOp::rectangle(
+                bbox(),
+                RectangleNode::new(0.0, ShapeStyle::default(), Some(gradient())),
+            ),
+            PaintOp::ellipse(
+                bbox(),
+                EllipseNode::new(ShapeStyle::default(), Some(gradient())),
+            ),
+            PaintOp::path(
+                bbox(),
+                PathNode::new(
+                    vec![
+                        PathCommand::MoveTo(0.0, 0.0),
+                        PathCommand::LineTo(20.0, 20.0),
+                    ],
+                    ShapeStyle::default(),
+                    Some(gradient()),
+                ),
+            ),
+        ]);
+        let gradient_plan =
+            analyze_canvaskit_replay_plan(&gradient_tree, CanvasKitReplayMode::Default);
+        assert_eq!(gradient_plan.summary.direct_items, 4);
+        assert_eq!(gradient_plan.summary.direct_required_items, 0);
+        assert!(gradient_plan
+            .items
+            .iter()
+            .all(|item| { item.status == CanvasKitReplayStatus::Direct && item.detail.is_none() }));
+
+        let shadowed = ShapeStyle {
+            shadow: Some(crate::renderer::ShadowStyle {
+                shadow_type: 1,
+                color: 0x0000_0000,
+                offset_x: 1.0,
+                offset_y: 1.0,
+                alpha: 0,
+            }),
+            ..Default::default()
+        };
+        let shadowed_tree = tree_with_ops(vec![PaintOp::rectangle(
+            bbox(),
+            RectangleNode::new(0.0, shadowed, Some(gradient())),
+        )]);
+        let shadowed_plan =
+            analyze_canvaskit_replay_plan(&shadowed_tree, CanvasKitReplayMode::Default);
+        assert_eq!(shadowed_plan.summary.direct_required_items, 1);
+        assert_eq!(
+            shadowed_plan.items[0].detail.as_deref(),
+            Some("shapeShadow")
+        );
     }
 
     #[test]

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -2505,7 +2505,7 @@
       "id": "src/renderer/canvaskit_policy.rs::tests#1",
       "file": "src/renderer/canvaskit_policy.rs",
       "sourcePath": "src/renderer/canvaskit_policy.rs",
-      "line": 2266,
+      "line": 2249,
       "module": "tests",
       "testAttributes": 43,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M07-5 (◆10 CanvasKit 폴백 소거). gradientFill 4지점만 CanvasKit 폴백에서 뺀다. 해당 채우기는 이미 paint JSON 으로 전달되고 CanvasKit 셰이더 재생이 있으므로 `gradientFill` 로 문서 revision 을 Canvas2D 에 고정하지 않는다.

- `src/renderer/canvaskit_policy.rs` 의 pageBackground·rectangle·ellipse·path `gradientFill` 차단을 제거한다.
- 런타임 `renderPageBackground`/`drawStyledShape`/`drawStyledPath` 를 같은 계약으로 맞춘다.
- rotatedText(#5436), 화살표, 복합선, 그림자 폴백은 그대로 둔다.
- CanvasKit 기본 렌더러 전환은 이 CLAIM 밖이다.

## 관련 이슈

closes #5437

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `node rhwp-studio/e2e/renderer-contract.test.mjs` 통과
- [ ] `cargo test --lib -- page_background_image_and_gradient_are_policy_visible` — 로컬 디스크 한도로 미실행. 정책 술어 자체는 기존 Direct 경로에 그라데이션 4지점만 추가
- [ ] `cargo clippy -- -D warnings` — 해당 범위 밖 (폴백 제거만)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 계약 시험(모의 replay)으로 대체
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음 (폴백 술어 + 셰이더 재생)
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (폴백 판정만, 기본 렌더러 전환 아님)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- rotatedText 폴백 (M07-4 #5436) — 이 CLAIM 에서 손대지 않음
- 화살표·복합선·그림자 폴백 유지
- showControlCodes `[표]`/`[그림]` 폴백 유지 (M07-2)
- boxed-PUA + 장평/효과 폴백 유지 (M07-1)
- CanvasKit 기본 렌더러 선언 (M07-14)
- gym 미수정
