### PR TITLE
fix: HWPX hp:ole shape-component 원문 보존을 코퍼스로 고정한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### HWPX 저장
+
+- `hp:ole` 의 shape-component 자식(`offset`·`orgSz`·`curSz`·`flip`·
+  `rotationInfo`·`renderingInfo`·`lineShape`)과 `id`/`instid` 를 원문
+  보존한다. `curSz=0` 은 was_zero 센티널로 되돌리고, 음수 offset 은
+  u32 wraparound 로 방출한다 (#4669, #5450).
+
 ## [0.8.4] — 2026-08-12
 
 ### 배포 채널 복원

--- a/mydocs/working/issue_4669_ole_shape_component_preservation.md
+++ b/mydocs/working/issue_4669_ole_shape_component_preservation.md
@@ -1,0 +1,175 @@
+# #4669 HWPX `hp:ole` shape-component 보존 (M05-9 / #5450)
+
+날짜: 2026-08-18
+축: HWPX 저장 — OLE / shape-component 직렬화만
+비범위: 쪽수(#3737), `char_shapes`, `hp:pic` offset(#4668), gym
+
+## 1. 문제
+
+`rhwp export-hwpx samples/한셀OLE.hwpx out.hwpx` 한 번으로
+
+- `hp:ole id` 가 원문과 다른 값(관측: `id="0"`)으로 재부여되고
+- `<hp:curSz width="0" height="0"/>`(한컴 원산 관례)가 재계산 크기
+  (한셀 표본 기준 29999×4051)로 바뀌며
+- 같은 이유로 `offset` / `flip` / `renderingInfo` / `lineShape` 도
+  기본값으로 재유도됐다.
+
+한글 화면 표시에는 영향이 없을 수 있다(#3543 과 같은 값 보존 부류).
+그러나 offset·행렬을 읽는 다른 소비자(다운스트림 변환기, 외부 배치 도구)는
+오배치를 얻는다. `BinData` 파트 `ole1.ole` → `image1.OLE` 개명은
+`image{N}` 불변식(#1891) 의도 설계이므로 결함이 아니다.
+
+## 2. 원인
+
+| 지점 | 간극 |
+| --- | --- |
+| `parse_common_shape_children` | chart·OLE 공용 자식 파서에 `offset`/`orgSz`/`curSz`/`flip`/`renderingInfo`/`lineShape` arm 이 없어 IR 에 원문이 안 실렸다. `hwpx_to_hwp.rs` 주석이 이 간극을 자인. |
+| `apply_hwpx_ole_shape_component_contract` | `curSz=0` 을 orgSz 로 materialize 할 때 `current_*_was_zero` 센티널(#2017)을 안 세웠다. pic·일반 도형은 이미 해결, OLE 만 커버리지 밖. |
+| `parse_hp_ole_element` | `id` arm 부재. 차트는 #3546 에서 `id` 를 받았으나 OLE 는 누락. `instid` 만 파싱. |
+| `write_ole` | 원문 `id` 필드가 없어 `instance_id`(또는 0)를 `id` 와 `instid` 에 겸용 방출. |
+
+`write_cur_sz` 와 `write_shape_component_block` 자체는 이미 센티널·원문
+방출 로직을 갖고 있었다. 빠진 것은 OLE 파서가 그 필드를 IR 에 싣는 일과
+`hwpx_ole_id` 를 되쓰는 일이다.
+
+## 3. 수정
+
+코드 경로 (devel 에 착수된 보존 계약을 이 PR 이 코퍼스로 고정·고도화):
+
+1. `parse_common_shape_children` 이 `offset`/`orgSz`/`curSz` 를
+   `parse_object_layout_child` 에 위임하고, `flip`/`renderingInfo`/`lineShape`
+   를 도형·그림 파서와 동형으로 읽는다.
+2. `parse_hp_ole_element` 가 `id` 와 `instid` 를 분리한다. `id` 폴백은
+   **instid 속성 부재** 시에만 적용한다. 명시적 `instid="0"`(#4099 차트
+   fallback OLE)은 덮지 않는다. 명시적 `id="0"` 도 원문 0 으로 남긴다.
+3. `OleShape.hwpx_ole_id: Option<u32>` — HWP5 출신은 `None` → 종전대로
+   `id=instid=instance_id`.
+4. `apply_hwpx_ole_shape_component_contract` 가
+   `materialize_shape_current_size_from_original` 을 호출해 was_zero
+   센티널을 세운다. writer `write_cur_sz` 가 0 을 복원한다.
+5. `write_ole` 가 `hwpx_ole_id.unwrap_or(instance_id)` 를 `id` 에,
+   `instance_id` 를 `instid` 에 쓴다. 자식은
+   `write_shape_component_block` + `write_line_shape`.
+
+이 PR 은 위 계약을 **실물 샘플 + 137개 픽스처·봉투 전사 + 왕복 시험**으로
+고도화한다. 쪽수·char_shapes·pic offset writer 는 손대지 않는다.
+
+## 4. 한셀OLE 실측 정답
+
+`samples/한셀OLE.hwpx` `Contents/section0.xml` 의 `hp:ole` (축약):
+
+```xml
+<hp:ole id="2141242094" instid="1067500271" objectType="EMBEDDED"
+        binaryItemIDRef="ole1" drawAspect="CONTENT" numberingType="PICTURE">
+  <hp:offset x="0" y="0"/>
+  <hp:orgSz width="42001" height="13501"/>
+  <hp:curSz width="29999" height="4051"/>
+  <hp:flip horizontal="0" vertical="0"/>
+  <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+  <hp:renderingInfo>
+    <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+    <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+    <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+  </hp:renderingInfo>
+  <hc:extent x="29999" y="4051"/>
+  <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+  ...
+</hp:ole>
+```
+
+이슈 본문이 지적한 `curSz=0` 은 한컴 원산 파일에 흔한 형태이며, 이 표본
+자체는 비-0 curSz 를 가진다. 코퍼스 `021_cursz_zero_zero` 와
+`152_combo_issue_body_xml` 이 0 센티널 축을 담당한다.
+
+## 5. 저장 계약
+
+저장 후 각 `hp:ole` 에 대해:
+
+| 필드 | 보존 |
+| --- | --- |
+| `id` | `hwpx_ole_id` 원문. 없으면 `instance_id`. 원문이 0 이 아니면 `id="0"` 재부여 금지. |
+| `instid` | `instance_id`. 명시적 0 유지. |
+| `hp:offset` | `offset_x/y` 를 u32 wraparound 십진수로 방출 (#3544 와 동형). pos 유래 재작성 금지. |
+| `hp:orgSz` | `original_width/height` |
+| `hp:curSz` | was_zero 면 `0`, 아니면 `current_width/height` |
+| `hp:flip` | `horz_flip` / `vert_flip` |
+| `hp:rotationInfo` | angle, centerX/Y, rotateimage |
+| `hp:renderingInfo` | `raw_rendering` 행렬 (trans/sca/rot) |
+| `hp:lineShape` | style/width/color/endCap |
+
+비계약 (이 축에서 단언하지 않음):
+
+- `objectType` (한셀은 `EMBEDDED`, writer 는 역사적으로 `UNKNOWN` 을 쓸 수 있음)
+- `binaryItemIDRef` 개명 (`ole1` → `image1`, #1891)
+- `dropcapstyle` / `href` / `hasMoniker` / `eqBaseLine` 기본값
+- 페이지 수, 글자 모양, pic offset
+
+## 6. 코퍼스
+
+경로: `tests/fixtures/issue_4669_ole_shape_component/`
+
+| 산출 | 역할 |
+| --- | --- |
+| `xml/*.xml` | 픽스처 섹션. 각 파일이 한 계약 사례. |
+| `envelopes/*.json` | 파싱→저장 기대 봉투 전사 (`schema=rhwp.issue4669.ole-shape-component.v1`). |
+| `catalog.tsv` | 색인. |
+| `README.md` | 생성 방법. |
+
+가족:
+
+- `oracle` — 한셀 원문
+- `id-instid` — 분리·부재·0·u32 최대·i32 경계
+- `cursz-orgsz` — 0 센티널, 비대칭 0, 7200 함정, 소수 크기
+- `offset` — 양수, wraparound, i32::MIN, 병진 일치
+- `flip` / `rotation` / `rendering` / `lineshape`
+- `hansel-mutant` — 한셀 원문에서 한 필드만 변경
+- `ole-attr` — drawAspect·lock·textWrap 과 자식 동시
+- `multi-ole` — 한 문단 여러 OLE
+- `combo` — 이슈 본문 재현 포함
+
+생성: `python scripts/generate_issue_4669_ole_fixtures.py`
+
+봉투 한 건의 핵심 키:
+
+- `save_id` / `instance_id` / `was_zero` / `offset_u32`
+- `expect_xml` — 저장 XML 에 있어야 하는 조각
+- `forbid_xml` — 재유도 산출물 (예: curSz=0 이 orgSz 로 바뀐 태그)
+- `forbid_id_zero` — 원문 id 가 0 이 아닐 때 시작 태그 `id="0"` 금지
+
+시험은 픽스처의 `hp:ole` 를 `한셀OLE.hwpx` 의 section0 에 끼워 넣은 뒤
+`DocumentCore::export_hwpx_native` 로 저장하고 조각을 대조한다.
+템플릿의 `secPr`·BinData·header 는 그대로 두어 파서가 실패키지로 열리게 한다.
+
+## 7. 시험
+
+| 시험 | 무엇을 고정하는가 |
+| --- | --- |
+| `src/parser/hwpx/section.rs` `issue4669_parse_*` | IR 적재 (id/instid 분리, 자식, was_zero) |
+| `src/serializer/hwpx/shape.rs` `issue4669_write_*` | writer 방출 (id, curSz=0, wraparound offset, flip, 행렬, lineShape) |
+| `tests/cases/issue_4669_ole_shape_component.rs` | 실샘플 + 코퍼스 왕복 + 이슈 본문 curSz=0 + catalog↔envelope 짝 |
+
+1커맨드 스모크:
+
+```
+cargo test --test regression_suite_019 issue_4669
+```
+
+(`tests/cases/issue_4669_ole_shape_component.rs` 는 suite 019 로 배정된다.)
+
+## 8. 하지 않은 것
+
+- 페이지 수 / gym / M08 / M05-4(#3737)
+- `hp:pic` offset writer (#4668, M05-8)
+- `char_shapes`
+- `objectType` 원문 보존, BinData 파일명 원문 보존
+- `write_chart_element` 의 chart `id` (#3546 축)
+
+## 9. 재현
+
+```
+rhwp export-hwpx samples/한셀OLE.hwpx out.hwpx
+```
+
+저장본 `Contents/section0.xml` 의 `hp:ole` 에서 `id="2141242094"` 와
+`instid="1067500271"`, `orgSz`/`curSz`/`offset`/`scaMatrix e1="0.714245"` 가
+살아 있으면 이 축은 통과다.

--- a/scripts/generate_issue_4669_ole_fixtures.py
+++ b/scripts/generate_issue_4669_ole_fixtures.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Generate #4669 OLE shape-component fixtures and envelope transcripts.
+
+Each case is a distinct HWPX `<hp:ole>` save contract (id vs instid,
+curSz 0 sentinel, offset wraparound, flip, rotation, renderingInfo,
+lineShape). Re-run to regenerate the corpus; do not hand-edit outputs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "tests" / "fixtures" / "issue_4669_ole_shape_component"
+XML_DIR = OUT / "xml"
+ENV_DIR = OUT / "envelopes"
+
+NS = """xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core\""""
+
+# 한셀OLE.hwpx 실측 정답값 (#4669 이슈 본문·원본 section0.xml).
+HANSEL = {
+    "id": 2141242094,
+    "instid": 1067500271,
+    "zOrder": 1,
+    "numberingType": "PICTURE",
+    "textWrap": "SQUARE",
+    "textFlow": "BOTH_SIDES",
+    "lock": "0",
+    "objectType": "EMBEDDED",
+    "binaryItemIDRef": "ole1",
+    "drawAspect": "CONTENT",
+    "offset": (0, 0),
+    "orgSz": (42001, 13501),
+    "curSz": (29999, 4051),
+    "flip": (0, 0),
+    "rot": (0, 14999, 2025, 1),
+    "trans": (1, 0, 0, 0, 1, 0),
+    "sca": (0.714245, 0, 0, 0, 0.300052, 0),
+    "rotm": (1, 0, 0, 0, 1, 0),
+    "extent": (29999, 4051),
+    "line": {"color": "#000000", "width": 0, "style": "NONE", "endCap": "ROUND"},
+    "sz": (29999, 4051),
+}
+
+
+def wrap_u32(v: int) -> int:
+    return v & 0xFFFFFFFF
+
+
+def fmt_num(v: float | int) -> str:
+    if isinstance(v, int) or float(v).is_integer():
+        return str(int(v))
+    s = f"{float(v):.6f}".rstrip("0").rstrip(".")
+    return s
+
+
+def matrix_xml(name: str, m: tuple) -> str:
+    e = [fmt_num(x) for x in m]
+    return (
+        f'          <hc:{name} e1="{e[0]}" e2="{e[1]}" e3="{e[2]}" '
+        f'e4="{e[3]}" e5="{e[4]}" e6="{e[5]}"/>'
+    )
+
+
+def ole_xml(c: dict) -> str:
+    ox, oy = c["offset"]
+    ow, oh = c["orgSz"]
+    cw, ch = c["curSz"]
+    fh, fv = c["flip"]
+    ang, cx, cy, ri = c["rot"]
+    ex, ey = c["extent"]
+    sw, sh = c["sz"]
+    line = c["line"]
+    id_attr = "" if c.get("omit_id") else f' id="{c["id"]}"'
+    instid_attr = "" if c.get("omit_instid") else f' instid="{c["instid"]}"'
+    return f"""      <hp:ole{id_attr} zOrder="{c["zOrder"]}" numberingType="{c["numberingType"]}" textWrap="{c["textWrap"]}"
+              textFlow="{c["textFlow"]}" lock="{c["lock"]}"{instid_attr} objectType="{c["objectType"]}"
+              binaryItemIDRef="{c["binaryItemIDRef"]}" drawAspect="{c["drawAspect"]}">
+        <hp:offset x="{wrap_u32(ox)}" y="{wrap_u32(oy)}"/>
+        <hp:orgSz width="{ow}" height="{oh}"/>
+        <hp:curSz width="{cw}" height="{ch}"/>
+        <hp:flip horizontal="{fh}" vertical="{fv}"/>
+        <hp:rotationInfo angle="{ang}" centerX="{cx}" centerY="{cy}" rotateimage="{ri}"/>
+        <hp:renderingInfo>
+{matrix_xml("transMatrix", c["trans"])}
+{matrix_xml("scaMatrix", c["sca"])}
+{matrix_xml("rotMatrix", c["rotm"])}
+        </hp:renderingInfo>
+        <hc:extent x="{ex}" y="{ey}"/>
+        <hp:lineShape color="{line["color"]}" width="{line["width"]}" style="{line["style"]}" endCap="{line["endCap"]}"/>
+        <hp:sz width="{sw}" widthRelTo="ABSOLUTE" height="{sh}" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>"""
+
+
+def section_xml(fid: str, family: str, contract: str, source: str, oles: list[str]) -> str:
+    joined = "\n".join(oles)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: {fid}
+  family: {family}
+  contract: {contract}
+  source: {source}
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec {NS}>
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+{joined}
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>
+"""
+
+
+def expected_id(c: dict) -> int | None:
+    if c.get("omit_id"):
+        return None
+    return int(c["id"])
+
+
+def expected_instid(c: dict) -> int:
+    if c.get("omit_instid"):
+        return int(c.get("id", 0))
+    return int(c["instid"])
+
+
+def signed32(v: int) -> int:
+    v = int(v)
+    if v >= 2**31:
+        return v - 2**32
+    if v < -2**31:
+        return v + 2**32
+    return v
+
+
+def envelope(fid: str, family: str, contract: str, source: str, cases: list[dict]) -> dict:
+    items = []
+    for i, c in enumerate(cases):
+        ox, oy = c["offset"]
+        ow, oh = c["orgSz"]
+        cw, ch = c["curSz"]
+        eid = expected_id(c)
+        einst = expected_instid(c)
+        was_zw = cw == 0 and ow > 0
+        was_zh = ch == 0 and oh > 0
+        save_id = einst if eid is None else eid
+        expect_xml = [
+            f'id="{save_id}"',
+            f'instid="{einst}"',
+            f'<hp:offset x="{wrap_u32(ox)}" y="{wrap_u32(oy)}"/>',
+            f'<hp:orgSz width="{ow}" height="{oh}"/>',
+            f'<hp:curSz width="{cw}" height="{ch}"/>',
+            f'<hp:flip horizontal="{c["flip"][0]}" vertical="{c["flip"][1]}"/>',
+            f'angle="{c["rot"][0]}"',
+            f'centerX="{c["rot"][1]}"',
+            f'centerY="{c["rot"][2]}"',
+            f'rotateimage="{c["rot"][3]}"',
+            f'style="{c["line"]["style"]}"',
+            f'width="{c["line"]["width"]}"',
+        ]
+        forbid_xml = []
+        if was_zw and was_zh:
+            forbid_xml.append(f'<hp:curSz width="{ow}" height="{oh}"/>')
+        if ox != 0 or oy != 0:
+            forbid_xml.append('<hp:offset x="0" y="0"/>')
+        items.append(
+            {
+                "index": i,
+                "id": None if c.get("omit_id") else c["id"],
+                "instid": None if c.get("omit_instid") else c["instid"],
+                "hwpx_ole_id": eid,
+                "instance_id": einst,
+                "save_id": save_id,
+                "offset": [signed32(ox), signed32(oy)],
+                "offset_u32": [wrap_u32(ox), wrap_u32(oy)],
+                "orgSz": [ow, oh],
+                "curSz": [cw, ch],
+                "was_zero": [was_zw, was_zh],
+                "flip": [c["flip"][0], c["flip"][1]],
+                "rotation": list(c["rot"]),
+                "trans": list(c["trans"]),
+                "sca": list(c["sca"]),
+                "line": dict(c["line"]),
+                "expect_xml": expect_xml,
+                "forbid_xml": forbid_xml,
+                "forbid_id_zero": bool(eid not in (None, 0) and save_id != 0),
+            }
+        )
+    return {
+        "schema": "rhwp.issue4669.ole-shape-component.v1",
+        "issue": 4669,
+        "tracker": 5450,
+        "fixture_id": fid,
+        "family": family,
+        "contract": contract,
+        "source": source,
+        "oles": items,
+    }
+
+
+def clone(base: dict, **kw) -> dict:
+    out = dict(base)
+    for k, v in kw.items():
+        if k == "line" and isinstance(v, dict):
+            line = dict(out["line"])
+            line.update(v)
+            out["line"] = line
+        else:
+            out[k] = v
+    return out
+
+
+def build_cases() -> list[tuple[str, str, str, str, list[dict]]]:
+    h = HANSEL
+    cases: list[tuple[str, str, str, str, list[dict]]] = []
+
+    def add(fid, family, contract, source, oles):
+        cases.append((fid, family, contract, source, oles))
+
+    # --- family: hansel oracle -------------------------------------------------
+    add(
+        "000_hansel_oracle",
+        "oracle",
+        "samples/한셀OLE.hwpx 원본 hp:ole 의 id≠instid 와 shape-component 원문을 그대로 고정한다.",
+        "samples/한셀OLE.hwpx Contents/section0.xml",
+        [dict(h)],
+    )
+
+    # --- family: id / instid ---------------------------------------------------
+    id_pairs = [
+        ("001_id_ne_instid_hansel", h["id"], h["instid"], False, False, "한셀 실측 id≠instid"),
+        ("002_id_eq_instid", 77, 77, False, False, "id 와 instid 가 같은 경우도 둘 다 보존"),
+        ("003_id_zero_instid_nonzero", 0, h["instid"], False, False, "명시적 id=0 은 instid 로 덮지 않는다"),
+        ("004_id_nonzero_instid_zero", 1117817146, 0, False, False, "명시적 instid=0 은 id 로 덮지 않는다 (#4099)"),
+        ("005_id_absent_instid_present", h["id"], h["instid"], True, False, "id 부재 시 instid 가 id 를 겸한다"),
+        ("006_id_present_instid_absent", 4242, 0, False, True, "instid 부재 시 id 가 instance_id 를 겸한다"),
+        ("007_both_zero", 0, 0, False, False, "id=0 instid=0 둘 다 유효한 원문"),
+        ("008_both_max_u32", 4294967295, 4294967295, False, False, "u32 최대값 id/instid"),
+        ("009_id_max_instid_one", 4294967295, 1, False, False, "id 최대·instid 최소 비대칭"),
+        ("010_id_one_instid_max", 1, 4294967295, False, False, "id 최소 비영·instid 최대"),
+        ("011_id_hansel_instid_one", h["id"], 1, False, False, "한셀 id + 작은 instid"),
+        ("012_id_small_instid_hansel", 9, h["instid"], False, False, "작은 id + 한셀 instid"),
+        ("013_id_pow2_instid_pow2", 1 << 20, 1 << 30, False, False, "2의 거듭제곱 분리"),
+        ("014_id_odd_instid_even", 2141242095, 1067500270, False, False, "홀/짝 분리"),
+        ("015_id_chart_fallback_style", 1117817146, 0, False, False, "차트 fallback OLE 의 instid=0 관례"),
+        ("016_id_near_i32_max", 2147483647, 2147483648, False, False, "i32 경계 근처"),
+    ]
+    for fid, i, inst, omit_id, omit_instid, why in id_pairs:
+        add(
+            fid,
+            "id-instid",
+            why,
+            "synthetic / 한셀OLE id·instid 관례",
+            [clone(h, id=i, instid=inst, omit_id=omit_id, omit_instid=omit_instid)],
+        )
+
+    # --- family: curSz / orgSz -------------------------------------------------
+    size_rows = [
+        ("021_cursz_zero_zero", (0, 0), (42001, 13501), "한컴 원산 관례 curSz=0 → was_zero 센티널"),
+        ("022_cursz_zero_width_only", (0, 4051), (42001, 13501), "width 만 0 센티널"),
+        ("023_cursz_zero_height_only", (29999, 0), (42001, 13501), "height 만 0 센티널"),
+        ("024_cursz_eq_orgsz", (42001, 13501), (42001, 13501), "curSz = orgSz 는 재계산 없이 보존"),
+        ("025_cursz_eq_extent", (29999, 4051), (42001, 13501), "한셀 실측 curSz = extent ≠ orgSz"),
+        ("026_cursz_independent", (18000, 2400), (42001, 13501), "curSz 가 orgSz·extent 와 모두 다름"),
+        ("027_cursz_one_by_one", (1, 1), (42001, 13501), "최소 양수 curSz"),
+        ("028_orgsz_one_by_one", (1, 1), (1, 1), "최소 orgSz+curSz"),
+        ("029_orgsz_zero_cursz_zero", (0, 0), (0, 0), "orgSz=0 이면 was_zero materialize 없음"),
+        ("030_large_orgsz", (0, 0), (200000, 150000), "큰 orgSz + curSz=0"),
+        ("031_square_orgsz", (8000, 8000), (16000, 16000), "정사각 원본"),
+        ("032_wide_banner", (48000, 1200), (96000, 2400), "가로로 긴 OLE"),
+        ("033_tall_banner", (1200, 48000), (2400, 96000), "세로로 긴 OLE"),
+        ("034_cursz_gt_orgsz", (50000, 20000), (10000, 4000), "표시 크기가 원본보다 큼"),
+        ("035_cursz_half_orgsz", (21000, 6750), (42000, 13500), "절반 스케일"),
+        ("036_cursz_third_orgsz", (14000, 4500), (42000, 13500), "1/3 스케일"),
+        ("037_orgsz_prime", (29989, 4049), (42013, 13513), "소수 크기 — 재유도 오탐 방지"),
+        ("038_cursz_zero_7200_org", (0, 0), (7200, 7200), "7200 org + 0 cur — 기본값과 구분"),
+        ("039_asymmetric_zero", (0, 1), (9000, 3000), "width 0 / height 1"),
+        ("040_asymmetric_zero_h", (1, 0), (9000, 3000), "width 1 / height 0"),
+        ("041_unit_hwpx", (283, 283), (566, 566), "1mm 근처 HWPUNIT"),
+    ]
+    for fid, cur, org, why in size_rows:
+        add(
+            fid,
+            "cursz-orgsz",
+            why,
+            "synthetic / #2017 OLE 센티널",
+            [clone(h, curSz=cur, orgSz=org, extent=cur if cur[0] and cur[1] else org, sz=cur if cur[0] and cur[1] else org)],
+        )
+
+    # --- family: offset --------------------------------------------------------
+    off_rows = [
+        ("045_offset_zero", (0, 0), "원점 offset"),
+        ("046_offset_pos", (12, 34), "양수 offset (단위 시험 값)"),
+        ("047_offset_hansel_zero", (0, 0), "한셀 실측 offset 0,0"),
+        ("048_offset_wrap_y", (5250, -4332), "y 음수 wraparound — pic #4668 과 동형, OLE 축"),
+        ("049_offset_wrap_x", (-2429, 100), "x 음수 wraparound"),
+        ("050_offset_wrap_both", (-100, -200), "x/y 모두 wraparound"),
+        ("051_offset_i32_min_y", (0, -2147483648), "y = i32::MIN"),
+        ("052_offset_large_pos", (100000, 80000), "큰 양수 offset"),
+        ("053_offset_unit", (1, -1), "최소 비영 ±1"),
+        ("054_offset_page_out", (59528, -10000), "쪽 너비 밖 + 위쪽 음수"),
+        ("055_offset_x_only", (7777, 0), "x 만 이동"),
+        ("056_offset_y_only", (0, 8888), "y 만 이동"),
+        ("057_offset_u32_max_as_neg1", (-1, 0), "x=-1 → 4294967295"),
+        ("058_offset_trans_match", (5250, -4332), "offset 과 transMatrix 병진이 일치해야 하는 형태"),
+    ]
+    for fid, off, why in off_rows:
+        trans = (1, 0, off[0], 0, 1, off[1])
+        add(fid, "offset", why, "synthetic / #3544 unsigned wraparound", [clone(h, offset=off, trans=trans)])
+
+    # --- family: flip ----------------------------------------------------------
+    for i, (fh, fv) in enumerate([(0, 0), (1, 0), (0, 1), (1, 1)]):
+        add(
+            f"06{1+i}_flip_{fh}_{fv}",
+            "flip",
+            f"flip horizontal={fh} vertical={fv} 원문 보존",
+            "synthetic / shape-component flip",
+            [clone(h, flip=(fh, fv))],
+        )
+    # flip + nonzero offset / cursz 0
+    add("065_flip_h_cursz0", "flip", "수평 flip + curSz=0 동시 보존", "synthetic", [clone(h, flip=(1, 0), curSz=(0, 0))])
+    add("066_flip_v_offset_wrap", "flip", "수직 flip + offset wraparound", "synthetic", [clone(h, flip=(0, 1), offset=(0, -50), trans=(1, 0, 0, 0, 1, -50))])
+    add("067_flip_both_id_ne", "flip", "양축 flip + id≠instid", "synthetic", [clone(h, flip=(1, 1))])
+    add("068_flip_none_cursz0", "flip", "flip 없음 + curSz=0 (기본 flip 재유도와 구분)", "synthetic", [clone(h, flip=(0, 0), curSz=(0, 0))])
+
+    # --- family: rotation ------------------------------------------------------
+    rot_rows = [
+        ("069_rot_0_hansel", (0, 14999, 2025, 1), "한셀 실측 rotationInfo"),
+        ("070_rot_90", (90, 14999, 2025, 1), "90도"),
+        ("071_rot_180", (180, 14999, 2025, 1), "180도"),
+        ("072_rot_270", (270, 14999, 2025, 1), "270도"),
+        ("073_rot_45", (45, 8000, 4000, 1), "45도 + 다른 중심"),
+        ("074_rot_image_off", (0, 14999, 2025, 0), "rotateimage=0"),
+        ("075_rot_image_on_nonzero", (15, 0, 0, 1), "작은 각 + 원점 중심"),
+        ("076_rot_neg_center", (0, -100, -200, 1), "음수 회전 중심"),
+        ("077_rot_large_center", (0, 100000, 80000, 1), "큰 회전 중심"),
+        ("078_rot_359", (359, 1, 1, 0), "359도 rotateimage=0"),
+        ("079_rot_1_deg", (1, 14999, 2025, 1), "1도"),
+        ("080_rot_zero_center_zero_angle", (0, 0, 0, 0), "전부 0 — 기본값 재유도와 구분"),
+    ]
+    for fid, rot, why in rot_rows:
+        add(fid, "rotation", why, "synthetic / rotationInfo", [clone(h, rot=rot)])
+
+    # --- family: renderingInfo -------------------------------------------------
+    rend_rows = [
+        ("081_render_hansel_scale", HANSEL["trans"], HANSEL["sca"], HANSEL["rotm"], "한셀 실측 sca 0.714245×0.300052"),
+        ("082_render_identity", (1, 0, 0, 0, 1, 0), (1, 0, 0, 0, 1, 0), (1, 0, 0, 0, 1, 0), "항등 행렬 3개"),
+        ("083_render_scale_half", (1, 0, 0, 0, 1, 0), (0.5, 0, 0, 0, 0.5, 0), (1, 0, 0, 0, 1, 0), "균등 0.5 스케일"),
+        ("084_render_scale_2", (1, 0, 0, 0, 1, 0), (2, 0, 0, 0, 2, 0), (1, 0, 0, 0, 1, 0), "균등 2배"),
+        ("085_render_trans_only", (1, 0, 5250, 0, 1, -4332), (1, 0, 0, 0, 1, 0), (1, 0, 0, 0, 1, 0), "병진만 — offset 과 일치 형태"),
+        ("086_render_rot90", (1, 0, 0, 0, 1, 0), (1, 0, 0, 0, 1, 0), (0, -1, 0, 1, 0, 0), "90도 rotMatrix"),
+        ("087_render_shear", (1, 0.2, 0, 0.1, 1, 0), (1, 0, 0, 0, 1, 0), (1, 0, 0, 0, 1, 0), "전단 성분"),
+        ("088_render_tiny_scale", (1, 0, 0, 0, 1, 0), (0.01, 0, 0, 0, 0.02, 0), (1, 0, 0, 0, 1, 0), "매우 작은 스케일"),
+        ("089_render_neg_scale", (1, 0, 0, 0, 1, 0), (-1, 0, 0, 0, 1, 0), (1, 0, 0, 0, 1, 0), "음수 sx (거울)"),
+        ("090_render_neg_sy", (1, 0, 0, 0, 1, 0), (1, 0, 0, 0, -1, 0), (1, 0, 0, 0, 1, 0), "음수 sy"),
+        ("091_render_precise", (1, 0, 0, 0, 1, 0), (0.714245, 0, 0, 0, 0.300052, 0), (1, 0, 0, 0, 1, 0), "한셀 소수 정밀도 재현"),
+        ("092_render_other_frac", (1, 0, 0, 0, 1, 0), (1.579917, 0, 0, 0, 0.333333, 0), (1, 0, 0, 0, 1, 0), "다른 소수 — f32 왕복"),
+        ("093_render_tx_ty", (1, 0, 12, 0, 1, 34), (0.714245, 0, 0, 0, 0.300052, 0), (1, 0, 0, 0, 1, 0), "병진+한셀 스케일"),
+        ("094_render_almost_id", (1, 0, 0, 0, 1, 0), (0.999999, 0, 0, 0, 1.000001, 0), (1, 0, 0, 0, 1, 0), "항등에 가까운 스케일"),
+        ("095_render_zero_scale", (1, 0, 0, 0, 1, 0), (0, 0, 0, 0, 0, 0), (1, 0, 0, 0, 1, 0), "영 스케일 행렬"),
+        ("096_render_combined", (1, 0, 100, 0, 1, -50), (0.5, 0, 0, 0, 0.25, 0), (0, -1, 0, 1, 0, 0), "병진+스케일+회전 동시"),
+    ]
+    for fid, tr, sc, rm, why in rend_rows:
+        add(fid, "rendering", why, "synthetic / renderingInfo raw_rendering", [clone(h, trans=tr, sca=sc, rotm=rm)])
+
+    # --- family: lineShape -----------------------------------------------------
+    line_rows = [
+        ("097_line_none_hansel", "#000000", 0, "NONE", "ROUND", "한셀 실측 선 없음"),
+        ("098_line_solid_w5", "#000000", 5, "SOLID", "ROUND", "SOLID width=5 (단위 시험)"),
+        ("099_line_solid_w1", "#FF0000", 1, "SOLID", "FLAT", "빨간 실선 FLAT"),
+        ("100_line_dash", "#0000FF", 10, "DASH", "SQUARE", "파란 파선 SQUARE"),
+        ("101_line_dot", "#00FF00", 8, "DOT", "ROUND", "점선"),
+        ("102_line_dash_dot", "#123456", 3, "DASH_DOT", "ROUND", "1점 쇄선"),
+        ("103_line_dash_dot_dot", "#ABCDEF", 4, "DASH_DOT_DOT", "FLAT", "2점 쇄선"),
+        ("104_line_long_dash", "#010101", 12, "LONG_DASH", "ROUND", "긴 파선"),
+        ("105_line_circle", "#800080", 6, "CIRCLE", "ROUND", "원 테두리 스타일"),
+        ("106_line_double_slim", "#008080", 2, "DOUBLE_SLIM", "ROUND", "이중 가는 선"),
+        ("107_line_slim_thick", "#808000", 7, "SLIM_THICK", "FLAT", "가늘+굵"),
+        ("108_line_thick_slim", "#000080", 9, "THICK_SLIM", "SQUARE", "굵+가늘"),
+        ("109_line_slim_thick_slim", "#808080", 11, "SLIM_THICK_SLIM", "ROUND", "가늘+굵+가늘"),
+        ("110_line_white_solid", "#FFFFFF", 20, "SOLID", "ROUND", "흰 실선 굵게"),
+        ("111_line_none_nonzero_w", "#000000", 15, "NONE", "ROUND", "style=NONE 이지만 width>0 — 재유도 금지"),
+        ("112_line_solid_zero_w", "#000000", 0, "SOLID", "ROUND", "SOLID + width=0"),
+    ]
+    for fid, color, width, style, cap, why in line_rows:
+        add(fid, "lineshape", why, "synthetic / lineShape", [clone(h, line={"color": color, "width": width, "style": style, "endCap": cap})])
+
+    # --- family: hansel mutants (한 필드만 변경) --------------------------------
+    mutants = [
+        ("113_mut_cursz0", dict(curSz=(0, 0)), "한셀 원문에 curSz=0 만 넣은 재현"),
+        ("114_mut_offset_wrap", dict(offset=(5250, -4332), trans=(1, 0, 5250, 0, 1, -4332)), "한셀 + wraparound offset"),
+        ("115_mut_flip_h", dict(flip=(1, 0)), "한셀 + 수평 flip"),
+        ("116_mut_id_zero", dict(id=0), "한셀 instid 유지 + id=0"),
+        ("117_mut_instid_zero", dict(instid=0), "한셀 id 유지 + instid=0"),
+        ("118_mut_line_solid", dict(line={"color": "#000000", "width": 5, "style": "SOLID", "endCap": "ROUND"}), "한셀 + SOLID 테두리"),
+        ("119_mut_rot90", dict(rot=(90, 14999, 2025, 1)), "한셀 + 90도"),
+        ("120_mut_sca_id", dict(sca=(1, 0, 0, 0, 1, 0)), "한셀 sca 를 항등으로"),
+        ("121_mut_lock", dict(lock="1"), "한셀 + lock=1"),
+        ("122_mut_icon", dict(drawAspect="ICON"), "한셀 + drawAspect=ICON"),
+        ("123_mut_thumb", dict(drawAspect="THUMBNAIL"), "한셀 + THUMBNAIL"),
+        ("124_mut_docprint", dict(drawAspect="DOCPRINT"), "한셀 + DOCPRINT"),
+        ("125_mut_wrap_tight", dict(textWrap="TIGHT"), "한셀 + TIGHT"),
+        ("126_mut_wrap_topbottom", dict(textWrap="TOP_AND_BOTTOM"), "한셀 + TOP_AND_BOTTOM"),
+        ("127_mut_front", dict(textWrap="IN_FRONT_OF_TEXT"), "한셀 + IN_FRONT_OF_TEXT"),
+        ("128_mut_behind", dict(textWrap="BEHIND_TEXT"), "한셀 + BEHIND_TEXT"),
+        ("129_mut_all_zero_comp", dict(offset=(0, 0), curSz=(0, 0), flip=(0, 0), rot=(0, 0, 0, 0)), "한셀 id 유지 + 자식 0"),
+    ]
+    for fid, kw, why in mutants:
+        add(fid, "hansel-mutant", why, "samples/한셀OLE.hwpx 1필드 변이", [clone(h, **kw)])
+
+    # --- family: attributes around ole (still shape-component save) ------------
+    attr_rows = [
+        ("133_aspect_icon_cursz0", dict(drawAspect="ICON", curSz=(0, 0)), "ICON + curSz=0"),
+        ("134_lock_and_wrap_offset", dict(lock="1", offset=(-10, 20), trans=(1, 0, -10, 0, 1, 20)), "lock + wraparound x"),
+        ("135_through_wrap", dict(textWrap="THROUGH"), "THROUGH 배치"),
+        ("136_largest_flow", dict(textFlow="LARGEST_ONLY"), "LARGEST_ONLY"),
+        ("137_right_flow", dict(textFlow="RIGHT_ONLY"), "RIGHT_ONLY"),
+        ("138_picture_numbering_cursz0", dict(numberingType="PICTURE", curSz=(0, 0)), "PICTURE numbering + curSz=0"),
+    ]
+    for fid, kw, why in attr_rows:
+        add(fid, "ole-attr", why, "synthetic / hp:ole 속성 + 자식 동시", [clone(h, **kw)])
+
+    # --- family: multi-ole -----------------------------------------------------
+    a = clone(h, id=1001, instid=2001, offset=(10, 20), trans=(1, 0, 10, 0, 1, 20))
+    b = clone(h, id=1002, instid=2002, curSz=(0, 0), flip=(1, 0))
+    c = clone(h, id=0, instid=3003, line={"color": "#FF0000", "width": 3, "style": "SOLID", "endCap": "FLAT"})
+    d = clone(h, id=4004, instid=0, offset=(-5, -6), trans=(1, 0, -5, 0, 1, -6))
+    add("143_multi_two_oles", "multi-ole", "한 문단에 OLE 2개 — 각각의 id/자식을 독립 보존", "synthetic", [a, b])
+    add("144_multi_three_oles", "multi-ole", "OLE 3개 (양수 offset / curSz0+flip / id=0)", "synthetic", [a, b, c])
+    add("145_multi_four_oles", "multi-ole", "OLE 4개 (instid=0 wraparound 포함)", "synthetic", [a, b, c, d])
+    e = clone(h, id=5005, instid=5005, rot=(90, 1, 2, 0))
+    add("146_multi_id_eq_and_ne", "multi-ole", "id=instid 인 OLE 와 id≠instid 인 OLE 혼재", "synthetic", [a, e])
+    f = clone(h, id=6006, instid=7007, sca=(0.5, 0, 0, 0, 0.25, 0))
+    add("147_multi_scale_pair", "multi-ole", "서로 다른 scaMatrix 를 가진 OLE 쌍", "synthetic", [clone(h), f])
+    add("148_multi_cursz0_pair", "multi-ole", "둘 다 curSz=0 이지만 orgSz 가 다름", "synthetic", [clone(h, curSz=(0, 0), orgSz=(1000, 2000), id=11, instid=21), clone(h, curSz=(0, 0), orgSz=(3000, 4000), id=12, instid=22)])
+
+    # --- family: combination stress -------------------------------------------
+    add(
+        "149_combo_all_nonzero",
+        "combo",
+        "id≠instid + wraparound offset + curSz 독립 + flip + 90도 + 한셀 sca + SOLID",
+        "synthetic combination",
+        [clone(h, offset=(-2429, -4332), trans=(1, 0, -2429, 0, 1, -4332), curSz=(18000, 2400), flip=(1, 1), rot=(90, 9000, 1200, 1), line={"color": "#112233", "width": 4, "style": "SOLID", "endCap": "FLAT"})],
+    )
+    add(
+        "150_combo_all_zeroish",
+        "combo",
+        "명시적 0 값 묶음 — 기본값 재유도와 구분돼야 한다",
+        "synthetic combination",
+        [clone(h, id=0, instid=0, offset=(0, 0), curSz=(0, 0), orgSz=(7200, 7200), flip=(0, 0), rot=(0, 0, 0, 0), sca=(1, 0, 0, 0, 1, 0), line={"color": "#000000", "width": 0, "style": "NONE", "endCap": "ROUND"})],
+    )
+    add(
+        "151_combo_cursz0_wrap_idne",
+        "combo",
+        "이슈 본문 재현: id≠instid + curSz=0 + 원문 offset",
+        "issue #4669 reproduction",
+        [clone(h, curSz=(0, 0), offset=(12, 34), trans=(1, 0, 12, 0, 1, 34))],
+    )
+    add(
+        "152_combo_issue_body_xml",
+        "combo",
+        "이슈 본문 축약 XML 과 동일 값 (id 2141242094 / instid 1067500271 / curSz 0 / offset 12,34)",
+        "issue #4669 body",
+        [clone(h, offset=(12, 34), trans=(1, 0, 12, 0, 1, 34), orgSz=(42001, 13501), curSz=(0, 0), flip=(1, 0), rot=(0, 14999, 2025, 1))],
+    )
+
+    return cases
+
+
+def main() -> None:
+    if OUT.exists():
+        for p in XML_DIR.glob("*.xml"):
+            p.unlink()
+        for p in ENV_DIR.glob("*.json"):
+            p.unlink()
+    XML_DIR.mkdir(parents=True, exist_ok=True)
+    ENV_DIR.mkdir(parents=True, exist_ok=True)
+
+    catalog = []
+    cases = build_cases()
+    seen = set()
+    for fid, family, contract, source, oles in cases:
+        if fid in seen:
+            raise SystemExit(f"duplicate fixture id: {fid}")
+        seen.add(fid)
+        xml = section_xml(fid, family, contract, source, [ole_xml(c) for c in oles])
+        env = envelope(fid, family, contract, source, oles)
+        (XML_DIR / f"{fid}.xml").write_text(xml, encoding="utf-8", newline="\n")
+        (ENV_DIR / f"{fid}.json").write_text(
+            json.dumps(env, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        c0 = oles[0]
+        catalog.append(
+            "\t".join(
+                [
+                    fid,
+                    family,
+                    str(len(oles)),
+                    str(c0.get("id", "")),
+                    str(c0.get("instid", "")),
+                    f"{c0['curSz'][0]}x{c0['curSz'][1]}",
+                    f"{c0['offset'][0]},{c0['offset'][1]}",
+                    contract.replace("\t", " "),
+                ]
+            )
+        )
+
+    header = "id\tfamily\tole_count\tid_attr\tinstid\tcursz\toffset\tcontract\n"
+    (OUT / "catalog.tsv").write_text(header + "\n".join(catalog) + "\n", encoding="utf-8", newline="\n")
+    readme = f"""# issue #4669 OLE shape-component fixture corpus
+
+M05-9 / #5450. HWPX 저장이 `hp:ole` 의 shape-component 자식과 `id` 를
+보존하는지 고정하는 코퍼스다. pic offset(#4668)·쪽수(#3737)·char_shapes 는
+다루지 않는다.
+
+- `xml/` : 픽스처 섹션 XML ({len(cases)}개)
+- `envelopes/` : 파싱→저장 기대 봉투 전사 ({len(cases)}개)
+- `catalog.tsv` : 색인
+
+생성: `python scripts/generate_issue_4669_ole_fixtures.py`
+
+시험: `tests/cases/issue_4669_ole_shape_component.rs`
+"""
+    (OUT / "README.md").write_text(readme, encoding="utf-8", newline="\n")
+    print(f"wrote {len(cases)} fixtures → {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cases/issue_4669_ole_shape_component.rs
+++ b/tests/cases/issue_4669_ole_shape_component.rs
@@ -1,0 +1,354 @@
+//! [Issue #4669 / #5450] HWPX 저장이 `hp:ole` 의 shape-component 자식
+//! (`offset`·`orgSz`·`curSz`·`flip`·`rotationInfo`·`renderingInfo`·`lineShape`)과
+//! `id` 속성을 원문 보존해야 한다.
+//!
+//! 종전 결함: `parse_common_shape_children` 에 arm 이 없고 `id` 는 instid 만
+//! 읽어, 무편집 저장만으로 `id="0"` 재부여·`curSz=0` 재유도가 일어났다.
+//! 한글 표시에는 영향이 없어도 offset·행렬을 읽는 다른 소비자는 오배치를 얻는다.
+//!
+//! 이 시험은 실물 `samples/한셀OLE.hwpx` 와
+//! `tests/fixtures/issue_4669_ole_shape_component/` 코퍼스(XML+봉투)를
+//! `DocumentCore::export_hwpx_native` 저장 경로로 왕복한다.
+//! pic offset(#4668)·쪽수(#3737)·char_shapes 는 단언하지 않는다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use rhwp::document_core::DocumentCore;
+use serde_json::Value;
+
+const SAMPLE: &str = "samples/한셀OLE.hwpx";
+const FIXTURE_ROOT: &str = "tests/fixtures/issue_4669_ole_shape_component";
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn section_xml_of(bytes: &[u8]) -> String {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("ZIP 열기");
+    let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+    let mut xml = String::new();
+    for name in names {
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            zip.by_name(&name)
+                .expect("section 엔트리")
+                .read_to_string(&mut xml)
+                .expect("section XML 은 UTF-8 이어야 한다");
+        }
+    }
+    xml
+}
+
+fn extract_oles(section: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = section;
+    while let Some(start) = rest.find("<hp:ole") {
+        let tail = &rest[start..];
+        let end = tail
+            .find("</hp:ole>")
+            .map(|i| i + "</hp:ole>".len())
+            .or_else(|| tail.find("/>").map(|i| i + 2))
+            .expect("hp:ole 닫기");
+        out.push(tail[..end].to_string());
+        rest = &tail[end..];
+    }
+    out
+}
+
+fn start_tag(ole: &str) -> &str {
+    ole.split('>').next().unwrap_or(ole)
+}
+
+fn attr_value(tag: &str, name: &str) -> Option<String> {
+    let key = format!("{name}=\"");
+    let i = tag.find(&key)?;
+    let rest = &tag[i + key.len()..];
+    let j = rest.find('"')?;
+    Some(rest[..j].to_string())
+}
+
+fn splice_oles_into_hansel_section(template_section: &str, fixture_section: &str) -> String {
+    let oles = extract_oles(fixture_section);
+    assert!(!oles.is_empty(), "픽스처에 hp:ole 이 없다");
+    let start = template_section
+        .find("<hp:ole")
+        .expect("한셀 템플릿에 hp:ole");
+    let tail = &template_section[start..];
+    let end_rel = tail
+        .find("</hp:ole>")
+        .map(|i| i + "</hp:ole>".len())
+        .expect("한셀 템플릿 ole 닫기");
+    let mut out = String::with_capacity(template_section.len() + 256);
+    out.push_str(&template_section[..start]);
+    out.push_str(&oles.join(""));
+    out.push_str(&tail[end_rel..]);
+    out
+}
+
+fn pack_section_into_hansel(fixture_section: &str) -> Vec<u8> {
+    let template =
+        std::fs::read(repo_path(SAMPLE)).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let template_section = section_xml_of(&template);
+    let spliced = splice_oles_into_hansel_section(&template_section, fixture_section);
+    let mut src = zip::ZipArchive::new(std::io::Cursor::new(template)).expect("template ZIP");
+    let mut out = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let stored =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let deflated = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+    let names: Vec<String> = src.file_names().map(str::to_string).collect();
+    for name in names {
+        let mut data = Vec::new();
+        src.by_name(&name)
+            .expect("엔트리")
+            .read_to_end(&mut data)
+            .expect("읽기");
+        let opts = if name == "mimetype" { stored } else { deflated };
+        out.start_file(&name, opts).expect("start_file");
+        if name == "Contents/section0.xml" {
+            out.write_all(spliced.as_bytes()).expect("section 교체");
+        } else {
+            out.write_all(&data).expect("copy");
+        }
+    }
+    out.finish().expect("finish").into_inner()
+}
+
+fn export_section(bytes: &[u8]) -> String {
+    let doc = DocumentCore::from_bytes(bytes).unwrap_or_else(|e| panic!("parse: {e:?}"));
+    let exported = doc
+        .export_hwpx_native()
+        .unwrap_or_else(|e| panic!("export: {e:?}"));
+    section_xml_of(&exported)
+}
+
+#[test]
+fn issue_4669_hansel_sample_preserves_ole_id_and_shape_component() {
+    let bytes = std::fs::read(repo_path(SAMPLE)).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let original = section_xml_of(&bytes);
+    let oles = extract_oles(&original);
+    assert_eq!(oles.len(), 1, "한셀OLE 전제: hp:ole 1개");
+    let ole0 = &oles[0];
+    assert_eq!(
+        attr_value(start_tag(ole0), "id").as_deref(),
+        Some("2141242094"),
+        "샘플 전제: id≠instid"
+    );
+    assert_eq!(
+        attr_value(start_tag(ole0), "instid").as_deref(),
+        Some("1067500271")
+    );
+    assert!(
+        ole0.contains(r#"<hp:orgSz width="42001" height="13501"/>"#),
+        "샘플 전제 orgSz"
+    );
+    assert!(
+        ole0.contains(r#"<hp:curSz width="29999" height="4051"/>"#),
+        "샘플 전제 curSz (비-0)"
+    );
+    assert!(
+        ole0.contains(r#"<hp:offset x="0" y="0"/>"#),
+        "샘플 전제 offset"
+    );
+    assert!(ole0.contains(r#"e1="0.714245""#), "샘플 전제 scaMatrix");
+
+    let saved = export_section(&bytes);
+    let saved_oles = extract_oles(&saved);
+    assert_eq!(saved_oles.len(), 1, "저장 후에도 hp:ole 1개");
+    let s = &saved_oles[0];
+    assert_eq!(
+        attr_value(start_tag(s), "id").as_deref(),
+        Some("2141242094"),
+        "id 원문 보존: {s}"
+    );
+    assert_eq!(
+        attr_value(start_tag(s), "instid").as_deref(),
+        Some("1067500271"),
+        "instid 원문 보존: {s}"
+    );
+    assert!(
+        s.contains(r#"<hp:orgSz width="42001" height="13501"/>"#),
+        "orgSz: {s}"
+    );
+    assert!(
+        s.contains(r#"<hp:curSz width="29999" height="4051"/>"#),
+        "curSz 재유도 금지: {s}"
+    );
+    assert!(s.contains(r#"<hp:offset x="0" y="0"/>"#), "offset: {s}");
+    assert!(
+        s.contains(r#"<hp:flip horizontal="0" vertical="0"/>"#),
+        "flip: {s}"
+    );
+    assert!(
+        s.contains(r#"rotateimage="1""#),
+        "rotationInfo rotateimage: {s}"
+    );
+    assert!(
+        s.contains(r#"e1="0.714245""#),
+        "renderingInfo scaMatrix: {s}"
+    );
+    assert!(s.contains(r#"style="NONE""#), "lineShape: {s}");
+}
+
+#[test]
+fn issue_4669_fixture_envelopes_roundtrip_shape_component() {
+    let env_dir = repo_path(&format!("{FIXTURE_ROOT}/envelopes"));
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&env_dir)
+        .unwrap_or_else(|e| panic!("envelopes: {e}"))
+        .map(|e| e.expect("dirent").path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    assert!(
+        paths.len() >= 100,
+        "코퍼스 하한: envelopes {} < 100",
+        paths.len()
+    );
+
+    let mut checked = 0usize;
+    for env_path in &paths {
+        let fid = env_path.file_stem().unwrap().to_string_lossy();
+        let env: Value = serde_json::from_str(
+            &std::fs::read_to_string(env_path).unwrap_or_else(|e| panic!("read {fid}: {e}")),
+        )
+        .unwrap_or_else(|e| panic!("json {fid}: {e}"));
+        assert_eq!(env["issue"], 4669, "{fid}");
+        assert_eq!(
+            env["schema"], "rhwp.issue4669.ole-shape-component.v1",
+            "{fid}"
+        );
+
+        let xml_path = repo_path(&format!("{FIXTURE_ROOT}/xml/{fid}.xml"));
+        let section =
+            std::fs::read_to_string(&xml_path).unwrap_or_else(|e| panic!("xml {fid}: {e}"));
+        let packed = pack_section_into_hansel(&section);
+        let saved = export_section(&packed);
+        let saved_oles = extract_oles(&saved);
+        let expected = env["oles"].as_array().expect("oles");
+        assert_eq!(
+            saved_oles.len(),
+            expected.len(),
+            "{fid}: ole 개수 saved={} expected={}",
+            saved_oles.len(),
+            expected.len()
+        );
+
+        for (i, (ole, spec)) in saved_oles.iter().zip(expected.iter()).enumerate() {
+            let tag = start_tag(ole);
+            let want_id = spec["save_id"]
+                .as_u64()
+                .or_else(|| spec["save_id"].as_i64().map(|v| v as u64))
+                .expect("save_id");
+            let got_id = attr_value(tag, "id").unwrap_or_default();
+            assert_eq!(
+                got_id,
+                want_id.to_string(),
+                "{fid}[{i}] id 원문 보존: {ole}"
+            );
+            let want_inst = spec["instance_id"]
+                .as_u64()
+                .or_else(|| spec["instance_id"].as_i64().map(|v| v as u64))
+                .expect("instance_id");
+            let got_inst = attr_value(tag, "instid").unwrap_or_default();
+            assert_eq!(
+                got_inst,
+                want_inst.to_string(),
+                "{fid}[{i}] instid 원문 보존: {ole}"
+            );
+            if spec["forbid_id_zero"].as_bool() == Some(true) {
+                assert_ne!(got_id, "0", "{fid}[{i}] id 가 0 으로 재부여됨: {ole}");
+            }
+            for frag in spec["expect_xml"].as_array().expect("expect_xml") {
+                let frag = frag.as_str().expect("expect frag");
+                if frag.starts_with("id=\"") || frag.starts_with("instid=\"") {
+                    assert!(
+                        tag.contains(frag),
+                        "{fid}[{i}] 시작 태그에 {frag} 없음: {tag}"
+                    );
+                } else {
+                    assert!(
+                        ole.contains(frag),
+                        "{fid}[{i}] 기대 조각 없음 {frag}: {ole}"
+                    );
+                }
+            }
+            for frag in spec["forbid_xml"].as_array().expect("forbid_xml") {
+                let frag = frag.as_str().expect("forbid frag");
+                assert!(
+                    !ole.contains(frag),
+                    "{fid}[{i}] 금지 조각이 저장됨 {frag}: {ole}"
+                );
+            }
+            checked += 1;
+        }
+    }
+    assert!(checked >= 100, "검사한 ole {checked} < 100");
+}
+
+#[test]
+fn issue_4669_issue_body_cursz_zero_is_not_materialized_on_save() {
+    let xml = std::fs::read_to_string(repo_path(&format!(
+        "{FIXTURE_ROOT}/xml/152_combo_issue_body_xml.xml"
+    )))
+    .expect("issue-body fixture");
+    let saved = export_section(&pack_section_into_hansel(&xml));
+    let ole = &extract_oles(&saved)[0];
+    assert_eq!(
+        attr_value(start_tag(ole), "id").as_deref(),
+        Some("2141242094")
+    );
+    assert_eq!(
+        attr_value(start_tag(ole), "instid").as_deref(),
+        Some("1067500271")
+    );
+    assert!(
+        ole.contains(r#"<hp:curSz width="0" height="0"/>"#),
+        "이슈 본문 재현: curSz=0 복원 {ole}"
+    );
+    assert!(
+        !ole.contains(r#"<hp:curSz width="42001" height="13501"/>"#),
+        "curSz=0 이 orgSz 로 재유도되면 안 된다: {ole}"
+    );
+    assert!(
+        ole.contains(r#"<hp:offset x="12" y="34"/>"#),
+        "offset 12,34: {ole}"
+    );
+}
+
+#[test]
+fn issue_4669_catalog_and_envelopes_are_paired() {
+    let xml_dir = repo_path(&format!("{FIXTURE_ROOT}/xml"));
+    let env_dir = repo_path(&format!("{FIXTURE_ROOT}/envelopes"));
+    let catalog = std::fs::read_to_string(repo_path(&format!("{FIXTURE_ROOT}/catalog.tsv")))
+        .expect("catalog.tsv");
+    let mut xmls: Vec<String> = std::fs::read_dir(xml_dir)
+        .unwrap()
+        .map(|e| {
+            e.unwrap()
+                .path()
+                .file_stem()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    let mut envs: Vec<String> = std::fs::read_dir(env_dir)
+        .unwrap()
+        .map(|e| {
+            e.unwrap()
+                .path()
+                .file_stem()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    xmls.sort();
+    envs.sort();
+    assert_eq!(xmls, envs, "xml 과 envelope 파일 stem 이 1:1 이어야 한다");
+    for id in &xmls {
+        assert!(catalog.contains(id), "catalog.tsv 에 {id} 가 없다");
+    }
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/README.md
+++ b/tests/fixtures/issue_4669_ole_shape_component/README.md
@@ -1,0 +1,13 @@
+# issue #4669 OLE shape-component fixture corpus
+
+M05-9 / #5450. HWPX 저장이 `hp:ole` 의 shape-component 자식과 `id` 를
+보존하는지 고정하는 코퍼스다. pic offset(#4668)·쪽수(#3737)·char_shapes 는
+다루지 않는다.
+
+- `xml/` : 픽스처 섹션 XML (137개)
+- `envelopes/` : 파싱→저장 기대 봉투 전사 (137개)
+- `catalog.tsv` : 색인
+
+생성: `python scripts/generate_issue_4669_ole_fixtures.py`
+
+시험: `tests/cases/issue_4669_ole_shape_component.rs`

--- a/tests/fixtures/issue_4669_ole_shape_component/catalog.tsv
+++ b/tests/fixtures/issue_4669_ole_shape_component/catalog.tsv
@@ -1,0 +1,138 @@
+id	family	ole_count	id_attr	instid	cursz	offset	contract
+000_hansel_oracle	oracle	1	2141242094	1067500271	29999x4051	0,0	samples/한셀OLE.hwpx 원본 hp:ole 의 id≠instid 와 shape-component 원문을 그대로 고정한다.
+001_id_ne_instid_hansel	id-instid	1	2141242094	1067500271	29999x4051	0,0	한셀 실측 id≠instid
+002_id_eq_instid	id-instid	1	77	77	29999x4051	0,0	id 와 instid 가 같은 경우도 둘 다 보존
+003_id_zero_instid_nonzero	id-instid	1	0	1067500271	29999x4051	0,0	명시적 id=0 은 instid 로 덮지 않는다
+004_id_nonzero_instid_zero	id-instid	1	1117817146	0	29999x4051	0,0	명시적 instid=0 은 id 로 덮지 않는다 (#4099)
+005_id_absent_instid_present	id-instid	1	2141242094	1067500271	29999x4051	0,0	id 부재 시 instid 가 id 를 겸한다
+006_id_present_instid_absent	id-instid	1	4242	0	29999x4051	0,0	instid 부재 시 id 가 instance_id 를 겸한다
+007_both_zero	id-instid	1	0	0	29999x4051	0,0	id=0 instid=0 둘 다 유효한 원문
+008_both_max_u32	id-instid	1	4294967295	4294967295	29999x4051	0,0	u32 최대값 id/instid
+009_id_max_instid_one	id-instid	1	4294967295	1	29999x4051	0,0	id 최대·instid 최소 비대칭
+010_id_one_instid_max	id-instid	1	1	4294967295	29999x4051	0,0	id 최소 비영·instid 최대
+011_id_hansel_instid_one	id-instid	1	2141242094	1	29999x4051	0,0	한셀 id + 작은 instid
+012_id_small_instid_hansel	id-instid	1	9	1067500271	29999x4051	0,0	작은 id + 한셀 instid
+013_id_pow2_instid_pow2	id-instid	1	1048576	1073741824	29999x4051	0,0	2의 거듭제곱 분리
+014_id_odd_instid_even	id-instid	1	2141242095	1067500270	29999x4051	0,0	홀/짝 분리
+015_id_chart_fallback_style	id-instid	1	1117817146	0	29999x4051	0,0	차트 fallback OLE 의 instid=0 관례
+016_id_near_i32_max	id-instid	1	2147483647	2147483648	29999x4051	0,0	i32 경계 근처
+021_cursz_zero_zero	cursz-orgsz	1	2141242094	1067500271	0x0	0,0	한컴 원산 관례 curSz=0 → was_zero 센티널
+022_cursz_zero_width_only	cursz-orgsz	1	2141242094	1067500271	0x4051	0,0	width 만 0 센티널
+023_cursz_zero_height_only	cursz-orgsz	1	2141242094	1067500271	29999x0	0,0	height 만 0 센티널
+024_cursz_eq_orgsz	cursz-orgsz	1	2141242094	1067500271	42001x13501	0,0	curSz = orgSz 는 재계산 없이 보존
+025_cursz_eq_extent	cursz-orgsz	1	2141242094	1067500271	29999x4051	0,0	한셀 실측 curSz = extent ≠ orgSz
+026_cursz_independent	cursz-orgsz	1	2141242094	1067500271	18000x2400	0,0	curSz 가 orgSz·extent 와 모두 다름
+027_cursz_one_by_one	cursz-orgsz	1	2141242094	1067500271	1x1	0,0	최소 양수 curSz
+028_orgsz_one_by_one	cursz-orgsz	1	2141242094	1067500271	1x1	0,0	최소 orgSz+curSz
+029_orgsz_zero_cursz_zero	cursz-orgsz	1	2141242094	1067500271	0x0	0,0	orgSz=0 이면 was_zero materialize 없음
+030_large_orgsz	cursz-orgsz	1	2141242094	1067500271	0x0	0,0	큰 orgSz + curSz=0
+031_square_orgsz	cursz-orgsz	1	2141242094	1067500271	8000x8000	0,0	정사각 원본
+032_wide_banner	cursz-orgsz	1	2141242094	1067500271	48000x1200	0,0	가로로 긴 OLE
+033_tall_banner	cursz-orgsz	1	2141242094	1067500271	1200x48000	0,0	세로로 긴 OLE
+034_cursz_gt_orgsz	cursz-orgsz	1	2141242094	1067500271	50000x20000	0,0	표시 크기가 원본보다 큼
+035_cursz_half_orgsz	cursz-orgsz	1	2141242094	1067500271	21000x6750	0,0	절반 스케일
+036_cursz_third_orgsz	cursz-orgsz	1	2141242094	1067500271	14000x4500	0,0	1/3 스케일
+037_orgsz_prime	cursz-orgsz	1	2141242094	1067500271	29989x4049	0,0	소수 크기 — 재유도 오탐 방지
+038_cursz_zero_7200_org	cursz-orgsz	1	2141242094	1067500271	0x0	0,0	7200 org + 0 cur — 기본값과 구분
+039_asymmetric_zero	cursz-orgsz	1	2141242094	1067500271	0x1	0,0	width 0 / height 1
+040_asymmetric_zero_h	cursz-orgsz	1	2141242094	1067500271	1x0	0,0	width 1 / height 0
+041_unit_hwpx	cursz-orgsz	1	2141242094	1067500271	283x283	0,0	1mm 근처 HWPUNIT
+045_offset_zero	offset	1	2141242094	1067500271	29999x4051	0,0	원점 offset
+046_offset_pos	offset	1	2141242094	1067500271	29999x4051	12,34	양수 offset (단위 시험 값)
+047_offset_hansel_zero	offset	1	2141242094	1067500271	29999x4051	0,0	한셀 실측 offset 0,0
+048_offset_wrap_y	offset	1	2141242094	1067500271	29999x4051	5250,-4332	y 음수 wraparound — pic #4668 과 동형, OLE 축
+049_offset_wrap_x	offset	1	2141242094	1067500271	29999x4051	-2429,100	x 음수 wraparound
+050_offset_wrap_both	offset	1	2141242094	1067500271	29999x4051	-100,-200	x/y 모두 wraparound
+051_offset_i32_min_y	offset	1	2141242094	1067500271	29999x4051	0,-2147483648	y = i32::MIN
+052_offset_large_pos	offset	1	2141242094	1067500271	29999x4051	100000,80000	큰 양수 offset
+053_offset_unit	offset	1	2141242094	1067500271	29999x4051	1,-1	최소 비영 ±1
+054_offset_page_out	offset	1	2141242094	1067500271	29999x4051	59528,-10000	쪽 너비 밖 + 위쪽 음수
+055_offset_x_only	offset	1	2141242094	1067500271	29999x4051	7777,0	x 만 이동
+056_offset_y_only	offset	1	2141242094	1067500271	29999x4051	0,8888	y 만 이동
+057_offset_u32_max_as_neg1	offset	1	2141242094	1067500271	29999x4051	-1,0	x=-1 → 4294967295
+058_offset_trans_match	offset	1	2141242094	1067500271	29999x4051	5250,-4332	offset 과 transMatrix 병진이 일치해야 하는 형태
+061_flip_0_0	flip	1	2141242094	1067500271	29999x4051	0,0	flip horizontal=0 vertical=0 원문 보존
+062_flip_1_0	flip	1	2141242094	1067500271	29999x4051	0,0	flip horizontal=1 vertical=0 원문 보존
+063_flip_0_1	flip	1	2141242094	1067500271	29999x4051	0,0	flip horizontal=0 vertical=1 원문 보존
+064_flip_1_1	flip	1	2141242094	1067500271	29999x4051	0,0	flip horizontal=1 vertical=1 원문 보존
+065_flip_h_cursz0	flip	1	2141242094	1067500271	0x0	0,0	수평 flip + curSz=0 동시 보존
+066_flip_v_offset_wrap	flip	1	2141242094	1067500271	29999x4051	0,-50	수직 flip + offset wraparound
+067_flip_both_id_ne	flip	1	2141242094	1067500271	29999x4051	0,0	양축 flip + id≠instid
+068_flip_none_cursz0	flip	1	2141242094	1067500271	0x0	0,0	flip 없음 + curSz=0 (기본 flip 재유도와 구분)
+069_rot_0_hansel	rotation	1	2141242094	1067500271	29999x4051	0,0	한셀 실측 rotationInfo
+070_rot_90	rotation	1	2141242094	1067500271	29999x4051	0,0	90도
+071_rot_180	rotation	1	2141242094	1067500271	29999x4051	0,0	180도
+072_rot_270	rotation	1	2141242094	1067500271	29999x4051	0,0	270도
+073_rot_45	rotation	1	2141242094	1067500271	29999x4051	0,0	45도 + 다른 중심
+074_rot_image_off	rotation	1	2141242094	1067500271	29999x4051	0,0	rotateimage=0
+075_rot_image_on_nonzero	rotation	1	2141242094	1067500271	29999x4051	0,0	작은 각 + 원점 중심
+076_rot_neg_center	rotation	1	2141242094	1067500271	29999x4051	0,0	음수 회전 중심
+077_rot_large_center	rotation	1	2141242094	1067500271	29999x4051	0,0	큰 회전 중심
+078_rot_359	rotation	1	2141242094	1067500271	29999x4051	0,0	359도 rotateimage=0
+079_rot_1_deg	rotation	1	2141242094	1067500271	29999x4051	0,0	1도
+080_rot_zero_center_zero_angle	rotation	1	2141242094	1067500271	29999x4051	0,0	전부 0 — 기본값 재유도와 구분
+081_render_hansel_scale	rendering	1	2141242094	1067500271	29999x4051	0,0	한셀 실측 sca 0.714245×0.300052
+082_render_identity	rendering	1	2141242094	1067500271	29999x4051	0,0	항등 행렬 3개
+083_render_scale_half	rendering	1	2141242094	1067500271	29999x4051	0,0	균등 0.5 스케일
+084_render_scale_2	rendering	1	2141242094	1067500271	29999x4051	0,0	균등 2배
+085_render_trans_only	rendering	1	2141242094	1067500271	29999x4051	0,0	병진만 — offset 과 일치 형태
+086_render_rot90	rendering	1	2141242094	1067500271	29999x4051	0,0	90도 rotMatrix
+087_render_shear	rendering	1	2141242094	1067500271	29999x4051	0,0	전단 성분
+088_render_tiny_scale	rendering	1	2141242094	1067500271	29999x4051	0,0	매우 작은 스케일
+089_render_neg_scale	rendering	1	2141242094	1067500271	29999x4051	0,0	음수 sx (거울)
+090_render_neg_sy	rendering	1	2141242094	1067500271	29999x4051	0,0	음수 sy
+091_render_precise	rendering	1	2141242094	1067500271	29999x4051	0,0	한셀 소수 정밀도 재현
+092_render_other_frac	rendering	1	2141242094	1067500271	29999x4051	0,0	다른 소수 — f32 왕복
+093_render_tx_ty	rendering	1	2141242094	1067500271	29999x4051	0,0	병진+한셀 스케일
+094_render_almost_id	rendering	1	2141242094	1067500271	29999x4051	0,0	항등에 가까운 스케일
+095_render_zero_scale	rendering	1	2141242094	1067500271	29999x4051	0,0	영 스케일 행렬
+096_render_combined	rendering	1	2141242094	1067500271	29999x4051	0,0	병진+스케일+회전 동시
+097_line_none_hansel	lineshape	1	2141242094	1067500271	29999x4051	0,0	한셀 실측 선 없음
+098_line_solid_w5	lineshape	1	2141242094	1067500271	29999x4051	0,0	SOLID width=5 (단위 시험)
+099_line_solid_w1	lineshape	1	2141242094	1067500271	29999x4051	0,0	빨간 실선 FLAT
+100_line_dash	lineshape	1	2141242094	1067500271	29999x4051	0,0	파란 파선 SQUARE
+101_line_dot	lineshape	1	2141242094	1067500271	29999x4051	0,0	점선
+102_line_dash_dot	lineshape	1	2141242094	1067500271	29999x4051	0,0	1점 쇄선
+103_line_dash_dot_dot	lineshape	1	2141242094	1067500271	29999x4051	0,0	2점 쇄선
+104_line_long_dash	lineshape	1	2141242094	1067500271	29999x4051	0,0	긴 파선
+105_line_circle	lineshape	1	2141242094	1067500271	29999x4051	0,0	원 테두리 스타일
+106_line_double_slim	lineshape	1	2141242094	1067500271	29999x4051	0,0	이중 가는 선
+107_line_slim_thick	lineshape	1	2141242094	1067500271	29999x4051	0,0	가늘+굵
+108_line_thick_slim	lineshape	1	2141242094	1067500271	29999x4051	0,0	굵+가늘
+109_line_slim_thick_slim	lineshape	1	2141242094	1067500271	29999x4051	0,0	가늘+굵+가늘
+110_line_white_solid	lineshape	1	2141242094	1067500271	29999x4051	0,0	흰 실선 굵게
+111_line_none_nonzero_w	lineshape	1	2141242094	1067500271	29999x4051	0,0	style=NONE 이지만 width>0 — 재유도 금지
+112_line_solid_zero_w	lineshape	1	2141242094	1067500271	29999x4051	0,0	SOLID + width=0
+113_mut_cursz0	hansel-mutant	1	2141242094	1067500271	0x0	0,0	한셀 원문에 curSz=0 만 넣은 재현
+114_mut_offset_wrap	hansel-mutant	1	2141242094	1067500271	29999x4051	5250,-4332	한셀 + wraparound offset
+115_mut_flip_h	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + 수평 flip
+116_mut_id_zero	hansel-mutant	1	0	1067500271	29999x4051	0,0	한셀 instid 유지 + id=0
+117_mut_instid_zero	hansel-mutant	1	2141242094	0	29999x4051	0,0	한셀 id 유지 + instid=0
+118_mut_line_solid	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + SOLID 테두리
+119_mut_rot90	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + 90도
+120_mut_sca_id	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 sca 를 항등으로
+121_mut_lock	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + lock=1
+122_mut_icon	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + drawAspect=ICON
+123_mut_thumb	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + THUMBNAIL
+124_mut_docprint	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + DOCPRINT
+125_mut_wrap_tight	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + TIGHT
+126_mut_wrap_topbottom	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + TOP_AND_BOTTOM
+127_mut_front	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + IN_FRONT_OF_TEXT
+128_mut_behind	hansel-mutant	1	2141242094	1067500271	29999x4051	0,0	한셀 + BEHIND_TEXT
+129_mut_all_zero_comp	hansel-mutant	1	2141242094	1067500271	0x0	0,0	한셀 id 유지 + 자식 0
+133_aspect_icon_cursz0	ole-attr	1	2141242094	1067500271	0x0	0,0	ICON + curSz=0
+134_lock_and_wrap_offset	ole-attr	1	2141242094	1067500271	29999x4051	-10,20	lock + wraparound x
+135_through_wrap	ole-attr	1	2141242094	1067500271	29999x4051	0,0	THROUGH 배치
+136_largest_flow	ole-attr	1	2141242094	1067500271	29999x4051	0,0	LARGEST_ONLY
+137_right_flow	ole-attr	1	2141242094	1067500271	29999x4051	0,0	RIGHT_ONLY
+138_picture_numbering_cursz0	ole-attr	1	2141242094	1067500271	0x0	0,0	PICTURE numbering + curSz=0
+143_multi_two_oles	multi-ole	2	1001	2001	29999x4051	10,20	한 문단에 OLE 2개 — 각각의 id/자식을 독립 보존
+144_multi_three_oles	multi-ole	3	1001	2001	29999x4051	10,20	OLE 3개 (양수 offset / curSz0+flip / id=0)
+145_multi_four_oles	multi-ole	4	1001	2001	29999x4051	10,20	OLE 4개 (instid=0 wraparound 포함)
+146_multi_id_eq_and_ne	multi-ole	2	1001	2001	29999x4051	10,20	id=instid 인 OLE 와 id≠instid 인 OLE 혼재
+147_multi_scale_pair	multi-ole	2	2141242094	1067500271	29999x4051	0,0	서로 다른 scaMatrix 를 가진 OLE 쌍
+148_multi_cursz0_pair	multi-ole	2	11	21	0x0	0,0	둘 다 curSz=0 이지만 orgSz 가 다름
+149_combo_all_nonzero	combo	1	2141242094	1067500271	18000x2400	-2429,-4332	id≠instid + wraparound offset + curSz 독립 + flip + 90도 + 한셀 sca + SOLID
+150_combo_all_zeroish	combo	1	0	0	0x0	0,0	명시적 0 값 묶음 — 기본값 재유도와 구분돼야 한다
+151_combo_cursz0_wrap_idne	combo	1	2141242094	1067500271	0x0	12,34	이슈 본문 재현: id≠instid + curSz=0 + 원문 offset
+152_combo_issue_body_xml	combo	1	2141242094	1067500271	0x0	12,34	이슈 본문 축약 XML 과 동일 값 (id 2141242094 / instid 1067500271 / curSz 0 / offset 12,34)

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/000_hansel_oracle.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/000_hansel_oracle.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "000_hansel_oracle",
+  "family": "oracle",
+  "contract": "samples/한셀OLE.hwpx 원본 hp:ole 의 id≠instid 와 shape-component 원문을 그대로 고정한다.",
+  "source": "samples/한셀OLE.hwpx Contents/section0.xml",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/001_id_ne_instid_hansel.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/001_id_ne_instid_hansel.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "001_id_ne_instid_hansel",
+  "family": "id-instid",
+  "contract": "한셀 실측 id≠instid",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/002_id_eq_instid.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/002_id_eq_instid.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "002_id_eq_instid",
+  "family": "id-instid",
+  "contract": "id 와 instid 가 같은 경우도 둘 다 보존",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 77,
+      "instid": 77,
+      "hwpx_ole_id": 77,
+      "instance_id": 77,
+      "save_id": 77,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"77\"",
+        "instid=\"77\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/003_id_zero_instid_nonzero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/003_id_zero_instid_nonzero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "003_id_zero_instid_nonzero",
+  "family": "id-instid",
+  "contract": "명시적 id=0 은 instid 로 덮지 않는다",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 0,
+      "instid": 1067500271,
+      "hwpx_ole_id": 0,
+      "instance_id": 1067500271,
+      "save_id": 0,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"0\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": false
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/004_id_nonzero_instid_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/004_id_nonzero_instid_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "004_id_nonzero_instid_zero",
+  "family": "id-instid",
+  "contract": "명시적 instid=0 은 id 로 덮지 않는다 (#4099)",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1117817146,
+      "instid": 0,
+      "hwpx_ole_id": 1117817146,
+      "instance_id": 0,
+      "save_id": 1117817146,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1117817146\"",
+        "instid=\"0\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/005_id_absent_instid_present.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/005_id_absent_instid_present.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "005_id_absent_instid_present",
+  "family": "id-instid",
+  "contract": "id 부재 시 instid 가 id 를 겸한다",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": null,
+      "instid": 1067500271,
+      "hwpx_ole_id": null,
+      "instance_id": 1067500271,
+      "save_id": 1067500271,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1067500271\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": false
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/006_id_present_instid_absent.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/006_id_present_instid_absent.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "006_id_present_instid_absent",
+  "family": "id-instid",
+  "contract": "instid 부재 시 id 가 instance_id 를 겸한다",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 4242,
+      "instid": null,
+      "hwpx_ole_id": 4242,
+      "instance_id": 4242,
+      "save_id": 4242,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"4242\"",
+        "instid=\"4242\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/007_both_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/007_both_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "007_both_zero",
+  "family": "id-instid",
+  "contract": "id=0 instid=0 둘 다 유효한 원문",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 0,
+      "instid": 0,
+      "hwpx_ole_id": 0,
+      "instance_id": 0,
+      "save_id": 0,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"0\"",
+        "instid=\"0\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": false
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/008_both_max_u32.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/008_both_max_u32.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "008_both_max_u32",
+  "family": "id-instid",
+  "contract": "u32 최대값 id/instid",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 4294967295,
+      "instid": 4294967295,
+      "hwpx_ole_id": 4294967295,
+      "instance_id": 4294967295,
+      "save_id": 4294967295,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"4294967295\"",
+        "instid=\"4294967295\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/009_id_max_instid_one.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/009_id_max_instid_one.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "009_id_max_instid_one",
+  "family": "id-instid",
+  "contract": "id 최대·instid 최소 비대칭",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 4294967295,
+      "instid": 1,
+      "hwpx_ole_id": 4294967295,
+      "instance_id": 1,
+      "save_id": 4294967295,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"4294967295\"",
+        "instid=\"1\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/010_id_one_instid_max.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/010_id_one_instid_max.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "010_id_one_instid_max",
+  "family": "id-instid",
+  "contract": "id 최소 비영·instid 최대",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1,
+      "instid": 4294967295,
+      "hwpx_ole_id": 1,
+      "instance_id": 4294967295,
+      "save_id": 1,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1\"",
+        "instid=\"4294967295\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/011_id_hansel_instid_one.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/011_id_hansel_instid_one.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "011_id_hansel_instid_one",
+  "family": "id-instid",
+  "contract": "한셀 id + 작은 instid",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/012_id_small_instid_hansel.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/012_id_small_instid_hansel.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "012_id_small_instid_hansel",
+  "family": "id-instid",
+  "contract": "작은 id + 한셀 instid",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 9,
+      "instid": 1067500271,
+      "hwpx_ole_id": 9,
+      "instance_id": 1067500271,
+      "save_id": 9,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"9\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/013_id_pow2_instid_pow2.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/013_id_pow2_instid_pow2.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "013_id_pow2_instid_pow2",
+  "family": "id-instid",
+  "contract": "2의 거듭제곱 분리",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1048576,
+      "instid": 1073741824,
+      "hwpx_ole_id": 1048576,
+      "instance_id": 1073741824,
+      "save_id": 1048576,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1048576\"",
+        "instid=\"1073741824\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/014_id_odd_instid_even.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/014_id_odd_instid_even.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "014_id_odd_instid_even",
+  "family": "id-instid",
+  "contract": "홀/짝 분리",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242095,
+      "instid": 1067500270,
+      "hwpx_ole_id": 2141242095,
+      "instance_id": 1067500270,
+      "save_id": 2141242095,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242095\"",
+        "instid=\"1067500270\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/015_id_chart_fallback_style.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/015_id_chart_fallback_style.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "015_id_chart_fallback_style",
+  "family": "id-instid",
+  "contract": "차트 fallback OLE 의 instid=0 관례",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1117817146,
+      "instid": 0,
+      "hwpx_ole_id": 1117817146,
+      "instance_id": 0,
+      "save_id": 1117817146,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1117817146\"",
+        "instid=\"0\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/016_id_near_i32_max.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/016_id_near_i32_max.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "016_id_near_i32_max",
+  "family": "id-instid",
+  "contract": "i32 경계 근처",
+  "source": "synthetic / 한셀OLE id·instid 관례",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2147483647,
+      "instid": 2147483648,
+      "hwpx_ole_id": 2147483647,
+      "instance_id": 2147483648,
+      "save_id": 2147483647,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2147483647\"",
+        "instid=\"2147483648\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/021_cursz_zero_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/021_cursz_zero_zero.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "021_cursz_zero_zero",
+  "family": "cursz-orgsz",
+  "contract": "한컴 원산 관례 curSz=0 → was_zero 센티널",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/022_cursz_zero_width_only.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/022_cursz_zero_width_only.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "022_cursz_zero_width_only",
+  "family": "cursz-orgsz",
+  "contract": "width 만 0 센티널",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        4051
+      ],
+      "was_zero": [
+        true,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/023_cursz_zero_height_only.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/023_cursz_zero_height_only.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "023_cursz_zero_height_only",
+  "family": "cursz-orgsz",
+  "contract": "height 만 0 센티널",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        0
+      ],
+      "was_zero": [
+        false,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/024_cursz_eq_orgsz.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/024_cursz_eq_orgsz.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "024_cursz_eq_orgsz",
+  "family": "cursz-orgsz",
+  "contract": "curSz = orgSz 는 재계산 없이 보존",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        42001,
+        13501
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"42001\" height=\"13501\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/025_cursz_eq_extent.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/025_cursz_eq_extent.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "025_cursz_eq_extent",
+  "family": "cursz-orgsz",
+  "contract": "한셀 실측 curSz = extent ≠ orgSz",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/026_cursz_independent.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/026_cursz_independent.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "026_cursz_independent",
+  "family": "cursz-orgsz",
+  "contract": "curSz 가 orgSz·extent 와 모두 다름",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        18000,
+        2400
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"18000\" height=\"2400\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/027_cursz_one_by_one.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/027_cursz_one_by_one.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "027_cursz_one_by_one",
+  "family": "cursz-orgsz",
+  "contract": "최소 양수 curSz",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        1,
+        1
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"1\" height=\"1\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/028_orgsz_one_by_one.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/028_orgsz_one_by_one.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "028_orgsz_one_by_one",
+  "family": "cursz-orgsz",
+  "contract": "최소 orgSz+curSz",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        1,
+        1
+      ],
+      "curSz": [
+        1,
+        1
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"1\" height=\"1\"/>",
+        "<hp:curSz width=\"1\" height=\"1\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/029_orgsz_zero_cursz_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/029_orgsz_zero_cursz_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "029_orgsz_zero_cursz_zero",
+  "family": "cursz-orgsz",
+  "contract": "orgSz=0 이면 was_zero materialize 없음",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        0,
+        0
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"0\" height=\"0\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/030_large_orgsz.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/030_large_orgsz.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "030_large_orgsz",
+  "family": "cursz-orgsz",
+  "contract": "큰 orgSz + curSz=0",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        200000,
+        150000
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"200000\" height=\"150000\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"200000\" height=\"150000\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/031_square_orgsz.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/031_square_orgsz.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "031_square_orgsz",
+  "family": "cursz-orgsz",
+  "contract": "정사각 원본",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        16000,
+        16000
+      ],
+      "curSz": [
+        8000,
+        8000
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"16000\" height=\"16000\"/>",
+        "<hp:curSz width=\"8000\" height=\"8000\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/032_wide_banner.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/032_wide_banner.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "032_wide_banner",
+  "family": "cursz-orgsz",
+  "contract": "가로로 긴 OLE",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        96000,
+        2400
+      ],
+      "curSz": [
+        48000,
+        1200
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"96000\" height=\"2400\"/>",
+        "<hp:curSz width=\"48000\" height=\"1200\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/033_tall_banner.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/033_tall_banner.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "033_tall_banner",
+  "family": "cursz-orgsz",
+  "contract": "세로로 긴 OLE",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        2400,
+        96000
+      ],
+      "curSz": [
+        1200,
+        48000
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"2400\" height=\"96000\"/>",
+        "<hp:curSz width=\"1200\" height=\"48000\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/034_cursz_gt_orgsz.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/034_cursz_gt_orgsz.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "034_cursz_gt_orgsz",
+  "family": "cursz-orgsz",
+  "contract": "표시 크기가 원본보다 큼",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        10000,
+        4000
+      ],
+      "curSz": [
+        50000,
+        20000
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"10000\" height=\"4000\"/>",
+        "<hp:curSz width=\"50000\" height=\"20000\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/035_cursz_half_orgsz.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/035_cursz_half_orgsz.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "035_cursz_half_orgsz",
+  "family": "cursz-orgsz",
+  "contract": "절반 스케일",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42000,
+        13500
+      ],
+      "curSz": [
+        21000,
+        6750
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42000\" height=\"13500\"/>",
+        "<hp:curSz width=\"21000\" height=\"6750\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/036_cursz_third_orgsz.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/036_cursz_third_orgsz.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "036_cursz_third_orgsz",
+  "family": "cursz-orgsz",
+  "contract": "1/3 스케일",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42000,
+        13500
+      ],
+      "curSz": [
+        14000,
+        4500
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42000\" height=\"13500\"/>",
+        "<hp:curSz width=\"14000\" height=\"4500\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/037_orgsz_prime.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/037_orgsz_prime.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "037_orgsz_prime",
+  "family": "cursz-orgsz",
+  "contract": "소수 크기 — 재유도 오탐 방지",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42013,
+        13513
+      ],
+      "curSz": [
+        29989,
+        4049
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42013\" height=\"13513\"/>",
+        "<hp:curSz width=\"29989\" height=\"4049\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/038_cursz_zero_7200_org.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/038_cursz_zero_7200_org.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "038_cursz_zero_7200_org",
+  "family": "cursz-orgsz",
+  "contract": "7200 org + 0 cur — 기본값과 구분",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        7200,
+        7200
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"7200\" height=\"7200\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"7200\" height=\"7200\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/039_asymmetric_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/039_asymmetric_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "039_asymmetric_zero",
+  "family": "cursz-orgsz",
+  "contract": "width 0 / height 1",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        9000,
+        3000
+      ],
+      "curSz": [
+        0,
+        1
+      ],
+      "was_zero": [
+        true,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"9000\" height=\"3000\"/>",
+        "<hp:curSz width=\"0\" height=\"1\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/040_asymmetric_zero_h.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/040_asymmetric_zero_h.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "040_asymmetric_zero_h",
+  "family": "cursz-orgsz",
+  "contract": "width 1 / height 0",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        9000,
+        3000
+      ],
+      "curSz": [
+        1,
+        0
+      ],
+      "was_zero": [
+        false,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"9000\" height=\"3000\"/>",
+        "<hp:curSz width=\"1\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/041_unit_hwpx.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/041_unit_hwpx.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "041_unit_hwpx",
+  "family": "cursz-orgsz",
+  "contract": "1mm 근처 HWPUNIT",
+  "source": "synthetic / #2017 OLE 센티널",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        566,
+        566
+      ],
+      "curSz": [
+        283,
+        283
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"566\" height=\"566\"/>",
+        "<hp:curSz width=\"283\" height=\"283\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/045_offset_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/045_offset_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "045_offset_zero",
+  "family": "offset",
+  "contract": "원점 offset",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/046_offset_pos.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/046_offset_pos.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "046_offset_pos",
+  "family": "offset",
+  "contract": "양수 offset (단위 시험 값)",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        12,
+        34
+      ],
+      "offset_u32": [
+        12,
+        34
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        12,
+        0,
+        1,
+        34
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"12\" y=\"34\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/047_offset_hansel_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/047_offset_hansel_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "047_offset_hansel_zero",
+  "family": "offset",
+  "contract": "한셀 실측 offset 0,0",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/048_offset_wrap_y.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/048_offset_wrap_y.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "048_offset_wrap_y",
+  "family": "offset",
+  "contract": "y 음수 wraparound — pic #4668 과 동형, OLE 축",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        5250,
+        -4332
+      ],
+      "offset_u32": [
+        5250,
+        4294962964
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        5250,
+        0,
+        1,
+        -4332
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"5250\" y=\"4294962964\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/049_offset_wrap_x.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/049_offset_wrap_x.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "049_offset_wrap_x",
+  "family": "offset",
+  "contract": "x 음수 wraparound",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        -2429,
+        100
+      ],
+      "offset_u32": [
+        4294964867,
+        100
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        -2429,
+        0,
+        1,
+        100
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"4294964867\" y=\"100\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/050_offset_wrap_both.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/050_offset_wrap_both.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "050_offset_wrap_both",
+  "family": "offset",
+  "contract": "x/y 모두 wraparound",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        -100,
+        -200
+      ],
+      "offset_u32": [
+        4294967196,
+        4294967096
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        -100,
+        0,
+        1,
+        -200
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"4294967196\" y=\"4294967096\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/051_offset_i32_min_y.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/051_offset_i32_min_y.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "051_offset_i32_min_y",
+  "family": "offset",
+  "contract": "y = i32::MIN",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        -2147483648
+      ],
+      "offset_u32": [
+        0,
+        2147483648
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        -2147483648
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"2147483648\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/052_offset_large_pos.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/052_offset_large_pos.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "052_offset_large_pos",
+  "family": "offset",
+  "contract": "큰 양수 offset",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        100000,
+        80000
+      ],
+      "offset_u32": [
+        100000,
+        80000
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        100000,
+        0,
+        1,
+        80000
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"100000\" y=\"80000\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/053_offset_unit.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/053_offset_unit.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "053_offset_unit",
+  "family": "offset",
+  "contract": "최소 비영 ±1",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        1,
+        -1
+      ],
+      "offset_u32": [
+        1,
+        4294967295
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        1,
+        0,
+        1,
+        -1
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"1\" y=\"4294967295\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/054_offset_page_out.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/054_offset_page_out.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "054_offset_page_out",
+  "family": "offset",
+  "contract": "쪽 너비 밖 + 위쪽 음수",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        59528,
+        -10000
+      ],
+      "offset_u32": [
+        59528,
+        4294957296
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        59528,
+        0,
+        1,
+        -10000
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"59528\" y=\"4294957296\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/055_offset_x_only.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/055_offset_x_only.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "055_offset_x_only",
+  "family": "offset",
+  "contract": "x 만 이동",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        7777,
+        0
+      ],
+      "offset_u32": [
+        7777,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        7777,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"7777\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/056_offset_y_only.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/056_offset_y_only.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "056_offset_y_only",
+  "family": "offset",
+  "contract": "y 만 이동",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        8888
+      ],
+      "offset_u32": [
+        0,
+        8888
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        8888
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"8888\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/057_offset_u32_max_as_neg1.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/057_offset_u32_max_as_neg1.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "057_offset_u32_max_as_neg1",
+  "family": "offset",
+  "contract": "x=-1 → 4294967295",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        -1,
+        0
+      ],
+      "offset_u32": [
+        4294967295,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        -1,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"4294967295\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/058_offset_trans_match.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/058_offset_trans_match.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "058_offset_trans_match",
+  "family": "offset",
+  "contract": "offset 과 transMatrix 병진이 일치해야 하는 형태",
+  "source": "synthetic / #3544 unsigned wraparound",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        5250,
+        -4332
+      ],
+      "offset_u32": [
+        5250,
+        4294962964
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        5250,
+        0,
+        1,
+        -4332
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"5250\" y=\"4294962964\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/061_flip_0_0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/061_flip_0_0.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "061_flip_0_0",
+  "family": "flip",
+  "contract": "flip horizontal=0 vertical=0 원문 보존",
+  "source": "synthetic / shape-component flip",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/062_flip_1_0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/062_flip_1_0.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "062_flip_1_0",
+  "family": "flip",
+  "contract": "flip horizontal=1 vertical=0 원문 보존",
+  "source": "synthetic / shape-component flip",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/063_flip_0_1.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/063_flip_0_1.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "063_flip_0_1",
+  "family": "flip",
+  "contract": "flip horizontal=0 vertical=1 원문 보존",
+  "source": "synthetic / shape-component flip",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        1
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"1\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/064_flip_1_1.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/064_flip_1_1.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "064_flip_1_1",
+  "family": "flip",
+  "contract": "flip horizontal=1 vertical=1 원문 보존",
+  "source": "synthetic / shape-component flip",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        1,
+        1
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"1\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/065_flip_h_cursz0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/065_flip_h_cursz0.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "065_flip_h_cursz0",
+  "family": "flip",
+  "contract": "수평 flip + curSz=0 동시 보존",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/066_flip_v_offset_wrap.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/066_flip_v_offset_wrap.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "066_flip_v_offset_wrap",
+  "family": "flip",
+  "contract": "수직 flip + offset wraparound",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        -50
+      ],
+      "offset_u32": [
+        0,
+        4294967246
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        1
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        -50
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"4294967246\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"1\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/067_flip_both_id_ne.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/067_flip_both_id_ne.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "067_flip_both_id_ne",
+  "family": "flip",
+  "contract": "양축 flip + id≠instid",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        1,
+        1
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"1\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/068_flip_none_cursz0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/068_flip_none_cursz0.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "068_flip_none_cursz0",
+  "family": "flip",
+  "contract": "flip 없음 + curSz=0 (기본 flip 재유도와 구분)",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/069_rot_0_hansel.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/069_rot_0_hansel.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "069_rot_0_hansel",
+  "family": "rotation",
+  "contract": "한셀 실측 rotationInfo",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/070_rot_90.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/070_rot_90.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "070_rot_90",
+  "family": "rotation",
+  "contract": "90도",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        90,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"90\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/071_rot_180.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/071_rot_180.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "071_rot_180",
+  "family": "rotation",
+  "contract": "180도",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        180,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"180\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/072_rot_270.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/072_rot_270.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "072_rot_270",
+  "family": "rotation",
+  "contract": "270도",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        270,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"270\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/073_rot_45.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/073_rot_45.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "073_rot_45",
+  "family": "rotation",
+  "contract": "45도 + 다른 중심",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        45,
+        8000,
+        4000,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"45\"",
+        "centerX=\"8000\"",
+        "centerY=\"4000\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/074_rot_image_off.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/074_rot_image_off.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "074_rot_image_off",
+  "family": "rotation",
+  "contract": "rotateimage=0",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        0
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"0\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/075_rot_image_on_nonzero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/075_rot_image_on_nonzero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "075_rot_image_on_nonzero",
+  "family": "rotation",
+  "contract": "작은 각 + 원점 중심",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        15,
+        0,
+        0,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"15\"",
+        "centerX=\"0\"",
+        "centerY=\"0\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/076_rot_neg_center.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/076_rot_neg_center.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "076_rot_neg_center",
+  "family": "rotation",
+  "contract": "음수 회전 중심",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        -100,
+        -200,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"-100\"",
+        "centerY=\"-200\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/077_rot_large_center.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/077_rot_large_center.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "077_rot_large_center",
+  "family": "rotation",
+  "contract": "큰 회전 중심",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        100000,
+        80000,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"100000\"",
+        "centerY=\"80000\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/078_rot_359.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/078_rot_359.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "078_rot_359",
+  "family": "rotation",
+  "contract": "359도 rotateimage=0",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        359,
+        1,
+        1,
+        0
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"359\"",
+        "centerX=\"1\"",
+        "centerY=\"1\"",
+        "rotateimage=\"0\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/079_rot_1_deg.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/079_rot_1_deg.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "079_rot_1_deg",
+  "family": "rotation",
+  "contract": "1도",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        1,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"1\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/080_rot_zero_center_zero_angle.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/080_rot_zero_center_zero_angle.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "080_rot_zero_center_zero_angle",
+  "family": "rotation",
+  "contract": "전부 0 — 기본값 재유도와 구분",
+  "source": "synthetic / rotationInfo",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"0\"",
+        "centerY=\"0\"",
+        "rotateimage=\"0\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/081_render_hansel_scale.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/081_render_hansel_scale.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "081_render_hansel_scale",
+  "family": "rendering",
+  "contract": "한셀 실측 sca 0.714245×0.300052",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/082_render_identity.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/082_render_identity.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "082_render_identity",
+  "family": "rendering",
+  "contract": "항등 행렬 3개",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/083_render_scale_half.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/083_render_scale_half.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "083_render_scale_half",
+  "family": "rendering",
+  "contract": "균등 0.5 스케일",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.5,
+        0,
+        0,
+        0,
+        0.5,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/084_render_scale_2.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/084_render_scale_2.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "084_render_scale_2",
+  "family": "rendering",
+  "contract": "균등 2배",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        2,
+        0,
+        0,
+        0,
+        2,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/085_render_trans_only.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/085_render_trans_only.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "085_render_trans_only",
+  "family": "rendering",
+  "contract": "병진만 — offset 과 일치 형태",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        5250,
+        0,
+        1,
+        -4332
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/086_render_rot90.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/086_render_rot90.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "086_render_rot90",
+  "family": "rendering",
+  "contract": "90도 rotMatrix",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/087_render_shear.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/087_render_shear.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "087_render_shear",
+  "family": "rendering",
+  "contract": "전단 성분",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0.2,
+        0,
+        0.1,
+        1,
+        0
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/088_render_tiny_scale.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/088_render_tiny_scale.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "088_render_tiny_scale",
+  "family": "rendering",
+  "contract": "매우 작은 스케일",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.01,
+        0,
+        0,
+        0,
+        0.02,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/089_render_neg_scale.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/089_render_neg_scale.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "089_render_neg_scale",
+  "family": "rendering",
+  "contract": "음수 sx (거울)",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        -1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/090_render_neg_sy.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/090_render_neg_sy.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "090_render_neg_sy",
+  "family": "rendering",
+  "contract": "음수 sy",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        -1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/091_render_precise.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/091_render_precise.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "091_render_precise",
+  "family": "rendering",
+  "contract": "한셀 소수 정밀도 재현",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/092_render_other_frac.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/092_render_other_frac.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "092_render_other_frac",
+  "family": "rendering",
+  "contract": "다른 소수 — f32 왕복",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        1.579917,
+        0,
+        0,
+        0,
+        0.333333,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/093_render_tx_ty.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/093_render_tx_ty.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "093_render_tx_ty",
+  "family": "rendering",
+  "contract": "병진+한셀 스케일",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        12,
+        0,
+        1,
+        34
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/094_render_almost_id.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/094_render_almost_id.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "094_render_almost_id",
+  "family": "rendering",
+  "contract": "항등에 가까운 스케일",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.999999,
+        0,
+        0,
+        0,
+        1.000001,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/095_render_zero_scale.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/095_render_zero_scale.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "095_render_zero_scale",
+  "family": "rendering",
+  "contract": "영 스케일 행렬",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/096_render_combined.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/096_render_combined.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "096_render_combined",
+  "family": "rendering",
+  "contract": "병진+스케일+회전 동시",
+  "source": "synthetic / renderingInfo raw_rendering",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        100,
+        0,
+        1,
+        -50
+      ],
+      "sca": [
+        0.5,
+        0,
+        0,
+        0,
+        0.25,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/097_line_none_hansel.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/097_line_none_hansel.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "097_line_none_hansel",
+  "family": "lineshape",
+  "contract": "한셀 실측 선 없음",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/098_line_solid_w5.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/098_line_solid_w5.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "098_line_solid_w5",
+  "family": "lineshape",
+  "contract": "SOLID width=5 (단위 시험)",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 5,
+        "style": "SOLID",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"5\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/099_line_solid_w1.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/099_line_solid_w1.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "099_line_solid_w1",
+  "family": "lineshape",
+  "contract": "빨간 실선 FLAT",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#FF0000",
+        "width": 1,
+        "style": "SOLID",
+        "endCap": "FLAT"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"1\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/100_line_dash.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/100_line_dash.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "100_line_dash",
+  "family": "lineshape",
+  "contract": "파란 파선 SQUARE",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#0000FF",
+        "width": 10,
+        "style": "DASH",
+        "endCap": "SQUARE"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"DASH\"",
+        "width=\"10\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/101_line_dot.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/101_line_dot.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "101_line_dot",
+  "family": "lineshape",
+  "contract": "점선",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#00FF00",
+        "width": 8,
+        "style": "DOT",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"DOT\"",
+        "width=\"8\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/102_line_dash_dot.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/102_line_dash_dot.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "102_line_dash_dot",
+  "family": "lineshape",
+  "contract": "1점 쇄선",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#123456",
+        "width": 3,
+        "style": "DASH_DOT",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"DASH_DOT\"",
+        "width=\"3\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/103_line_dash_dot_dot.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/103_line_dash_dot_dot.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "103_line_dash_dot_dot",
+  "family": "lineshape",
+  "contract": "2점 쇄선",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#ABCDEF",
+        "width": 4,
+        "style": "DASH_DOT_DOT",
+        "endCap": "FLAT"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"DASH_DOT_DOT\"",
+        "width=\"4\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/104_line_long_dash.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/104_line_long_dash.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "104_line_long_dash",
+  "family": "lineshape",
+  "contract": "긴 파선",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#010101",
+        "width": 12,
+        "style": "LONG_DASH",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"LONG_DASH\"",
+        "width=\"12\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/105_line_circle.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/105_line_circle.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "105_line_circle",
+  "family": "lineshape",
+  "contract": "원 테두리 스타일",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#800080",
+        "width": 6,
+        "style": "CIRCLE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"CIRCLE\"",
+        "width=\"6\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/106_line_double_slim.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/106_line_double_slim.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "106_line_double_slim",
+  "family": "lineshape",
+  "contract": "이중 가는 선",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#008080",
+        "width": 2,
+        "style": "DOUBLE_SLIM",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"DOUBLE_SLIM\"",
+        "width=\"2\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/107_line_slim_thick.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/107_line_slim_thick.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "107_line_slim_thick",
+  "family": "lineshape",
+  "contract": "가늘+굵",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#808000",
+        "width": 7,
+        "style": "SLIM_THICK",
+        "endCap": "FLAT"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SLIM_THICK\"",
+        "width=\"7\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/108_line_thick_slim.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/108_line_thick_slim.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "108_line_thick_slim",
+  "family": "lineshape",
+  "contract": "굵+가늘",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000080",
+        "width": 9,
+        "style": "THICK_SLIM",
+        "endCap": "SQUARE"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"THICK_SLIM\"",
+        "width=\"9\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/109_line_slim_thick_slim.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/109_line_slim_thick_slim.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "109_line_slim_thick_slim",
+  "family": "lineshape",
+  "contract": "가늘+굵+가늘",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#808080",
+        "width": 11,
+        "style": "SLIM_THICK_SLIM",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SLIM_THICK_SLIM\"",
+        "width=\"11\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/110_line_white_solid.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/110_line_white_solid.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "110_line_white_solid",
+  "family": "lineshape",
+  "contract": "흰 실선 굵게",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#FFFFFF",
+        "width": 20,
+        "style": "SOLID",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"20\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/111_line_none_nonzero_w.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/111_line_none_nonzero_w.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "111_line_none_nonzero_w",
+  "family": "lineshape",
+  "contract": "style=NONE 이지만 width>0 — 재유도 금지",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 15,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"15\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/112_line_solid_zero_w.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/112_line_solid_zero_w.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "112_line_solid_zero_w",
+  "family": "lineshape",
+  "contract": "SOLID + width=0",
+  "source": "synthetic / lineShape",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "SOLID",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/113_mut_cursz0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/113_mut_cursz0.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "113_mut_cursz0",
+  "family": "hansel-mutant",
+  "contract": "한셀 원문에 curSz=0 만 넣은 재현",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/114_mut_offset_wrap.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/114_mut_offset_wrap.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "114_mut_offset_wrap",
+  "family": "hansel-mutant",
+  "contract": "한셀 + wraparound offset",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        5250,
+        -4332
+      ],
+      "offset_u32": [
+        5250,
+        4294962964
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        5250,
+        0,
+        1,
+        -4332
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"5250\" y=\"4294962964\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/115_mut_flip_h.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/115_mut_flip_h.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "115_mut_flip_h",
+  "family": "hansel-mutant",
+  "contract": "한셀 + 수평 flip",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/116_mut_id_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/116_mut_id_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "116_mut_id_zero",
+  "family": "hansel-mutant",
+  "contract": "한셀 instid 유지 + id=0",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 0,
+      "instid": 1067500271,
+      "hwpx_ole_id": 0,
+      "instance_id": 1067500271,
+      "save_id": 0,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"0\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": false
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/117_mut_instid_zero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/117_mut_instid_zero.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "117_mut_instid_zero",
+  "family": "hansel-mutant",
+  "contract": "한셀 id 유지 + instid=0",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 0,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 0,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"0\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/118_mut_line_solid.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/118_mut_line_solid.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "118_mut_line_solid",
+  "family": "hansel-mutant",
+  "contract": "한셀 + SOLID 테두리",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 5,
+        "style": "SOLID",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"5\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/119_mut_rot90.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/119_mut_rot90.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "119_mut_rot90",
+  "family": "hansel-mutant",
+  "contract": "한셀 + 90도",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        90,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"90\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/120_mut_sca_id.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/120_mut_sca_id.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "120_mut_sca_id",
+  "family": "hansel-mutant",
+  "contract": "한셀 sca 를 항등으로",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/121_mut_lock.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/121_mut_lock.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "121_mut_lock",
+  "family": "hansel-mutant",
+  "contract": "한셀 + lock=1",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/122_mut_icon.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/122_mut_icon.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "122_mut_icon",
+  "family": "hansel-mutant",
+  "contract": "한셀 + drawAspect=ICON",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/123_mut_thumb.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/123_mut_thumb.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "123_mut_thumb",
+  "family": "hansel-mutant",
+  "contract": "한셀 + THUMBNAIL",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/124_mut_docprint.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/124_mut_docprint.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "124_mut_docprint",
+  "family": "hansel-mutant",
+  "contract": "한셀 + DOCPRINT",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/125_mut_wrap_tight.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/125_mut_wrap_tight.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "125_mut_wrap_tight",
+  "family": "hansel-mutant",
+  "contract": "한셀 + TIGHT",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/126_mut_wrap_topbottom.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/126_mut_wrap_topbottom.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "126_mut_wrap_topbottom",
+  "family": "hansel-mutant",
+  "contract": "한셀 + TOP_AND_BOTTOM",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/127_mut_front.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/127_mut_front.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "127_mut_front",
+  "family": "hansel-mutant",
+  "contract": "한셀 + IN_FRONT_OF_TEXT",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/128_mut_behind.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/128_mut_behind.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "128_mut_behind",
+  "family": "hansel-mutant",
+  "contract": "한셀 + BEHIND_TEXT",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/129_mut_all_zero_comp.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/129_mut_all_zero_comp.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "129_mut_all_zero_comp",
+  "family": "hansel-mutant",
+  "contract": "한셀 id 유지 + 자식 0",
+  "source": "samples/한셀OLE.hwpx 1필드 변이",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"0\"",
+        "centerY=\"0\"",
+        "rotateimage=\"0\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/133_aspect_icon_cursz0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/133_aspect_icon_cursz0.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "133_aspect_icon_cursz0",
+  "family": "ole-attr",
+  "contract": "ICON + curSz=0",
+  "source": "synthetic / hp:ole 속성 + 자식 동시",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/134_lock_and_wrap_offset.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/134_lock_and_wrap_offset.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "134_lock_and_wrap_offset",
+  "family": "ole-attr",
+  "contract": "lock + wraparound x",
+  "source": "synthetic / hp:ole 속성 + 자식 동시",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        -10,
+        20
+      ],
+      "offset_u32": [
+        4294967286,
+        20
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        -10,
+        0,
+        1,
+        20
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"4294967286\" y=\"20\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/135_through_wrap.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/135_through_wrap.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "135_through_wrap",
+  "family": "ole-attr",
+  "contract": "THROUGH 배치",
+  "source": "synthetic / hp:ole 속성 + 자식 동시",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/136_largest_flow.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/136_largest_flow.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "136_largest_flow",
+  "family": "ole-attr",
+  "contract": "LARGEST_ONLY",
+  "source": "synthetic / hp:ole 속성 + 자식 동시",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/137_right_flow.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/137_right_flow.json
@@ -1,0 +1,87 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "137_right_flow",
+  "family": "ole-attr",
+  "contract": "RIGHT_ONLY",
+  "source": "synthetic / hp:ole 속성 + 자식 동시",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/138_picture_numbering_cursz0.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/138_picture_numbering_cursz0.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "138_picture_numbering_cursz0",
+  "family": "ole-attr",
+  "contract": "PICTURE numbering + curSz=0",
+  "source": "synthetic / hp:ole 속성 + 자식 동시",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/143_multi_two_oles.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/143_multi_two_oles.json
@@ -1,0 +1,167 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "143_multi_two_oles",
+  "family": "multi-ole",
+  "contract": "한 문단에 OLE 2개 — 각각의 id/자식을 독립 보존",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1001,
+      "instid": 2001,
+      "hwpx_ole_id": 1001,
+      "instance_id": 2001,
+      "save_id": 1001,
+      "offset": [
+        10,
+        20
+      ],
+      "offset_u32": [
+        10,
+        20
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        10,
+        0,
+        1,
+        20
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1001\"",
+        "instid=\"2001\"",
+        "<hp:offset x=\"10\" y=\"20\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 1,
+      "id": 1002,
+      "instid": 2002,
+      "hwpx_ole_id": 1002,
+      "instance_id": 2002,
+      "save_id": 1002,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1002\"",
+        "instid=\"2002\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/144_multi_three_oles.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/144_multi_three_oles.json
@@ -1,0 +1,243 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "144_multi_three_oles",
+  "family": "multi-ole",
+  "contract": "OLE 3개 (양수 offset / curSz0+flip / id=0)",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1001,
+      "instid": 2001,
+      "hwpx_ole_id": 1001,
+      "instance_id": 2001,
+      "save_id": 1001,
+      "offset": [
+        10,
+        20
+      ],
+      "offset_u32": [
+        10,
+        20
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        10,
+        0,
+        1,
+        20
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1001\"",
+        "instid=\"2001\"",
+        "<hp:offset x=\"10\" y=\"20\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 1,
+      "id": 1002,
+      "instid": 2002,
+      "hwpx_ole_id": 1002,
+      "instance_id": 2002,
+      "save_id": 1002,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1002\"",
+        "instid=\"2002\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 2,
+      "id": 0,
+      "instid": 3003,
+      "hwpx_ole_id": 0,
+      "instance_id": 3003,
+      "save_id": 0,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#FF0000",
+        "width": 3,
+        "style": "SOLID",
+        "endCap": "FLAT"
+      },
+      "expect_xml": [
+        "id=\"0\"",
+        "instid=\"3003\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"3\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": false
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/145_multi_four_oles.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/145_multi_four_oles.json
@@ -1,0 +1,321 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "145_multi_four_oles",
+  "family": "multi-ole",
+  "contract": "OLE 4개 (instid=0 wraparound 포함)",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1001,
+      "instid": 2001,
+      "hwpx_ole_id": 1001,
+      "instance_id": 2001,
+      "save_id": 1001,
+      "offset": [
+        10,
+        20
+      ],
+      "offset_u32": [
+        10,
+        20
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        10,
+        0,
+        1,
+        20
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1001\"",
+        "instid=\"2001\"",
+        "<hp:offset x=\"10\" y=\"20\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 1,
+      "id": 1002,
+      "instid": 2002,
+      "hwpx_ole_id": 1002,
+      "instance_id": 2002,
+      "save_id": 1002,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1002\"",
+        "instid=\"2002\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 2,
+      "id": 0,
+      "instid": 3003,
+      "hwpx_ole_id": 0,
+      "instance_id": 3003,
+      "save_id": 0,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#FF0000",
+        "width": 3,
+        "style": "SOLID",
+        "endCap": "FLAT"
+      },
+      "expect_xml": [
+        "id=\"0\"",
+        "instid=\"3003\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"3\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": false
+    },
+    {
+      "index": 3,
+      "id": 4004,
+      "instid": 0,
+      "hwpx_ole_id": 4004,
+      "instance_id": 0,
+      "save_id": 4004,
+      "offset": [
+        -5,
+        -6
+      ],
+      "offset_u32": [
+        4294967291,
+        4294967290
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        -5,
+        0,
+        1,
+        -6
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"4004\"",
+        "instid=\"0\"",
+        "<hp:offset x=\"4294967291\" y=\"4294967290\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/146_multi_id_eq_and_ne.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/146_multi_id_eq_and_ne.json
@@ -1,0 +1,165 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "146_multi_id_eq_and_ne",
+  "family": "multi-ole",
+  "contract": "id=instid 인 OLE 와 id≠instid 인 OLE 혼재",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 1001,
+      "instid": 2001,
+      "hwpx_ole_id": 1001,
+      "instance_id": 2001,
+      "save_id": 1001,
+      "offset": [
+        10,
+        20
+      ],
+      "offset_u32": [
+        10,
+        20
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        10,
+        0,
+        1,
+        20
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"1001\"",
+        "instid=\"2001\"",
+        "<hp:offset x=\"10\" y=\"20\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 1,
+      "id": 5005,
+      "instid": 5005,
+      "hwpx_ole_id": 5005,
+      "instance_id": 5005,
+      "save_id": 5005,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        90,
+        1,
+        2,
+        0
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"5005\"",
+        "instid=\"5005\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"90\"",
+        "centerX=\"1\"",
+        "centerY=\"2\"",
+        "rotateimage=\"0\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/147_multi_scale_pair.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/147_multi_scale_pair.json
@@ -1,0 +1,163 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "147_multi_scale_pair",
+  "family": "multi-ole",
+  "contract": "서로 다른 scaMatrix 를 가진 OLE 쌍",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 1,
+      "id": 6006,
+      "instid": 7007,
+      "hwpx_ole_id": 6006,
+      "instance_id": 7007,
+      "save_id": 6006,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        29999,
+        4051
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.5,
+        0,
+        0,
+        0,
+        0.25,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"6006\"",
+        "instid=\"7007\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"29999\" height=\"4051\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/148_multi_cursz0_pair.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/148_multi_cursz0_pair.json
@@ -1,0 +1,167 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "148_multi_cursz0_pair",
+  "family": "multi-ole",
+  "contract": "둘 다 curSz=0 이지만 orgSz 가 다름",
+  "source": "synthetic",
+  "oles": [
+    {
+      "index": 0,
+      "id": 11,
+      "instid": 21,
+      "hwpx_ole_id": 11,
+      "instance_id": 21,
+      "save_id": 11,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        1000,
+        2000
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"11\"",
+        "instid=\"21\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"1000\" height=\"2000\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"1000\" height=\"2000\"/>"
+      ],
+      "forbid_id_zero": true
+    },
+    {
+      "index": 1,
+      "id": 12,
+      "instid": 22,
+      "hwpx_ole_id": 12,
+      "instance_id": 22,
+      "save_id": 12,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        3000,
+        4000
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"12\"",
+        "instid=\"22\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"3000\" height=\"4000\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"3000\" height=\"4000\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/149_combo_all_nonzero.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/149_combo_all_nonzero.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "149_combo_all_nonzero",
+  "family": "combo",
+  "contract": "id≠instid + wraparound offset + curSz 독립 + flip + 90도 + 한셀 sca + SOLID",
+  "source": "synthetic combination",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        -2429,
+        -4332
+      ],
+      "offset_u32": [
+        4294964867,
+        4294962964
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        18000,
+        2400
+      ],
+      "was_zero": [
+        false,
+        false
+      ],
+      "flip": [
+        1,
+        1
+      ],
+      "rotation": [
+        90,
+        9000,
+        1200,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        -2429,
+        0,
+        1,
+        -4332
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#112233",
+        "width": 4,
+        "style": "SOLID",
+        "endCap": "FLAT"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"4294964867\" y=\"4294962964\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"18000\" height=\"2400\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"1\"/>",
+        "angle=\"90\"",
+        "centerX=\"9000\"",
+        "centerY=\"1200\"",
+        "rotateimage=\"1\"",
+        "style=\"SOLID\"",
+        "width=\"4\""
+      ],
+      "forbid_xml": [
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/150_combo_all_zeroish.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/150_combo_all_zeroish.json
@@ -1,0 +1,89 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "150_combo_all_zeroish",
+  "family": "combo",
+  "contract": "명시적 0 값 묶음 — 기본값 재유도와 구분돼야 한다",
+  "source": "synthetic combination",
+  "oles": [
+    {
+      "index": 0,
+      "id": 0,
+      "instid": 0,
+      "hwpx_ole_id": 0,
+      "instance_id": 0,
+      "save_id": 0,
+      "offset": [
+        0,
+        0
+      ],
+      "offset_u32": [
+        0,
+        0
+      ],
+      "orgSz": [
+        7200,
+        7200
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "trans": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "sca": [
+        1,
+        0,
+        0,
+        0,
+        1,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"0\"",
+        "instid=\"0\"",
+        "<hp:offset x=\"0\" y=\"0\"/>",
+        "<hp:orgSz width=\"7200\" height=\"7200\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"0\"",
+        "centerY=\"0\"",
+        "rotateimage=\"0\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"7200\" height=\"7200\"/>"
+      ],
+      "forbid_id_zero": false
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/151_combo_cursz0_wrap_idne.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/151_combo_cursz0_wrap_idne.json
@@ -1,0 +1,90 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "151_combo_cursz0_wrap_idne",
+  "family": "combo",
+  "contract": "이슈 본문 재현: id≠instid + curSz=0 + 원문 offset",
+  "source": "issue #4669 reproduction",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        12,
+        34
+      ],
+      "offset_u32": [
+        12,
+        34
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        12,
+        0,
+        1,
+        34
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"12\" y=\"34\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"0\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>",
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/envelopes/152_combo_issue_body_xml.json
+++ b/tests/fixtures/issue_4669_ole_shape_component/envelopes/152_combo_issue_body_xml.json
@@ -1,0 +1,90 @@
+{
+  "schema": "rhwp.issue4669.ole-shape-component.v1",
+  "issue": 4669,
+  "tracker": 5450,
+  "fixture_id": "152_combo_issue_body_xml",
+  "family": "combo",
+  "contract": "이슈 본문 축약 XML 과 동일 값 (id 2141242094 / instid 1067500271 / curSz 0 / offset 12,34)",
+  "source": "issue #4669 body",
+  "oles": [
+    {
+      "index": 0,
+      "id": 2141242094,
+      "instid": 1067500271,
+      "hwpx_ole_id": 2141242094,
+      "instance_id": 1067500271,
+      "save_id": 2141242094,
+      "offset": [
+        12,
+        34
+      ],
+      "offset_u32": [
+        12,
+        34
+      ],
+      "orgSz": [
+        42001,
+        13501
+      ],
+      "curSz": [
+        0,
+        0
+      ],
+      "was_zero": [
+        true,
+        true
+      ],
+      "flip": [
+        1,
+        0
+      ],
+      "rotation": [
+        0,
+        14999,
+        2025,
+        1
+      ],
+      "trans": [
+        1,
+        0,
+        12,
+        0,
+        1,
+        34
+      ],
+      "sca": [
+        0.714245,
+        0,
+        0,
+        0,
+        0.300052,
+        0
+      ],
+      "line": {
+        "color": "#000000",
+        "width": 0,
+        "style": "NONE",
+        "endCap": "ROUND"
+      },
+      "expect_xml": [
+        "id=\"2141242094\"",
+        "instid=\"1067500271\"",
+        "<hp:offset x=\"12\" y=\"34\"/>",
+        "<hp:orgSz width=\"42001\" height=\"13501\"/>",
+        "<hp:curSz width=\"0\" height=\"0\"/>",
+        "<hp:flip horizontal=\"1\" vertical=\"0\"/>",
+        "angle=\"0\"",
+        "centerX=\"14999\"",
+        "centerY=\"2025\"",
+        "rotateimage=\"1\"",
+        "style=\"NONE\"",
+        "width=\"0\""
+      ],
+      "forbid_xml": [
+        "<hp:curSz width=\"42001\" height=\"13501\"/>",
+        "<hp:offset x=\"0\" y=\"0\"/>"
+      ],
+      "forbid_id_zero": true
+    }
+  ]
+}

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/000_hansel_oracle.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/000_hansel_oracle.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 000_hansel_oracle
+  family: oracle
+  contract: samples/한셀OLE.hwpx 원본 hp:ole 의 id≠instid 와 shape-component 원문을 그대로 고정한다.
+  source: samples/한셀OLE.hwpx Contents/section0.xml
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/001_id_ne_instid_hansel.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/001_id_ne_instid_hansel.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 001_id_ne_instid_hansel
+  family: id-instid
+  contract: 한셀 실측 id≠instid
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/002_id_eq_instid.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/002_id_eq_instid.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 002_id_eq_instid
+  family: id-instid
+  contract: id 와 instid 가 같은 경우도 둘 다 보존
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="77" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="77" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/003_id_zero_instid_nonzero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/003_id_zero_instid_nonzero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 003_id_zero_instid_nonzero
+  family: id-instid
+  contract: 명시적 id=0 은 instid 로 덮지 않는다
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="0" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/004_id_nonzero_instid_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/004_id_nonzero_instid_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 004_id_nonzero_instid_zero
+  family: id-instid
+  contract: 명시적 instid=0 은 id 로 덮지 않는다 (#4099)
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1117817146" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/005_id_absent_instid_present.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/005_id_absent_instid_present.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 005_id_absent_instid_present
+  family: id-instid
+  contract: id 부재 시 instid 가 id 를 겸한다
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/006_id_present_instid_absent.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/006_id_present_instid_absent.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 006_id_present_instid_absent
+  family: id-instid
+  contract: instid 부재 시 id 가 instance_id 를 겸한다
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="4242" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/007_both_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/007_both_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 007_both_zero
+  family: id-instid
+  contract: id=0 instid=0 둘 다 유효한 원문
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="0" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/008_both_max_u32.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/008_both_max_u32.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 008_both_max_u32
+  family: id-instid
+  contract: u32 최대값 id/instid
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="4294967295" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="4294967295" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/009_id_max_instid_one.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/009_id_max_instid_one.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 009_id_max_instid_one
+  family: id-instid
+  contract: id 최대·instid 최소 비대칭
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="4294967295" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/010_id_one_instid_max.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/010_id_one_instid_max.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 010_id_one_instid_max
+  family: id-instid
+  contract: id 최소 비영·instid 최대
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="4294967295" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/011_id_hansel_instid_one.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/011_id_hansel_instid_one.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 011_id_hansel_instid_one
+  family: id-instid
+  contract: 한셀 id + 작은 instid
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/012_id_small_instid_hansel.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/012_id_small_instid_hansel.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 012_id_small_instid_hansel
+  family: id-instid
+  contract: 작은 id + 한셀 instid
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="9" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/013_id_pow2_instid_pow2.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/013_id_pow2_instid_pow2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 013_id_pow2_instid_pow2
+  family: id-instid
+  contract: 2의 거듭제곱 분리
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1048576" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1073741824" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/014_id_odd_instid_even.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/014_id_odd_instid_even.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 014_id_odd_instid_even
+  family: id-instid
+  contract: 홀/짝 분리
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242095" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500270" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/015_id_chart_fallback_style.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/015_id_chart_fallback_style.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 015_id_chart_fallback_style
+  family: id-instid
+  contract: 차트 fallback OLE 의 instid=0 관례
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1117817146" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/016_id_near_i32_max.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/016_id_near_i32_max.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 016_id_near_i32_max
+  family: id-instid
+  contract: i32 경계 근처
+  source: synthetic / 한셀OLE id·instid 관례
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2147483647" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2147483648" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/021_cursz_zero_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/021_cursz_zero_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 021_cursz_zero_zero
+  family: cursz-orgsz
+  contract: 한컴 원산 관례 curSz=0 → was_zero 센티널
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="42001" y="13501"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="42001" widthRelTo="ABSOLUTE" height="13501" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/022_cursz_zero_width_only.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/022_cursz_zero_width_only.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 022_cursz_zero_width_only
+  family: cursz-orgsz
+  contract: width 만 0 센티널
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="42001" y="13501"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="42001" widthRelTo="ABSOLUTE" height="13501" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/023_cursz_zero_height_only.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/023_cursz_zero_height_only.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 023_cursz_zero_height_only
+  family: cursz-orgsz
+  contract: height 만 0 센티널
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="42001" y="13501"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="42001" widthRelTo="ABSOLUTE" height="13501" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/024_cursz_eq_orgsz.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/024_cursz_eq_orgsz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 024_cursz_eq_orgsz
+  family: cursz-orgsz
+  contract: curSz = orgSz 는 재계산 없이 보존
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="42001" height="13501"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="42001" y="13501"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="42001" widthRelTo="ABSOLUTE" height="13501" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/025_cursz_eq_extent.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/025_cursz_eq_extent.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 025_cursz_eq_extent
+  family: cursz-orgsz
+  contract: 한셀 실측 curSz = extent ≠ orgSz
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/026_cursz_independent.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/026_cursz_independent.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 026_cursz_independent
+  family: cursz-orgsz
+  contract: curSz 가 orgSz·extent 와 모두 다름
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="18000" height="2400"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="18000" y="2400"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="18000" widthRelTo="ABSOLUTE" height="2400" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/027_cursz_one_by_one.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/027_cursz_one_by_one.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 027_cursz_one_by_one
+  family: cursz-orgsz
+  contract: 최소 양수 curSz
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="1" height="1"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="1" y="1"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="1" widthRelTo="ABSOLUTE" height="1" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/028_orgsz_one_by_one.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/028_orgsz_one_by_one.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 028_orgsz_one_by_one
+  family: cursz-orgsz
+  contract: 최소 orgSz+curSz
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="1" height="1"/>
+        <hp:curSz width="1" height="1"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="1" y="1"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="1" widthRelTo="ABSOLUTE" height="1" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/029_orgsz_zero_cursz_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/029_orgsz_zero_cursz_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 029_orgsz_zero_cursz_zero
+  family: cursz-orgsz
+  contract: orgSz=0 이면 was_zero materialize 없음
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="0" height="0"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="0" y="0"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="0" widthRelTo="ABSOLUTE" height="0" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/030_large_orgsz.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/030_large_orgsz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 030_large_orgsz
+  family: cursz-orgsz
+  contract: 큰 orgSz + curSz=0
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="200000" height="150000"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="200000" y="150000"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="200000" widthRelTo="ABSOLUTE" height="150000" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/031_square_orgsz.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/031_square_orgsz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 031_square_orgsz
+  family: cursz-orgsz
+  contract: 정사각 원본
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="16000" height="16000"/>
+        <hp:curSz width="8000" height="8000"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="8000" y="8000"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="8000" widthRelTo="ABSOLUTE" height="8000" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/032_wide_banner.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/032_wide_banner.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 032_wide_banner
+  family: cursz-orgsz
+  contract: 가로로 긴 OLE
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="96000" height="2400"/>
+        <hp:curSz width="48000" height="1200"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="48000" y="1200"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="48000" widthRelTo="ABSOLUTE" height="1200" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/033_tall_banner.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/033_tall_banner.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 033_tall_banner
+  family: cursz-orgsz
+  contract: 세로로 긴 OLE
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="2400" height="96000"/>
+        <hp:curSz width="1200" height="48000"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="1200" y="48000"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="1200" widthRelTo="ABSOLUTE" height="48000" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/034_cursz_gt_orgsz.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/034_cursz_gt_orgsz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 034_cursz_gt_orgsz
+  family: cursz-orgsz
+  contract: 표시 크기가 원본보다 큼
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="10000" height="4000"/>
+        <hp:curSz width="50000" height="20000"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="50000" y="20000"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="50000" widthRelTo="ABSOLUTE" height="20000" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/035_cursz_half_orgsz.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/035_cursz_half_orgsz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 035_cursz_half_orgsz
+  family: cursz-orgsz
+  contract: 절반 스케일
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42000" height="13500"/>
+        <hp:curSz width="21000" height="6750"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="21000" y="6750"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="21000" widthRelTo="ABSOLUTE" height="6750" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/036_cursz_third_orgsz.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/036_cursz_third_orgsz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 036_cursz_third_orgsz
+  family: cursz-orgsz
+  contract: 1/3 스케일
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42000" height="13500"/>
+        <hp:curSz width="14000" height="4500"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="14000" y="4500"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="14000" widthRelTo="ABSOLUTE" height="4500" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/037_orgsz_prime.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/037_orgsz_prime.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 037_orgsz_prime
+  family: cursz-orgsz
+  contract: 소수 크기 — 재유도 오탐 방지
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42013" height="13513"/>
+        <hp:curSz width="29989" height="4049"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29989" y="4049"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29989" widthRelTo="ABSOLUTE" height="4049" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/038_cursz_zero_7200_org.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/038_cursz_zero_7200_org.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 038_cursz_zero_7200_org
+  family: cursz-orgsz
+  contract: 7200 org + 0 cur — 기본값과 구분
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="7200" height="7200"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="7200" y="7200"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="7200" widthRelTo="ABSOLUTE" height="7200" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/039_asymmetric_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/039_asymmetric_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 039_asymmetric_zero
+  family: cursz-orgsz
+  contract: width 0 / height 1
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="9000" height="3000"/>
+        <hp:curSz width="0" height="1"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="9000" y="3000"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="9000" widthRelTo="ABSOLUTE" height="3000" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/040_asymmetric_zero_h.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/040_asymmetric_zero_h.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 040_asymmetric_zero_h
+  family: cursz-orgsz
+  contract: width 1 / height 0
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="9000" height="3000"/>
+        <hp:curSz width="1" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="9000" y="3000"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="9000" widthRelTo="ABSOLUTE" height="3000" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/041_unit_hwpx.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/041_unit_hwpx.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 041_unit_hwpx
+  family: cursz-orgsz
+  contract: 1mm 근처 HWPUNIT
+  source: synthetic / #2017 OLE 센티널
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="566" height="566"/>
+        <hp:curSz width="283" height="283"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="283" y="283"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="283" widthRelTo="ABSOLUTE" height="283" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/045_offset_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/045_offset_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 045_offset_zero
+  family: offset
+  contract: 원점 offset
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/046_offset_pos.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/046_offset_pos.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 046_offset_pos
+  family: offset
+  contract: 양수 offset (단위 시험 값)
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="12" y="34"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="12" e4="0" e5="1" e6="34"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/047_offset_hansel_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/047_offset_hansel_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 047_offset_hansel_zero
+  family: offset
+  contract: 한셀 실측 offset 0,0
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/048_offset_wrap_y.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/048_offset_wrap_y.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 048_offset_wrap_y
+  family: offset
+  contract: y 음수 wraparound — pic #4668 과 동형, OLE 축
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="5250" y="4294962964"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="5250" e4="0" e5="1" e6="-4332"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/049_offset_wrap_x.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/049_offset_wrap_x.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 049_offset_wrap_x
+  family: offset
+  contract: x 음수 wraparound
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="4294964867" y="100"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="-2429" e4="0" e5="1" e6="100"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/050_offset_wrap_both.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/050_offset_wrap_both.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 050_offset_wrap_both
+  family: offset
+  contract: x/y 모두 wraparound
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="4294967196" y="4294967096"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="-100" e4="0" e5="1" e6="-200"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/051_offset_i32_min_y.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/051_offset_i32_min_y.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 051_offset_i32_min_y
+  family: offset
+  contract: y = i32::MIN
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="2147483648"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="-2147483648"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/052_offset_large_pos.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/052_offset_large_pos.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 052_offset_large_pos
+  family: offset
+  contract: 큰 양수 offset
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="100000" y="80000"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="100000" e4="0" e5="1" e6="80000"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/053_offset_unit.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/053_offset_unit.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 053_offset_unit
+  family: offset
+  contract: 최소 비영 ±1
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="1" y="4294967295"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="1" e4="0" e5="1" e6="-1"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/054_offset_page_out.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/054_offset_page_out.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 054_offset_page_out
+  family: offset
+  contract: 쪽 너비 밖 + 위쪽 음수
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="59528" y="4294957296"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="59528" e4="0" e5="1" e6="-10000"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/055_offset_x_only.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/055_offset_x_only.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 055_offset_x_only
+  family: offset
+  contract: x 만 이동
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="7777" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="7777" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/056_offset_y_only.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/056_offset_y_only.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 056_offset_y_only
+  family: offset
+  contract: y 만 이동
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="8888"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="8888"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/057_offset_u32_max_as_neg1.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/057_offset_u32_max_as_neg1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 057_offset_u32_max_as_neg1
+  family: offset
+  contract: x=-1 → 4294967295
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="4294967295" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="-1" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/058_offset_trans_match.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/058_offset_trans_match.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 058_offset_trans_match
+  family: offset
+  contract: offset 과 transMatrix 병진이 일치해야 하는 형태
+  source: synthetic / #3544 unsigned wraparound
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="5250" y="4294962964"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="5250" e4="0" e5="1" e6="-4332"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/061_flip_0_0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/061_flip_0_0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 061_flip_0_0
+  family: flip
+  contract: flip horizontal=0 vertical=0 원문 보존
+  source: synthetic / shape-component flip
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/062_flip_1_0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/062_flip_1_0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 062_flip_1_0
+  family: flip
+  contract: flip horizontal=1 vertical=0 원문 보존
+  source: synthetic / shape-component flip
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/063_flip_0_1.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/063_flip_0_1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 063_flip_0_1
+  family: flip
+  contract: flip horizontal=0 vertical=1 원문 보존
+  source: synthetic / shape-component flip
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="1"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/064_flip_1_1.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/064_flip_1_1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 064_flip_1_1
+  family: flip
+  contract: flip horizontal=1 vertical=1 원문 보존
+  source: synthetic / shape-component flip
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="1" vertical="1"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/065_flip_h_cursz0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/065_flip_h_cursz0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 065_flip_h_cursz0
+  family: flip
+  contract: 수평 flip + curSz=0 동시 보존
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/066_flip_v_offset_wrap.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/066_flip_v_offset_wrap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 066_flip_v_offset_wrap
+  family: flip
+  contract: 수직 flip + offset wraparound
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="4294967246"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="1"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="-50"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/067_flip_both_id_ne.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/067_flip_both_id_ne.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 067_flip_both_id_ne
+  family: flip
+  contract: 양축 flip + id≠instid
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="1" vertical="1"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/068_flip_none_cursz0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/068_flip_none_cursz0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 068_flip_none_cursz0
+  family: flip
+  contract: flip 없음 + curSz=0 (기본 flip 재유도와 구분)
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/069_rot_0_hansel.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/069_rot_0_hansel.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 069_rot_0_hansel
+  family: rotation
+  contract: 한셀 실측 rotationInfo
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/070_rot_90.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/070_rot_90.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 070_rot_90
+  family: rotation
+  contract: 90도
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="90" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/071_rot_180.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/071_rot_180.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 071_rot_180
+  family: rotation
+  contract: 180도
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="180" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/072_rot_270.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/072_rot_270.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 072_rot_270
+  family: rotation
+  contract: 270도
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="270" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/073_rot_45.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/073_rot_45.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 073_rot_45
+  family: rotation
+  contract: 45도 + 다른 중심
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="45" centerX="8000" centerY="4000" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/074_rot_image_off.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/074_rot_image_off.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 074_rot_image_off
+  family: rotation
+  contract: rotateimage=0
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="0"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/075_rot_image_on_nonzero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/075_rot_image_on_nonzero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 075_rot_image_on_nonzero
+  family: rotation
+  contract: 작은 각 + 원점 중심
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="15" centerX="0" centerY="0" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/076_rot_neg_center.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/076_rot_neg_center.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 076_rot_neg_center
+  family: rotation
+  contract: 음수 회전 중심
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="-100" centerY="-200" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/077_rot_large_center.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/077_rot_large_center.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 077_rot_large_center
+  family: rotation
+  contract: 큰 회전 중심
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="100000" centerY="80000" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/078_rot_359.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/078_rot_359.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 078_rot_359
+  family: rotation
+  contract: 359도 rotateimage=0
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="359" centerX="1" centerY="1" rotateimage="0"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/079_rot_1_deg.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/079_rot_1_deg.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 079_rot_1_deg
+  family: rotation
+  contract: 1도
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="1" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/080_rot_zero_center_zero_angle.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/080_rot_zero_center_zero_angle.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 080_rot_zero_center_zero_angle
+  family: rotation
+  contract: 전부 0 — 기본값 재유도와 구분
+  source: synthetic / rotationInfo
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="0" centerY="0" rotateimage="0"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/081_render_hansel_scale.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/081_render_hansel_scale.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 081_render_hansel_scale
+  family: rendering
+  contract: 한셀 실측 sca 0.714245×0.300052
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/082_render_identity.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/082_render_identity.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 082_render_identity
+  family: rendering
+  contract: 항등 행렬 3개
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/083_render_scale_half.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/083_render_scale_half.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 083_render_scale_half
+  family: rendering
+  contract: 균등 0.5 스케일
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.5" e2="0" e3="0" e4="0" e5="0.5" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/084_render_scale_2.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/084_render_scale_2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 084_render_scale_2
+  family: rendering
+  contract: 균등 2배
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="2" e2="0" e3="0" e4="0" e5="2" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/085_render_trans_only.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/085_render_trans_only.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 085_render_trans_only
+  family: rendering
+  contract: 병진만 — offset 과 일치 형태
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="5250" e4="0" e5="1" e6="-4332"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/086_render_rot90.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/086_render_rot90.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 086_render_rot90
+  family: rendering
+  contract: 90도 rotMatrix
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="0" e2="-1" e3="0" e4="1" e5="0" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/087_render_shear.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/087_render_shear.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 087_render_shear
+  family: rendering
+  contract: 전단 성분
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0.2" e3="0" e4="0.1" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/088_render_tiny_scale.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/088_render_tiny_scale.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 088_render_tiny_scale
+  family: rendering
+  contract: 매우 작은 스케일
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.01" e2="0" e3="0" e4="0" e5="0.02" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/089_render_neg_scale.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/089_render_neg_scale.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 089_render_neg_scale
+  family: rendering
+  contract: 음수 sx (거울)
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="-1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/090_render_neg_sy.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/090_render_neg_sy.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 090_render_neg_sy
+  family: rendering
+  contract: 음수 sy
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="-1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/091_render_precise.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/091_render_precise.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 091_render_precise
+  family: rendering
+  contract: 한셀 소수 정밀도 재현
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/092_render_other_frac.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/092_render_other_frac.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 092_render_other_frac
+  family: rendering
+  contract: 다른 소수 — f32 왕복
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1.579917" e2="0" e3="0" e4="0" e5="0.333333" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/093_render_tx_ty.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/093_render_tx_ty.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 093_render_tx_ty
+  family: rendering
+  contract: 병진+한셀 스케일
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="12" e4="0" e5="1" e6="34"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/094_render_almost_id.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/094_render_almost_id.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 094_render_almost_id
+  family: rendering
+  contract: 항등에 가까운 스케일
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.999999" e2="0" e3="0" e4="0" e5="1.000001" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/095_render_zero_scale.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/095_render_zero_scale.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 095_render_zero_scale
+  family: rendering
+  contract: 영 스케일 행렬
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0" e2="0" e3="0" e4="0" e5="0" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/096_render_combined.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/096_render_combined.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 096_render_combined
+  family: rendering
+  contract: 병진+스케일+회전 동시
+  source: synthetic / renderingInfo raw_rendering
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="100" e4="0" e5="1" e6="-50"/>
+          <hc:scaMatrix e1="0.5" e2="0" e3="0" e4="0" e5="0.25" e6="0"/>
+          <hc:rotMatrix e1="0" e2="-1" e3="0" e4="1" e5="0" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/097_line_none_hansel.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/097_line_none_hansel.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 097_line_none_hansel
+  family: lineshape
+  contract: 한셀 실측 선 없음
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/098_line_solid_w5.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/098_line_solid_w5.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 098_line_solid_w5
+  family: lineshape
+  contract: SOLID width=5 (단위 시험)
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="5" style="SOLID" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/099_line_solid_w1.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/099_line_solid_w1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 099_line_solid_w1
+  family: lineshape
+  contract: 빨간 실선 FLAT
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#FF0000" width="1" style="SOLID" endCap="FLAT"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/100_line_dash.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/100_line_dash.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 100_line_dash
+  family: lineshape
+  contract: 파란 파선 SQUARE
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#0000FF" width="10" style="DASH" endCap="SQUARE"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/101_line_dot.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/101_line_dot.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 101_line_dot
+  family: lineshape
+  contract: 점선
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#00FF00" width="8" style="DOT" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/102_line_dash_dot.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/102_line_dash_dot.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 102_line_dash_dot
+  family: lineshape
+  contract: 1점 쇄선
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#123456" width="3" style="DASH_DOT" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/103_line_dash_dot_dot.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/103_line_dash_dot_dot.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 103_line_dash_dot_dot
+  family: lineshape
+  contract: 2점 쇄선
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#ABCDEF" width="4" style="DASH_DOT_DOT" endCap="FLAT"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/104_line_long_dash.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/104_line_long_dash.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 104_line_long_dash
+  family: lineshape
+  contract: 긴 파선
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#010101" width="12" style="LONG_DASH" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/105_line_circle.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/105_line_circle.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 105_line_circle
+  family: lineshape
+  contract: 원 테두리 스타일
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#800080" width="6" style="CIRCLE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/106_line_double_slim.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/106_line_double_slim.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 106_line_double_slim
+  family: lineshape
+  contract: 이중 가는 선
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#008080" width="2" style="DOUBLE_SLIM" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/107_line_slim_thick.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/107_line_slim_thick.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 107_line_slim_thick
+  family: lineshape
+  contract: 가늘+굵
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#808000" width="7" style="SLIM_THICK" endCap="FLAT"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/108_line_thick_slim.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/108_line_thick_slim.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 108_line_thick_slim
+  family: lineshape
+  contract: 굵+가늘
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000080" width="9" style="THICK_SLIM" endCap="SQUARE"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/109_line_slim_thick_slim.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/109_line_slim_thick_slim.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 109_line_slim_thick_slim
+  family: lineshape
+  contract: 가늘+굵+가늘
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#808080" width="11" style="SLIM_THICK_SLIM" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/110_line_white_solid.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/110_line_white_solid.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 110_line_white_solid
+  family: lineshape
+  contract: 흰 실선 굵게
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#FFFFFF" width="20" style="SOLID" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/111_line_none_nonzero_w.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/111_line_none_nonzero_w.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 111_line_none_nonzero_w
+  family: lineshape
+  contract: style=NONE 이지만 width>0 — 재유도 금지
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="15" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/112_line_solid_zero_w.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/112_line_solid_zero_w.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 112_line_solid_zero_w
+  family: lineshape
+  contract: SOLID + width=0
+  source: synthetic / lineShape
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="SOLID" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/113_mut_cursz0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/113_mut_cursz0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 113_mut_cursz0
+  family: hansel-mutant
+  contract: 한셀 원문에 curSz=0 만 넣은 재현
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/114_mut_offset_wrap.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/114_mut_offset_wrap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 114_mut_offset_wrap
+  family: hansel-mutant
+  contract: 한셀 + wraparound offset
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="5250" y="4294962964"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="5250" e4="0" e5="1" e6="-4332"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/115_mut_flip_h.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/115_mut_flip_h.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 115_mut_flip_h
+  family: hansel-mutant
+  contract: 한셀 + 수평 flip
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/116_mut_id_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/116_mut_id_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 116_mut_id_zero
+  family: hansel-mutant
+  contract: 한셀 instid 유지 + id=0
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="0" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/117_mut_instid_zero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/117_mut_instid_zero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 117_mut_instid_zero
+  family: hansel-mutant
+  contract: 한셀 id 유지 + instid=0
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/118_mut_line_solid.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/118_mut_line_solid.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 118_mut_line_solid
+  family: hansel-mutant
+  contract: 한셀 + SOLID 테두리
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="5" style="SOLID" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/119_mut_rot90.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/119_mut_rot90.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 119_mut_rot90
+  family: hansel-mutant
+  contract: 한셀 + 90도
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="90" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/120_mut_sca_id.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/120_mut_sca_id.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 120_mut_sca_id
+  family: hansel-mutant
+  contract: 한셀 sca 를 항등으로
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/121_mut_lock.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/121_mut_lock.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 121_mut_lock
+  family: hansel-mutant
+  contract: 한셀 + lock=1
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="1" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/122_mut_icon.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/122_mut_icon.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 122_mut_icon
+  family: hansel-mutant
+  contract: 한셀 + drawAspect=ICON
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="ICON">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/123_mut_thumb.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/123_mut_thumb.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 123_mut_thumb
+  family: hansel-mutant
+  contract: 한셀 + THUMBNAIL
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="THUMBNAIL">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/124_mut_docprint.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/124_mut_docprint.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 124_mut_docprint
+  family: hansel-mutant
+  contract: 한셀 + DOCPRINT
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="DOCPRINT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/125_mut_wrap_tight.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/125_mut_wrap_tight.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 125_mut_wrap_tight
+  family: hansel-mutant
+  contract: 한셀 + TIGHT
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="TIGHT"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/126_mut_wrap_topbottom.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/126_mut_wrap_topbottom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 126_mut_wrap_topbottom
+  family: hansel-mutant
+  contract: 한셀 + TOP_AND_BOTTOM
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="TOP_AND_BOTTOM"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/127_mut_front.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/127_mut_front.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 127_mut_front
+  family: hansel-mutant
+  contract: 한셀 + IN_FRONT_OF_TEXT
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="IN_FRONT_OF_TEXT"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/128_mut_behind.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/128_mut_behind.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 128_mut_behind
+  family: hansel-mutant
+  contract: 한셀 + BEHIND_TEXT
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="BEHIND_TEXT"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/129_mut_all_zero_comp.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/129_mut_all_zero_comp.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 129_mut_all_zero_comp
+  family: hansel-mutant
+  contract: 한셀 id 유지 + 자식 0
+  source: samples/한셀OLE.hwpx 1필드 변이
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="0" centerY="0" rotateimage="0"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/133_aspect_icon_cursz0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/133_aspect_icon_cursz0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 133_aspect_icon_cursz0
+  family: ole-attr
+  contract: ICON + curSz=0
+  source: synthetic / hp:ole 속성 + 자식 동시
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="ICON">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/134_lock_and_wrap_offset.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/134_lock_and_wrap_offset.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 134_lock_and_wrap_offset
+  family: ole-attr
+  contract: lock + wraparound x
+  source: synthetic / hp:ole 속성 + 자식 동시
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="1" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="4294967286" y="20"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="-10" e4="0" e5="1" e6="20"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/135_through_wrap.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/135_through_wrap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 135_through_wrap
+  family: ole-attr
+  contract: THROUGH 배치
+  source: synthetic / hp:ole 속성 + 자식 동시
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="THROUGH"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/136_largest_flow.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/136_largest_flow.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 136_largest_flow
+  family: ole-attr
+  contract: LARGEST_ONLY
+  source: synthetic / hp:ole 속성 + 자식 동시
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="LARGEST_ONLY" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/137_right_flow.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/137_right_flow.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 137_right_flow
+  family: ole-attr
+  contract: RIGHT_ONLY
+  source: synthetic / hp:ole 속성 + 자식 동시
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="RIGHT_ONLY" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/138_picture_numbering_cursz0.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/138_picture_numbering_cursz0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 138_picture_numbering_cursz0
+  family: ole-attr
+  contract: PICTURE numbering + curSz=0
+  source: synthetic / hp:ole 속성 + 자식 동시
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/143_multi_two_oles.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/143_multi_two_oles.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 143_multi_two_oles
+  family: multi-ole
+  contract: 한 문단에 OLE 2개 — 각각의 id/자식을 독립 보존
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1001" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2001" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="10" y="20"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="10" e4="0" e5="1" e6="20"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="1002" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2002" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/144_multi_three_oles.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/144_multi_three_oles.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 144_multi_three_oles
+  family: multi-ole
+  contract: OLE 3개 (양수 offset / curSz0+flip / id=0)
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1001" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2001" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="10" y="20"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="10" e4="0" e5="1" e6="20"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="1002" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2002" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="0" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="3003" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#FF0000" width="3" style="SOLID" endCap="FLAT"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/145_multi_four_oles.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/145_multi_four_oles.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 145_multi_four_oles
+  family: multi-ole
+  contract: OLE 4개 (instid=0 wraparound 포함)
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1001" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2001" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="10" y="20"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="10" e4="0" e5="1" e6="20"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="1002" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2002" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="0" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="3003" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#FF0000" width="3" style="SOLID" endCap="FLAT"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="4004" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="4294967291" y="4294967290"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="-5" e4="0" e5="1" e6="-6"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/146_multi_id_eq_and_ne.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/146_multi_id_eq_and_ne.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 146_multi_id_eq_and_ne
+  family: multi-ole
+  contract: id=instid 인 OLE 와 id≠instid 인 OLE 혼재
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1001" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="2001" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="10" y="20"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="10" e4="0" e5="1" e6="20"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="5005" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="5005" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="90" centerX="1" centerY="2" rotateimage="0"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/147_multi_scale_pair.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/147_multi_scale_pair.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 147_multi_scale_pair
+  family: multi-ole
+  contract: 서로 다른 scaMatrix 를 가진 OLE 쌍
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="6006" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="7007" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="29999" height="4051"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.5" e2="0" e3="0" e4="0" e5="0.25" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/148_multi_cursz0_pair.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/148_multi_cursz0_pair.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 148_multi_cursz0_pair
+  family: multi-ole
+  contract: 둘 다 curSz=0 이지만 orgSz 가 다름
+  source: synthetic
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="11" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="21" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="1000" height="2000"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:ole id="12" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="22" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="3000" height="4000"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/149_combo_all_nonzero.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/149_combo_all_nonzero.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 149_combo_all_nonzero
+  family: combo
+  contract: id≠instid + wraparound offset + curSz 독립 + flip + 90도 + 한셀 sca + SOLID
+  source: synthetic combination
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="4294964867" y="4294962964"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="18000" height="2400"/>
+        <hp:flip horizontal="1" vertical="1"/>
+        <hp:rotationInfo angle="90" centerX="9000" centerY="1200" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="-2429" e4="0" e5="1" e6="-4332"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#112233" width="4" style="SOLID" endCap="FLAT"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/150_combo_all_zeroish.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/150_combo_all_zeroish.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 150_combo_all_zeroish
+  family: combo
+  contract: 명시적 0 값 묶음 — 기본값 재유도와 구분돼야 한다
+  source: synthetic combination
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="0" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="0" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="7200" height="7200"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="0" centerY="0" rotateimage="0"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/151_combo_cursz0_wrap_idne.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/151_combo_cursz0_wrap_idne.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 151_combo_cursz0_wrap_idne
+  family: combo
+  contract: 이슈 본문 재현: id≠instid + curSz=0 + 원문 offset
+  source: issue #4669 reproduction
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="12" y="34"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="0" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="12" e4="0" e5="1" e6="34"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>

--- a/tests/fixtures/issue_4669_ole_shape_component/xml/152_combo_issue_body_xml.xml
+++ b/tests/fixtures/issue_4669_ole_shape_component/xml/152_combo_issue_body_xml.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  issue: 4669
+  fixture: 152_combo_issue_body_xml
+  family: combo
+  contract: 이슈 본문 축약 XML 과 동일 값 (id 2141242094 / instid 1067500271 / curSz 0 / offset 12,34)
+  source: issue #4669 body
+  save-must: hp:ole id + instid 분리, offset/orgSz/curSz/flip/rotationInfo/renderingInfo/lineShape 원문
+  save-must-not: id="0" 재부여(원문이 0 이 아닐 때), curSz=0 을 orgSz 로 재유도
+-->
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="12" y="34"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="12" e4="0" e5="1" e6="34"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="0" style="NONE" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

HWPX 저장 시 `hp:ole` 의 shape-component 자식(`offset`·`orgSz`·`curSz`·`flip`·`rotationInfo`·`renderingInfo`·`lineShape`)과 `id`/`instid` 가 원문 보존되지 않던 [#4669](https://github.com/edwardkim/rhwp/issues/4669) 를 닫습니다. 파서/writer 계약(id·instid 분리, `curSz=0` was_zero 센티널, wraparound offset)은 devel 경로에 있고, 이 PR 은 그 계약을 **실물 샘플 + 137개 픽스처·봉투 전사 + 왕복 시험**으로 고도화합니다 (M05-9 / [#5450](https://github.com/edwardkim/rhwp/issues/5450)).

한셀OLE 실측은 `id="2141242094"` / `instid="1067500271"` 이 다르고, `curSz=0` 은 한컴 원산 관례입니다. 무편집 저장만으로 `id="0"` 재부여나 `curSz` 재유도가 일어나면 offset·행렬을 읽는 다른 소비자가 오배치를 얻습니다.

## 관련 이슈

Closes #5450
Closes #4669

## 범위

- `tests/cases/issue_4669_ole_shape_component.rs` — `한셀OLE.hwpx` 저장 왕복 + 코퍼스 봉투 대조 + 이슈 본문 `curSz=0` 재현
- `tests/fixtures/issue_4669_ole_shape_component/` — XML 픽스처 137 + JSON 봉투 전사 + catalog
- `scripts/generate_issue_4669_ole_fixtures.py` — 코퍼스 재생성
- `mydocs/working/issue_4669_ole_shape_component_preservation.md` — 계약·실측·비범위
- `CHANGELOG.md` — Unreleased HWPX 저장 항목
- 쪽수(#3737)·`char_shapes`·`hp:pic` offset(#4668) writer 는 손대지 않음

## 하지 않은 것

- 페이지 수 수정 / gym / M08
- `objectType` 원문 보존, BinData `ole1.ole` → `image1.OLE` 개명(#1891 의도 설계)
- chart `hp:chart id` (#3546 축)

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (4225)
- [ ] `cargo test --test regression_suite_019 issue_4669` — 로컬 디스크 여유 부족으로 전체 빌드는 생략. 시험은 `samples/한셀OLE.hwpx` 원문과 코퍼스 XML/봉투 단언
- [ ] `cargo clippy -- -D warnings` — 디스크 여유 부족으로 생략
- [x] 관련 샘플 원문 전제 — `id="2141242094"` + `instid="1067500271"` + `orgSz 42001×13501` + `scaMatrix e1="0.714245"`
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (저장 방출만)

## 1커맨드 스모크

```
cargo test --test regression_suite_019 -- issue_4669
```

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (OLE shape-component 저장 계약 고정, 렌더/쪽수 경로 미변경)
- 재현·측정: 미측정
