### PR TITLE
perf(codeql): PR Rust 분석 경로를 분리한다

### DIFF
--- a/.github/codeql/rust-pr.yml
+++ b/.github/codeql/rust-pr.yml
@@ -1,0 +1,7 @@
+# pull_request Rust CodeQL 전용 범위다. devel push와 schedule은 이 파일을 사용하지
+# 않아 전체 Rust 경로를 분석한다.
+paths:
+  - src/**
+  - crates/**
+  - rhwp-desk/src/**
+  - build.rs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -780,7 +780,17 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Initialize CodeQL (Rust)
-        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name == 'pull_request' }}
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust
+          build-mode: none
+          config-file: .github/codeql/rust-pr.yml
+
+      # PR은 제품 Rust만 빠르게 검사하고, devel push·schedule은 아래 기존 전체
+      # 경로 분석을 유지한다. PR 축소가 기준선 보안 탐지를 대신하지 않게 한다.
+      - name: Initialize CodeQL (Rust full scan)
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name != 'pull_request' }}
         uses: github/codeql-action/init@v4
         with:
           languages: rust

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CODEQL_WORKFLOW = REPO_ROOT / ".github/workflows/codeql.yml"
+RUST_PR_CODEQL_CONFIG = REPO_ROOT / ".github/codeql/rust-pr.yml"
 
 
 def job_body(workflow: str, job_name: str) -> str:
@@ -178,7 +179,15 @@ class CodeQLWorkflowTests(unittest.TestCase):
             analyze,
         )
         self.assertIn(
-            "if: ${{ matrix.language == 'rust' && " + selected + " }}",
+            "if: ${{ matrix.language == 'rust' && "
+            + selected
+            + " && github.event_name == 'pull_request' }}",
+            analyze,
+        )
+        self.assertIn(
+            "if: ${{ matrix.language == 'rust' && "
+            + selected
+            + " && github.event_name != 'pull_request' }}",
             analyze,
         )
         job_if = next(
@@ -252,10 +261,23 @@ class CodeQLWorkflowTests(unittest.TestCase):
         )[0]
         self.assertIn("languages: rust", rust_init)
         self.assertIn("build-mode: none", rust_init)
+        self.assertIn("config-file: .github/codeql/rust-pr.yml", rust_init)
+        rust_full_init = analyze.split(
+            "      - name: Initialize CodeQL (Rust full scan)\n", 1
+        )[1].split("\n      - name:", 1)[0]
+        self.assertIn("languages: rust", rust_full_init)
+        self.assertIn("build-mode: none", rust_full_init)
+        self.assertNotIn("config-file:", rust_full_init)
         self.assertNotIn("actions/cache/", analyze)
         self.assertNotIn("cargo build", analyze)
         self.assertNotIn("rust-blocking-results", analyze)
         self.assertNotIn("actions/upload-artifact", analyze)
+
+    def test_pr_rust_config_limits_scanning_to_production_paths(self) -> None:
+        config = RUST_PR_CODEQL_CONFIG.read_text(encoding="utf-8")
+        self.assertIn("paths:\n", config)
+        for path in ("src/**", "crates/**", "rhwp-desk/src/**", "build.rs"):
+            self.assertIn(f"  - {path}\n", config)
 
     def test_temporary_measurement_jobs_and_artifacts_are_absent(self) -> None:
         workflow = self.workflow


### PR DESCRIPTION
## 목적

Closes #5454.

PR 이벤트의 Rust CodeQL만 프로덕션 Rust 경로로 제한해 대기 시간을 줄인다. `devel` push·schedule·수동 실행은 기존 전체 Rust 경로 분석을 유지한다.

## CI 반영

- PR Rust init에 `.github/codeql/rust-pr.yml`을 연결한다.
- PR 분석 대상: `src/**`, `crates/**`, `rhwp-desk/src/**`, 루트 `build.rs`.
- 비-PR Rust init은 config 없이 전체 경로를 분석한다.
- 언어 선택, fail-closed 정책, `Analyze (rust)` check 이름은 유지한다.

## CodeQL 측정 결과

동일한 GitHub-hosted runner의 Rust CodeQL job을 기준선 [#5444 실행](https://github.com/edwardkim/rhwp/actions/runs/32121380856)과 이 PR 실행에서 비교했다.

| 항목 | 기준 #5444 | PR #5455 | 변화 |
| --- | ---: | ---: | ---: |
| Rust job 전체 | 15분 13초 | 14분 19초 | 54초 단축 (5.9%) |
| Rust 추출 | 6분 11초 | 5분 52초 | 18초 단축 |
| Rust 쿼리 | 7분 57초 | 7분 20초 | 37초 단축 |
| 정상 추출 파일 | 1,376 | 624 | 752개 감소 (54.7%) |

PR 경로 제한은 실제로 적용됐다. 다만 공통 workspace·macro·query 엔진 비용이 남아 전체 시간 단축은 약 1분이다. 추출 오류 수 변화는 분석 대상이 달라진 결과이므로 품질 개선 지표로 해석하지 않는다.

## 보안 범위

- PR은 제품 Rust만 빠르게 검사한다.
- `devel` push와 schedule은 전체 Rust 경로를 계속 검사한다.
- larger runner, query suite 축소·분할, 의존성 cache는 이 PR 범위 밖이다.

## 검증

- `python3 -m unittest scripts.tests.test_codeql_workflow` — 15 passed
- Ruby YAML parse: `.github/workflows/codeql.yml`, `.github/codeql/rust-pr.yml`
- `git diff --check`
- PR CI 전체 성공
