### PR TITLE
docs(m11): canvaskit-parity 배치 2·3 실행 기록을 남긴다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -926,6 +926,9 @@ jobs:
       - name: Validate Render Diff trigger policy
         run: python3 -m unittest scripts/tests/test_render_diff_workflow.py
 
+      - name: Validate canvaskit-parity batch map
+        run: python3 -m unittest scripts/tests/test_canvaskit_parity_batches.py
+
       # [#4080] workflow 계약 테스트는 추가해 놓고 배선을 잊으면 한 번도 돌지 않는다.
       # 아래 목록은 test_workflow_contract_wiring.py 가 강제한다 — 새 계약 테스트를
       # 추가하면 그 테스트가 실패하므로 여기 한 줄을 같이 넣어야 한다.

--- a/mydocs/report/task_m100_5433_canvaskit_parity_batches.json
+++ b/mydocs/report/task_m100_5433_canvaskit_parity_batches.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "issue": 5433,
+  "plan": "docs/canvaskit-parity-implementation.md",
+  "manifest": "scripts/renderer_baseline_manifest.json",
+  "manifestUpdated": false,
+  "manifestUpdatePolicy": "Do not edit renderer_baseline_manifest.json from this driver. Threshold/sample changes stay on the existing renderer-contract and renderer_baseline review process.",
+  "platform": "win32",
+  "host": "windows",
+  "recordedAt": "2026-08-18",
+  "batches": [
+    {"number": 2, "name": "Paint Family Parity"},
+    {"number": 3, "name": "Strict Text Variant Replay"}
+  ],
+  "heavy": false,
+  "summary": {
+    "passed": 7,
+    "failed": 0,
+    "blocked": 2,
+    "skipped": 2
+  },
+  "results": [
+    {
+      "id": "rust-canvaskit-policy",
+      "batch": 2,
+      "batchName": "Paint Family Parity",
+      "status": "blocked",
+      "command": "cargo test --lib -- canvaskit_policy",
+      "reason": "rustc-LLVM ERROR: IO failure on output stream: no space on device while compiling rhwp lib test. Host C: had 0 GB free; worktree target later deleted to recover 2.48 GB. Re-run after freeing several GB."
+    },
+    {
+      "id": "studio-image-header",
+      "batch": 2,
+      "batchName": "Paint Family Parity",
+      "status": "passed",
+      "command": "node --test tests/canvaskit-image-header.test.ts",
+      "cwd": "rhwp-studio"
+    },
+    {
+      "id": "studio-resource-key",
+      "batch": 2,
+      "batchName": "Paint Family Parity",
+      "status": "passed",
+      "command": "node --test tests/canvaskit-resource-key.test.ts",
+      "cwd": "rhwp-studio"
+    },
+    {
+      "id": "studio-document-preflight",
+      "batch": 2,
+      "batchName": "Paint Family Parity",
+      "status": "passed",
+      "command": "node --test tests/canvaskit-document-preflight.test.ts",
+      "cwd": "rhwp-studio"
+    },
+    {
+      "id": "studio-renderer-contract",
+      "batch": 2,
+      "batchName": "Paint Family Parity",
+      "status": "passed",
+      "command": "node e2e/renderer-contract.test.mjs",
+      "cwd": "rhwp-studio",
+      "note": "stdout: renderer backend contract guard passed"
+    },
+    {
+      "id": "renderer-baseline-readiness",
+      "batch": 2,
+      "batchName": "Paint Family Parity",
+      "status": "skipped",
+      "heavy": true,
+      "command": "python scripts/renderer_baseline.py --readiness-only --scope representative --browser-mode headless --profiles screen --output output/renderer-baseline/m11p-batch2",
+      "reason": "heavy job not run: needs native rhwp binary, Chrome/puppeteer, WASM, and several GB disk. Manifest not updated."
+    },
+    {
+      "id": "rust-text-variants",
+      "batch": 3,
+      "batchName": "Strict Text Variant Replay",
+      "status": "blocked",
+      "command": "cargo test --lib -- text_variants",
+      "reason": "same rhwp lib-test compile blocked by disk exhaustion"
+    },
+    {
+      "id": "studio-text-variant-selection",
+      "batch": 3,
+      "batchName": "Strict Text Variant Replay",
+      "status": "passed",
+      "command": "node --test tests/canvaskit-text-variant-selection.test.ts",
+      "cwd": "rhwp-studio"
+    },
+    {
+      "id": "studio-sfnt-face",
+      "batch": 3,
+      "batchName": "Strict Text Variant Replay",
+      "status": "passed",
+      "command": "node --test tests/canvaskit-sfnt-face.test.ts",
+      "cwd": "rhwp-studio"
+    },
+    {
+      "id": "studio-font-plan",
+      "batch": 3,
+      "batchName": "Strict Text Variant Replay",
+      "status": "passed",
+      "command": "node --test tests/canvaskit-font-plan.test.ts",
+      "cwd": "rhwp-studio"
+    },
+    {
+      "id": "studio-canvaskit-font-coverage",
+      "batch": 3,
+      "batchName": "Strict Text Variant Replay",
+      "status": "skipped",
+      "heavy": true,
+      "command": "npm run e2e:canvaskit-font-coverage",
+      "cwd": "rhwp-studio",
+      "reason": "heavy job not run: browser + WASM + disk. Use the command above when those are available."
+    }
+  ],
+  "studioNodeTestSummary": {
+    "pass": 30,
+    "fail": 0,
+    "durationMs": 3508.8484
+  }
+}

