### PR TITLE
fix(render/pdf): svg2pdf SubsetError 를 페이지 단위로 격리한다 (#3773)

### DIFF
--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -801,6 +801,108 @@ pub fn svg_to_pdf_with_options(
     svgs_to_pdf_with_options(&[svg_content.to_string()], options)
 }
 
+/// #3773: 한 페이지의 svg2pdf `SubsetError` 를 문서 전체 실패로 올리지 않는다.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Svg2pdfPageIsolation {
+    /// 서브셋과 무관한 변환 오류. 문서 전체를 실패시킨다.
+    Fatal,
+    /// `embed_text=true` 첫 실패. 글리프 path 변환으로 한 번 재시도한다.
+    RetryWithoutEmbedText,
+    /// 재시도 뒤에도 `SubsetError`. 해당 페이지만 건너뛴다.
+    SkipPage,
+}
+
+/// svg2pdf 페이지 변환 오류를 격리 정책으로 분류한다.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn classify_svg2pdf_page_error(
+    err: &svg2pdf::ConversionError,
+    embed_text: bool,
+    already_retried: bool,
+) -> Svg2pdfPageIsolation {
+    if !matches!(err, svg2pdf::ConversionError::SubsetError(_)) {
+        return Svg2pdfPageIsolation::Fatal;
+    }
+    if embed_text && !already_retried {
+        Svg2pdfPageIsolation::RetryWithoutEmbedText
+    } else {
+        Svg2pdfPageIsolation::SkipPage
+    }
+}
+
+/// 시험용 dummy `SubsetError`. 실제 폰트 ID 가 없어도 격리 분기를 탈 수 있다.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn svg2pdf_subset_error_stub() -> svg2pdf::ConversionError {
+    svg2pdf::ConversionError::SubsetError(usvg::fontdb::ID::dummy())
+}
+
+/// 시험용 비-Subset 변환 오류. 문서 전체 실패 분기를 고정한다.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn svg2pdf_invalid_image_error() -> svg2pdf::ConversionError {
+    svg2pdf::ConversionError::InvalidImage
+}
+
+/// svg2pdf `to_chunk` 래퍼. 시험이 성공 경로를 재사용할 때 쓴다.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn svg2pdf_to_chunk(
+    tree: &usvg::Tree,
+    embed_text: bool,
+) -> Result<(pdf_writer::Chunk, pdf_writer::Ref), svg2pdf::ConversionError> {
+    let mut conversion = svg2pdf::ConversionOptions::default();
+    conversion.embed_text = embed_text;
+    svg2pdf::to_chunk(tree, conversion)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn convert_page_chunk<F>(
+    tree: &usvg::Tree,
+    embed_text: bool,
+    page_index: usize,
+    to_chunk: &mut F,
+) -> Result<Option<(pdf_writer::Chunk, pdf_writer::Ref)>, String>
+where
+    F: FnMut(
+        &usvg::Tree,
+        bool,
+    ) -> Result<(pdf_writer::Chunk, pdf_writer::Ref), svg2pdf::ConversionError>,
+{
+    match to_chunk(tree, embed_text) {
+        Ok(ok) => Ok(Some(ok)),
+        Err(err) => match classify_svg2pdf_page_error(&err, embed_text, false) {
+            Svg2pdfPageIsolation::Fatal => Err(format!("SVG→chunk 변환 실패: {:?}", err)),
+            Svg2pdfPageIsolation::RetryWithoutEmbedText => {
+                eprintln!(
+                    "WARN: 페이지 {} svg2pdf SubsetError({err:?}) — embed_text=false 로 재시도합니다.",
+                    page_index + 1
+                );
+                match to_chunk(tree, false) {
+                    Ok(ok) => Ok(Some(ok)),
+                    Err(err2) => match classify_svg2pdf_page_error(&err2, false, true) {
+                        Svg2pdfPageIsolation::SkipPage => {
+                            eprintln!(
+                                "WARN: 페이지 {} svg2pdf SubsetError({err2:?}) — 이 페이지만 건너뛰고 PDF 를 계속합니다.",
+                                page_index + 1
+                            );
+                            Ok(None)
+                        }
+                        Svg2pdfPageIsolation::Fatal
+                        | Svg2pdfPageIsolation::RetryWithoutEmbedText => {
+                            Err(format!("SVG→chunk 변환 실패: {:?}", err2))
+                        }
+                    },
+                }
+            }
+            Svg2pdfPageIsolation::SkipPage => {
+                eprintln!(
+                    "WARN: 페이지 {} svg2pdf SubsetError({err:?}) — 이 페이지만 건너뛰고 PDF 를 계속합니다.",
+                    page_index + 1
+                );
+                Ok(None)
+            }
+        },
+    }
+}
+
 /// 여러 SVG 페이지를 단일 다중 페이지 PDF로 생성
 #[cfg(not(target_arch = "wasm32"))]
 pub fn svgs_to_pdf(svg_pages: &[String]) -> Result<Vec<u8>, String> {
@@ -813,6 +915,24 @@ pub fn svgs_to_pdf_with_options(
     svg_pages: &[String],
     export_options: &PdfExportOptions,
 ) -> Result<Vec<u8>, String> {
+    svgs_to_pdf_with_to_chunk(svg_pages, export_options, svg2pdf_to_chunk)
+}
+
+/// 페이지별 `to_chunk` 를 주입할 수 있는 PDF 변환.
+///
+/// #3773: `SubsetError` 는 경고로 강등하고 나머지 페이지를 계속한다.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn svgs_to_pdf_with_to_chunk<F>(
+    svg_pages: &[String],
+    export_options: &PdfExportOptions,
+    mut to_chunk: F,
+) -> Result<Vec<u8>, String>
+where
+    F: FnMut(
+        &usvg::Tree,
+        bool,
+    ) -> Result<(pdf_writer::Chunk, pdf_writer::Ref), svg2pdf::ConversionError>,
+{
     if svg_pages.is_empty() {
         return Err("페이지가 없습니다".to_string());
     }
@@ -837,18 +957,19 @@ pub fn svgs_to_pdf_with_options(
 
     let mut page_datas: Vec<PageData> = Vec::new();
 
-    for svg in svg_pages {
+    for (page_index, svg) in svg_pages.iter().enumerate() {
         let svg_with_fallback = apply_pdf_font_options(svg, export_options);
         let tree = usvg::Tree::from_str(&svg_with_fallback, &options)
             .map_err(|e| format!("SVG 파싱 실패: {}", e))?;
 
         // [Task #2264] 텍스트 임베드(폰트 서브셋)가 PDF 변환 메모리의 지배항이다.
         // `embed_text=false` 면 글리프를 path 로 변환해 서브셋 경로를 통째로 건너뛴다.
-        let mut conversion = svg2pdf::ConversionOptions::default();
-        conversion.embed_text = export_options.embed_text;
-
-        let (chunk, svg_ref) = svg2pdf::to_chunk(&tree, conversion)
-            .map_err(|e| format!("SVG→chunk 변환 실패: {:?}", e))?;
+        // [#3773] SubsetError 는 페이지 단위로 격리한다.
+        let Some((chunk, svg_ref)) =
+            convert_page_chunk(&tree, export_options.embed_text, page_index, &mut to_chunk)?
+        else {
+            continue;
+        };
 
         let dpi_ratio = 72.0 / 96.0; // 96 DPI → 72 pt
         let w = tree.size().width() * dpi_ratio;
@@ -860,6 +981,10 @@ pub fn svgs_to_pdf_with_options(
             width: w,
             height: h,
         });
+    }
+
+    if page_datas.is_empty() {
+        return Err("모든 페이지의 SVG→PDF 변환이 SubsetError 로 건너뛰어졌습니다".to_string());
     }
 
     // 각 chunk를 재번호화하고 페이지 참조 수집

--- a/tests/cases/issue_3773_svg2pdf_subset_isolation.rs
+++ b/tests/cases/issue_3773_svg2pdf_subset_isolation.rs
@@ -1,0 +1,126 @@
+//! #3773: svg2pdf `SubsetError` 를 페이지 단위로 격리하고 경고로 강등한다.
+//!
+//! 한 페이지의 서브셋 실패가 문서 전체 PDF 변환을 죽이면 안 된다. 첫 실패는
+//! `embed_text=false`(글리프 path)로 재시도하고, 그래도 실패하면 그 페이지만 건너뛴다.
+
+use rhwp::renderer::pdf::{
+    classify_svg2pdf_page_error, svg2pdf_invalid_image_error, svg2pdf_subset_error_stub,
+    svg2pdf_to_chunk, svgs_to_pdf, svgs_to_pdf_with_to_chunk, PdfExportOptions,
+    Svg2pdfPageIsolation,
+};
+
+fn page_svg(label: &str, width: u32, height: u32) -> String {
+    format!(
+        concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">"#,
+            r#"<text x="8" y="24">{label}</text>"#,
+            r#"</svg>"#,
+        ),
+        width = width,
+        height = height,
+        label = label
+    )
+}
+
+fn is_isolated_page(width: f32) -> bool {
+    (width - 200.0).abs() < 0.5
+}
+
+fn pdf_page_count(pdf: &[u8]) -> usize {
+    let text = String::from_utf8_lossy(pdf);
+    text.match_indices("/Count ")
+        .filter_map(|(idx, _)| {
+            text[idx + "/Count ".len()..]
+                .split(|c: char| !c.is_ascii_digit())
+                .next()
+                .and_then(|n| n.parse::<usize>().ok())
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+#[test]
+fn issue_3773_subset_error_is_classified_as_isolated_warning() {
+    let subset = svg2pdf_subset_error_stub();
+    assert_eq!(
+        classify_svg2pdf_page_error(&subset, true, false),
+        Svg2pdfPageIsolation::RetryWithoutEmbedText
+    );
+    assert_eq!(
+        classify_svg2pdf_page_error(&subset, false, true),
+        Svg2pdfPageIsolation::SkipPage
+    );
+    assert_eq!(
+        classify_svg2pdf_page_error(&svg2pdf_invalid_image_error(), true, false),
+        Svg2pdfPageIsolation::Fatal
+    );
+}
+
+#[test]
+fn issue_3773_subset_error_retries_without_embed_text() {
+    let pages = [
+        page_svg("good-1", 120, 80),
+        page_svg("subset-fail", 200, 80),
+        page_svg("good-3", 120, 80),
+    ];
+    let pdf =
+        svgs_to_pdf_with_to_chunk(&pages, &PdfExportOptions::default(), |tree, embed_text| {
+            if is_isolated_page(tree.size().width()) && embed_text {
+                return Err(svg2pdf_subset_error_stub());
+            }
+            svg2pdf_to_chunk(tree, embed_text)
+        })
+        .expect("한 페이지 SubsetError 가 전체 PDF 를 죽이면 안 된다");
+
+    assert!(pdf.starts_with(b"%PDF-"), "PDF 헤더가 없다");
+    assert_eq!(
+        pdf_page_count(&pdf),
+        3,
+        "재시도 성공 페이지를 포함해야 한다"
+    );
+}
+
+#[test]
+fn issue_3773_subset_error_skips_only_the_failing_page() {
+    let pages = [
+        page_svg("good-1", 120, 80),
+        page_svg("subset-fail", 200, 80),
+        page_svg("good-3", 120, 80),
+    ];
+    let pdf =
+        svgs_to_pdf_with_to_chunk(&pages, &PdfExportOptions::default(), |tree, embed_text| {
+            if is_isolated_page(tree.size().width()) {
+                return Err(svg2pdf_subset_error_stub());
+            }
+            svg2pdf_to_chunk(tree, embed_text)
+        })
+        .expect("실패한 페이지만 건너뛰고 나머지를 유지해야 한다");
+
+    assert!(pdf.starts_with(b"%PDF-"), "PDF 헤더가 없다");
+    assert_eq!(pdf_page_count(&pdf), 2, "SubsetError 페이지만 빠져야 한다");
+}
+
+#[test]
+fn issue_3773_non_subset_error_still_aborts_document() {
+    let pages = [page_svg("good-1", 120, 80), page_svg("bad-image", 200, 80)];
+    let err =
+        svgs_to_pdf_with_to_chunk(&pages, &PdfExportOptions::default(), |tree, embed_text| {
+            if is_isolated_page(tree.size().width()) {
+                return Err(svg2pdf_invalid_image_error());
+            }
+            svg2pdf_to_chunk(tree, embed_text)
+        })
+        .expect_err("SubsetError 가 아닌 변환 실패는 문서 전체 오류여야 한다");
+    assert!(
+        err.contains("SVG→chunk 변환 실패"),
+        "예상과 다른 오류: {err}"
+    );
+}
+
+#[test]
+fn issue_3773_two_good_pages_still_export() {
+    let pages = [page_svg("ok-1", 120, 80), page_svg("ok-2", 160, 90)];
+    let pdf = svgs_to_pdf(&pages).expect("정상 페이지 PDF 변환이 실패했다");
+    assert!(pdf.starts_with(b"%PDF-"));
+    assert_eq!(pdf_page_count(&pdf), 2);
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

MEGA QUEUE M11-3 (◆10 멀티 렌더러). [#3773](https://github.com/edwardkim/rhwp/issues/3773) svg2pdf `SubsetError` 가 한 페이지에서 나면 `export-pdf` 전체가 죽던 문제만 고친다.

PUA/희귀 글리프가 CFF 폴백(Noto Serif CJK TTC 등)으로 떨어지면 `subsetter` 가 `SubsetError(ID(...))` 를 내고, 기존 루프는 그 오류를 문서 전체 실패로 올렸다.

- `classify_svg2pdf_page_error` — `SubsetError` 만 격리하고 나머지는 그대로 fatal.
- 첫 실패는 `embed_text=false`(글리프 path, Task #2264)로 재시도하고 `WARN` 을 남긴다.
- 재시도도 `SubsetError` 이면 그 페이지만 건너뛰고 나머지 페이지로 PDF 를 만든다.
- 모든 페이지가 건너뛰어지면 그때만 문서 실패.

#3772(PDF ExtraLight bold, M11-2 #5427)와 #4764(PDF raster fidelity)는 이번 범위 밖이다.

## 관련 이슈

closes #5430
closes #3773

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --test regression_suite_012 issue_3773` — 5/5 통과
- [ ] `cargo clippy -- -D warnings` — 로컬 디스크 부족으로 미실행
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 단위 시험으로 `SubsetError` 주입 경로를 고정
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (네이티브 PDF)
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] `.claude/agents/`·스킬 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (실패 페이지에만 재시도/스킵)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- #3772 PDF ExtraLight bold (#5427)
- #4764 PDF raster fidelity
- gym / `scripts/visual_sweep.py` 미수정
- svg2pdf fork subsetter 업그레이드 (이슈의 근본 후보 2)
