### PR TITLE
fix(hwpx): hp:pic offset 을 pos 유래로 재작성하지 않는다 (#4668)

### DIFF
--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -99,7 +99,9 @@ pub fn write_picture<W: Write>(
     // --- 자식 순서 (한컴 관찰 샘플 기준) ---
     // offset, orgSz, curSz, flip, rotationInfo, renderingInfo, imgRect, imgClip,
     // inMargin, imgDim, img, effects, sz, pos, outMargin
-    write_offset(w, &pic.shape_attr)?;
+    // [#4668] hp:offset 은 shape_attr 원문 — pic 전용 writer 가 pos 유래로
+    // 재작성하면 쪽 밖(wraparound) 그림이 무편집 저장 후 쪽 안에 노출된다.
+    super::shape::write_offset(w, &pic.shape_attr)?;
     write_org_sz(w, &pic.shape_attr)?;
     write_cur_sz(w, pic)?;
     write_flip(w, &pic.shape_attr)?;
@@ -128,20 +130,6 @@ pub fn write_picture<W: Write>(
 }
 
 // ---------- 자식 요소 ----------
-
-// [#4668] hp:offset 은 파서가 보존한 shape_attr.offset_x/y 원문을 되쓴다 —
-// 종전에는 pic 전용 writer 만 pos 유래(c.horizontal_offset/vertical_offset)로
-// 재유도해, 음수(u32 wraparound) offset 으로 쪽 밖에 둔 그림이 무편집 저장 후
-// 쪽 안에 노출됐다(transMatrix 병진과도 모순). 도형·OLE·컨테이너 공용
-// writer(shape.rs write_offset, #3544)와 동형.
-fn write_offset<W: Write>(
-    w: &mut Writer<W>,
-    sa: &ShapeComponentAttr,
-) -> Result<(), SerializeError> {
-    let x = (sa.offset_x as u32).to_string();
-    let y = (sa.offset_y as u32).to_string();
-    empty_tag(w, "hp:offset", &[("x", &x), ("y", &y)])
-}
 
 fn write_org_sz<W: Write>(
     w: &mut Writer<W>,

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -615,7 +615,7 @@ pub(crate) fn write_shape_component_block<W: Write>(
     Ok(())
 }
 
-fn write_offset<W: Write>(
+pub(super) fn write_offset<W: Write>(
     w: &mut Writer<W>,
     sa: &ShapeComponentAttr,
 ) -> Result<(), SerializeError> {

--- a/tests/issue_4668_pic_offset_preserved.rs
+++ b/tests/issue_4668_pic_offset_preserved.rs
@@ -64,4 +64,9 @@ fn issue_4668_pic_offset_is_not_rewritten_from_pos() {
         !saved.contains(r#"<hp:offset x="0" y="10436"/>"#),
         "hp:pic offset 이 pos vertOffset 으로 재작성됐다(#4668 재발)"
     );
+    // offset↔행렬 병진이 입력에서 일치하던 값이 저장 후에도 맞아야 한다.
+    assert!(
+        saved.contains(r#"<hc:transMatrix e1="1" e2="0" e3="5250" e4="0" e5="1" e6="-4332"/>"#),
+        "transMatrix 병진이 offset wraparound 와 어긋나면 한글 표시가 갈라진다"
+    );
 }

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -3623,7 +3623,7 @@
       "id": "src/serializer/hwpx/picture.rs::tests#1",
       "file": "src/serializer/hwpx/picture.rs",
       "sourcePath": "src/serializer/hwpx/picture.rs",
-      "line": 551,
+      "line": 539,
       "module": "tests",
       "testAttributes": 26,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

HWPX 저장 시 `hp:pic` 의 `<hp:offset>` 이 원본 값 대신 `<hp:pos>` 의 vertOffset/horzOffset 에서 재유도되던 [#4668](https://github.com/edwardkim/rhwp/issues/4668) 을 닫습니다. pic 전용 writer 가 pos 유래로 방출하면, 음수(u32 wraparound) offset 으로 쪽 밖에 둔 그림이 **무편집 저장만으로** 쪽 안(문단 앵커 위치)에 노출되고, 무변경 `hc:transMatrix` 병진과도 모순이 납니다.

이 PR 은 pic 경로를 도형·OLE·컨테이너 공용 writer(`shape.rs write_offset`, [#3544](https://github.com/edwardkim/rhwp/issues/3544))에 합칩니다. `shape_attr.offset_x/y` 원문만 u32 wraparound 로 방출하고, pos 오프셋은 `hp:pos` 에만 둡니다.

## 관련 이슈

Closes [#5439](https://github.com/edwardkim/rhwp/issues/5439)
Closes [#4668](https://github.com/edwardkim/rhwp/issues/4668)

## 범위

- `picture.rs` — 로컬 `write_offset` 제거, `shape::write_offset` 공용 경로 사용
- `shape.rs` — `write_offset` 을 `pub(super)` 로 공유
- 회귀 시험 `tests/issue_4668_pic_offset_preserved.rs` — wraparound offset 보존 + pos 재작성 금지 + transMatrix 병진 일치
- 쪽수 로직·페이지 왕복 하네스는 손대지 않음 ([#3737](https://github.com/edwardkim/rhwp/issues/3737) 은 M05-4)

## 하지 않은 것

- 페이지 수 수정 / gym / M08
- `write_img_dim` 신설(이슈 부수 관찰) — offset 직렬화만

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (4225)
- [ ] `cargo test --test regression_suite_020 issue_4668_pic_offset` — 로컬 디스크 여유 부족으로 전체 빌드는 생략. 시험은 기존 샘플 `samples/ta-pic-cell-center-pos-bottom.hwpx` XML 원문 단언
- [ ] `cargo clippy -- -D warnings` — 디스크 여유 부족으로 생략
- [x] 관련 샘플 원문 전제 — `<hp:offset x="5250" y="4294962964"/>` + `vertOffset="10436"` + `transMatrix e3="5250" e6="-4332"`
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (저장 방출만)

## 1커맨드 스모크

```
cargo test --test regression_suite_020 issue_4668_pic_offset
```

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (pic offset 방출 경로만 공용 writer 로 합침)
- 재현·측정: 미측정