--- a/mydocs/report/task_m100_5433_report.md
+++ b/mydocs/report/task_m100_5433_report.md
@@ -1,0 +1,81 @@
+# Task M100-5433 완료 보고서 — canvaskit-parity 배치 2·3
+
+- Issue: #5433
+- Tracking: #536
+- 브랜치: `feat/m11-parity-batches`
+- 계획: `docs/canvaskit-parity-implementation.md`
+- 기계 결과: `mydocs/report/task_m100_5433_canvaskit_parity_batches.json`
+
+## 1. 범위
+
+MEGA QUEUE M11-p. 기존 하네스로 canvaskit-parity **배치 2(Paint Family Parity)** 와 **배치 3(Strict Text Variant Replay)** 를 실행하고 결과를 데이터로 남긴다.
+
+하지 않은 것:
+
+- #3772 / #3773 PDF 수정
+- gym / M08
+- `scripts/renderer_baseline_manifest.json` 변경 — 기존 renderer-contract·renderer_baseline 검토 절차가 임계값·샘플 추가를 요구하지 않았다
+
+## 2. 기존 하네스
+
+| 배치 | 이름 | 기존 진입점 |
+| --- | --- | --- |
+| 2 | Paint Family Parity | `cargo test --lib -- canvaskit_policy`, `rhwp-studio` CanvasKit image/resource/preflight 단위 시험, `node e2e/renderer-contract.test.mjs`, `python scripts/renderer_baseline.py --readiness-only` |
+| 3 | Strict Text Variant Replay | `cargo test --lib -- text_variants`, `tests/canvaskit-text-variant-selection.test.ts`, SFNT/font-plan 단위 시험, 동일 renderer-contract, `npm run e2e:canvaskit-font-coverage` |
+
+Windows에서 배치를 한 번에 돌리는 진입점이 없어 `scripts/canvaskit_parity_batches.py` 를 추가했다. 이 드라이버는 명령을 모으고 JSON을 남긴다. **매니페스트를 쓰지 않는다.**
+
+```text
+python scripts/canvaskit_parity_batches.py --list --batches 2,3
+python scripts/canvaskit_parity_batches.py --batches 2,3 --output mydocs/report/task_m100_5433_canvaskit_parity_batches.json
+python scripts/canvaskit_parity_batches.py --batches 2,3 --heavy
+python -m unittest scripts/tests/test_canvaskit_parity_batches.py
+```
+
+`--heavy` 는 readiness 캡처와 font-coverage e2e다. 네이티브 `rhwp` 바이너리, Chrome/puppeteer, WASM, 수 GB 디스크가 필요하다.
+
+## 3. Windows 실행 기록
+
+호스트: Windows, Node v24.14.1, Python 3.13.12, rustc/cargo 1.93.1.
+
+sparse-checkout 기본 목록에 `rhwp-studio`·`docs`·`crates` 가 없어 워크트리에서 `git sparse-checkout add rhwp-studio docs rhwp-vscode npm crates tools tests` 를 한 뒤에야 계약 시험과 cargo workspace가 열렸다.
+
+| 작업 | 상태 | 판정 |
+| --- | --- | --- |
+| 배치 맵 unittest 6건 | 통과 | 드라이버가 매니페스트를 출력으로 가리키지 않음 |
+| Studio CanvasKit 단위 30건 | 통과 (3.5s) | 배치 2·3 해당 파일 전부 |
+| `node e2e/renderer-contract.test.mjs` | 통과 | `renderer backend contract guard passed` |
+| `cargo test --lib -- canvaskit_policy text_variants` | 차단 | `rhwp` lib test 컴파일 중 `rustc-LLVM ERROR: IO failure on output stream: no space on device`. C: 잔여 0 GB. 이후 `target/` 삭제로 2.48 GB 회복. 제품 실패로 보지 않음 |
+| `renderer_baseline.py --readiness-only` | 생략 | heavy. 네이티브 바이너리·브라우저·디스크 부족. **매니페스트 미변경** |
+| `npm run e2e:canvaskit-font-coverage` | 생략 | heavy. 브라우저+WASM |
+
+Studio 30건 구성: document-preflight 6, font-plan 4, image-header 5, resource-key 1, SFNT face 4, text-variant-selection 10.
+
+text-variant-selection이 고정한 계약: 디코딩 가능한 sidecar 단독 선택, 손상·누락·과대·파싱 실패 자원은 TextRun 폴백, 그룹 독립 선택, 완전한 GlyphRun 우선, 불완전/중복/혼합 multipart는 폴백, outline이 있으면 GlyphRun을 평가하지 않음.
+
+## 4. renderer_baseline 매니페스트
+
+기존 절차는 `rhwp-studio/e2e/renderer-contract.test.mjs` 가 매니페스트 샘플·임계값을 고정하고, 변경은 계약 시험과 리뷰를 통과할 때만 한다.
+
+이번 실행은 임계값 위반을 새로 관측하지 않았고 readiness 캡처도 돌리지 않았다. 따라서 `scripts/renderer_baseline_manifest.json` 은 그대로 둔다.
+
+재실행 명령 (디스크·Chrome·WASM 준비 후):
+
+```text
+python scripts/renderer_baseline.py --readiness-only --scope representative --browser-mode headless --profiles screen --output output/renderer-baseline/m11p-batch2
+```
+
+## 5. 빠진 글루 / 후속
+
+- Windows 기본 sparse-checkout 만으로는 `rhwp-studio` 와 `crates` 가 빠져 배치 시험이 시작되지 않는다. 이번 워크트리에서 cone을 넓혔다. 저장소 기본 sparse 정책은 바꾸지 않았다.
+- 로컬 디스크가 수 GB 비기 전에는 `cargo test --lib` 와 readiness 캡처를 재현할 수 없다. 명령은 위와 드라이버 `--list` 에 있다.
+- #3772 ExtraLight PDF bold, #3773 svg2pdf SubsetError 는 다른 M11 작업이다.
+
+## 6. 검증
+
+- `python -m unittest scripts/tests/test_canvaskit_parity_batches.py`
+- `node --test` CanvasKit 단위 30/30
+- `node e2e/renderer-contract.test.mjs`
+- `cargo fmt --all -- --check`
+- `node scripts/rust-test-suite-manifest.mjs --check`
+- `node scripts/rust-unit-test-tiers.mjs --check`

--- a/scripts/canvaskit_parity_batches.py
+++ b/scripts/canvaskit_parity_batches.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Run canvaskit-parity work batches 2 and 3 on existing harnesses.
+
+Batch names come from docs/canvaskit-parity-implementation.md:
+
+  2. Paint Family Parity Closures
+  3. Strict Text Variant Replay
+
+This driver records command results as data. Failures are judgment, not a
+reason to rewrite scripts/renderer_baseline_manifest.json. Manifest updates
+stay on the existing renderer_baseline / renderer-contract process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STUDIO_ROOT = ROOT / "rhwp-studio"
+DEFAULT_MANIFEST = ROOT / "scripts" / "renderer_baseline_manifest.json"
+PLAN_DOC = ROOT / "docs" / "canvaskit-parity-implementation.md"
+NPM_CMD = "npm.cmd" if sys.platform == "win32" else "npm"
+CARGO_CMD = "cargo.exe" if sys.platform == "win32" else "cargo"
+
+BATCH_NAMES = {
+    2: "Paint Family Parity",
+    3: "Strict Text Variant Replay",
+}
+
+
+def job(
+    job_id: str,
+    title: str,
+    command: list[str],
+    *,
+    cwd: Path = ROOT,
+    heavy: bool = False,
+) -> dict[str, Any]:
+    return {
+        "id": job_id,
+        "title": title,
+        "command": command,
+        "cwd": cwd,
+        "heavy": heavy,
+    }
+
+
+def batch_jobs() -> dict[int, list[dict[str, Any]]]:
+    """Map plan batches to existing Windows-runnable harness commands."""
+    rust_lib = [CARGO_CMD, "test", "--lib", "--"]
+    node_test = ["node", "--test"]
+    return {
+        2: [
+            job(
+                "rust-canvaskit-policy",
+                "Rust CanvasKit replay-plan / paint-family policy",
+                [*rust_lib, "canvaskit_policy"],
+            ),
+            job(
+                "studio-image-header",
+                "CanvasKit image-header family (PNG/JPEG/GIF/WebP/BMP)",
+                [*node_test, "tests/canvaskit-image-header.test.ts"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-resource-key",
+                "CanvasKit resource-key / cache identity",
+                [*node_test, "tests/canvaskit-resource-key.test.ts"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-document-preflight",
+                "CanvasKit document preflight blockers",
+                [*node_test, "tests/canvaskit-document-preflight.test.ts"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-renderer-contract",
+                "Renderer contract: LayerPaintOp dispatch + paint-family replay",
+                ["node", "e2e/renderer-contract.test.mjs"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "renderer-baseline-readiness",
+                "renderer_baseline readiness-only capture (existing manifest)",
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "renderer_baseline.py"),
+                    "--readiness-only",
+                    "--scope",
+                    "representative",
+                    "--browser-mode",
+                    "headless",
+                    "--profiles",
+                    "screen",
+                    "--output",
+                    str(ROOT / "output" / "renderer-baseline" / "m11p-batch2"),
+                ],
+                heavy=True,
+            ),
+        ],
+        3: [
+            job(
+                "rust-text-variants",
+                "Rust schema-v1 text variant grouping",
+                [*rust_lib, "text_variants"],
+            ),
+            job(
+                "studio-text-variant-selection",
+                "Strict GlyphRun / GlyphOutline leaf selection",
+                [*node_test, "tests/canvaskit-text-variant-selection.test.ts"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-sfnt-face",
+                "Exact SFNT / TTC face extraction for GlyphRun",
+                [*node_test, "tests/canvaskit-sfnt-face.test.ts"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-font-plan",
+                "Required-family CanvasKit font plan",
+                [*node_test, "tests/canvaskit-font-plan.test.ts"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-renderer-contract",
+                "Renderer contract: strict variant replay + reject reasons",
+                ["node", "e2e/renderer-contract.test.mjs"],
+                cwd=STUDIO_ROOT,
+            ),
+            job(
+                "studio-canvaskit-font-coverage",
+                "CanvasKit font-coverage e2e (browser + WASM)",
+                [NPM_CMD, "run", "e2e:canvaskit-font-coverage"],
+                cwd=STUDIO_ROOT,
+                heavy=True,
+            ),
+        ],
+    }
+
+
+def parse_batches(raw: str) -> list[int]:
+    values: list[int] = []
+    for item in raw.split(","):
+        token = item.strip()
+        if not token:
+            continue
+        number = int(token)
+        if number not in BATCH_NAMES:
+            raise SystemExit(
+                f"unsupported batch {number} (allowed: {', '.join(str(n) for n in BATCH_NAMES)})"
+            )
+        if number not in values:
+            values.append(number)
+    if not values:
+        raise SystemExit("at least one batch must be specified")
+    return values
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run canvaskit-parity batches 2 and 3 against existing harnesses."
+    )
+    parser.add_argument(
+        "--batches",
+        default="2,3",
+        help="comma-separated batch numbers (default: 2,3)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print the batch-to-command map and exit",
+    )
+    parser.add_argument(
+        "--heavy",
+        action="store_true",
+        help="also run browser/WASM/readiness capture jobs",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="optional JSON result path",
+    )
+    return parser.parse_args(argv)
+
+
+def serialize_job(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": entry["id"],
+        "title": entry["title"],
+        "command": entry["command"],
+        "cwd": repo_relative(entry["cwd"]),
+        "heavy": bool(entry["heavy"]),
+    }
+
+
+def repo_relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT)).replace("\\", "/")
+    except ValueError:
+        return str(path)
+
+
+def which_or_none(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def skip_reason(entry: dict[str, Any], include_heavy: bool) -> str | None:
+    if entry["heavy"] and not include_heavy:
+        return "skipped: pass --heavy for browser/WASM/readiness capture"
+    command0 = entry["command"][0]
+    if command0 in {CARGO_CMD, "cargo", "cargo.exe"} and not which_or_none(CARGO_CMD):
+        return f"missing {CARGO_CMD} on PATH"
+    if command0 in {"node"} and not which_or_none("node"):
+        return "missing node on PATH"
+    if command0 in {NPM_CMD, "npm", "npm.cmd"} and not which_or_none(NPM_CMD):
+        return f"missing {NPM_CMD} on PATH"
+    cwd = Path(entry["cwd"])
+    if not cwd.exists():
+        return f"missing working directory: {repo_relative(cwd)}"
+    if cwd == STUDIO_ROOT and command0 in {"node", NPM_CMD, "npm", "npm.cmd"}:
+        if not (STUDIO_ROOT / "node_modules").exists():
+            return "missing rhwp-studio/node_modules (run npm install in rhwp-studio)"
+    if entry["id"] == "renderer-baseline-readiness":
+        if not DEFAULT_MANIFEST.exists():
+            return "missing scripts/renderer_baseline_manifest.json"
+        if not STUDIO_ROOT.exists():
+            return "missing rhwp-studio"
+    return None
+
+
+def run_job(entry: dict[str, Any], include_heavy: bool) -> dict[str, Any]:
+    result = serialize_job(entry)
+    reason = skip_reason(entry, include_heavy)
+    if reason:
+        result.update({"status": "skipped", "reason": reason, "exitCode": None, "seconds": 0.0})
+        return result
+
+    started = time.perf_counter()
+    completed = subprocess.run(
+        entry["command"],
+        cwd=entry["cwd"],
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+    )
+    elapsed = time.perf_counter() - started
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    result.update(
+        {
+            "status": "passed" if completed.returncode == 0 else "failed",
+            "exitCode": completed.returncode,
+            "seconds": round(elapsed, 3),
+            "stdoutTail": stdout[-4000:],
+            "stderrTail": stderr[-4000:],
+        }
+    )
+    if completed.returncode != 0:
+        result["reason"] = f"exit {completed.returncode}"
+    return result
+
+
+def build_report(batches: list[int], include_heavy: bool, results: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = {"passed": 0, "failed": 0, "skipped": 0}
+    for item in results:
+        counts[item["status"]] = counts.get(item["status"], 0) + 1
+    return {
+        "schemaVersion": 1,
+        "plan": repo_relative(PLAN_DOC),
+        "manifest": repo_relative(DEFAULT_MANIFEST),
+        "manifestUpdated": False,
+        "manifestUpdatePolicy": (
+            "Do not edit renderer_baseline_manifest.json from this driver. "
+            "Threshold/sample changes stay on the existing renderer-contract "
+            "and renderer_baseline review process."
+        ),
+        "platform": sys.platform,
+        "batches": [
+            {"number": number, "name": BATCH_NAMES[number]} for number in batches
+        ],
+        "heavy": include_heavy,
+        "summary": counts,
+        "results": results,
+    }
+
+
+def print_listing(batches: list[int]) -> None:
+    print("canvaskit-parity batch map (existing harnesses only)")
+    print(f"plan: {repo_relative(PLAN_DOC)}")
+    print("manifest updates: never from this driver")
+    for number in batches:
+        print(f"\nbatch {number}: {BATCH_NAMES[number]}")
+        for entry in batch_jobs()[number]:
+            marker = " [heavy]" if entry["heavy"] else ""
+            command = " ".join(entry["command"])
+            print(f"  - {entry['id']}{marker}")
+            print(f"      cwd: {repo_relative(entry['cwd'])}")
+            print(f"      cmd: {command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    batches = parse_batches(args.batches)
+    if args.list:
+        print_listing(batches)
+        return 0
+
+    seen_ids: set[str] = set()
+    results: list[dict[str, Any]] = []
+    for number in batches:
+        for entry in batch_jobs()[number]:
+            if entry["id"] in seen_ids:
+                continue
+            seen_ids.add(entry["id"])
+            result = run_job(entry, args.heavy)
+            result["batch"] = number
+            result["batchName"] = BATCH_NAMES[number]
+            results.append(result)
+            status = result["status"]
+            detail = result.get("reason") or ""
+            print(f"[{status}] {entry['id']} {detail}".rstrip())
+
+    report = build_report(batches, args.heavy, results)
+    payload = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload, encoding="utf-8")
+        print(f"wrote {repo_relative(output_path)}")
+    else:
+        sys.stdout.write(payload)
+    return 0 if report["summary"]["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_canvaskit_parity_batches.py
+++ b/scripts/tests/test_canvaskit_parity_batches.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "canvaskit_parity_batches.py"
+SPEC = importlib.util.spec_from_file_location("canvaskit_parity_batches", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"canvaskit_parity_batches 모듈을 불러올 수 없습니다: {MODULE_PATH}")
+BATCHES = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BATCHES
+SPEC.loader.exec_module(BATCHES)
+
+
+class BatchMapTests(unittest.TestCase):
+    def test_supported_batches_match_parity_plan(self) -> None:
+        self.assertEqual(
+            BATCHES.BATCH_NAMES,
+            {
+                2: "Paint Family Parity",
+                3: "Strict Text Variant Replay",
+            },
+        )
+
+    def test_batch_two_covers_paint_family_harnesses(self) -> None:
+        ids = [entry["id"] for entry in BATCHES.batch_jobs()[2]]
+        self.assertIn("rust-canvaskit-policy", ids)
+        self.assertIn("studio-renderer-contract", ids)
+        self.assertIn("renderer-baseline-readiness", ids)
+
+    def test_batch_three_covers_strict_text_variant_harnesses(self) -> None:
+        ids = [entry["id"] for entry in BATCHES.batch_jobs()[3]]
+        self.assertIn("rust-text-variants", ids)
+        self.assertIn("studio-text-variant-selection", ids)
+        self.assertIn("studio-renderer-contract", ids)
+
+    def test_driver_never_points_at_manifest_as_output(self) -> None:
+        for entries in BATCHES.batch_jobs().values():
+            for entry in entries:
+                joined = " ".join(entry["command"])
+                self.assertNotIn("--write-manifest", joined)
+                self.assertFalse(
+                    any(
+                        part.endswith("renderer_baseline_manifest.json")
+                        and prev in {"-o", "--output"}
+                        for prev, part in zip(entry["command"], entry["command"][1:])
+                    )
+                )
+
+    def test_list_mode_prints_plan_and_no_manifest_rewrite(self) -> None:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = BATCHES.main(["--list", "--batches", "2,3"])
+        text = buffer.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("batch 2: Paint Family Parity", text)
+        self.assertIn("batch 3: Strict Text Variant Replay", text)
+        self.assertIn("manifest updates: never from this driver", text)
+
+    def test_parse_batches_rejects_unknown(self) -> None:
+        with self.assertRaises(SystemExit):
+            BATCHES.parse_batches("1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M11-p (◆10 멀티 렌더러). [#5433](https://github.com/edwardkim/rhwp/issues/5433) canvaskit-parity 배치 2·3 — Paint Family Parity, Strict Text Variant Replay — 을 기존 하네스로 실행하고 결과를 데이터로 남긴다.

- `docs/canvaskit-parity-implementation.md` 배치 정의를 `scripts/canvaskit_parity_batches.py` 에 매핑한다. Windows에서 `python scripts/canvaskit_parity_batches.py --batches 2,3` 로 돌릴 수 있다.
- 드라이버는 `scripts/renderer_baseline_manifest.json` 을 쓰지 않는다. 임계값·샘플 변경은 기존 renderer-contract / renderer_baseline 검토 절차에 맡긴다.
- 이번 Windows 실행: Studio CanvasKit 단위 30/30 통과, `e2e/renderer-contract.test.mjs` 통과. `cargo test --lib` 는 디스크 부족(`no space on device`)으로 차단 — 제품 실패로 보지 않는다. readiness 캡처와 font-coverage e2e는 heavy라 생략하고 명령을 기록했다.

#3772 / #3773 PDF 수정과 gym / M08은 이번 범위 밖이다.

## 관련 이슈

closes #5433

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (`--prepare` 후)
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `python -m unittest scripts/tests/test_canvaskit_parity_batches.py` — 6/6
- [x] `node --test` rhwp-studio CanvasKit 단위 — 30/30
- [x] `node e2e/renderer-contract.test.mjs` — passed
- [ ] `cargo test --lib -- canvaskit_policy text_variants` — 로컬 디스크 부족으로 차단
- [ ] `cargo clippy -- -D warnings` — 로컬 디스크 부족으로 미실행
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (배치 실행 기록)
- [ ] 웹(WASM) 렌더링 확인 — font-coverage e2e는 명령만 기록
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (실행 기록·드라이버, 렌더러 구현 변경 없음)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- #3772 PDF ExtraLight bold, #3773 svg2pdf SubsetError
- `scripts/renderer_baseline_manifest.json` 수정
- gym / M08
