### PR TITLE
test: 수식 골든 변형·예외 확장 (M09-g)

### DIFF
--- a/src/renderer/equation/fixtures/README.md
+++ b/src/renderer/equation/fixtures/README.md
@@ -1,0 +1,56 @@
+# 수식 명령 골든 (M09-1 + M09-g)
+
+현행 엔진 잠금이다. 한컴 정답 오라클이 아니다. 엔진을 고치거나
+디스패치를 리팩터하지 않는다(M09-2). #4056 은 이 트리에서 다루지 않는다.
+
+- 카탈로그: [`catalog.tsv`](catalog.tsv) (`id`, `dir`, `command`, `honesty`, `script`)
+- M09-1 원본 31종: [`m09_1/`](m09_1/)
+- 변형·예외·미구현 정직 표: [`m09_expand/`](m09_expand/)
+- 시험: `tests/cases/equation_command_goldens.rs`
+
+갱신:
+
+```bash
+UPDATE_EQ_GOLDENS=1 cargo test --test <regression_suite> equation_command_goldens
+```
+
+의도된 엔진 변경이 아니면 골든을 다시 찍지 않는다.
+
+## honesty 태그
+
+| 태그 | 의미 (현행 동작) |
+| --- | --- |
+| `implemented` | M09-1 대표 경로. 파서·레이아웃·SVG 가 해당 명령을 처리한다. |
+| `implemented-variant` | 같은 명령의 공백·대소문자·크기·중첩·불규칙 격자 변형. |
+| `root-aliases-sqrt` | `ROOT` 는 `parse_sqrt` 와 같은 분기라 AST 가 `Sqrt` 이다. |
+| `pile-layout-as-row` | `PILE`/`LPILE`/`RPILE` AST 는 `Pile` 이지만 레이아웃은 전용 kind 없이 `Row` 로 세로 쌓는다. |
+| `matrix-no-brace-empty` | `parse_matrix`/`parse_eqalign`/`parse_pile` 은 여는 `{` 가 없으면 `Empty`. |
+| `missing-operand` | 피연산자·본문·인덱스가 비면 `Empty` 를 끼워 진행한다. |
+| `case-insensitive` | hwpeq 명령은 ASCII 대소문자를 가리지 않는다. |
+| `atop-vs-over` | `ATOP` 는 분수선 없는 위/아래(`Atop`). `OVER` 와 같은 중위 결합을 쓴다. |
+| `latex-frac` | `FRAC`/`DFRAC`/`TFRAC` 는 LaTeX 스타일 두 인자 분수. |
+| `vmatrix-unimpl-text` | `VMATRIX` 는 `is_structure_command` 에 있으나 `parse_command` 미분기 → `Text("VMATRIX")` + 뒤 그룹. |
+| `smallmatrix-unimpl-text` | `SMALLMATRIX` 동일. 전용 스타일/축소 행렬이 없다. |
+| `ladder-fallback-matrix` | `LADDER`/`SLADDER` 는 `parse_matrix(Plain)` 으로 떨어진다. |
+| `benzene-placeholder` | `BENZENE` 은 분자 그림 대신 `MathSymbol("⌬")`. |
+| `bigg-size-ignored` | `BIGG` 는 크기 변경 없이 다음 요소만 반환한다. |
+| `choose-empty-top` | `CHOOSE` 는 앞 요소를 결합하지 못해 `Atop` 윗칸이 `Empty` 다. `BINOM` 은 두 인자를 쓴다. |
+| `longdiv-simplified-row` | `LONGDIV` 는 장제법 그림이 아니라 `몫 ÷ 제수 = 본문` 가로 나열. |
+| `color-passthrough` | `COLOR` 는 색을 레이아웃 kind 로 남기지 않고 본문만 통과한다. |
+| `unknown-command-text` | 미지 명령은 `Text(cmd)` 로 누수한다. |
+| `cases-related` | `CASES` 는 행렬 가족이 아니지만 같은 `{ # & }` 수집기다. |
+| `rel-buildrel` | `REL`/`BUILDREL` 화살표 위·아래. 한컴 장식 화살표의 현행 근사. |
+| `phantom-space` | `PHANTOM` 계열은 본문을 버리고 공백 `Text` 한 칸. |
+| `latex-env-partial` | `BEGIN{matrix}` 등 LaTeX 환경은 부분 구현. `END` 단독은 `Empty`. |
+| `latex-space` | `QUAD` 등 간격 명령은 심볼 표의 공백 문자. |
+| `latex-text` | `TEXT`/`OPERATORNAME` 은 Roman `FontStyle`. |
+| `latex-stack` | `OVERSET`/`UNDERSET`/`STACKREL` 은 첨자 노드로 근사. |
+| `limit-cmd` | `lim`/`Lim` 전용 극한 분기 (`Lim` 만 대소문자 구분). |
+| `left-script` | `LSUB`/`LSUP`/`SUB`/`SUP` 의 현행 첨자 부착. |
+
+## 하지 않은 것
+
+- 수식 디스패치 재작성 (M09-2, PR #5420 이 있으면 유지)
+- #4056 수정 (planet PR #5253)
+- gym / `scripts/visual_sweep.py`
+- 파서·레이아웃·SVG 렌더러 구현 변경

--- a/src/renderer/equation/fixtures/catalog.tsv
+++ b/src/renderer/equation/fixtures/catalog.tsv
@@ -1,0 +1,262 @@
+# id	dir	command	honesty	script
+# M09-1 31 + M09-g variants/exceptions/unimplemented honesty.
+# Current-engine lock. Not a Hancom oracle. TAB-separated. Scripts must not contain TAB.
+over_simple	m09_1	OVER	implemented	1 OVER 2
+over_grouped	m09_1	OVER	implemented	{a+b} OVER {c-d}
+over_nested	m09_1	OVER	implemented	{1 OVER 2} OVER 3
+over_glued_denom	m09_1	OVER	implemented	7 OVER10
+over_in_paren	m09_1	OVER	implemented	LEFT ( x OVER y RIGHT )
+sqrt_ident	m09_1	SQRT	implemented	SQRT x
+sqrt_group	m09_1	SQRT	implemented	SQRT {a+b}
+sqrt_index_paren	m09_1	SQRT	implemented	SQRT(3) of x
+sqrt_index_brace	m09_1	SQRT	implemented	SQRT {3} of {x}
+root_ident	m09_1	ROOT	root-aliases-sqrt	ROOT x
+root_group	m09_1	ROOT	root-aliases-sqrt	ROOT {a+b}
+root_index	m09_1	ROOT	root-aliases-sqrt	ROOT(3) of x
+matrix_2x2	m09_1	MATRIX	implemented	MATRIX{a & b # c & d}
+matrix_col	m09_1	MATRIX	implemented	MATRIX{1 # 2 # 3}
+matrix_row	m09_1	MATRIX	implemented	MATRIX{a & b & c}
+matrix_no_brace	m09_1	MATRIX	matrix-no-brace-empty	MATRIX
+pmatrix_2x2	m09_1	PMATRIX	implemented	PMATRIX{a & b # c & d}
+pmatrix_1x1	m09_1	PMATRIX	implemented	PMATRIX{x}
+pmatrix_frac	m09_1	PMATRIX	implemented	PMATRIX{{1} OVER {2} & 0 # 0 & 1}
+bmatrix_2x2	m09_1	BMATRIX	implemented	BMATRIX{a & b # c & d}
+bmatrix_identity	m09_1	BMATRIX	implemented	BMATRIX{1 & 0 # 0 & 1}
+bmatrix_1x2	m09_1	BMATRIX	implemented	BMATRIX{x & y}
+dmatrix_2x2	m09_1	DMATRIX	implemented	DMATRIX{a & b # c & d}
+dmatrix_col	m09_1	DMATRIX	implemented	DMATRIX{x # y}
+dmatrix_1x1	m09_1	DMATRIX	implemented	DMATRIX{1}
+eqalign_two	m09_1	EQALIGN	implemented	EQALIGN{x &= 1 # y &= 2}
+eqalign_one	m09_1	EQALIGN	implemented	EQALIGN{a + b &= c}
+eqalign_no_amp	m09_1	EQALIGN	implemented	EQALIGN{x = 1 # y = 2}
+pile_center	m09_1	PILE	pile-layout-as-row	PILE{a # b # c}
+lpile_left	m09_1	PILE	pile-layout-as-row	LPILE{a # b}
+rpile_right	m09_1	PILE	pile-layout-as-row	RPILE{a # b}
+over_bare	m09_expand	OVER	missing-operand	OVER
+over_empty_numer	m09_expand	OVER	missing-operand	OVER 2
+over_empty_denom	m09_expand	OVER	missing-operand	1 OVER
+over_lower	m09_expand	OVER	case-insensitive	1 over 2
+over_mixed_case	m09_expand	OVER	case-insensitive	1 Over 2
+over_chain_three	m09_expand	OVER	implemented-variant	1 OVER 2 OVER 3
+over_chain_four	m09_expand	OVER	implemented-variant	1 OVER 2 OVER 3 OVER 4
+over_ws_pad	m09_expand	OVER	implemented-variant	1  OVER  2
+over_idents	m09_expand	OVER	implemented-variant	a OVER b
+over_greek	m09_expand	OVER	implemented-variant	ALPHA OVER BETA
+over_func	m09_expand	OVER	implemented-variant	sin x OVER cos x
+over_sqrt	m09_expand	OVER	implemented-variant	SQRT 2 OVER SQRT 3
+over_empty_groups	m09_expand	OVER	missing-operand	{} OVER {}
+over_glued_both	m09_expand	OVER	implemented-variant	1OVER2
+over_neg	m09_expand	OVER	implemented-variant	-1 OVER -2
+over_decimal	m09_expand	OVER	implemented-variant	1.5 OVER 2.5
+over_multidigit	m09_expand	OVER	implemented-variant	123 OVER 456
+over_sup	m09_expand	OVER	implemented-variant	x^2 OVER y^2
+over_sub	m09_expand	OVER	implemented-variant	x_1 OVER y_1
+over_subsup	m09_expand	OVER	implemented-variant	x_i^2 OVER y_j^3
+over_triple_nest	m09_expand	OVER	implemented-variant	{{{1 OVER 2} OVER 3} OVER 4}
+over_in_left_brace	m09_expand	OVER	implemented-variant	LEFT { a OVER b RIGHT }
+over_sum	m09_expand	OVER	implemented-variant	sum_i a_i OVER n
+over_matrix_numer	m09_expand	OVER	implemented-variant	MATRIX{1 & 2 # 3 & 4} OVER 2
+over_plus_ungrouped	m09_expand	OVER	implemented-variant	a+b OVER c+d
+over_paren_no_left	m09_expand	OVER	implemented-variant	(x OVER y)
+over_times	m09_expand	OVER	implemented-variant	a TIMES b OVER c TIMES d
+over_pi	m09_expand	OVER	implemented-variant	pi OVER 2
+over_infty	m09_expand	OVER	implemented-variant	1 OVER infty
+atop_simple	m09_expand	OVER	atop-vs-over	1 ATOP 2
+atop_grouped	m09_expand	OVER	atop-vs-over	{a+b} ATOP {c-d}
+atop_chain	m09_expand	OVER	atop-vs-over	1 ATOP 2 ATOP 3
+frac_latex	m09_expand	OVER	latex-frac	FRAC{1}{2}
+dfrac_latex	m09_expand	OVER	latex-frac	DFRAC{1}{2}
+tfrac_latex	m09_expand	OVER	latex-frac	TFRAC{a}{b}
+frac_missing_denom	m09_expand	OVER	missing-operand	FRAC{1}
+over_root	m09_expand	OVER	root-aliases-sqrt	ROOT 8 OVER ROOT 2
+sqrt_bare	m09_expand	SQRT	missing-operand	SQRT
+root_bare	m09_expand	ROOT	root-aliases-sqrt	ROOT
+sqrt_lower	m09_expand	SQRT	case-insensitive	sqrt x
+root_lower	m09_expand	ROOT	root-aliases-sqrt	root x
+sqrt_latex_index	m09_expand	SQRT	implemented-variant	SQRT[3]{x}
+sqrt_latex_empty_idx	m09_expand	SQRT	missing-operand	SQRT[]{x}
+sqrt_paren_no_of	m09_expand	SQRT	implemented-variant	SQRT(3) x
+sqrt_empty_paren	m09_expand	SQRT	missing-operand	SQRT() of x
+root_brace_of	m09_expand	ROOT	root-aliases-sqrt	ROOT {3} of {x}
+root_latex_index	m09_expand	ROOT	root-aliases-sqrt	ROOT[4]{y}
+sqrt_nested	m09_expand	SQRT	implemented-variant	SQRT SQRT x
+sqrt_of_frac	m09_expand	SQRT	implemented-variant	SQRT {1 OVER 2}
+root_of_frac	m09_expand	ROOT	root-aliases-sqrt	ROOT {a OVER b}
+sqrt_of_matrix	m09_expand	SQRT	implemented-variant	SQRT MATRIX{1 & 0 # 0 & 1}
+sqrt_sup	m09_expand	SQRT	implemented-variant	SQRT x^2
+sqrt_empty_body	m09_expand	SQRT	missing-operand	SQRT { }
+root_empty_body	m09_expand	ROOT	root-aliases-sqrt	ROOT { }
+sqrt_long	m09_expand	SQRT	implemented-variant	SQRT {a+b+c+d+e+f}
+sqrt_mixed_case	m09_expand	SQRT	case-insensitive	SqRt x
+root_mixed_case	m09_expand	ROOT	root-aliases-sqrt	RoOt {a+b}
+sqrt_of_pile	m09_expand	SQRT	pile-layout-as-row	SQRT PILE{a # b}
+root_of_paren_idx	m09_expand	ROOT	root-aliases-sqrt	ROOT(n) of {x+y}
+sqrt_index_zero	m09_expand	SQRT	implemented-variant	SQRT(0) of 1
+sqrt_index_frac	m09_expand	SQRT	implemented-variant	SQRT {1 OVER 2} of {x}
+root_index_frac	m09_expand	ROOT	root-aliases-sqrt	ROOT {1 OVER 2} of {x}
+sqrt_of_over_chain	m09_expand	SQRT	implemented-variant	SQRT {1 OVER 2 OVER 3}
+root_nested	m09_expand	ROOT	root-aliases-sqrt	ROOT ROOT x
+sqrt_int	m09_expand	SQRT	implemented-variant	SQRT {int_0^1 x dx}
+sqrt_of_pmatrix	m09_expand	SQRT	implemented-variant	SQRT PMATRIX{1 & 2 # 3 & 4}
+matrix_empty_brace	m09_expand	MATRIX	missing-operand	MATRIX{}
+matrix_1x1	m09_expand	MATRIX	implemented-variant	MATRIX{z}
+matrix_lower	m09_expand	MATRIX	case-insensitive	matrix{a & b # c & d}
+matrix_2x3	m09_expand	MATRIX	implemented-variant	MATRIX{a & b & c # d & e & f}
+matrix_3x2	m09_expand	MATRIX	implemented-variant	MATRIX{a & b # c & d # e & f}
+matrix_3x3	m09_expand	MATRIX	implemented-variant	MATRIX{a & b & c # d & e & f # g & h & i}
+matrix_trailing_hash	m09_expand	MATRIX	implemented-variant	MATRIX{a & b #}
+matrix_trailing_amp	m09_expand	MATRIX	implemented-variant	MATRIX{a & b &}
+matrix_jagged	m09_expand	MATRIX	implemented-variant	MATRIX{a # b & c # d & e & f}
+matrix_spacey	m09_expand	MATRIX	implemented-variant	MATRIX{ a  &  b  #  c  &  d }
+pmatrix_empty_brace	m09_expand	PMATRIX	missing-operand	PMATRIX{}
+pmatrix_no_brace	m09_expand	PMATRIX	matrix-no-brace-empty	PMATRIX
+pmatrix_lower	m09_expand	PMATRIX	case-insensitive	pmatrix{a & b # c & d}
+pmatrix_2x3	m09_expand	PMATRIX	implemented-variant	PMATRIX{a & b & c # d & e & f}
+pmatrix_3x2	m09_expand	PMATRIX	implemented-variant	PMATRIX{a & b # c & d # e & f}
+pmatrix_3x3	m09_expand	PMATRIX	implemented-variant	PMATRIX{a & b & c # d & e & f # g & h & i}
+pmatrix_trailing_hash	m09_expand	PMATRIX	implemented-variant	PMATRIX{a & b #}
+pmatrix_trailing_amp	m09_expand	PMATRIX	implemented-variant	PMATRIX{a & b &}
+pmatrix_jagged	m09_expand	PMATRIX	implemented-variant	PMATRIX{a # b & c # d & e & f}
+pmatrix_spacey	m09_expand	PMATRIX	implemented-variant	PMATRIX{ a  &  b  #  c  &  d }
+bmatrix_empty_brace	m09_expand	BMATRIX	missing-operand	BMATRIX{}
+bmatrix_no_brace	m09_expand	BMATRIX	matrix-no-brace-empty	BMATRIX
+bmatrix_1x1	m09_expand	BMATRIX	implemented-variant	BMATRIX{z}
+bmatrix_lower	m09_expand	BMATRIX	case-insensitive	bmatrix{a & b # c & d}
+bmatrix_2x3	m09_expand	BMATRIX	implemented-variant	BMATRIX{a & b & c # d & e & f}
+bmatrix_3x2	m09_expand	BMATRIX	implemented-variant	BMATRIX{a & b # c & d # e & f}
+bmatrix_3x3	m09_expand	BMATRIX	implemented-variant	BMATRIX{a & b & c # d & e & f # g & h & i}
+bmatrix_trailing_hash	m09_expand	BMATRIX	implemented-variant	BMATRIX{a & b #}
+bmatrix_trailing_amp	m09_expand	BMATRIX	implemented-variant	BMATRIX{a & b &}
+bmatrix_jagged	m09_expand	BMATRIX	implemented-variant	BMATRIX{a # b & c # d & e & f}
+bmatrix_spacey	m09_expand	BMATRIX	implemented-variant	BMATRIX{ a  &  b  #  c  &  d }
+dmatrix_empty_brace	m09_expand	DMATRIX	missing-operand	DMATRIX{}
+dmatrix_no_brace	m09_expand	DMATRIX	matrix-no-brace-empty	DMATRIX
+dmatrix_lower	m09_expand	DMATRIX	case-insensitive	dmatrix{a & b # c & d}
+dmatrix_2x3	m09_expand	DMATRIX	implemented-variant	DMATRIX{a & b & c # d & e & f}
+dmatrix_3x2	m09_expand	DMATRIX	implemented-variant	DMATRIX{a & b # c & d # e & f}
+dmatrix_3x3	m09_expand	DMATRIX	implemented-variant	DMATRIX{a & b & c # d & e & f # g & h & i}
+dmatrix_trailing_hash	m09_expand	DMATRIX	implemented-variant	DMATRIX{a & b #}
+dmatrix_trailing_amp	m09_expand	DMATRIX	implemented-variant	DMATRIX{a & b &}
+dmatrix_jagged	m09_expand	DMATRIX	implemented-variant	DMATRIX{a # b & c # d & e & f}
+dmatrix_spacey	m09_expand	DMATRIX	implemented-variant	DMATRIX{ a  &  b  #  c  &  d }
+matrix_empty_row	m09_expand	MATRIX	implemented-variant	MATRIX{a & b # # c & d}
+matrix_amp_only	m09_expand	MATRIX	missing-operand	MATRIX{&}
+matrix_hash_only	m09_expand	MATRIX	missing-operand	MATRIX{#}
+matrix_sqrt_cells	m09_expand	MATRIX	implemented-variant	MATRIX{SQRT 1 & SQRT 2 # SQRT 3 & SQRT 4}
+pmatrix_over_all	m09_expand	PMATRIX	implemented-variant	PMATRIX{{1} OVER {2} & {3} OVER {4} # {5} OVER {6} & {7} OVER {8}}
+bmatrix_func	m09_expand	BMATRIX	implemented-variant	BMATRIX{sin x & cos x # -sin x & cos x}
+dmatrix_nested_over	m09_expand	DMATRIX	implemented-variant	DMATRIX{{{1} OVER {2}} OVER 3 & 0 # 0 & 1}
+vmatrix_2x2	m09_expand	MATRIX	vmatrix-unimpl-text	VMATRIX{a & b # c & d}
+smallmatrix_2x2	m09_expand	MATRIX	smallmatrix-unimpl-text	SMALLMATRIX{a & b # c & d}
+vmatrix_no_brace	m09_expand	MATRIX	vmatrix-unimpl-text	VMATRIX
+smallmatrix_no_brace	m09_expand	MATRIX	smallmatrix-unimpl-text	SMALLMATRIX
+ladder_2x2	m09_expand	MATRIX	ladder-fallback-matrix	LADDER{a & b # c & d}
+sladder_2x2	m09_expand	MATRIX	ladder-fallback-matrix	SLADDER{a & b # c & d}
+ladder_no_brace	m09_expand	MATRIX	ladder-fallback-matrix	LADDER
+sladder_no_brace	m09_expand	MATRIX	ladder-fallback-matrix	SLADDER
+matrix_over_3x3	m09_expand	MATRIX	implemented-variant	MATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} # {7} OVER {8} & {9} OVER {10} & {11} OVER {12} # {13} OVER {14} & {15} OVER {16} & {17} OVER {18}}
+matrix_5x5_over	m09_expand	MATRIX	implemented-variant	MATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+matrix_5x5_sqrt	m09_expand	MATRIX	implemented-variant	MATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+matrix_4x4_mixed	m09_expand	MATRIX	implemented-variant	MATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+matrix_4x4_numbers	m09_expand	MATRIX	implemented-variant	MATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+matrix_3x3_over	m09_expand	MATRIX	implemented-variant	MATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+pmatrix_5x5_over	m09_expand	PMATRIX	implemented-variant	PMATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+pmatrix_5x5_sqrt	m09_expand	PMATRIX	implemented-variant	PMATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+pmatrix_4x4_mixed	m09_expand	PMATRIX	implemented-variant	PMATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+pmatrix_4x4_numbers	m09_expand	PMATRIX	implemented-variant	PMATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+pmatrix_3x3_over	m09_expand	PMATRIX	implemented-variant	PMATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+bmatrix_5x5_over	m09_expand	BMATRIX	implemented-variant	BMATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+bmatrix_5x5_sqrt	m09_expand	BMATRIX	implemented-variant	BMATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+bmatrix_4x4_mixed	m09_expand	BMATRIX	implemented-variant	BMATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+bmatrix_4x4_numbers	m09_expand	BMATRIX	implemented-variant	BMATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+bmatrix_3x3_over	m09_expand	BMATRIX	implemented-variant	BMATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+dmatrix_5x5_over	m09_expand	DMATRIX	implemented-variant	DMATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+dmatrix_5x5_sqrt	m09_expand	DMATRIX	implemented-variant	DMATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+dmatrix_4x4_mixed	m09_expand	DMATRIX	implemented-variant	DMATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+dmatrix_4x4_numbers	m09_expand	DMATRIX	implemented-variant	DMATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+dmatrix_3x3_over	m09_expand	DMATRIX	implemented-variant	DMATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+matrix_7x3_over	m09_expand	MATRIX	implemented-variant	MATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+matrix_3x7_over	m09_expand	MATRIX	implemented-variant	MATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+pmatrix_7x3_over	m09_expand	PMATRIX	implemented-variant	PMATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+pmatrix_3x7_over	m09_expand	PMATRIX	implemented-variant	PMATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+bmatrix_7x3_over	m09_expand	BMATRIX	implemented-variant	BMATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+bmatrix_3x7_over	m09_expand	BMATRIX	implemented-variant	BMATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+dmatrix_7x3_over	m09_expand	DMATRIX	implemented-variant	DMATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+dmatrix_3x7_over	m09_expand	DMATRIX	implemented-variant	DMATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+eqalign_no_brace	m09_expand	EQALIGN	matrix-no-brace-empty	EQALIGN
+eqalign_empty	m09_expand	EQALIGN	missing-operand	EQALIGN{}
+eqalign_three	m09_expand	EQALIGN	implemented-variant	EQALIGN{x &= 1 # y &= 2 # z &= 3}
+eqalign_four	m09_expand	EQALIGN	implemented-variant	EQALIGN{a &= 1 # b &= 2 # c &= 3 # d &= 4}
+eqalign_left_only	m09_expand	EQALIGN	implemented-variant	EQALIGN{x # y}
+eqalign_andand	m09_expand	EQALIGN	implemented-variant	EQALIGN{x && 1}
+eqalign_over	m09_expand	EQALIGN	implemented-variant	EQALIGN{a OVER b &= c OVER d}
+eqalign_sqrt	m09_expand	EQALIGN	implemented-variant	EQALIGN{SQRT x &= 2 # SQRT y &= 3}
+eqalign_trailing_hash	m09_expand	EQALIGN	implemented-variant	EQALIGN{x &= 1 #}
+eqalign_lower	m09_expand	EQALIGN	case-insensitive	eqalign{x &= 1 # y &= 2}
+eqalign_mixed_amp	m09_expand	EQALIGN	implemented-variant	EQALIGN{x = 1 # y &= 2}
+eqalign_six_over	m09_expand	EQALIGN	implemented-variant	EQALIGN{{1} OVER {2} &= {3} OVER {4} # {2} OVER {3} &= {4} OVER {5} # {3} OVER {4} &= {5} OVER {6} # {4} OVER {5} &= {6} OVER {7} # {5} OVER {6} &= {7} OVER {8} # {6} OVER {7} &= {8} OVER {9}}
+eqalign_ten_over	m09_expand	EQALIGN	implemented-variant	EQALIGN{{1} OVER {2} &= {3} OVER {4} # {2} OVER {3} &= {4} OVER {5} # {3} OVER {4} &= {5} OVER {6} # {4} OVER {5} &= {6} OVER {7} # {5} OVER {6} &= {7} OVER {8} # {6} OVER {7} &= {8} OVER {9} # {7} OVER {8} &= {9} OVER {10} # {8} OVER {9} &= {10} OVER {11} # {9} OVER {10} &= {11} OVER {12} # {10} OVER {11} &= {12} OVER {13}}
+eqalign_matrix	m09_expand	EQALIGN	implemented-variant	EQALIGN{A &= MATRIX{1 & 0 # 0 & 1} # B &= MATRIX{0 & 1 # 1 & 0}}
+eqalign_root	m09_expand	EQALIGN	root-aliases-sqrt	EQALIGN{ROOT 8 &= 2 # ROOT 27 &= 3}
+pile_no_brace	m09_expand	PILE	pile-layout-as-row	PILE
+lpile_no_brace	m09_expand	PILE	pile-layout-as-row	LPILE
+rpile_no_brace	m09_expand	PILE	pile-layout-as-row	RPILE
+pile_empty	m09_expand	PILE	missing-operand	PILE{}
+pile_single	m09_expand	PILE	pile-layout-as-row	PILE{a}
+pile_over	m09_expand	PILE	pile-layout-as-row	PILE{{1} OVER {2} # {3} OVER {4}}
+pile_sqrt	m09_expand	PILE	pile-layout-as-row	PILE{SQRT a # SQRT b # SQRT c}
+pile_five	m09_expand	PILE	pile-layout-as-row	PILE{a # b # c # d # e}
+pile_lower	m09_expand	PILE	case-insensitive	pile{a # b}
+lpile_over	m09_expand	PILE	pile-layout-as-row	LPILE{{1} OVER {2} # x}
+rpile_over	m09_expand	PILE	pile-layout-as-row	RPILE{{1} OVER {2} # x}
+pile_eight_frac	m09_expand	PILE	pile-layout-as-row	PILE{{1} OVER {2} # {2} OVER {3} # {3} OVER {4} # {4} OVER {5} # {5} OVER {6} # {6} OVER {7} # {7} OVER {8} # {8} OVER {9}}
+lpile_eight_frac	m09_expand	PILE	pile-layout-as-row	LPILE{{1} OVER {2} # {2} OVER {3} # {3} OVER {4} # {4} OVER {5} # {5} OVER {6} # {6} OVER {7} # {7} OVER {8} # {8} OVER {9}}
+rpile_eight_frac	m09_expand	PILE	pile-layout-as-row	RPILE{{1} OVER {2} # {2} OVER {3} # {3} OVER {4} # {4} OVER {5} # {5} OVER {6} # {6} OVER {7} # {7} OVER {8} # {8} OVER {9}}
+lpile_three	m09_expand	PILE	pile-layout-as-row	LPILE{a # b # c}
+rpile_three	m09_expand	PILE	pile-layout-as-row	RPILE{a # b # c}
+pile_matrix	m09_expand	PILE	pile-layout-as-row	PILE{MATRIX{1 & 0 # 0 & 1} # MATRIX{0 & 1 # 1 & 0}}
+lpile_lower	m09_expand	PILE	case-insensitive	lpile{a # b}
+rpile_lower	m09_expand	PILE	case-insensitive	rpile{a # b}
+benzene	m09_expand	MATRIX	benzene-placeholder	BENZENE
+benzene_group	m09_expand	MATRIX	benzene-placeholder	BENZENE{C6H6}
+bigg_paren	m09_expand	MATRIX	bigg-size-ignored	BIGG (
+bigg_ident	m09_expand	MATRIX	bigg-size-ignored	BIGG x
+choose_simple	m09_expand	OVER	choose-empty-top	n CHOOSE k
+binom_simple	m09_expand	OVER	choose-empty-top	BINOM{n}{k}
+longdiv_simple	m09_expand	MATRIX	longdiv-simplified-row	LONGDIV{3}{2}{6}
+color_red	m09_expand	MATRIX	color-passthrough	COLOR red x
+unknown_foobar	m09_expand	MATRIX	unknown-command-text	FOOBAR
+unknown_xyz	m09_expand	MATRIX	unknown-command-text	XYZ{1}
+cases_2	m09_expand	MATRIX	cases-related	CASES{x & if x>0 # -x & if x<0}
+cases_no_brace	m09_expand	MATRIX	cases-related	CASES
+rel_arrow	m09_expand	MATRIX	rel-buildrel	REL -> {f} {g}
+buildrel_arrow	m09_expand	MATRIX	rel-buildrel	BUILDREL -> {def}
+phantom_x	m09_expand	MATRIX	phantom-space	PHANTOM{x}
+begin_matrix	m09_expand	MATRIX	latex-env-partial	BEGIN{matrix} a & b # c & d END{matrix}
+end_matrix_alone	m09_expand	MATRIX	latex-env-partial	END{matrix}
+begin_pmatrix	m09_expand	PMATRIX	latex-env-partial	BEGIN{pmatrix} 1 & 0 # 0 & 1 END{pmatrix}
+quad_space	m09_expand	MATRIX	latex-space	a QUAD b
+operatorname_sin	m09_expand	MATRIX	latex-text	OPERATORNAME{sin}
+text_cmd	m09_expand	MATRIX	latex-text	TEXT{if}
+overset_hat	m09_expand	OVER	latex-stack	OVERSET{^}{x}
+underset_bar	m09_expand	OVER	latex-stack	UNDERSET{_}{x}
+stackrel_star	m09_expand	OVER	latex-stack	STACKREL{*}{=}
+lim_cmd	m09_expand	MATRIX	limit-cmd	lim_x->0 f(x)
+lim_upper_cmd	m09_expand	MATRIX	limit-cmd	Lim_n->infty a_n
+lsub_cmd	m09_expand	MATRIX	left-script	LSUB{i}{A}
+lsup_cmd	m09_expand	MATRIX	left-script	LSUP{i}{A}
+sub_cmd	m09_expand	MATRIX	left-script	SUB{i}
+sup_cmd	m09_expand	MATRIX	left-script	SUP{2}
+over_eqalign	m09_expand	OVER	implemented-variant	EQALIGN{1 OVER 2 &= 3 OVER 6}
+over_pile	m09_expand	OVER	pile-layout-as-row	PILE{1 OVER 2 # 3 OVER 4} OVER 5
+sqrt_eqalign	m09_expand	SQRT	implemented-variant	EQALIGN{SQRT x &= y}
+root_matrix	m09_expand	ROOT	root-aliases-sqrt	ROOT MATRIX{1 & 0 # 0 & 1}
+over_choose	m09_expand	OVER	choose-empty-top	{n CHOOSE k} OVER 2
+matrix_cases_cell	m09_expand	MATRIX	cases-related	MATRIX{CASES{1 # 0} & 2}
+pmatrix_pile_cell	m09_expand	PMATRIX	pile-layout-as-row	PMATRIX{PILE{a # b} & 0 # 0 & 1}
+bmatrix_eqalign_cell	m09_expand	BMATRIX	implemented-variant	BMATRIX{EQALIGN{x &= 1} & 0 # 0 & 1}
+dmatrix_root_cell	m09_expand	DMATRIX	root-aliases-sqrt	DMATRIX{ROOT 2 & 0 # 0 & ROOT 3}
+over_nested_matrix_3	m09_expand	OVER	implemented-variant	{MATRIX{{1} OVER {2} & {3} OVER {4} # {5} OVER {6} & {7} OVER {8}}} OVER {MATRIX{{9} OVER {10} & {11} OVER {12} # {13} OVER {14} & {15} OVER {16}}}
+sqrt_nested_pmatrix_3	m09_expand	SQRT	implemented-variant	SQRT {3} of {PMATRIX{{1} OVER {2} & {3} OVER {4} # {5} OVER {6} & {7} OVER {8}}}
+eqalign_matrix_fracs	m09_expand	EQALIGN	implemented-variant	EQALIGN{MATRIX{{1} OVER {2} & 0 # 0 & {3} OVER {4}} &= I # PMATRIX{{5} OVER {6} & 1 # 1 & {7} OVER {8}} &= A}
+pile_four_matrices	m09_expand	PILE	pile-layout-as-row	PILE{MATRIX{1 & 0 # 0 & 1} # PMATRIX{1 & 0 # 0 & 1} # BMATRIX{1 & 0 # 0 & 1} # DMATRIX{1 & 0 # 0 & 1}}

--- a/src/renderer/equation/fixtures/m09_1/bmatrix_1x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/bmatrix_1x2.golden
@@ -1,0 +1,30 @@
+# M09-1 equation golden — current-engine lock
+command: BMATRIX
+script: BMATRIX{x & y}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "x",
+            ),
+            Text(
+                "y",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=20.0000 bl=10.0000
+  row0:
+    Text("x") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("y") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,20.00 L4.20,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,20.00 L54.90,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_1/bmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/bmatrix_2x2.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: BMATRIX
+script: BMATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,46.00 L54.90,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/bmatrix_identity.golden
+++ b/src/renderer/equation/fixtures/m09_1/bmatrix_identity.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: BMATRIX
+script: BMATRIX{1 & 0 # 0 & 1}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=58.0000 h=46.0000 bl=23.0000
+  row0:
+    Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M53.80,0.00 L56.20,0.00 L56.20,46.00 L53.80,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_1/dmatrix_1x1.golden
+++ b/src/renderer/equation/fixtures/m09_1/dmatrix_1x1.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: DMATRIX
+script: DMATRIX{1}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=31.0000 h=20.0000 bl=10.0000
+  row0:
+    Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="28.00" y1="0.00" x2="28.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_1/dmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/dmatrix_2x2.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: DMATRIX
+script: DMATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="56.10" y1="0.00" x2="56.10" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/dmatrix_col.golden
+++ b/src/renderer/equation/fixtures/m09_1/dmatrix_col.golden
@@ -1,0 +1,33 @@
+# M09-1 equation golden — current-engine lock
+command: DMATRIX
+script: DMATRIX{x # y}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "x",
+            ),
+        ],
+        [
+            Text(
+                "y",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=31.5500 h=46.0000 bl=23.0000
+  row0:
+    Text("x") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("y") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="28.55" y1="0.00" x2="28.55" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_1/eqalign_no_amp.golden
+++ b/src/renderer/equation/fixtures/m09_1/eqalign_no_amp.golden
@@ -1,0 +1,66 @@
+# M09-1 equation golden — current-engine lock
+command: EQALIGN
+script: EQALIGN{x = 1 # y = 2}
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Row(
+                [
+                    Text(
+                        "x",
+                    ),
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+            Empty,
+        ),
+        (
+            Row(
+                [
+                    Text(
+                        "y",
+                    ),
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+            Empty,
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Row x=0.0000 y=0.0000 w=38.5500 h=20.0000 bl=16.0000
+      Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=27.5500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Empty x=41.5500 y=16.0000 w=0.0000 h=0.0000 bl=0.0000
+  row1.left:
+    Row x=0.0000 y=26.0000 w=38.5500 h=20.0000 bl=16.0000
+      Text("y") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=27.5500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.right:
+    Empty x=41.5500 y=42.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="19.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="27.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="19.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="27.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_1/eqalign_one.golden
+++ b/src/renderer/equation/fixtures/m09_1/eqalign_one.golden
@@ -1,0 +1,53 @@
+# M09-1 equation golden — current-engine lock
+command: EQALIGN
+script: EQALIGN{a + b &= c}
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Row(
+                [
+                    Text(
+                        "a",
+                    ),
+                    Symbol(
+                        "+",
+                    ),
+                    Text(
+                        "b",
+                    ),
+                ],
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Text(
+                        "c",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=69.6500 h=20.0000 bl=10.0000
+  row0.left:
+    Row x=0.0000 y=0.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=42.1000 y=0.0000 w=27.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("c") x=16.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="19.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="27.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="50.10" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="58.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_1/eqalign_two.golden
+++ b/src/renderer/equation/fixtures/m09_1/eqalign_two.golden
@@ -1,0 +1,62 @@
+# M09-1 equation golden — current-engine lock
+command: EQALIGN
+script: EQALIGN{x &= 1 # y &= 2}
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "y",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Text("y") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=14.5500 y=26.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="22.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="22.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_1/lpile_left.golden
+++ b/src/renderer/equation/fixtures/m09_1/lpile_left.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: PILE
+script: LPILE{a # b}
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Left,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/matrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_2x2.golden
@@ -1,0 +1,41 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/matrix_col.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_col.golden
@@ -1,0 +1,39 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX{1 # 2 # 3}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+        ],
+        [
+            Number(
+                "2",
+            ),
+        ],
+        [
+            Number(
+                "3",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=19.0000 h=72.0000 bl=36.0000
+  row0:
+    Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("2") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Number("3") x=4.0000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_1/matrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_no_brace.golden
@@ -1,0 +1,11 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_1/matrix_row.golden
+++ b/src/renderer/equation/fixtures/m09_1/matrix_row.golden
@@ -1,0 +1,33 @@
+# M09-1 equation golden — current-engine lock
+command: MATRIX
+script: MATRIX{a & b & c}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=74.6500 h=20.0000 bl=10.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=59.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="59.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_1/over_glued_denom.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_glued_denom.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: 7 OVER10
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "7",
+    ),
+    denom: Number(
+        "10",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("7") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="9.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="1.00" y1="24.40" x2="29.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>

--- a/src/renderer/equation/fixtures/m09_1/over_grouped.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_grouped.golden
@@ -1,0 +1,55 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: {a+b} OVER {c-d}
+
+=== ast ===
+Fraction {
+    numer: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+    denom: Row(
+        [
+            Text(
+                "c",
+            ),
+            Symbol(
+                "-",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=47.1000 h=48.8000 bl=29.4000
+  numer:
+    Row x=4.0000 y=4.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  denom:
+    Row x=4.0000 y=24.8000 w=39.1000 h=20.0000 bl=16.0000
+      Text("c") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("-") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("d") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="23.55" y="20.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="31.55" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<line x1="1.00" y1="24.40" x2="46.10" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="23.55" y="40.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="31.55" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/over_in_paren.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_in_paren.golden
@@ -1,0 +1,32 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: LEFT ( x OVER y RIGHT )
+
+=== ast ===
+Paren {
+    left: "(",
+    right: ")",
+    body: Fraction {
+        numer: Text(
+            "x",
+        ),
+        denom: Text(
+            "y",
+        ),
+    },
+}
+
+=== layout ===
+Paren("(",")") x=0.0000 y=0.0000 w=31.5500 h=48.8000 bl=29.4000
+  Fraction x=6.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+    numer:
+      Text("x") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Text("y") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.86,0.00 C0.27,8.78 0.27,40.02 4.86,48.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<line x1="7.00" y1="24.40" x2="24.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<path d="M26.69,0.00 C31.28,8.78 31.28,40.02 26.69,48.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>

--- a/src/renderer/equation/fixtures/m09_1/over_nested.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_nested.golden
@@ -1,0 +1,36 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: {1 OVER 2} OVER 3
+
+=== ast ===
+Fraction {
+    numer: Fraction {
+        numer: Number(
+            "1",
+        ),
+        denom: Number(
+            "2",
+        ),
+    },
+    denom: Number(
+        "3",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=27.0000 h=77.6000 bl=58.2000
+  numer:
+    Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="5.00" y1="28.40" x2="22.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="53.20" x2="26.00" y2="53.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="69.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_1/over_simple.golden
+++ b/src/renderer/equation/fixtures/m09_1/over_simple.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: OVER
+script: 1 OVER 2
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_1/pile_center.golden
+++ b/src/renderer/equation/fixtures/m09_1/pile_center.golden
@@ -1,0 +1,30 @@
+# M09-1 equation golden — current-engine lock
+command: PILE
+script: PILE{a # b # c}
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+        Text(
+            "c",
+        ),
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=72.0000 bl=36.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("c") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_1/pmatrix_1x1.golden
+++ b/src/renderer/equation/fixtures/m09_1/pmatrix_1x1.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: PMATRIX
+script: PMATRIX{x}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "x",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=31.5500 h=20.0000 bl=10.0000
+  row0:
+    Text("x") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,3.60 0.30,16.40 5.40,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M26.15,0.00 C31.25,3.60 31.25,16.40 26.15,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/pmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_1/pmatrix_2x2.golden
@@ -1,0 +1,43 @@
+# M09-1 equation golden — current-engine lock
+command: PMATRIX
+script: PMATRIX{a & b # c & d}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.70,0.00 C58.80,8.28 58.80,37.72 53.70,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_1/pmatrix_frac.golden
+++ b/src/renderer/equation/fixtures/m09_1/pmatrix_frac.golden
@@ -1,0 +1,54 @@
+# M09-1 equation golden — current-engine lock
+command: PMATRIX
+script: PMATRIX{{1} OVER {2} & 0 # 0 & 1}
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=66.0000 h=74.8000 bl=37.4000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=45.0000 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=14.0000 y=54.8000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=45.0000 y=54.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,13.46 0.30,61.34 5.40,74.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M60.60,0.00 C65.70,13.46 65.70,61.34 60.60,74.80" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="11.00" y1="24.40" x2="28.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="45.00" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="14.00" y="70.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="45.00" y="70.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_1/root_group.golden
+++ b/src/renderer/equation/fixtures/m09_1/root_group.golden
@@ -1,0 +1,35 @@
+# M09-1 equation golden — current-engine lock
+command: ROOT
+script: ROOT {a+b}
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=53.1000 h=24.0000 bl=18.0000
+  body:
+    Row x=13.0000 y=2.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L53.10,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="32.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="40.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/root_ident.golden
+++ b/src/renderer/equation/fixtures/m09_1/root_ident.golden
@@ -1,0 +1,20 @@
+# M09-1 equation golden — current-engine lock
+command: ROOT
+script: ROOT x
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/root_index.golden
+++ b/src/renderer/equation/fixtures/m09_1/root_index.golden
@@ -1,0 +1,27 @@
+# M09-1 equation golden — current-engine lock
+command: ROOT
+script: ROOT(3) of x
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/rpile_right.golden
+++ b/src/renderer/equation/fixtures/m09_1/rpile_right.golden
@@ -1,0 +1,25 @@
+# M09-1 equation golden — current-engine lock
+command: PILE
+script: RPILE{a # b}
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Right,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_group.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_group.golden
@@ -1,0 +1,35 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT {a+b}
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=53.1000 h=24.0000 bl=18.0000
+  body:
+    Row x=13.0000 y=2.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L53.10,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="32.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="40.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_ident.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_ident.golden
@@ -1,0 +1,20 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT x
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_index_brace.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_index_brace.golden
@@ -1,0 +1,27 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT {3} of {x}
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_1/sqrt_index_paren.golden
+++ b/src/renderer/equation/fixtures/m09_1/sqrt_index_paren.golden
@@ -1,0 +1,27 @@
+# M09-1 equation golden — current-engine lock
+command: SQRT
+script: SQRT(3) of x
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/atop_chain.golden
+++ b/src/renderer/equation/fixtures/m09_expand/atop_chain.golden
@@ -1,0 +1,35 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 ATOP 2 ATOP 3
+honesty: atop-vs-over
+
+=== ast ===
+Atop {
+    top: Atop {
+        top: Number(
+            "1",
+        ),
+        bottom: Number(
+            "2",
+        ),
+    },
+    bottom: Number(
+        "3",
+    ),
+}
+
+=== layout ===
+Atop x=0.0000 y=0.0000 w=27.0000 h=76.0000 bl=57.0000
+  top:
+    Atop x=4.0000 y=4.0000 w=19.0000 h=48.0000 bl=29.0000
+      top:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      bottom:
+        Number("2") x=4.0000 y=24.0000 w=11.0000 h=20.0000 bl=16.0000
+  bottom:
+    Number("3") x=8.0000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="8.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="8.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/atop_grouped.golden
+++ b/src/renderer/equation/fixtures/m09_expand/atop_grouped.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: {a+b} ATOP {c-d}
+honesty: atop-vs-over
+
+=== ast ===
+Atop {
+    top: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+    bottom: Row(
+        [
+            Text(
+                "c",
+            ),
+            Symbol(
+                "-",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Atop x=0.0000 y=0.0000 w=47.1000 h=48.0000 bl=29.0000
+  top:
+    Row x=4.0000 y=4.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  bottom:
+    Row x=4.0000 y=24.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("c") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("-") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("d") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="23.55" y="20.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="31.55" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="40.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="23.55" y="40.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="31.55" y="40.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/atop_simple.golden
+++ b/src/renderer/equation/fixtures/m09_expand/atop_simple.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 ATOP 2
+honesty: atop-vs-over
+
+=== ast ===
+Atop {
+    top: Number(
+        "1",
+    ),
+    bottom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Atop x=0.0000 y=0.0000 w=19.0000 h=48.0000 bl=29.0000
+  top:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  bottom:
+    Number("2") x=4.0000 y=24.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="4.00" y="40.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/begin_matrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/begin_matrix.golden
@@ -1,0 +1,42 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: BEGIN{matrix} a & b # c & d END{matrix}
+honesty: latex-env-partial
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/begin_pmatrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/begin_pmatrix.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: BEGIN{pmatrix} 1 & 0 # 0 & 1 END{pmatrix}
+honesty: latex-env-partial
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=58.0000 h=46.0000 bl=23.0000
+  row0:
+    Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M52.60,0.00 C57.70,8.28 57.70,37.72 52.60,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/benzene.golden
+++ b/src/renderer/equation/fixtures/m09_expand/benzene.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: BENZENE
+honesty: benzene-placeholder
+
+=== ast ===
+MathSymbol(
+    "⌬",
+)
+
+=== layout ===
+MathSymbol("⌬") x=0.0000 y=0.0000 w=12.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">⌬</text>

--- a/src/renderer/equation/fixtures/m09_expand/benzene_group.golden
+++ b/src/renderer/equation/fixtures/m09_expand/benzene_group.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: BENZENE{C6H6}
+honesty: benzene-placeholder
+
+=== ast ===
+Row(
+    [
+        MathSymbol(
+            "⌬",
+        ),
+        Text(
+            "C6H6",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=62.4000 h=20.0000 bl=16.0000
+  MathSymbol("⌬") x=0.0000 y=0.0000 w=12.0000 h=20.0000 bl=16.0000
+  Text("C6H6") x=12.0000 y=0.0000 w=50.4000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">⌬</text>
+<text x="12.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">C6H6</text>

--- a/src/renderer/equation/fixtures/m09_expand/bigg_ident.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bigg_ident.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: BIGG x
+honesty: bigg-size-ignored
+
+=== ast ===
+Text(
+    "x",
+)
+
+=== layout ===
+Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/bigg_paren.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bigg_paren.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: BIGG (
+honesty: bigg-size-ignored
+
+=== ast ===
+Symbol(
+    "(",
+)
+
+=== layout ===
+Symbol("(") x=0.0000 y=0.0000 w=12.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="6.00" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">(</text>

--- a/src/renderer/equation/fixtures/m09_expand/binom_simple.golden
+++ b/src/renderer/equation/fixtures/m09_expand/binom_simple.golden
@@ -1,0 +1,32 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: BINOM{n}{k}
+honesty: choose-empty-top
+
+=== ast ===
+Paren {
+    left: "(",
+    right: ")",
+    body: Atop {
+        top: Text(
+            "n",
+        ),
+        bottom: Text(
+            "k",
+        ),
+    },
+}
+
+=== layout ===
+Paren("(",")") x=0.0000 y=0.0000 w=31.5500 h=48.0000 bl=29.0000
+  Atop x=6.0000 y=0.0000 w=19.5500 h=48.0000 bl=29.0000
+    top:
+      Text("n") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    bottom:
+      Text("k") x=4.0000 y=24.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.86,0.00 C0.27,8.64 0.27,39.36 4.86,48.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>
+<text x="10.00" y="40.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">k</text>
+<path d="M26.69,0.00 C31.28,8.64 31.28,39.36 26.69,48.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_1x1.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_1x1.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{z}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "z",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=31.5500 h=20.0000 bl=10.0000
+  row0:
+    Text("z") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,20.00 L4.20,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M27.35,0.00 L29.75,0.00 L29.75,20.00 L27.35,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">z</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_2x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_2x3.golden
@@ -1,0 +1,54 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{a & b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=86.6500 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=65.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M82.45,0.00 L84.85,0.00 L84.85,46.00 L82.45,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="65.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_3x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_3x2.golden
@@ -1,0 +1,57 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{a & b # c & d # e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("e") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,72.00 L4.20,72.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,72.00 L54.90,72.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_3x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_3x3.golden
@@ -1,0 +1,72 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{a & b & c # d & e & f # g & h & i}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+        [
+            Text(
+                "g",
+            ),
+            Text(
+                "h",
+            ),
+            Text(
+                "i",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=86.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=65.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("g") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("h") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("i") x=65.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,72.00 L4.20,72.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M82.45,0.00 L84.85,0.00 L84.85,72.00 L82.45,72.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="65.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">g</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">h</text>
+<text x="65.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_3x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_3x3_over.golden
@@ -1,0 +1,171 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=142.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,158.40 L4.20,158.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M137.80,0.00 L140.20,0.00 L140.20,158.40 L137.80,158.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="11.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="60.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="57.00" y1="24.40" x2="85.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="106.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="103.00" y1="24.40" x2="131.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_3x7_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_3x7_over.golden
@@ -1,0 +1,363 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "83",
+                ),
+                denom: Number(
+                    "84",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "85",
+                ),
+                denom: Number(
+                    "86",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "87",
+                ),
+                denom: Number(
+                    "88",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "89",
+                ),
+                denom: Number(
+                    "90",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "91",
+                ),
+                denom: Number(
+                    "92",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "93",
+                ),
+                denom: Number(
+                    "94",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "95",
+                ),
+                denom: Number(
+                    "96",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "97",
+                ),
+                denom: Number(
+                    "98",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "99",
+                ),
+                denom: Number(
+                    "100",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "101",
+                ),
+                denom: Number(
+                    "102",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "103",
+                ),
+                denom: Number(
+                    "104",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "105",
+                ),
+                denom: Number(
+                    "106",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "107",
+                ),
+                denom: Number(
+                    "108",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "109",
+                ),
+                denom: Number(
+                    "110",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "111",
+                ),
+                denom: Number(
+                    "112",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "113",
+                ),
+                denom: Number(
+                    "114",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "115",
+                ),
+                denom: Number(
+                    "116",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "117",
+                ),
+                denom: Number(
+                    "118",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "119",
+                ),
+                denom: Number(
+                    "120",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "121",
+                ),
+                denom: Number(
+                    "122",
+                ),
+            },
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=403.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=15.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=72.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("83") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("84") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=129.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("85") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("86") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=186.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("87") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("88") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=243.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("89") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("90") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=300.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("91") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("92") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=357.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("93") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("94") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=15.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("95") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("96") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=72.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("97") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("98") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=124.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("99") x=9.5000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("100") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=181.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("101") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("102") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=238.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("103") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("104") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=295.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("105") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("106") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=352.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("107") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("108") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("109") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("110") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=67.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("111") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("112") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=124.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("113") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("114") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=181.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("115") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("116") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=238.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("117") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("118") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=295.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("119") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("120") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=352.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("121") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("122") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,158.40 L4.20,158.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M398.80,0.00 L401.20,0.00 L401.20,158.40 L398.80,158.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="16.50" y1="24.40" x2="44.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>
+<text x="76.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">83</text>
+<line x1="73.50" y1="24.40" x2="101.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="76.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">84</text>
+<text x="133.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">85</text>
+<line x1="130.50" y1="24.40" x2="158.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="133.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">86</text>
+<text x="190.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">87</text>
+<line x1="187.50" y1="24.40" x2="215.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="190.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">88</text>
+<text x="247.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">89</text>
+<line x1="244.50" y1="24.40" x2="272.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="247.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">90</text>
+<text x="304.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">91</text>
+<line x1="301.50" y1="24.40" x2="329.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="304.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">92</text>
+<text x="361.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">93</text>
+<line x1="358.50" y1="24.40" x2="386.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="361.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">94</text>
+<text x="19.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">95</text>
+<line x1="16.50" y1="79.20" x2="44.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">96</text>
+<text x="76.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">97</text>
+<line x1="73.50" y1="79.20" x2="101.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="76.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">98</text>
+<text x="133.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">99</text>
+<line x1="125.00" y1="79.20" x2="164.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="128.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">100</text>
+<text x="185.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">101</text>
+<line x1="182.00" y1="79.20" x2="221.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="185.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">102</text>
+<text x="242.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">103</text>
+<line x1="239.00" y1="79.20" x2="278.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="242.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">104</text>
+<text x="299.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">105</text>
+<line x1="296.00" y1="79.20" x2="335.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="299.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">106</text>
+<text x="356.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">107</text>
+<line x1="353.00" y1="79.20" x2="392.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="356.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">108</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">109</text>
+<line x1="11.00" y1="134.00" x2="50.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">110</text>
+<text x="71.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">111</text>
+<line x1="68.00" y1="134.00" x2="107.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="71.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">112</text>
+<text x="128.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">113</text>
+<line x1="125.00" y1="134.00" x2="164.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="128.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">114</text>
+<text x="185.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">115</text>
+<line x1="182.00" y1="134.00" x2="221.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="185.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">116</text>
+<text x="242.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">117</text>
+<line x1="239.00" y1="134.00" x2="278.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="242.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">118</text>
+<text x="299.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">119</text>
+<line x1="296.00" y1="134.00" x2="335.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="299.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">120</text>
+<text x="356.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">121</text>
+<line x1="353.00" y1="134.00" x2="392.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="356.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">122</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_4x4_mixed.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_4x4_mixed.golden
@@ -1,0 +1,206 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "3",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "2",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "11",
+            ),
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "5",
+                ),
+            },
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Number(
+                "14",
+            ),
+            Fraction {
+                numer: Number(
+                    "4",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=174.8000 h=213.2000 bl=106.6000
+  row0:
+    Number("1") x=17.8500 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=56.5500 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=95.4000 y=12.4000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=145.6750 y=14.4000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=13.8500 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=52.7000 y=67.2000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=102.9750 y=69.2000 w=11.5500 h=20.0000 bl=16.0000
+    Number("8") x=145.9500 y=69.2000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=10.0000 y=122.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=60.2750 y=124.0000 w=11.5500 h=20.0000 bl=16.0000
+    Number("11") x=97.7500 y=124.0000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=141.9500 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3:
+    Text("d") x=17.5750 y=178.8000 w=11.5500 h=20.0000 bl=16.0000
+    Number("14") x=55.0500 y=178.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=99.2500 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=138.1000 y=176.8000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,213.20 L4.20,213.20" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M170.60,0.00 L173.00,0.00 L173.00,213.20 L170.60,213.20" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.85" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="60.55" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="57.55" y1="24.40" x2="74.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.55" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<path d="M97.10,25.80 L99.10,26.80 L105.10,36.40 L108.10,12.40 L122.10,12.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="95.40" y="23.60" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="110.10" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="145.68" y="30.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="17.85" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="14.85" y1="79.20" x2="31.85" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="17.85" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M54.40,80.60 L56.40,81.60 L62.40,91.20 L65.40,67.20 L79.40,67.20" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="52.70" y="78.40" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="67.40" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="102.98" y="85.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="145.95" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M11.70,135.40 L13.70,136.40 L19.70,146.00 L22.70,122.00 L36.70,122.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="133.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="24.70" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="60.28" y="140.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="97.75" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="145.95" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="142.95" y1="134.00" x2="159.95" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="145.95" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="17.58" y="194.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="55.05" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="103.25" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="100.25" y1="188.80" x2="117.25" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="103.25" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<path d="M139.80,190.20 L141.80,191.20 L147.80,200.80 L150.80,176.80 L164.80,176.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="138.10" y="188.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="152.80" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_4x4_numbers.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_4x4_numbers.golden
@@ -1,0 +1,110 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "2",
+            ),
+            Number(
+                "3",
+            ),
+            Number(
+                "4",
+            ),
+        ],
+        [
+            Number(
+                "5",
+            ),
+            Number(
+                "6",
+            ),
+            Number(
+                "7",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Number(
+                "9",
+            ),
+            Number(
+                "10",
+            ),
+            Number(
+                "11",
+            ),
+            Number(
+                "12",
+            ),
+        ],
+        [
+            Number(
+                "13",
+            ),
+            Number(
+                "14",
+            ),
+            Number(
+                "15",
+            ),
+            Number(
+                "16",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=156.0000 h=98.0000 bl=49.0000
+  row0:
+    Number("1") x=15.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("2") x=53.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("3") x=91.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("4") x=129.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("5") x=15.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("6") x=53.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("7") x=91.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("8") x=129.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Number("9") x=15.5000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("10") x=48.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("11") x=86.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("12") x=124.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Number("13") x=10.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("14") x=48.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("15") x=86.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("16") x=124.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,98.00 L4.20,98.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M151.80,0.00 L154.20,0.00 L154.20,98.00 L151.80,98.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="15.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="53.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="91.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="129.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="15.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="53.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="91.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="129.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="15.50" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="48.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="86.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="124.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="10.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="48.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="86.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="124.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_5x5_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_5x5_over.golden
@@ -1,0 +1,433 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "9",
+                ),
+                denom: Number(
+                    "10",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "11",
+                ),
+                denom: Number(
+                    "12",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "13",
+                ),
+                denom: Number(
+                    "14",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "15",
+                ),
+                denom: Number(
+                    "16",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "17",
+                ),
+                denom: Number(
+                    "18",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "19",
+                ),
+                denom: Number(
+                    "20",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "39",
+                ),
+                denom: Number(
+                    "40",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=234.0000 h=268.0000 bl=134.0000
+  row0:
+    Fraction x=15.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=61.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=107.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=153.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("13") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("14") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("15") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("16") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("17") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("18") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("19") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("20") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=10.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("39") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("40") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=10.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,268.00 L4.20,268.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M229.80,0.00 L232.20,0.00 L232.20,268.00 L229.80,268.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="16.50" y1="24.40" x2="33.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="65.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="62.50" y1="24.40" x2="79.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="65.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="111.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="108.50" y1="24.40" x2="125.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="111.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="157.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="154.50" y1="24.40" x2="171.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="157.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="203.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="195.00" y1="24.40" x2="223.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="152.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<line x1="149.00" y1="79.20" x2="177.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="198.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<line x1="195.00" y1="79.20" x2="223.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="152.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="149.00" y1="134.00" x2="177.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="198.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="195.00" y1="134.00" x2="223.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="14.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="11.00" y1="188.80" x2="39.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="60.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="57.00" y1="188.80" x2="85.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="106.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="103.00" y1="188.80" x2="131.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="152.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="149.00" y1="188.80" x2="177.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>
+<text x="198.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">39</text>
+<line x1="195.00" y1="188.80" x2="223.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">40</text>
+<text x="14.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="11.00" y1="243.60" x2="39.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="60.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="57.00" y1="243.60" x2="85.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="106.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="103.00" y1="243.60" x2="131.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="152.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="149.00" y1="243.60" x2="177.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="198.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="195.00" y1="243.60" x2="223.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_5x5_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_5x5_sqrt.golden
@@ -1,0 +1,483 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "6",
+                    ),
+                ),
+                body: Number(
+                    "9",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "7",
+                    ),
+                ),
+                body: Number(
+                    "10",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "8",
+                    ),
+                ),
+                body: Number(
+                    "11",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "9",
+                    ),
+                ),
+                body: Number(
+                    "12",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "10",
+                    ),
+                ),
+                body: Number(
+                    "13",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "11",
+                    ),
+                ),
+                body: Number(
+                    "14",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "12",
+                    ),
+                ),
+                body: Number(
+                    "15",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "13",
+                    ),
+                ),
+                body: Number(
+                    "16",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "14",
+                    ),
+                ),
+                body: Number(
+                    "17",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "15",
+                    ),
+                ),
+                body: Number(
+                    "18",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "16",
+                    ),
+                ),
+                body: Number(
+                    "19",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "17",
+                    ),
+                ),
+                body: Number(
+                    "20",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "18",
+                    ),
+                ),
+                body: Number(
+                    "21",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "19",
+                    ),
+                ),
+                body: Number(
+                    "22",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "20",
+                    ),
+                ),
+                body: Number(
+                    "23",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "21",
+                    ),
+                ),
+                body: Number(
+                    "24",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "22",
+                    ),
+                ),
+                body: Number(
+                    "25",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "23",
+                    ),
+                ),
+                body: Number(
+                    "26",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "24",
+                    ),
+                ),
+                body: Number(
+                    "27",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "25",
+                    ),
+                ),
+                body: Number(
+                    "28",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "26",
+                    ),
+                ),
+                body: Number(
+                    "29",
+                ),
+            },
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=311.0000 h=144.0000 bl=72.0000
+  row0:
+    Sqrt x=19.3500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=80.7500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=142.1500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=203.5500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=264.9500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("6") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("9") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Sqrt x=13.8500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("7") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("10") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=75.2500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("8") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("11") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=136.6500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("9") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("12") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("10") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("13") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("11") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("14") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=10.0000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("12") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("15") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("13") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("16") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("14") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("17") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("15") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("18") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("16") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("19") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Sqrt x=10.0000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("17") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("20") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("18") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("21") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("19") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("22") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("20") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("23") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("21") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("24") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Sqrt x=10.0000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("22") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("25") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("23") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("26") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("24") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("27") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("25") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("28") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("26") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("29") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,144.00 L4.20,144.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M306.80,0.00 L309.20,0.00 L309.20,144.00 L306.80,144.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M21.05,13.40 L23.05,14.40 L29.05,24.00 L32.05,0.00 L46.05,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="19.35" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="34.05" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<path d="M82.45,13.40 L84.45,14.40 L90.45,24.00 L93.45,0.00 L107.45,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="80.75" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="95.45" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<path d="M143.85,13.40 L145.85,14.40 L151.85,24.00 L154.85,0.00 L168.85,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="142.15" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="156.85" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<path d="M205.25,13.40 L207.25,14.40 L213.25,24.00 L216.25,0.00 L230.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="203.55" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="218.25" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M266.65,13.40 L268.65,14.40 L274.65,24.00 L277.65,0.00 L291.65,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="264.95" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="279.65" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<path d="M15.55,43.40 L17.55,44.40 L23.55,54.00 L26.55,30.00 L51.55,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.85" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="28.55" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<path d="M76.95,43.40 L78.95,44.40 L84.95,54.00 L87.95,30.00 L112.95,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="75.25" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="89.95" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<path d="M138.35,43.40 L140.35,44.40 L146.35,54.00 L149.35,30.00 L174.35,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="136.65" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="151.35" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<path d="M203.60,43.40 L205.60,44.40 L211.60,54.00 L214.60,30.00 L239.60,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="216.60" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<path d="M265.00,43.40 L267.00,44.40 L273.00,54.00 L276.00,30.00 L301.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="278.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<path d="M19.40,73.40 L21.40,74.40 L27.40,84.00 L30.40,60.00 L55.40,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="32.40" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<path d="M80.80,73.40 L82.80,74.40 L88.80,84.00 L91.80,60.00 L116.80,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="93.80" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<path d="M142.20,73.40 L144.20,74.40 L150.20,84.00 L153.20,60.00 L178.20,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="155.20" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<path d="M203.60,73.40 L205.60,74.40 L211.60,84.00 L214.60,60.00 L239.60,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="216.60" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<path d="M265.00,73.40 L267.00,74.40 L273.00,84.00 L276.00,60.00 L301.00,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="278.00" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<path d="M19.40,103.40 L21.40,104.40 L27.40,114.00 L30.40,90.00 L55.40,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<text x="32.40" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<path d="M80.80,103.40 L82.80,104.40 L88.80,114.00 L91.80,90.00 L116.80,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="93.80" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<path d="M142.20,103.40 L144.20,104.40 L150.20,114.00 L153.20,90.00 L178.20,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<text x="155.20" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<path d="M203.60,103.40 L205.60,104.40 L211.60,114.00 L214.60,90.00 L239.60,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="216.60" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<path d="M265.00,103.40 L267.00,104.40 L273.00,114.00 L276.00,90.00 L301.00,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<text x="278.00" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<path d="M19.40,133.40 L21.40,134.40 L27.40,144.00 L30.40,120.00 L55.40,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="32.40" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<path d="M80.80,133.40 L82.80,134.40 L88.80,144.00 L91.80,120.00 L116.80,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<text x="93.80" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<path d="M142.20,133.40 L144.20,134.40 L150.20,144.00 L153.20,120.00 L178.20,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="155.20" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<path d="M203.60,133.40 L205.60,134.40 L211.60,144.00 L214.60,120.00 L239.60,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<text x="216.60" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<path d="M265.00,133.40 L267.00,134.40 L273.00,144.00 L276.00,120.00 L301.00,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="278.00" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_7x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_7x3_over.golden
@@ -1,0 +1,375 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "51",
+                ),
+                denom: Number(
+                    "52",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "53",
+                ),
+                denom: Number(
+                    "54",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "55",
+                ),
+                denom: Number(
+                    "56",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "57",
+                ),
+                denom: Number(
+                    "58",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "59",
+                ),
+                denom: Number(
+                    "60",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "61",
+                ),
+                denom: Number(
+                    "62",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "63",
+                ),
+                denom: Number(
+                    "64",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "65",
+                ),
+                denom: Number(
+                    "66",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "67",
+                ),
+                denom: Number(
+                    "68",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "69",
+                ),
+                denom: Number(
+                    "70",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "71",
+                ),
+                denom: Number(
+                    "72",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "73",
+                ),
+                denom: Number(
+                    "74",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "75",
+                ),
+                denom: Number(
+                    "76",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "77",
+                ),
+                denom: Number(
+                    "78",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "79",
+                ),
+                denom: Number(
+                    "80",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=142.0000 h=377.6000 bl=188.8000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("51") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("52") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("53") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("54") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("55") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("56") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("57") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("58") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=10.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("59") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("60") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("61") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("62") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("63") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("64") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=10.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("65") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("66") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("67") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("68") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("69") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("70") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row5:
+    Fraction x=10.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("71") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("72") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("73") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("74") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("75") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("76") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row6:
+    Fraction x=10.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("77") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("78") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("79") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("80") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,377.60 L4.20,377.60" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M137.80,0.00 L140.20,0.00 L140.20,377.60 L137.80,377.60" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="11.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="60.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="57.00" y1="24.40" x2="85.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="106.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="103.00" y1="24.40" x2="131.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">51</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">52</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">53</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">54</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">55</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">56</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">57</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">58</text>
+<text x="14.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">59</text>
+<line x1="11.00" y1="188.80" x2="39.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">60</text>
+<text x="60.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">61</text>
+<line x1="57.00" y1="188.80" x2="85.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">62</text>
+<text x="106.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">63</text>
+<line x1="103.00" y1="188.80" x2="131.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">64</text>
+<text x="14.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">65</text>
+<line x1="11.00" y1="243.60" x2="39.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">66</text>
+<text x="60.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">67</text>
+<line x1="57.00" y1="243.60" x2="85.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">68</text>
+<text x="106.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">69</text>
+<line x1="103.00" y1="243.60" x2="131.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">70</text>
+<text x="14.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">71</text>
+<line x1="11.00" y1="298.40" x2="39.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">72</text>
+<text x="60.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">73</text>
+<line x1="57.00" y1="298.40" x2="85.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">74</text>
+<text x="106.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">75</text>
+<line x1="103.00" y1="298.40" x2="131.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">76</text>
+<text x="14.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">77</text>
+<line x1="11.00" y1="353.20" x2="39.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">78</text>
+<text x="60.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">79</text>
+<line x1="57.00" y1="353.20" x2="85.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">80</text>
+<text x="106.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="103.00" y1="353.20" x2="131.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_empty_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_empty_brace.golden
@@ -1,0 +1,20 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{}
+honesty: missing-operand
+
+=== ast ===
+Matrix {
+    rows: [
+        [],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=20.0000 h=20.0000 bl=10.0000
+  row0:
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,20.00 L4.20,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M15.80,0.00 L18.20,0.00 L18.20,20.00 L15.80,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_eqalign_cell.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_eqalign_cell.golden
@@ -1,0 +1,68 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{EQALIGN{x &= 1} & 0 # 0 & 1}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            EqAlign {
+                rows: [
+                    (
+                        Text(
+                            "x",
+                        ),
+                        Row(
+                            [
+                                Symbol(
+                                    "=",
+                                ),
+                                Number(
+                                    "1",
+                                ),
+                            ],
+                        ),
+                    ),
+                ],
+            },
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=88.5500 h=46.0000 bl=23.0000
+  row0:
+    EqAlign x=10.0000 y=0.0000 w=41.5500 h=20.0000 bl=10.0000
+      row0.left:
+        Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      row0.right:
+        Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+          Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+          Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=67.5500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=25.2750 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=67.5500 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M84.35,0.00 L86.75,0.00 L86.75,46.00 L84.35,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="32.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="40.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="67.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="25.27" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="67.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_func.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_func.golden
@@ -1,0 +1,89 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{sin x & cos x # -sin x & cos x}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Row(
+                [
+                    Function(
+                        "sin",
+                    ),
+                    Text(
+                        "x",
+                    ),
+                ],
+            ),
+            Row(
+                [
+                    Function(
+                        "cos",
+                    ),
+                    Text(
+                        "x",
+                    ),
+                ],
+            ),
+        ],
+        [
+            Row(
+                [
+                    Symbol(
+                        "-",
+                    ),
+                    Function(
+                        "sin",
+                    ),
+                    Text(
+                        "x",
+                    ),
+                ],
+            ),
+            Row(
+                [
+                    Function(
+                        "cos",
+                    ),
+                    Text(
+                        "x",
+                    ),
+                ],
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=141.9000 h=46.0000 bl=23.0000
+  row0:
+    Row x=18.0000 y=0.0000 w=44.9500 h=20.0000 bl=16.0000
+      Function("sin") x=0.0000 y=0.0000 w=33.4000 h=20.0000 bl=16.0000
+      Text("x") x=33.4000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Row x=86.9500 y=0.0000 w=44.9500 h=20.0000 bl=16.0000
+      Function("cos") x=0.0000 y=0.0000 w=33.4000 h=20.0000 bl=16.0000
+      Text("x") x=33.4000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Row x=10.0000 y=26.0000 w=60.9500 h=20.0000 bl=16.0000
+      Symbol("-") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Function("sin") x=16.0000 y=0.0000 w=33.4000 h=20.0000 bl=16.0000
+      Text("x") x=49.4000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Row x=86.9500 y=26.0000 w=44.9500 h=20.0000 bl=16.0000
+      Function("cos") x=0.0000 y=0.0000 w=33.4000 h=20.0000 bl=16.0000
+      Text("x") x=33.4000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M137.70,0.00 L140.10,0.00 L140.10,46.00 L137.70,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="18.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">sin</text>
+<text x="51.40" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="86.95" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">cos</text>
+<text x="120.35" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="18.00" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="26.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">sin</text>
+<text x="59.40" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="86.95" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">cos</text>
+<text x="120.35" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_jagged.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_jagged.golden
@@ -1,0 +1,57 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{a # b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+        ],
+        [
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=86.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("b") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("d") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,72.00 L4.20,72.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M82.45,0.00 L84.85,0.00 L84.85,72.00 L82.45,72.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_lower.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: bmatrix{a & b # c & d}
+honesty: case-insensitive
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,46.00 L54.90,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX
+honesty: matrix-no-brace-empty
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_spacey.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_spacey.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{ a  &  b  #  c  &  d }
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,46.00 L54.90,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_trailing_amp.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_trailing_amp.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{a & b &}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Empty,
+        ],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=75.1000 h=20.0000 bl=10.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Empty x=65.1000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,20.00 L4.20,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M70.90,0.00 L73.30,0.00 L73.30,20.00 L70.90,20.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/bmatrix_trailing_hash.golden
+++ b/src/renderer/equation/fixtures/m09_expand/bmatrix_trailing_hash.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: BMATRIX
+script: BMATRIX{a & b #}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [],
+    ],
+    style: Bracket,
+}
+
+=== layout ===
+Matrix(Bracket) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+
+=== svg ===
+<path d="M4.20,0.00 L1.80,0.00 L1.80,46.00 L4.20,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M54.90,0.00 L57.30,0.00 L57.30,46.00 L54.90,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/buildrel_arrow.golden
+++ b/src/renderer/equation/fixtures/m09_expand/buildrel_arrow.golden
@@ -1,0 +1,24 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: BUILDREL -> {def}
+honesty: rel-buildrel
+
+=== ast ===
+Rel {
+    arrow: "→",
+    over: Text(
+        "def",
+    ),
+    under: None,
+}
+
+=== layout ===
+Rel x=0.0000 y=0.0000 w=24.2550 h=36.0000 bl=26.0000
+  arrow:
+    MathSymbol("→") x=0.0000 y=16.0000 w=24.2550 h=20.0000 bl=16.0000
+  over:
+    Text("def") x=0.0000 y=0.0000 w=24.2550 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="0.00" y="11.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">def</text>
+<text x="0.00" y="32.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">→</text>

--- a/src/renderer/equation/fixtures/m09_expand/cases_2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/cases_2.golden
@@ -1,0 +1,90 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: CASES{x & if x>0 # -x & if x<0}
+honesty: cases-related
+
+=== ast ===
+Cases {
+    rows: [
+        Row(
+            [
+                Text(
+                    "x",
+                ),
+                Space(
+                    Tab,
+                ),
+                Text(
+                    "if",
+                ),
+                Text(
+                    "x",
+                ),
+                Symbol(
+                    ">",
+                ),
+                Number(
+                    "0",
+                ),
+            ],
+        ),
+        Row(
+            [
+                Symbol(
+                    "-",
+                ),
+                Text(
+                    "x",
+                ),
+                Space(
+                    Tab,
+                ),
+                Text(
+                    "if",
+                ),
+                Text(
+                    "x",
+                ),
+                Symbol(
+                    "<",
+                ),
+                Number(
+                    "0",
+                ),
+            ],
+        ),
+    ],
+}
+
+=== layout ===
+Paren("{","") x=0.0000 y=0.0000 w=127.2000 h=46.0000 bl=23.0000
+  Row x=0.0000 y=0.0000 w=121.2000 h=46.0000 bl=23.0000
+    Row x=6.0000 y=0.0000 w=93.2000 h=20.0000 bl=16.0000
+      Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Space(20.0000) x=11.5500 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+      Text("if") x=31.5500 y=0.0000 w=23.1000 h=20.0000 bl=16.0000
+      Text("x") x=54.6500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol(">") x=66.2000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("0") x=82.2000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Row x=6.0000 y=26.0000 w=109.2000 h=20.0000 bl=16.0000
+      Symbol("-") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("x") x=16.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Space(20.0000) x=27.5500 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+      Text("if") x=47.5500 y=0.0000 w=23.1000 h=20.0000 bl=16.0000
+      Text("x") x=70.6500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("<") x=82.2000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("0") x=98.2000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M3.78,0.00 Q2.16,0.00 2.16,11.50 Q2.16,23.00 1.08,23.00 Q2.16,23.00 2.16,34.50 Q2.16,46.00 3.78,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="6.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">if</text>
+<text x="60.65" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="80.20" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">&gt;</text>
+<text x="88.20" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="14.00" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="22.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="53.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">if</text>
+<text x="76.65" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="96.20" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">&lt;</text>
+<text x="104.20" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>

--- a/src/renderer/equation/fixtures/m09_expand/cases_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/cases_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: CASES
+honesty: cases-related
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/choose_simple.golden
+++ b/src/renderer/equation/fixtures/m09_expand/choose_simple.golden
@@ -1,0 +1,39 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: n CHOOSE k
+honesty: choose-empty-top
+
+=== ast ===
+Row(
+    [
+        Text(
+            "n",
+        ),
+        Paren {
+            left: "(",
+            right: ")",
+            body: Atop {
+                top: Empty,
+                bottom: Text(
+                    "k",
+                ),
+            },
+        },
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=43.1000 h=35.0000 bl=16.0000
+  Text("n") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Paren("(",")") x=11.5500 y=7.0000 w=31.5500 h=28.0000 bl=9.0000
+    Atop x=6.0000 y=0.0000 w=19.5500 h=28.0000 bl=9.0000
+      top:
+        Empty x=9.7750 y=4.0000 w=0.0000 h=0.0000 bl=0.0000
+      bottom:
+        Text("k") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>
+<path d="M16.41,7.00 C11.82,12.04 11.82,29.96 16.41,35.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="21.55" y="27.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">k</text>
+<path d="M38.24,7.00 C42.83,12.04 42.83,29.96 38.24,35.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>

--- a/src/renderer/equation/fixtures/m09_expand/color_red.golden
+++ b/src/renderer/equation/fixtures/m09_expand/color_red.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: COLOR red x
+honesty: color-passthrough
+
+=== ast ===
+Row(
+    [
+        Text(
+            "red",
+        ),
+        Text(
+            "x",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=46.2000 h=20.0000 bl=16.0000
+  Text("red") x=0.0000 y=0.0000 w=34.6500 h=20.0000 bl=16.0000
+  Text("x") x=34.6500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">red</text>
+<text x="34.65" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/dfrac_latex.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dfrac_latex.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: DFRAC{1}{2}
+honesty: latex-frac
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_2x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_2x3.golden
@@ -1,0 +1,54 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{a & b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=86.6500 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=65.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="83.65" y1="0.00" x2="83.65" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="65.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_3x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_3x2.golden
@@ -1,0 +1,57 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{a & b # c & d # e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=59.1000 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("e") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="72.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="56.10" y1="0.00" x2="56.10" y2="72.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_3x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_3x3.golden
@@ -1,0 +1,72 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{a & b & c # d & e & f # g & h & i}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+        [
+            Text(
+                "g",
+            ),
+            Text(
+                "h",
+            ),
+            Text(
+                "i",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=86.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=65.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("g") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("h") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("i") x=65.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="72.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="83.65" y1="0.00" x2="83.65" y2="72.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="65.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">g</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">h</text>
+<text x="65.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_3x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_3x3_over.golden
@@ -1,0 +1,171 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=142.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="158.40" stroke="#000000" stroke-width="0.80"/>
+<line x1="139.00" y1="0.00" x2="139.00" y2="158.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="11.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="60.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="57.00" y1="24.40" x2="85.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="106.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="103.00" y1="24.40" x2="131.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_3x7_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_3x7_over.golden
@@ -1,0 +1,363 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "83",
+                ),
+                denom: Number(
+                    "84",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "85",
+                ),
+                denom: Number(
+                    "86",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "87",
+                ),
+                denom: Number(
+                    "88",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "89",
+                ),
+                denom: Number(
+                    "90",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "91",
+                ),
+                denom: Number(
+                    "92",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "93",
+                ),
+                denom: Number(
+                    "94",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "95",
+                ),
+                denom: Number(
+                    "96",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "97",
+                ),
+                denom: Number(
+                    "98",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "99",
+                ),
+                denom: Number(
+                    "100",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "101",
+                ),
+                denom: Number(
+                    "102",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "103",
+                ),
+                denom: Number(
+                    "104",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "105",
+                ),
+                denom: Number(
+                    "106",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "107",
+                ),
+                denom: Number(
+                    "108",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "109",
+                ),
+                denom: Number(
+                    "110",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "111",
+                ),
+                denom: Number(
+                    "112",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "113",
+                ),
+                denom: Number(
+                    "114",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "115",
+                ),
+                denom: Number(
+                    "116",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "117",
+                ),
+                denom: Number(
+                    "118",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "119",
+                ),
+                denom: Number(
+                    "120",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "121",
+                ),
+                denom: Number(
+                    "122",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=403.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=15.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=72.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("83") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("84") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=129.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("85") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("86") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=186.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("87") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("88") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=243.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("89") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("90") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=300.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("91") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("92") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=357.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("93") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("94") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=15.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("95") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("96") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=72.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("97") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("98") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=124.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("99") x=9.5000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("100") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=181.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("101") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("102") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=238.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("103") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("104") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=295.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("105") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("106") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=352.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("107") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("108") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("109") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("110") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=67.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("111") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("112") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=124.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("113") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("114") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=181.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("115") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("116") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=238.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("117") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("118") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=295.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("119") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("120") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=352.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("121") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("122") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="158.40" stroke="#000000" stroke-width="0.80"/>
+<line x1="400.00" y1="0.00" x2="400.00" y2="158.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="16.50" y1="24.40" x2="44.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>
+<text x="76.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">83</text>
+<line x1="73.50" y1="24.40" x2="101.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="76.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">84</text>
+<text x="133.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">85</text>
+<line x1="130.50" y1="24.40" x2="158.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="133.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">86</text>
+<text x="190.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">87</text>
+<line x1="187.50" y1="24.40" x2="215.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="190.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">88</text>
+<text x="247.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">89</text>
+<line x1="244.50" y1="24.40" x2="272.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="247.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">90</text>
+<text x="304.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">91</text>
+<line x1="301.50" y1="24.40" x2="329.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="304.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">92</text>
+<text x="361.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">93</text>
+<line x1="358.50" y1="24.40" x2="386.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="361.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">94</text>
+<text x="19.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">95</text>
+<line x1="16.50" y1="79.20" x2="44.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">96</text>
+<text x="76.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">97</text>
+<line x1="73.50" y1="79.20" x2="101.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="76.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">98</text>
+<text x="133.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">99</text>
+<line x1="125.00" y1="79.20" x2="164.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="128.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">100</text>
+<text x="185.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">101</text>
+<line x1="182.00" y1="79.20" x2="221.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="185.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">102</text>
+<text x="242.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">103</text>
+<line x1="239.00" y1="79.20" x2="278.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="242.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">104</text>
+<text x="299.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">105</text>
+<line x1="296.00" y1="79.20" x2="335.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="299.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">106</text>
+<text x="356.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">107</text>
+<line x1="353.00" y1="79.20" x2="392.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="356.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">108</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">109</text>
+<line x1="11.00" y1="134.00" x2="50.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">110</text>
+<text x="71.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">111</text>
+<line x1="68.00" y1="134.00" x2="107.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="71.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">112</text>
+<text x="128.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">113</text>
+<line x1="125.00" y1="134.00" x2="164.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="128.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">114</text>
+<text x="185.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">115</text>
+<line x1="182.00" y1="134.00" x2="221.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="185.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">116</text>
+<text x="242.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">117</text>
+<line x1="239.00" y1="134.00" x2="278.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="242.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">118</text>
+<text x="299.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">119</text>
+<line x1="296.00" y1="134.00" x2="335.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="299.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">120</text>
+<text x="356.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">121</text>
+<line x1="353.00" y1="134.00" x2="392.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="356.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">122</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_4x4_mixed.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_4x4_mixed.golden
@@ -1,0 +1,206 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "3",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "2",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "11",
+            ),
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "5",
+                ),
+            },
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Number(
+                "14",
+            ),
+            Fraction {
+                numer: Number(
+                    "4",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=174.8000 h=213.2000 bl=106.6000
+  row0:
+    Number("1") x=17.8500 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=56.5500 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=95.4000 y=12.4000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=145.6750 y=14.4000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=13.8500 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=52.7000 y=67.2000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=102.9750 y=69.2000 w=11.5500 h=20.0000 bl=16.0000
+    Number("8") x=145.9500 y=69.2000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=10.0000 y=122.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=60.2750 y=124.0000 w=11.5500 h=20.0000 bl=16.0000
+    Number("11") x=97.7500 y=124.0000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=141.9500 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3:
+    Text("d") x=17.5750 y=178.8000 w=11.5500 h=20.0000 bl=16.0000
+    Number("14") x=55.0500 y=178.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=99.2500 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=138.1000 y=176.8000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="213.20" stroke="#000000" stroke-width="0.80"/>
+<line x1="171.80" y1="0.00" x2="171.80" y2="213.20" stroke="#000000" stroke-width="0.80"/>
+<text x="17.85" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="60.55" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="57.55" y1="24.40" x2="74.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.55" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<path d="M97.10,25.80 L99.10,26.80 L105.10,36.40 L108.10,12.40 L122.10,12.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="95.40" y="23.60" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="110.10" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="145.68" y="30.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="17.85" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="14.85" y1="79.20" x2="31.85" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="17.85" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M54.40,80.60 L56.40,81.60 L62.40,91.20 L65.40,67.20 L79.40,67.20" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="52.70" y="78.40" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="67.40" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="102.98" y="85.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="145.95" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M11.70,135.40 L13.70,136.40 L19.70,146.00 L22.70,122.00 L36.70,122.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="133.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="24.70" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="60.28" y="140.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="97.75" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="145.95" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="142.95" y1="134.00" x2="159.95" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="145.95" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="17.58" y="194.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="55.05" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="103.25" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="100.25" y1="188.80" x2="117.25" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="103.25" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<path d="M139.80,190.20 L141.80,191.20 L147.80,200.80 L150.80,176.80 L164.80,176.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="138.10" y="188.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="152.80" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_4x4_numbers.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_4x4_numbers.golden
@@ -1,0 +1,110 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "2",
+            ),
+            Number(
+                "3",
+            ),
+            Number(
+                "4",
+            ),
+        ],
+        [
+            Number(
+                "5",
+            ),
+            Number(
+                "6",
+            ),
+            Number(
+                "7",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Number(
+                "9",
+            ),
+            Number(
+                "10",
+            ),
+            Number(
+                "11",
+            ),
+            Number(
+                "12",
+            ),
+        ],
+        [
+            Number(
+                "13",
+            ),
+            Number(
+                "14",
+            ),
+            Number(
+                "15",
+            ),
+            Number(
+                "16",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=156.0000 h=98.0000 bl=49.0000
+  row0:
+    Number("1") x=15.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("2") x=53.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("3") x=91.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("4") x=129.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("5") x=15.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("6") x=53.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("7") x=91.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("8") x=129.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Number("9") x=15.5000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("10") x=48.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("11") x=86.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("12") x=124.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Number("13") x=10.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("14") x=48.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("15") x=86.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("16") x=124.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="98.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="153.00" y1="0.00" x2="153.00" y2="98.00" stroke="#000000" stroke-width="0.80"/>
+<text x="15.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="53.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="91.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="129.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="15.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="53.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="91.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="129.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="15.50" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="48.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="86.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="124.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="10.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="48.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="86.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="124.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_5x5_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_5x5_over.golden
@@ -1,0 +1,433 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "9",
+                ),
+                denom: Number(
+                    "10",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "11",
+                ),
+                denom: Number(
+                    "12",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "13",
+                ),
+                denom: Number(
+                    "14",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "15",
+                ),
+                denom: Number(
+                    "16",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "17",
+                ),
+                denom: Number(
+                    "18",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "19",
+                ),
+                denom: Number(
+                    "20",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "39",
+                ),
+                denom: Number(
+                    "40",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=234.0000 h=268.0000 bl=134.0000
+  row0:
+    Fraction x=15.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=61.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=107.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=153.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("13") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("14") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("15") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("16") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("17") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("18") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("19") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("20") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=10.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("39") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("40") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=10.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="268.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="231.00" y1="0.00" x2="231.00" y2="268.00" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="16.50" y1="24.40" x2="33.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="65.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="62.50" y1="24.40" x2="79.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="65.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="111.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="108.50" y1="24.40" x2="125.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="111.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="157.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="154.50" y1="24.40" x2="171.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="157.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="203.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="195.00" y1="24.40" x2="223.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="152.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<line x1="149.00" y1="79.20" x2="177.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="198.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<line x1="195.00" y1="79.20" x2="223.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="152.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="149.00" y1="134.00" x2="177.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="198.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="195.00" y1="134.00" x2="223.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="14.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="11.00" y1="188.80" x2="39.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="60.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="57.00" y1="188.80" x2="85.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="106.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="103.00" y1="188.80" x2="131.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="152.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="149.00" y1="188.80" x2="177.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>
+<text x="198.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">39</text>
+<line x1="195.00" y1="188.80" x2="223.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">40</text>
+<text x="14.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="11.00" y1="243.60" x2="39.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="60.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="57.00" y1="243.60" x2="85.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="106.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="103.00" y1="243.60" x2="131.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="152.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="149.00" y1="243.60" x2="177.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="198.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="195.00" y1="243.60" x2="223.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_5x5_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_5x5_sqrt.golden
@@ -1,0 +1,483 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "6",
+                    ),
+                ),
+                body: Number(
+                    "9",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "7",
+                    ),
+                ),
+                body: Number(
+                    "10",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "8",
+                    ),
+                ),
+                body: Number(
+                    "11",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "9",
+                    ),
+                ),
+                body: Number(
+                    "12",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "10",
+                    ),
+                ),
+                body: Number(
+                    "13",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "11",
+                    ),
+                ),
+                body: Number(
+                    "14",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "12",
+                    ),
+                ),
+                body: Number(
+                    "15",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "13",
+                    ),
+                ),
+                body: Number(
+                    "16",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "14",
+                    ),
+                ),
+                body: Number(
+                    "17",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "15",
+                    ),
+                ),
+                body: Number(
+                    "18",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "16",
+                    ),
+                ),
+                body: Number(
+                    "19",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "17",
+                    ),
+                ),
+                body: Number(
+                    "20",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "18",
+                    ),
+                ),
+                body: Number(
+                    "21",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "19",
+                    ),
+                ),
+                body: Number(
+                    "22",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "20",
+                    ),
+                ),
+                body: Number(
+                    "23",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "21",
+                    ),
+                ),
+                body: Number(
+                    "24",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "22",
+                    ),
+                ),
+                body: Number(
+                    "25",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "23",
+                    ),
+                ),
+                body: Number(
+                    "26",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "24",
+                    ),
+                ),
+                body: Number(
+                    "27",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "25",
+                    ),
+                ),
+                body: Number(
+                    "28",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "26",
+                    ),
+                ),
+                body: Number(
+                    "29",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=311.0000 h=144.0000 bl=72.0000
+  row0:
+    Sqrt x=19.3500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=80.7500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=142.1500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=203.5500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=264.9500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("6") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("9") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Sqrt x=13.8500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("7") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("10") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=75.2500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("8") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("11") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=136.6500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("9") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("12") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("10") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("13") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("11") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("14") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=10.0000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("12") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("15") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("13") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("16") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("14") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("17") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("15") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("18") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("16") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("19") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Sqrt x=10.0000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("17") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("20") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("18") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("21") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("19") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("22") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("20") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("23") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("21") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("24") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Sqrt x=10.0000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("22") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("25") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("23") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("26") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("24") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("27") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("25") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("28") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("26") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("29") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="144.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="308.00" y1="0.00" x2="308.00" y2="144.00" stroke="#000000" stroke-width="0.80"/>
+<path d="M21.05,13.40 L23.05,14.40 L29.05,24.00 L32.05,0.00 L46.05,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="19.35" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="34.05" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<path d="M82.45,13.40 L84.45,14.40 L90.45,24.00 L93.45,0.00 L107.45,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="80.75" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="95.45" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<path d="M143.85,13.40 L145.85,14.40 L151.85,24.00 L154.85,0.00 L168.85,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="142.15" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="156.85" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<path d="M205.25,13.40 L207.25,14.40 L213.25,24.00 L216.25,0.00 L230.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="203.55" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="218.25" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M266.65,13.40 L268.65,14.40 L274.65,24.00 L277.65,0.00 L291.65,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="264.95" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="279.65" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<path d="M15.55,43.40 L17.55,44.40 L23.55,54.00 L26.55,30.00 L51.55,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.85" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="28.55" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<path d="M76.95,43.40 L78.95,44.40 L84.95,54.00 L87.95,30.00 L112.95,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="75.25" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="89.95" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<path d="M138.35,43.40 L140.35,44.40 L146.35,54.00 L149.35,30.00 L174.35,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="136.65" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="151.35" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<path d="M203.60,43.40 L205.60,44.40 L211.60,54.00 L214.60,30.00 L239.60,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="216.60" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<path d="M265.00,43.40 L267.00,44.40 L273.00,54.00 L276.00,30.00 L301.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="278.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<path d="M19.40,73.40 L21.40,74.40 L27.40,84.00 L30.40,60.00 L55.40,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="32.40" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<path d="M80.80,73.40 L82.80,74.40 L88.80,84.00 L91.80,60.00 L116.80,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="93.80" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<path d="M142.20,73.40 L144.20,74.40 L150.20,84.00 L153.20,60.00 L178.20,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="155.20" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<path d="M203.60,73.40 L205.60,74.40 L211.60,84.00 L214.60,60.00 L239.60,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="216.60" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<path d="M265.00,73.40 L267.00,74.40 L273.00,84.00 L276.00,60.00 L301.00,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="278.00" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<path d="M19.40,103.40 L21.40,104.40 L27.40,114.00 L30.40,90.00 L55.40,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<text x="32.40" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<path d="M80.80,103.40 L82.80,104.40 L88.80,114.00 L91.80,90.00 L116.80,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="93.80" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<path d="M142.20,103.40 L144.20,104.40 L150.20,114.00 L153.20,90.00 L178.20,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<text x="155.20" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<path d="M203.60,103.40 L205.60,104.40 L211.60,114.00 L214.60,90.00 L239.60,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="216.60" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<path d="M265.00,103.40 L267.00,104.40 L273.00,114.00 L276.00,90.00 L301.00,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<text x="278.00" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<path d="M19.40,133.40 L21.40,134.40 L27.40,144.00 L30.40,120.00 L55.40,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="32.40" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<path d="M80.80,133.40 L82.80,134.40 L88.80,144.00 L91.80,120.00 L116.80,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<text x="93.80" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<path d="M142.20,133.40 L144.20,134.40 L150.20,144.00 L153.20,120.00 L178.20,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="155.20" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<path d="M203.60,133.40 L205.60,134.40 L211.60,144.00 L214.60,120.00 L239.60,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<text x="216.60" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<path d="M265.00,133.40 L267.00,134.40 L273.00,144.00 L276.00,120.00 L301.00,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="278.00" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_7x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_7x3_over.golden
@@ -1,0 +1,375 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "51",
+                ),
+                denom: Number(
+                    "52",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "53",
+                ),
+                denom: Number(
+                    "54",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "55",
+                ),
+                denom: Number(
+                    "56",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "57",
+                ),
+                denom: Number(
+                    "58",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "59",
+                ),
+                denom: Number(
+                    "60",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "61",
+                ),
+                denom: Number(
+                    "62",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "63",
+                ),
+                denom: Number(
+                    "64",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "65",
+                ),
+                denom: Number(
+                    "66",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "67",
+                ),
+                denom: Number(
+                    "68",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "69",
+                ),
+                denom: Number(
+                    "70",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "71",
+                ),
+                denom: Number(
+                    "72",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "73",
+                ),
+                denom: Number(
+                    "74",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "75",
+                ),
+                denom: Number(
+                    "76",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "77",
+                ),
+                denom: Number(
+                    "78",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "79",
+                ),
+                denom: Number(
+                    "80",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=142.0000 h=377.6000 bl=188.8000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("51") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("52") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("53") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("54") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("55") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("56") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("57") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("58") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=10.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("59") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("60") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("61") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("62") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("63") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("64") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=10.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("65") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("66") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("67") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("68") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("69") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("70") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row5:
+    Fraction x=10.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("71") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("72") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("73") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("74") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("75") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("76") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row6:
+    Fraction x=10.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("77") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("78") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("79") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("80") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="377.60" stroke="#000000" stroke-width="0.80"/>
+<line x1="139.00" y1="0.00" x2="139.00" y2="377.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="11.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="60.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="57.00" y1="24.40" x2="85.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="106.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="103.00" y1="24.40" x2="131.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">51</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">52</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">53</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">54</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">55</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">56</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">57</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">58</text>
+<text x="14.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">59</text>
+<line x1="11.00" y1="188.80" x2="39.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">60</text>
+<text x="60.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">61</text>
+<line x1="57.00" y1="188.80" x2="85.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">62</text>
+<text x="106.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">63</text>
+<line x1="103.00" y1="188.80" x2="131.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">64</text>
+<text x="14.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">65</text>
+<line x1="11.00" y1="243.60" x2="39.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">66</text>
+<text x="60.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">67</text>
+<line x1="57.00" y1="243.60" x2="85.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">68</text>
+<text x="106.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">69</text>
+<line x1="103.00" y1="243.60" x2="131.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">70</text>
+<text x="14.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">71</text>
+<line x1="11.00" y1="298.40" x2="39.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">72</text>
+<text x="60.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">73</text>
+<line x1="57.00" y1="298.40" x2="85.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">74</text>
+<text x="106.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">75</text>
+<line x1="103.00" y1="298.40" x2="131.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">76</text>
+<text x="14.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">77</text>
+<line x1="11.00" y1="353.20" x2="39.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">78</text>
+<text x="60.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">79</text>
+<line x1="57.00" y1="353.20" x2="85.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">80</text>
+<text x="106.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="103.00" y1="353.20" x2="131.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_empty_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_empty_brace.golden
@@ -1,0 +1,20 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{}
+honesty: missing-operand
+
+=== ast ===
+Matrix {
+    rows: [
+        [],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=20.0000 h=20.0000 bl=10.0000
+  row0:
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="17.00" y1="0.00" x2="17.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_jagged.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_jagged.golden
@@ -1,0 +1,57 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{a # b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+        ],
+        [
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=86.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("b") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("d") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="72.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="83.65" y1="0.00" x2="83.65" y2="72.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_lower.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: dmatrix{a & b # c & d}
+honesty: case-insensitive
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="56.10" y1="0.00" x2="56.10" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_nested_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_nested_over.golden
@@ -1,0 +1,66 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{{{1} OVER {2}} OVER 3 & 0 # 0 & 1}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Fraction {
+                    numer: Number(
+                        "1",
+                    ),
+                    denom: Number(
+                        "2",
+                    ),
+                },
+                denom: Number(
+                    "3",
+                ),
+            },
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=74.0000 h=103.6000 bl=51.8000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=27.0000 h=77.6000 bl=58.2000
+      numer:
+        Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=53.0000 y=28.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=18.0000 y=83.6000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=53.0000 y=83.6000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="103.60" stroke="#000000" stroke-width="0.80"/>
+<line x1="71.00" y1="0.00" x2="71.00" y2="103.60" stroke="#000000" stroke-width="0.80"/>
+<text x="18.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="15.00" y1="28.40" x2="32.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="18.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="11.00" y1="53.20" x2="36.00" y2="53.20" stroke="#000000" stroke-width="0.80"/>
+<text x="18.00" y="69.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="53.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="18.00" y="99.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="53.00" y="99.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX
+honesty: matrix-no-brace-empty
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_root_cell.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_root_cell.golden
@@ -1,0 +1,56 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{ROOT 2 & 0 # 0 & ROOT 3}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Sqrt {
+                index: None,
+                body: Number(
+                    "2",
+                ),
+            },
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Sqrt {
+                index: None,
+                body: Number(
+                    "3",
+                ),
+            },
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=86.0000 h=54.0000 bl=27.0000
+  row0:
+    Sqrt x=10.0000 y=0.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("2") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("0") x=58.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=17.0000 y=32.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=51.0000 y=30.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("3") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="54.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="83.00" y1="0.00" x2="83.00" y2="54.00" stroke="#000000" stroke-width="0.80"/>
+<path d="M10.00,13.40 L12.00,14.40 L18.00,24.00 L21.00,0.00 L35.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="23.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="58.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="17.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<path d="M51.00,43.40 L53.00,44.40 L59.00,54.00 L62.00,30.00 L76.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="64.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_spacey.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_spacey.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{ a  &  b  #  c  &  d }
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="56.10" y1="0.00" x2="56.10" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_trailing_amp.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_trailing_amp.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{a & b &}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Empty,
+        ],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=75.1000 h=20.0000 bl=10.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Empty x=65.1000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="72.10" y1="0.00" x2="72.10" y2="20.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/dmatrix_trailing_hash.golden
+++ b/src/renderer/equation/fixtures/m09_expand/dmatrix_trailing_hash.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: DMATRIX
+script: DMATRIX{a & b #}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [],
+    ],
+    style: Vert,
+}
+
+=== layout ===
+Matrix(Vert) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+
+=== svg ===
+<line x1="3.00" y1="0.00" x2="3.00" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="56.10" y1="0.00" x2="56.10" y2="46.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/end_matrix_alone.golden
+++ b/src/renderer/equation/fixtures/m09_expand/end_matrix_alone.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: END{matrix}
+honesty: latex-env-partial
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_andand.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_andand.golden
@@ -1,0 +1,38 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{x && 1}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Row(
+                [
+                    Space(
+                        Tab,
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=45.5500 h=20.0000 bl=10.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=31.0000 h=20.0000 bl=16.0000
+      Space(20.0000) x=0.0000 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+      Number("1") x=20.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="34.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_empty.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_empty.golden
@@ -1,0 +1,14 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{}
+honesty: missing-operand
+
+=== ast ===
+EqAlign {
+    rows: [],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_four.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_four.golden
@@ -1,0 +1,111 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{a &= 1 # b &= 2 # c &= 3 # d &= 4}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "a",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "b",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "c",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "3",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "d",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "4",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=98.0000 bl=49.0000
+  row0.left:
+    Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=14.5500 y=26.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2.left:
+    Text("c") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2.right:
+    Row x=14.5500 y=52.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("3") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row3.left:
+    Text("d") x=0.0000 y=78.0000 w=11.5500 h=20.0000 bl=16.0000
+  row3.right:
+    Row x=14.5500 y=78.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("4") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="22.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="22.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="22.55" y="68.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="0.00" y="94.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="22.55" y="94.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_left_only.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_left_only.golden
@@ -1,0 +1,37 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{x # y}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Empty,
+        ),
+        (
+            Text(
+                "y",
+            ),
+            Empty,
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=14.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Empty x=14.5500 y=16.0000 w=0.0000 h=0.0000 bl=0.0000
+  row1.left:
+    Text("y") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Empty x=14.5500 y=42.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_lower.golden
@@ -1,0 +1,63 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: eqalign{x &= 1 # y &= 2}
+honesty: case-insensitive
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "y",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Text("y") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=14.5500 y=26.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="22.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="22.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_matrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_matrix.golden
@@ -1,0 +1,117 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{A &= MATRIX{1 & 0 # 0 & 1} # B &= MATRIX{0 & 1 # 1 & 0}}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "A",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Matrix {
+                        rows: [
+                            [
+                                Number(
+                                    "1",
+                                ),
+                                Number(
+                                    "0",
+                                ),
+                            ],
+                            [
+                                Number(
+                                    "0",
+                                ),
+                                Number(
+                                    "1",
+                                ),
+                            ],
+                        ],
+                        style: Plain,
+                    },
+                ],
+            ),
+        ),
+        (
+            Text(
+                "B",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Matrix {
+                        rows: [
+                            [
+                                Number(
+                                    "0",
+                                ),
+                                Number(
+                                    "1",
+                                ),
+                            ],
+                            [
+                                Number(
+                                    "1",
+                                ),
+                                Number(
+                                    "0",
+                                ),
+                            ],
+                        ],
+                        style: Plain,
+                    },
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=78.6500 h=98.0000 bl=49.0000
+  row0.left:
+    Text("A") x=0.0000 y=7.0000 w=13.6500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=16.6500 y=0.0000 w=62.0000 h=46.0000 bl=23.0000
+      Symbol("=") x=0.0000 y=7.0000 w=16.0000 h=20.0000 bl=16.0000
+      Matrix(Plain) x=16.0000 y=0.0000 w=46.0000 h=46.0000 bl=23.0000
+        row0:
+          Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+          Number("0") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        row1:
+          Number("0") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+          Number("1") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Text("B") x=0.0000 y=59.0000 w=13.6500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=16.6500 y=52.0000 w=62.0000 h=46.0000 bl=23.0000
+      Symbol("=") x=0.0000 y=7.0000 w=16.0000 h=20.0000 bl=16.0000
+      Matrix(Plain) x=16.0000 y=0.0000 w=46.0000 h=46.0000 bl=23.0000
+        row0:
+          Number("0") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+          Number("1") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        row1:
+          Number("1") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+          Number("0") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="23.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">A</text>
+<text x="24.65" y="23.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="36.65" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="63.65" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="36.65" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="63.65" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="75.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">B</text>
+<text x="24.65" y="75.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="36.65" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="63.65" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="36.65" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="63.65" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_matrix_fracs.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_matrix_fracs.golden
@@ -1,0 +1,163 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{MATRIX{{1} OVER {2} & 0 # 0 & {3} OVER {4}} &= I # PMATRIX{{5} OVER {6} & 1 # 1 & {7} OVER {8}} &= A}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Matrix {
+                rows: [
+                    [
+                        Fraction {
+                            numer: Number(
+                                "1",
+                            ),
+                            denom: Number(
+                                "2",
+                            ),
+                        },
+                        Number(
+                            "0",
+                        ),
+                    ],
+                    [
+                        Number(
+                            "0",
+                        ),
+                        Fraction {
+                            numer: Number(
+                                "3",
+                            ),
+                            denom: Number(
+                                "4",
+                            ),
+                        },
+                    ],
+                ],
+                style: Plain,
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Text(
+                        "I",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Matrix {
+                rows: [
+                    [
+                        Fraction {
+                            numer: Number(
+                                "5",
+                            ),
+                            denom: Number(
+                                "6",
+                            ),
+                        },
+                        Number(
+                            "1",
+                        ),
+                    ],
+                    [
+                        Number(
+                            "1",
+                        ),
+                        Fraction {
+                            numer: Number(
+                                "7",
+                            ),
+                            denom: Number(
+                                "8",
+                            ),
+                        },
+                    ],
+                ],
+                style: Paren,
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Text(
+                        "A",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=106.6500 h=213.2000 bl=106.6000
+  row0.left:
+    Matrix(Plain) x=12.0000 y=0.0000 w=62.0000 h=103.6000 bl=51.8000
+      row0:
+        Fraction x=4.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+        Number("0") x=43.0000 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Number("0") x=8.0000 y=69.2000 w=11.0000 h=20.0000 bl=16.0000
+        Fraction x=39.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=77.0000 y=35.8000 w=29.6500 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("I") x=16.0000 y=0.0000 w=13.6500 h=20.0000 bl=16.0000
+  row1.left:
+    Matrix(Paren) x=0.0000 y=109.6000 w=74.0000 h=103.6000 bl=51.8000
+      row0:
+        Fraction x=10.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+        Number("1") x=49.0000 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Number("1") x=14.0000 y=69.2000 w=11.0000 h=20.0000 bl=16.0000
+        Fraction x=45.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=77.0000 y=145.4000 w=29.6500 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("A") x=16.0000 y=0.0000 w=13.6500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="20.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="17.00" y1="24.40" x2="34.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="20.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="55.00" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="20.00" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="55.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="52.00" y1="79.20" x2="69.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="55.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="85.00" y="51.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="93.00" y="51.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">I</text>
+<path d="M5.40,109.60 C0.30,128.25 0.30,194.55 5.40,213.20" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M68.60,109.60 C73.70,128.25 73.70,194.55 68.60,213.20" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="11.00" y1="134.00" x2="28.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="49.00" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="14.00" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="49.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="46.00" y1="188.80" x2="63.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="49.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="85.00" y="161.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="93.00" y="161.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">A</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_mixed_amp.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_mixed_amp.golden
@@ -1,0 +1,65 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{x = 1 # y &= 2}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Row(
+                [
+                    Text(
+                        "x",
+                    ),
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+            Empty,
+        ),
+        (
+            Text(
+                "y",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=68.5500 h=46.0000 bl=23.0000
+  row0.left:
+    Row x=0.0000 y=0.0000 w=38.5500 h=20.0000 bl=16.0000
+      Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=27.5500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Empty x=41.5500 y=16.0000 w=0.0000 h=0.0000 bl=0.0000
+  row1.left:
+    Text("y") x=27.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=41.5500 y=26.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="19.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="27.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="27.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="49.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="57.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN
+honesty: matrix-no-brace-empty
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_over.golden
@@ -1,0 +1,61 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{a OVER b &= c OVER d}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Fraction {
+                numer: Text(
+                    "a",
+                ),
+                denom: Text(
+                    "b",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Text(
+                            "c",
+                        ),
+                        denom: Text(
+                            "d",
+                        ),
+                    },
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=58.1000 h=48.8000 bl=24.4000
+  row0.left:
+    Fraction x=0.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+      numer:
+        Text("a") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+      denom:
+        Text("b") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=22.5500 y=0.0000 w=35.5500 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+        numer:
+          Text("c") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+        denom:
+          Text("d") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<line x1="1.00" y1="24.40" x2="18.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="30.55" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.55" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<line x1="39.55" y1="24.40" x2="57.10" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="42.55" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_root.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_root.golden
@@ -1,0 +1,75 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{ROOT 8 &= 2 # ROOT 27 &= 3}
+honesty: root-aliases-sqrt
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Sqrt {
+                index: None,
+                body: Number(
+                    "8",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Sqrt {
+                index: None,
+                body: Number(
+                    "27",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "3",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=66.0000 h=54.0000 bl=27.0000
+  row0.left:
+    Sqrt x=11.0000 y=0.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("8") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=39.0000 y=2.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Sqrt x=0.0000 y=30.0000 w=36.0000 h=24.0000 bl=18.0000
+      body:
+        Number("27") x=13.0000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=39.0000 y=32.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("3") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M11.00,13.40 L13.00,14.40 L19.00,24.00 L22.00,0.00 L36.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="24.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="47.00" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="55.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M0.00,43.40 L2.00,44.40 L8.00,54.00 L11.00,30.00 L36.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<text x="47.00" y="48.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="55.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_six_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_six_over.golden
@@ -1,0 +1,291 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{{1} OVER {2} &= {3} OVER {4} # {2} OVER {3} &= {4} OVER {5} # {3} OVER {4} &= {5} OVER {6} # {4} OVER {5} &= {6} OVER {7} # {5} OVER {6} &= {7} OVER {8} # {6} OVER {7} &= {8} OVER {9}}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "3",
+                        ),
+                        denom: Number(
+                            "4",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "2",
+                ),
+                denom: Number(
+                    "3",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "4",
+                        ),
+                        denom: Number(
+                            "5",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "5",
+                        ),
+                        denom: Number(
+                            "6",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "4",
+                ),
+                denom: Number(
+                    "5",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "6",
+                        ),
+                        denom: Number(
+                            "7",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "7",
+                        ),
+                        denom: Number(
+                            "8",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "6",
+                ),
+                denom: Number(
+                    "7",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "8",
+                        ),
+                        denom: Number(
+                            "9",
+                        ),
+                    },
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=57.0000 h=322.8000 bl=161.4000
+  row0.left:
+    Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=22.0000 y=0.0000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Fraction x=0.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=22.0000 y=54.8000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row2.left:
+    Fraction x=0.0000 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row2.right:
+    Row x=22.0000 y=109.6000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3.left:
+    Fraction x=0.0000 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3.right:
+    Row x=22.0000 y=164.4000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row4.left:
+    Fraction x=0.0000 y=219.2000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row4.right:
+    Row x=22.0000 y=219.2000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row5.left:
+    Fraction x=0.0000 y=274.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row5.right:
+    Row x=22.0000 y=274.0000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("8") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("9") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="30.00" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="39.00" y1="24.40" x2="56.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="4.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="79.20" x2="18.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="30.00" y="84.20" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="39.00" y1="79.20" x2="56.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="4.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="134.00" x2="18.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="30.00" y="139.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="39.00" y1="134.00" x2="56.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="4.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="1.00" y1="188.80" x2="18.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="30.00" y="193.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="39.00" y1="188.80" x2="56.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="4.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="1.00" y1="243.60" x2="18.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="30.00" y="248.60" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="39.00" y1="243.60" x2="56.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="4.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="1.00" y1="298.40" x2="18.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="30.00" y="303.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="39.00" y1="298.40" x2="56.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_sqrt.golden
@@ -1,0 +1,75 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{SQRT x &= 2 # SQRT y &= 3}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Sqrt {
+                index: None,
+                body: Text(
+                    "x",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Sqrt {
+                index: None,
+                body: Text(
+                    "y",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "3",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=55.5500 h=54.0000 bl=27.0000
+  row0.left:
+    Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+      body:
+        Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=28.5500 y=2.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Sqrt x=0.0000 y=30.0000 w=25.5500 h=24.0000 bl=18.0000
+      body:
+        Text("y") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=28.5500 y=32.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("3") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="36.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="44.55" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M0.00,43.40 L2.00,44.40 L8.00,54.00 L11.00,30.00 L25.55,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="48.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="36.55" y="48.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="44.55" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_ten_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_ten_over.golden
@@ -1,0 +1,475 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{{1} OVER {2} &= {3} OVER {4} # {2} OVER {3} &= {4} OVER {5} # {3} OVER {4} &= {5} OVER {6} # {4} OVER {5} &= {6} OVER {7} # {5} OVER {6} &= {7} OVER {8} # {6} OVER {7} &= {8} OVER {9} # {7} OVER {8} &= {9} OVER {10} # {8} OVER {9} &= {10} OVER {11} # {9} OVER {10} &= {11} OVER {12} # {10} OVER {11} &= {12} OVER {13}}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "3",
+                        ),
+                        denom: Number(
+                            "4",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "2",
+                ),
+                denom: Number(
+                    "3",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "4",
+                        ),
+                        denom: Number(
+                            "5",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "5",
+                        ),
+                        denom: Number(
+                            "6",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "4",
+                ),
+                denom: Number(
+                    "5",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "6",
+                        ),
+                        denom: Number(
+                            "7",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "7",
+                        ),
+                        denom: Number(
+                            "8",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "6",
+                ),
+                denom: Number(
+                    "7",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "8",
+                        ),
+                        denom: Number(
+                            "9",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "9",
+                        ),
+                        denom: Number(
+                            "10",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "8",
+                ),
+                denom: Number(
+                    "9",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "10",
+                        ),
+                        denom: Number(
+                            "11",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "9",
+                ),
+                denom: Number(
+                    "10",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "11",
+                        ),
+                        denom: Number(
+                            "12",
+                        ),
+                    },
+                ],
+            ),
+        ),
+        (
+            Fraction {
+                numer: Number(
+                    "10",
+                ),
+                denom: Number(
+                    "11",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "12",
+                        ),
+                        denom: Number(
+                            "13",
+                        ),
+                    },
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=79.0000 h=542.0000 bl=271.0000
+  row0.left:
+    Fraction x=11.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=33.0000 y=0.0000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Fraction x=11.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=33.0000 y=54.8000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row2.left:
+    Fraction x=11.0000 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row2.right:
+    Row x=33.0000 y=109.6000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3.left:
+    Fraction x=11.0000 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3.right:
+    Row x=33.0000 y=164.4000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row4.left:
+    Fraction x=11.0000 y=219.2000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row4.right:
+    Row x=33.0000 y=219.2000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row5.left:
+    Fraction x=11.0000 y=274.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row5.right:
+    Row x=33.0000 y=274.0000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("8") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("9") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row6.left:
+    Fraction x=11.0000 y=328.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row6.right:
+    Row x=33.0000 y=328.8000 w=46.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row7.left:
+    Fraction x=11.0000 y=383.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("8") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("9") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row7.right:
+    Row x=33.0000 y=383.6000 w=46.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("10") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("11") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row8.left:
+    Fraction x=0.0000 y=438.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row8.right:
+    Row x=33.0000 y=438.4000 w=46.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row9.left:
+    Fraction x=0.0000 y=493.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("10") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("11") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row9.right:
+    Row x=33.0000 y=493.2000 w=46.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("12") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("13") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="15.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="12.00" y1="24.40" x2="29.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="41.00" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="50.00" y1="24.40" x2="67.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="15.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="12.00" y1="79.20" x2="29.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="41.00" y="84.20" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="50.00" y1="79.20" x2="67.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="15.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="12.00" y1="134.00" x2="29.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="41.00" y="139.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="50.00" y1="134.00" x2="67.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="15.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="12.00" y1="188.80" x2="29.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="41.00" y="193.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="50.00" y1="188.80" x2="67.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="15.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="12.00" y1="243.60" x2="29.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="41.00" y="248.60" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="50.00" y1="243.60" x2="67.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="15.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="12.00" y1="298.40" x2="29.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="41.00" y="303.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="50.00" y1="298.40" x2="67.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="15.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="12.00" y1="353.20" x2="29.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="41.00" y="358.20" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="58.50" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="50.00" y1="353.20" x2="78.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="15.00" y="403.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="12.00" y1="408.00" x2="29.00" y2="408.00" stroke="#000000" stroke-width="0.80"/>
+<text x="15.00" y="424.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="41.00" y="413.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="403.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<line x1="50.00" y1="408.00" x2="78.00" y2="408.00" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="424.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="9.50" y="458.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="1.00" y1="462.80" x2="29.00" y2="462.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="479.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="41.00" y="467.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="458.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="50.00" y1="462.80" x2="78.00" y2="462.80" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="479.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="4.00" y="513.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<line x1="1.00" y1="517.60" x2="29.00" y2="517.60" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="534.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="41.00" y="522.60" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="53.00" y="513.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<line x1="50.00" y1="517.60" x2="78.00" y2="517.60" stroke="#000000" stroke-width="0.80"/>
+<text x="53.00" y="534.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_three.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_three.golden
@@ -1,0 +1,87 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{x &= 1 # y &= 2 # z &= 3}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "y",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "2",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Text(
+                "z",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "3",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=72.0000 bl=36.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1.left:
+    Text("y") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1.right:
+    Row x=14.5500 y=26.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("2") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2.left:
+    Text("z") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2.right:
+    Row x=14.5500 y=52.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("3") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="22.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="22.55" y="42.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">z</text>
+<text x="22.55" y="68.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/eqalign_trailing_hash.golden
+++ b/src/renderer/equation/fixtures/m09_expand/eqalign_trailing_hash.golden
@@ -1,0 +1,39 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: EQALIGN
+script: EQALIGN{x &= 1 #}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Text(
+                "x",
+            ),
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=41.5500 h=20.0000 bl=10.0000
+  row0.left:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=14.5500 y=0.0000 w=27.0000 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Number("1") x=16.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="22.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="30.55" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/frac_latex.golden
+++ b/src/renderer/equation/fixtures/m09_expand/frac_latex.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: FRAC{1}{2}
+honesty: latex-frac
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/frac_missing_denom.golden
+++ b/src/renderer/equation/fixtures/m09_expand/frac_missing_denom.golden
@@ -1,0 +1,23 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: FRAC{1}
+honesty: missing-operand
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Empty,
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=28.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Empty x=9.5000 y=24.8000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/ladder_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/ladder_2x2.golden
@@ -1,0 +1,42 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: LADDER{a & b # c & d}
+honesty: ladder-fallback-matrix
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/ladder_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/ladder_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: LADDER
+honesty: ladder-fallback-matrix
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/lim_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lim_cmd.golden
@@ -1,0 +1,63 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: lim_x->0 f(x)
+honesty: limit-cmd
+
+=== ast ===
+Row(
+    [
+        Limit {
+            is_upper: false,
+            sub: Some(
+                Row(
+                    [
+                        Text(
+                            "x",
+                        ),
+                        MathSymbol(
+                            "→",
+                        ),
+                        Number(
+                            "0",
+                        ),
+                    ],
+                ),
+            ),
+        },
+        Text(
+            "f",
+        ),
+        Symbol(
+            "(",
+        ),
+        Text(
+            "x",
+        ),
+        Symbol(
+            ")",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=80.1000 h=35.0000 bl=16.0000
+  Limit(is_upper=false) x=0.0000 y=0.0000 w=33.0000 h=35.0000 bl=16.0000
+    sub:
+      Row x=3.0075 y=20.0000 w=26.9850 h=14.0000 bl=11.2000
+        Text("x") x=0.0000 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+        MathSymbol("→") x=8.0850 y=0.0000 w=11.2000 h=14.0000 bl=11.2000
+        Number("0") x=19.2850 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  Text("f") x=33.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Symbol("(") x=44.5500 y=0.0000 w=12.0000 h=20.0000 bl=16.0000
+  Text("x") x=56.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Symbol(")") x=68.1000 y=0.0000 w=12.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">lim</text>
+<text x="3.01" y="31.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="11.09" y="31.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">→</text>
+<text x="22.29" y="31.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="33.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>
+<text x="50.55" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">(</text>
+<text x="56.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="74.10" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">)</text>

--- a/src/renderer/equation/fixtures/m09_expand/lim_upper_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lim_upper_cmd.golden
@@ -1,0 +1,58 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: Lim_n->infty a_n
+honesty: limit-cmd
+
+=== ast ===
+Row(
+    [
+        Limit {
+            is_upper: true,
+            sub: Some(
+                Row(
+                    [
+                        Text(
+                            "n",
+                        ),
+                        MathSymbol(
+                            "→",
+                        ),
+                        MathSymbol(
+                            "∞",
+                        ),
+                    ],
+                ),
+            ),
+        },
+        Subscript {
+            base: Text(
+                "a",
+            ),
+            sub: Text(
+                "n",
+            ),
+        },
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=54.6350 h=35.0000 bl=16.0000
+  Limit(is_upper=true) x=0.0000 y=0.0000 w=35.0000 h=35.0000 bl=16.0000
+    sub:
+      Row x=3.6575 y=20.0000 w=27.6850 h=14.0000 bl=11.2000
+        Text("n") x=0.0000 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+        MathSymbol("→") x=8.0850 y=0.0000 w=11.2000 h=14.0000 bl=11.2000
+        MathSymbol("∞") x=19.2850 y=0.0000 w=8.4000 h=14.0000 bl=11.2000
+  Subscript x=35.0000 y=0.0000 w=19.6350 h=20.4000 bl=16.0000
+    base:
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    sub:
+      Text("n") x=11.5500 y=6.4000 w=8.0850 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">Lim</text>
+<text x="3.66" y="31.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>
+<text x="11.74" y="31.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">→</text>
+<text x="22.94" y="31.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">∞</text>
+<text x="35.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="46.55" y="17.60" font-size="14.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>

--- a/src/renderer/equation/fixtures/m09_expand/longdiv_simple.golden
+++ b/src/renderer/equation/fixtures/m09_expand/longdiv_simple.golden
@@ -1,0 +1,40 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: LONGDIV{3}{2}{6}
+honesty: longdiv-simplified-row
+
+=== ast ===
+Row(
+    [
+        Number(
+            "2",
+        ),
+        Symbol(
+            "÷",
+        ),
+        Number(
+            "3",
+        ),
+        Symbol(
+            "=",
+        ),
+        Number(
+            "6",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=67.0000 h=20.0000 bl=16.0000
+  Number("2") x=0.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  Symbol("÷") x=11.0000 y=0.0000 w=18.0000 h=20.0000 bl=16.0000
+  Number("3") x=29.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  Symbol("=") x=40.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+  Number("6") x=56.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="20.00" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">÷</text>
+<text x="29.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="48.00" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="56.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>

--- a/src/renderer/equation/fixtures/m09_expand/lpile_eight_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lpile_eight_frac.golden
@@ -1,0 +1,144 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: LPILE{{1} OVER {2} # {2} OVER {3} # {3} OVER {4} # {4} OVER {5} # {5} OVER {6} # {6} OVER {7} # {7} OVER {8} # {8} OVER {9}}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "2",
+            ),
+            denom: Number(
+                "3",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "3",
+            ),
+            denom: Number(
+                "4",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "4",
+            ),
+            denom: Number(
+                "5",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "5",
+            ),
+            denom: Number(
+                "6",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "6",
+            ),
+            denom: Number(
+                "7",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "7",
+            ),
+            denom: Number(
+                "8",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "8",
+            ),
+            denom: Number(
+                "9",
+            ),
+        },
+    ],
+    align: Left,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=19.0000 h=432.4000 bl=216.2000
+  Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=219.2000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=274.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=328.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=383.6000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("8") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("9") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="4.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="79.20" x2="18.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="4.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="134.00" x2="18.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="4.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="1.00" y1="188.80" x2="18.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="4.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="1.00" y1="243.60" x2="18.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="4.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="1.00" y1="298.40" x2="18.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="4.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="1.00" y1="353.20" x2="18.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="4.00" y="403.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="1.00" y1="408.00" x2="18.00" y2="408.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="424.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>

--- a/src/renderer/equation/fixtures/m09_expand/lpile_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lpile_lower.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: lpile{a # b}
+honesty: case-insensitive
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Left,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/lpile_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lpile_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: LPILE
+honesty: pile-layout-as-row
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/lpile_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lpile_over.golden
@@ -1,0 +1,37 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: LPILE{{1} OVER {2} # x}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        Text(
+            "x",
+        ),
+    ],
+    align: Left,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=19.0000 h=74.8000 bl=37.4000
+  Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Text("x") x=0.0000 y=54.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="0.00" y="70.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/lpile_three.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lpile_three.golden
@@ -1,0 +1,31 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: LPILE{a # b # c}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+        Text(
+            "c",
+        ),
+    ],
+    align: Left,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=72.0000 bl=36.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("c") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_expand/lsub_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lsub_cmd.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: LSUB{i}{A}
+honesty: left-script
+
+=== ast ===
+Subscript {
+    base: Text(
+        "A",
+    ),
+    sub: Text(
+        "i",
+    ),
+}
+
+=== layout ===
+Subscript x=0.0000 y=0.0000 w=21.7350 h=20.4000 bl=16.0000
+  base:
+    Text("A") x=0.0000 y=0.0000 w=13.6500 h=20.0000 bl=16.0000
+  sub:
+    Text("i") x=13.6500 y=6.4000 w=8.0850 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">A</text>
+<text x="13.65" y="17.60" font-size="14.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/lsup_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/lsup_cmd.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: LSUP{i}{A}
+honesty: left-script
+
+=== ast ===
+Superscript {
+    base: Text(
+        "A",
+    ),
+    sup: Text(
+        "i",
+    ),
+}
+
+=== layout ===
+Superscript x=0.0000 y=0.0000 w=21.7350 h=20.0000 bl=16.0000
+  base:
+    Text("A") x=0.0000 y=0.0000 w=13.6500 h=20.0000 bl=16.0000
+  sup:
+    Text("i") x=13.6500 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">A</text>
+<text x="13.65" y="11.20" font-size="14.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_1x1.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_1x1.golden
@@ -1,0 +1,24 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{z}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "z",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=19.5500 h=20.0000 bl=10.0000
+  row0:
+    Text("z") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">z</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_2x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_2x3.golden
@@ -1,0 +1,52 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a & b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=74.6500 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=59.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=59.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="59.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="59.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_3x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_3x2.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a & b # c & d # e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("e") x=4.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=31.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="31.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_3x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_3x3.golden
@@ -1,0 +1,70 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a & b & c # d & e & f # g & h & i}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+        [
+            Text(
+                "g",
+            ),
+            Text(
+                "h",
+            ),
+            Text(
+                "i",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=74.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=59.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=59.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("g") x=4.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("h") x=31.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("i") x=59.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="59.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="59.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">g</text>
+<text x="31.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">h</text>
+<text x="59.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_3x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_3x3_over.golden
@@ -1,0 +1,169 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=130.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=4.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=4.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=4.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="5.00" y1="24.40" x2="33.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="54.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="51.00" y1="24.40" x2="79.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="100.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="97.00" y1="24.40" x2="125.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="8.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="5.00" y1="79.20" x2="33.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="54.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="51.00" y1="79.20" x2="79.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="100.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="97.00" y1="79.20" x2="125.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="8.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="5.00" y1="134.00" x2="33.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="54.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="51.00" y1="134.00" x2="79.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="100.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="97.00" y1="134.00" x2="125.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_3x7_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_3x7_over.golden
@@ -1,0 +1,361 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "83",
+                ),
+                denom: Number(
+                    "84",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "85",
+                ),
+                denom: Number(
+                    "86",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "87",
+                ),
+                denom: Number(
+                    "88",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "89",
+                ),
+                denom: Number(
+                    "90",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "91",
+                ),
+                denom: Number(
+                    "92",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "93",
+                ),
+                denom: Number(
+                    "94",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "95",
+                ),
+                denom: Number(
+                    "96",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "97",
+                ),
+                denom: Number(
+                    "98",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "99",
+                ),
+                denom: Number(
+                    "100",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "101",
+                ),
+                denom: Number(
+                    "102",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "103",
+                ),
+                denom: Number(
+                    "104",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "105",
+                ),
+                denom: Number(
+                    "106",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "107",
+                ),
+                denom: Number(
+                    "108",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "109",
+                ),
+                denom: Number(
+                    "110",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "111",
+                ),
+                denom: Number(
+                    "112",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "113",
+                ),
+                denom: Number(
+                    "114",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "115",
+                ),
+                denom: Number(
+                    "116",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "117",
+                ),
+                denom: Number(
+                    "118",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "119",
+                ),
+                denom: Number(
+                    "120",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "121",
+                ),
+                denom: Number(
+                    "122",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=391.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=9.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=66.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("83") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("84") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=123.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("85") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("86") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=180.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("87") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("88") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=237.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("89") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("90") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=294.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("91") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("92") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=351.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("93") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("94") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=9.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("95") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("96") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=66.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("97") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("98") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=118.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("99") x=9.5000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("100") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=175.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("101") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("102") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=232.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("103") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("104") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=289.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("105") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("106") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=346.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("107") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("108") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=4.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("109") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("110") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=61.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("111") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("112") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=118.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("113") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("114") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=175.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("115") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("116") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=232.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("117") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("118") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=289.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("119") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("120") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=346.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("121") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("122") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="13.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="10.50" y1="24.40" x2="38.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="13.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>
+<text x="70.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">83</text>
+<line x1="67.50" y1="24.40" x2="95.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="70.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">84</text>
+<text x="127.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">85</text>
+<line x1="124.50" y1="24.40" x2="152.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="127.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">86</text>
+<text x="184.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">87</text>
+<line x1="181.50" y1="24.40" x2="209.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="184.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">88</text>
+<text x="241.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">89</text>
+<line x1="238.50" y1="24.40" x2="266.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="241.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">90</text>
+<text x="298.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">91</text>
+<line x1="295.50" y1="24.40" x2="323.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="298.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">92</text>
+<text x="355.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">93</text>
+<line x1="352.50" y1="24.40" x2="380.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="355.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">94</text>
+<text x="13.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">95</text>
+<line x1="10.50" y1="79.20" x2="38.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="13.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">96</text>
+<text x="70.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">97</text>
+<line x1="67.50" y1="79.20" x2="95.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="70.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">98</text>
+<text x="127.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">99</text>
+<line x1="119.00" y1="79.20" x2="158.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="122.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">100</text>
+<text x="179.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">101</text>
+<line x1="176.00" y1="79.20" x2="215.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="179.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">102</text>
+<text x="236.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">103</text>
+<line x1="233.00" y1="79.20" x2="272.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="236.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">104</text>
+<text x="293.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">105</text>
+<line x1="290.00" y1="79.20" x2="329.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="293.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">106</text>
+<text x="350.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">107</text>
+<line x1="347.00" y1="79.20" x2="386.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="350.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">108</text>
+<text x="8.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">109</text>
+<line x1="5.00" y1="134.00" x2="44.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">110</text>
+<text x="65.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">111</text>
+<line x1="62.00" y1="134.00" x2="101.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="65.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">112</text>
+<text x="122.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">113</text>
+<line x1="119.00" y1="134.00" x2="158.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="122.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">114</text>
+<text x="179.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">115</text>
+<line x1="176.00" y1="134.00" x2="215.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="179.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">116</text>
+<text x="236.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">117</text>
+<line x1="233.00" y1="134.00" x2="272.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="236.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">118</text>
+<text x="293.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">119</text>
+<line x1="290.00" y1="134.00" x2="329.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="293.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">120</text>
+<text x="350.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">121</text>
+<line x1="347.00" y1="134.00" x2="386.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="350.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">122</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_4x4_mixed.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_4x4_mixed.golden
@@ -1,0 +1,204 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "3",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "2",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "11",
+            ),
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "5",
+                ),
+            },
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Number(
+                "14",
+            ),
+            Fraction {
+                numer: Number(
+                    "4",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=162.8000 h=213.2000 bl=106.6000
+  row0:
+    Number("1") x=11.8500 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=50.5500 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=89.4000 y=12.4000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=139.6750 y=14.4000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=7.8500 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=46.7000 y=67.2000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=96.9750 y=69.2000 w=11.5500 h=20.0000 bl=16.0000
+    Number("8") x=139.9500 y=69.2000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=4.0000 y=122.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=54.2750 y=124.0000 w=11.5500 h=20.0000 bl=16.0000
+    Number("11") x=91.7500 y=124.0000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=135.9500 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3:
+    Text("d") x=11.5750 y=178.8000 w=11.5500 h=20.0000 bl=16.0000
+    Number("14") x=49.0500 y=178.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=93.2500 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.1000 y=176.8000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="11.85" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="54.55" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="51.55" y1="24.40" x2="68.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="54.55" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<path d="M91.10,25.80 L93.10,26.80 L99.10,36.40 L102.10,12.40 L116.10,12.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="89.40" y="23.60" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="104.10" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="139.68" y="30.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="11.85" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="8.85" y1="79.20" x2="25.85" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="11.85" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M48.40,80.60 L50.40,81.60 L56.40,91.20 L59.40,67.20 L73.40,67.20" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="46.70" y="78.40" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="61.40" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="96.98" y="85.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="139.95" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M5.70,135.40 L7.70,136.40 L13.70,146.00 L16.70,122.00 L30.70,122.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="133.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="18.70" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="54.28" y="140.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="91.75" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="139.95" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="136.95" y1="134.00" x2="153.95" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="139.95" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="11.58" y="194.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="49.05" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="97.25" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="94.25" y1="188.80" x2="111.25" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="97.25" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<path d="M133.80,190.20 L135.80,191.20 L141.80,200.80 L144.80,176.80 L158.80,176.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.10" y="188.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="146.80" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_4x4_numbers.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_4x4_numbers.golden
@@ -1,0 +1,108 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "2",
+            ),
+            Number(
+                "3",
+            ),
+            Number(
+                "4",
+            ),
+        ],
+        [
+            Number(
+                "5",
+            ),
+            Number(
+                "6",
+            ),
+            Number(
+                "7",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Number(
+                "9",
+            ),
+            Number(
+                "10",
+            ),
+            Number(
+                "11",
+            ),
+            Number(
+                "12",
+            ),
+        ],
+        [
+            Number(
+                "13",
+            ),
+            Number(
+                "14",
+            ),
+            Number(
+                "15",
+            ),
+            Number(
+                "16",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=144.0000 h=98.0000 bl=49.0000
+  row0:
+    Number("1") x=9.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("2") x=47.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("3") x=85.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("4") x=123.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("5") x=9.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("6") x=47.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("7") x=85.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("8") x=123.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Number("9") x=9.5000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("10") x=42.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("11") x=80.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("12") x=118.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Number("13") x=4.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("14") x=42.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("15") x=80.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("16") x=118.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="9.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="47.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="85.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="123.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="9.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="47.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="85.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="123.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="9.50" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="42.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="80.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="118.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="4.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="42.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="80.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="118.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_5x5_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_5x5_over.golden
@@ -1,0 +1,431 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "9",
+                ),
+                denom: Number(
+                    "10",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "11",
+                ),
+                denom: Number(
+                    "12",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "13",
+                ),
+                denom: Number(
+                    "14",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "15",
+                ),
+                denom: Number(
+                    "16",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "17",
+                ),
+                denom: Number(
+                    "18",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "19",
+                ),
+                denom: Number(
+                    "20",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "39",
+                ),
+                denom: Number(
+                    "40",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=222.0000 h=268.0000 bl=134.0000
+  row0:
+    Fraction x=9.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=55.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=101.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=147.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=188.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=4.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("13") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("14") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("15") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("16") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=142.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("17") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("18") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=188.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("19") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("20") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=4.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=142.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=188.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=4.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=142.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=188.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("39") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("40") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=4.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=142.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=188.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="13.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="10.50" y1="24.40" x2="27.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="13.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="59.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="56.50" y1="24.40" x2="73.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="59.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="105.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="102.50" y1="24.40" x2="119.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="105.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="151.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="148.50" y1="24.40" x2="165.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="151.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="197.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="189.00" y1="24.40" x2="217.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="192.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="8.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="5.00" y1="79.20" x2="33.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="54.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<line x1="51.00" y1="79.20" x2="79.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="100.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<line x1="97.00" y1="79.20" x2="125.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="146.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<line x1="143.00" y1="79.20" x2="171.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="146.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="192.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<line x1="189.00" y1="79.20" x2="217.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="192.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="8.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="5.00" y1="134.00" x2="33.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="54.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="51.00" y1="134.00" x2="79.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="100.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="97.00" y1="134.00" x2="125.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="146.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="143.00" y1="134.00" x2="171.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="146.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="192.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="189.00" y1="134.00" x2="217.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="192.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="8.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="5.00" y1="188.80" x2="33.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="54.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="51.00" y1="188.80" x2="79.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="100.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="97.00" y1="188.80" x2="125.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="146.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="143.00" y1="188.80" x2="171.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="146.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>
+<text x="192.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">39</text>
+<line x1="189.00" y1="188.80" x2="217.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="192.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">40</text>
+<text x="8.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="5.00" y1="243.60" x2="33.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="54.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="51.00" y1="243.60" x2="79.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="100.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="97.00" y1="243.60" x2="125.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="146.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="143.00" y1="243.60" x2="171.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="146.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="192.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="189.00" y1="243.60" x2="217.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="192.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_5x5_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_5x5_sqrt.golden
@@ -1,0 +1,481 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "6",
+                    ),
+                ),
+                body: Number(
+                    "9",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "7",
+                    ),
+                ),
+                body: Number(
+                    "10",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "8",
+                    ),
+                ),
+                body: Number(
+                    "11",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "9",
+                    ),
+                ),
+                body: Number(
+                    "12",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "10",
+                    ),
+                ),
+                body: Number(
+                    "13",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "11",
+                    ),
+                ),
+                body: Number(
+                    "14",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "12",
+                    ),
+                ),
+                body: Number(
+                    "15",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "13",
+                    ),
+                ),
+                body: Number(
+                    "16",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "14",
+                    ),
+                ),
+                body: Number(
+                    "17",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "15",
+                    ),
+                ),
+                body: Number(
+                    "18",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "16",
+                    ),
+                ),
+                body: Number(
+                    "19",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "17",
+                    ),
+                ),
+                body: Number(
+                    "20",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "18",
+                    ),
+                ),
+                body: Number(
+                    "21",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "19",
+                    ),
+                ),
+                body: Number(
+                    "22",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "20",
+                    ),
+                ),
+                body: Number(
+                    "23",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "21",
+                    ),
+                ),
+                body: Number(
+                    "24",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "22",
+                    ),
+                ),
+                body: Number(
+                    "25",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "23",
+                    ),
+                ),
+                body: Number(
+                    "26",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "24",
+                    ),
+                ),
+                body: Number(
+                    "27",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "25",
+                    ),
+                ),
+                body: Number(
+                    "28",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "26",
+                    ),
+                ),
+                body: Number(
+                    "29",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=299.0000 h=144.0000 bl=72.0000
+  row0:
+    Sqrt x=13.3500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=74.7500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=136.1500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=197.5500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=258.9500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("6") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("9") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Sqrt x=7.8500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("7") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("10") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=69.2500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("8") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("11") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=130.6500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("9") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("12") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=188.2000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("10") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("13") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=249.6000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("11") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("14") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=4.0000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("12") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("15") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=65.4000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("13") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("16") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=126.8000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("14") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("17") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=188.2000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("15") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("18") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=249.6000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("16") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("19") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Sqrt x=4.0000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("17") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("20") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=65.4000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("18") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("21") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=126.8000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("19") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("22") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=188.2000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("20") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("23") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=249.6000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("21") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("24") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Sqrt x=4.0000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("22") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("25") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=65.4000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("23") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("26") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=126.8000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("24") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("27") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=188.2000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("25") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("28") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=249.6000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("26") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("29") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M15.05,13.40 L17.05,14.40 L23.05,24.00 L26.05,0.00 L40.05,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.35" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="28.05" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<path d="M76.45,13.40 L78.45,14.40 L84.45,24.00 L87.45,0.00 L101.45,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="74.75" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="89.45" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<path d="M137.85,13.40 L139.85,14.40 L145.85,24.00 L148.85,0.00 L162.85,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="136.15" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="150.85" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<path d="M199.25,13.40 L201.25,14.40 L207.25,24.00 L210.25,0.00 L224.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="197.55" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="212.25" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M260.65,13.40 L262.65,14.40 L268.65,24.00 L271.65,0.00 L285.65,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="258.95" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="273.65" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<path d="M9.55,43.40 L11.55,44.40 L17.55,54.00 L20.55,30.00 L45.55,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="7.85" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="22.55" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<path d="M70.95,43.40 L72.95,44.40 L78.95,54.00 L81.95,30.00 L106.95,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="69.25" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="83.95" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<path d="M132.35,43.40 L134.35,44.40 L140.35,54.00 L143.35,30.00 L168.35,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="130.65" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="145.35" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<path d="M197.60,43.40 L199.60,44.40 L205.60,54.00 L208.60,30.00 L233.60,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="188.20" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="210.60" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<path d="M259.00,43.40 L261.00,44.40 L267.00,54.00 L270.00,30.00 L295.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="249.60" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="272.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<path d="M13.40,73.40 L15.40,74.40 L21.40,84.00 L24.40,60.00 L49.40,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="26.40" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<path d="M74.80,73.40 L76.80,74.40 L82.80,84.00 L85.80,60.00 L110.80,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="65.40" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="87.80" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<path d="M136.20,73.40 L138.20,74.40 L144.20,84.00 L147.20,60.00 L172.20,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="126.80" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="149.20" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<path d="M197.60,73.40 L199.60,74.40 L205.60,84.00 L208.60,60.00 L233.60,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="188.20" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="210.60" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<path d="M259.00,73.40 L261.00,74.40 L267.00,84.00 L270.00,60.00 L295.00,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="249.60" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="272.00" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<path d="M13.40,103.40 L15.40,104.40 L21.40,114.00 L24.40,90.00 L49.40,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<text x="26.40" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<path d="M74.80,103.40 L76.80,104.40 L82.80,114.00 L85.80,90.00 L110.80,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="65.40" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="87.80" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<path d="M136.20,103.40 L138.20,104.40 L144.20,114.00 L147.20,90.00 L172.20,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="126.80" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<text x="149.20" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<path d="M197.60,103.40 L199.60,104.40 L205.60,114.00 L208.60,90.00 L233.60,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="188.20" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="210.60" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<path d="M259.00,103.40 L261.00,104.40 L267.00,114.00 L270.00,90.00 L295.00,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="249.60" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<text x="272.00" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<path d="M13.40,133.40 L15.40,134.40 L21.40,144.00 L24.40,120.00 L49.40,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="26.40" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<path d="M74.80,133.40 L76.80,134.40 L82.80,144.00 L85.80,120.00 L110.80,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="65.40" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<text x="87.80" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<path d="M136.20,133.40 L138.20,134.40 L144.20,144.00 L147.20,120.00 L172.20,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="126.80" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="149.20" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<path d="M197.60,133.40 L199.60,134.40 L205.60,144.00 L208.60,120.00 L233.60,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="188.20" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<text x="210.60" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<path d="M259.00,133.40 L261.00,134.40 L267.00,144.00 L270.00,120.00 L295.00,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="249.60" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="272.00" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_7x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_7x3_over.golden
@@ -1,0 +1,373 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "51",
+                ),
+                denom: Number(
+                    "52",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "53",
+                ),
+                denom: Number(
+                    "54",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "55",
+                ),
+                denom: Number(
+                    "56",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "57",
+                ),
+                denom: Number(
+                    "58",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "59",
+                ),
+                denom: Number(
+                    "60",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "61",
+                ),
+                denom: Number(
+                    "62",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "63",
+                ),
+                denom: Number(
+                    "64",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "65",
+                ),
+                denom: Number(
+                    "66",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "67",
+                ),
+                denom: Number(
+                    "68",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "69",
+                ),
+                denom: Number(
+                    "70",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "71",
+                ),
+                denom: Number(
+                    "72",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "73",
+                ),
+                denom: Number(
+                    "74",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "75",
+                ),
+                denom: Number(
+                    "76",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "77",
+                ),
+                denom: Number(
+                    "78",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "79",
+                ),
+                denom: Number(
+                    "80",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=130.0000 h=377.6000 bl=188.8000
+  row0:
+    Fraction x=4.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=4.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("51") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("52") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=4.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("53") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("54") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("55") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("56") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("57") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("58") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=4.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("59") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("60") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("61") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("62") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("63") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("64") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=4.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("65") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("66") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("67") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("68") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("69") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("70") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row5:
+    Fraction x=4.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("71") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("72") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("73") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("74") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("75") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("76") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row6:
+    Fraction x=4.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("77") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("78") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("79") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("80") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="5.00" y1="24.40" x2="33.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="54.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="51.00" y1="24.40" x2="79.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="100.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="97.00" y1="24.40" x2="125.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="8.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="5.00" y1="79.20" x2="33.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="54.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="51.00" y1="79.20" x2="79.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>
+<text x="100.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">51</text>
+<line x1="97.00" y1="79.20" x2="125.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">52</text>
+<text x="8.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">53</text>
+<line x1="5.00" y1="134.00" x2="33.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">54</text>
+<text x="54.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">55</text>
+<line x1="51.00" y1="134.00" x2="79.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">56</text>
+<text x="100.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">57</text>
+<line x1="97.00" y1="134.00" x2="125.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">58</text>
+<text x="8.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">59</text>
+<line x1="5.00" y1="188.80" x2="33.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">60</text>
+<text x="54.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">61</text>
+<line x1="51.00" y1="188.80" x2="79.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">62</text>
+<text x="100.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">63</text>
+<line x1="97.00" y1="188.80" x2="125.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">64</text>
+<text x="8.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">65</text>
+<line x1="5.00" y1="243.60" x2="33.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">66</text>
+<text x="54.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">67</text>
+<line x1="51.00" y1="243.60" x2="79.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">68</text>
+<text x="100.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">69</text>
+<line x1="97.00" y1="243.60" x2="125.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">70</text>
+<text x="8.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">71</text>
+<line x1="5.00" y1="298.40" x2="33.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">72</text>
+<text x="54.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">73</text>
+<line x1="51.00" y1="298.40" x2="79.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">74</text>
+<text x="100.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">75</text>
+<line x1="97.00" y1="298.40" x2="125.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">76</text>
+<text x="8.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">77</text>
+<line x1="5.00" y1="353.20" x2="33.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">78</text>
+<text x="54.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">79</text>
+<line x1="51.00" y1="353.20" x2="79.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">80</text>
+<text x="100.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="97.00" y1="353.20" x2="125.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_amp_only.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_amp_only.golden
@@ -1,0 +1,23 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{&}
+honesty: missing-operand
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Empty,
+            Empty,
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=24.0000 h=20.0000 bl=10.0000
+  row0:
+    Empty x=4.0000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+    Empty x=20.0000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/matrix_cases_cell.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_cases_cell.golden
@@ -1,0 +1,41 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{CASES{1 # 0} & 2}
+honesty: cases-related
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Cases {
+                rows: [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+            },
+            Number(
+                "2",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=64.0000 h=46.0000 bl=23.0000
+  row0:
+    Paren("{","") x=4.0000 y=0.0000 w=29.0000 h=46.0000 bl=23.0000
+      Row x=0.0000 y=0.0000 w=23.0000 h=46.0000 bl=23.0000
+        Number("1") x=6.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("0") x=6.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("2") x=49.0000 y=13.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M7.78,0.00 Q6.16,0.00 6.16,11.50 Q6.16,23.00 5.08,23.00 Q6.16,23.00 6.16,34.50 Q6.16,46.00 7.78,46.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="49.00" y="29.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_empty_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_empty_brace.golden
@@ -1,0 +1,18 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{}
+honesty: missing-operand
+
+=== ast ===
+Matrix {
+    rows: [
+        [],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=8.0000 h=20.0000 bl=10.0000
+  row0:
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/matrix_empty_row.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_empty_row.golden
@@ -1,0 +1,47 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a & b # # c & d}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Empty,
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Empty x=9.7750 y=36.0000 w=0.0000 h=0.0000 bl=0.0000
+  row2:
+    Text("c") x=4.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_hash_only.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_hash_only.golden
@@ -1,0 +1,23 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{#}
+honesty: missing-operand
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Empty,
+        ],
+        [],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=8.0000 h=46.0000 bl=23.0000
+  row0:
+    Empty x=4.0000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+  row1:
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/matrix_jagged.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_jagged.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a # b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+        ],
+        [
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=74.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("b") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("d") x=4.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=31.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=59.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="31.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="59.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_lower.golden
@@ -1,0 +1,42 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: matrix{a & b # c & d}
+honesty: case-insensitive
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_over_3x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_over_3x3.golden
@@ -1,0 +1,169 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} # {7} OVER {8} & {9} OVER {10} & {11} OVER {12} # {13} OVER {14} & {15} OVER {16} & {17} OVER {18}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "9",
+                ),
+                denom: Number(
+                    "10",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "11",
+                ),
+                denom: Number(
+                    "12",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "13",
+                ),
+                denom: Number(
+                    "14",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "15",
+                ),
+                denom: Number(
+                    "16",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "17",
+                ),
+                denom: Number(
+                    "18",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=130.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=9.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=55.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=101.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=9.5000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=4.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("13") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("14") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=50.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("15") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("16") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=96.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("17") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("18") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="13.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="10.50" y1="24.40" x2="27.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="13.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="59.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="56.50" y1="24.40" x2="73.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="59.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="105.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="102.50" y1="24.40" x2="119.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="105.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="13.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="10.50" y1="79.20" x2="27.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="13.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="59.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="51.00" y1="79.20" x2="79.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="100.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="97.00" y1="79.20" x2="125.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="8.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<line x1="5.00" y1="134.00" x2="33.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="54.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<line x1="51.00" y1="134.00" x2="79.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="54.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="100.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<line x1="97.00" y1="134.00" x2="125.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="100.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_spacey.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_spacey.golden
@@ -1,0 +1,42 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{ a  &  b  #  c  &  d }
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_sqrt_cells.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_sqrt_cells.golden
@@ -1,0 +1,66 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{SQRT 1 & SQRT 2 # SQRT 3 & SQRT 4}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Sqrt {
+                index: None,
+                body: Number(
+                    "1",
+                ),
+            },
+            Sqrt {
+                index: None,
+                body: Number(
+                    "2",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: None,
+                body: Number(
+                    "3",
+                ),
+            },
+            Sqrt {
+                index: None,
+                body: Number(
+                    "4",
+                ),
+            },
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=74.0000 h=54.0000 bl=27.0000
+  row0:
+    Sqrt x=4.0000 y=0.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("1") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=45.0000 y=0.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("2") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Sqrt x=4.0000 y=30.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("3") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=45.0000 y=30.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("4") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.00,13.40 L6.00,14.40 L12.00,24.00 L15.00,0.00 L29.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<path d="M45.00,13.40 L47.00,14.40 L53.00,24.00 L56.00,0.00 L70.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="58.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M4.00,43.40 L6.00,44.40 L12.00,54.00 L15.00,30.00 L29.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<path d="M45.00,43.40 L47.00,44.40 L53.00,54.00 L56.00,30.00 L70.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="58.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_trailing_amp.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_trailing_amp.golden
@@ -1,0 +1,31 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a & b &}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Empty,
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=63.1000 h=20.0000 bl=10.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Empty x=59.1000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/matrix_trailing_hash.golden
+++ b/src/renderer/equation/fixtures/m09_expand/matrix_trailing_hash.golden
@@ -1,0 +1,31 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: MATRIX{a & b #}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/operatorname_sin.golden
+++ b/src/renderer/equation/fixtures/m09_expand/operatorname_sin.golden
@@ -1,0 +1,19 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: OPERATORNAME{sin}
+honesty: latex-text
+
+=== ast ===
+FontStyle {
+    style: Roman,
+    body: Function(
+        "sin",
+    ),
+}
+
+=== layout ===
+FontStyle(Roman) x=0.0000 y=0.0000 w=33.4000 h=20.0000 bl=16.0000
+  Function("sin") x=0.0000 y=0.0000 w=33.4000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">sin</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_bare.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_bare.golden
@@ -1,0 +1,20 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: OVER
+honesty: missing-operand
+
+=== ast ===
+Fraction {
+    numer: Empty,
+    denom: Empty,
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=8.0000 h=8.8000 bl=9.4000
+  numer:
+    Empty x=4.0000 y=4.0000 w=0.0000 h=0.0000 bl=0.0000
+  denom:
+    Empty x=4.0000 y=4.8000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<line x1="1.00" y1="4.40" x2="7.00" y2="4.40" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/over_chain_four.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_chain_four.golden
@@ -1,0 +1,48 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 OVER 2 OVER 3 OVER 4
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Fraction {
+        numer: Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        denom: Number(
+            "3",
+        ),
+    },
+    denom: Number(
+        "4",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=35.0000 h=106.4000 bl=87.0000
+  numer:
+    Fraction x=4.0000 y=4.0000 w=27.0000 h=77.6000 bl=58.2000
+      numer:
+        Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("4") x=12.0000 y=82.4000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="12.00" y="28.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="9.00" y1="32.40" x2="26.00" y2="32.40" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="48.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="5.00" y1="57.20" x2="30.00" y2="57.20" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="73.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="82.00" x2="34.00" y2="82.00" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="98.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_chain_three.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_chain_three.golden
@@ -1,0 +1,37 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 OVER 2 OVER 3
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Fraction {
+        numer: Number(
+            "1",
+        ),
+        denom: Number(
+            "2",
+        ),
+    },
+    denom: Number(
+        "3",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=27.0000 h=77.6000 bl=58.2000
+  numer:
+    Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="5.00" y1="28.40" x2="22.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="53.20" x2="26.00" y2="53.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="69.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_choose.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_choose.golden
@@ -1,0 +1,50 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: {n CHOOSE k} OVER 2
+honesty: choose-empty-top
+
+=== ast ===
+Fraction {
+    numer: Row(
+        [
+            Text(
+                "n",
+            ),
+            Paren {
+                left: "(",
+                right: ")",
+                body: Atop {
+                    top: Empty,
+                    bottom: Text(
+                        "k",
+                    ),
+                },
+            },
+        ],
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=51.1000 h=63.8000 bl=44.4000
+  numer:
+    Row x=4.0000 y=4.0000 w=43.1000 h=35.0000 bl=16.0000
+      Text("n") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Paren("(",")") x=11.5500 y=7.0000 w=31.5500 h=28.0000 bl=9.0000
+        Atop x=6.0000 y=0.0000 w=19.5500 h=28.0000 bl=9.0000
+          top:
+            Empty x=9.7750 y=4.0000 w=0.0000 h=0.0000 bl=0.0000
+          bottom:
+            Text("k") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=20.0500 y=39.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>
+<path d="M20.41,11.00 C15.82,16.04 15.82,33.96 20.41,39.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="25.55" y="31.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">k</text>
+<path d="M42.24,11.00 C46.83,16.04 46.83,33.96 42.24,39.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<line x1="1.00" y1="39.40" x2="50.10" y2="39.40" stroke="#000000" stroke-width="0.80"/>
+<text x="20.05" y="55.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_decimal.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_decimal.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1.5 OVER 2.5
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1.5",
+    ),
+    denom: Number(
+        "2.5",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=40.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1.5") x=4.0000 y=4.0000 w=32.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2.5") x=4.0000 y=24.8000 w=32.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1.5</text>
+<line x1="1.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2.5</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_empty_denom.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_empty_denom.golden
@@ -1,0 +1,23 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 OVER
+honesty: missing-operand
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Empty,
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=28.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Empty x=9.5000 y=24.8000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/over_empty_groups.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_empty_groups.golden
@@ -1,0 +1,20 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: {} OVER {}
+honesty: missing-operand
+
+=== ast ===
+Fraction {
+    numer: Empty,
+    denom: Empty,
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=8.0000 h=8.8000 bl=9.4000
+  numer:
+    Empty x=4.0000 y=4.0000 w=0.0000 h=0.0000 bl=0.0000
+  denom:
+    Empty x=4.0000 y=4.8000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<line x1="1.00" y1="4.40" x2="7.00" y2="4.40" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/over_empty_numer.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_empty_numer.golden
@@ -1,0 +1,23 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: OVER 2
+honesty: missing-operand
+
+=== ast ===
+Fraction {
+    numer: Empty,
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=28.8000 bl=9.4000
+  numer:
+    Empty x=9.5000 y=4.0000 w=0.0000 h=0.0000 bl=0.0000
+  denom:
+    Number("2") x=4.0000 y=4.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<line x1="1.00" y1="4.40" x2="18.00" y2="4.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="20.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_eqalign.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_eqalign.golden
@@ -1,0 +1,61 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: EQALIGN{1 OVER 2 &= 3 OVER 6}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Fraction {
+                        numer: Number(
+                            "3",
+                        ),
+                        denom: Number(
+                            "6",
+                        ),
+                    },
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=57.0000 h=48.8000 bl=24.4000
+  row0.left:
+    Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=22.0000 y=0.0000 w=35.0000 h=48.8000 bl=29.4000
+      Symbol("=") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+      Fraction x=16.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="30.00" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="42.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="39.00" y1="24.40" x2="56.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="42.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_func.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_func.golden
@@ -1,0 +1,41 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: sin x OVER cos x
+honesty: implemented-variant
+
+=== ast ===
+Row(
+    [
+        Function(
+            "sin",
+        ),
+        Fraction {
+            numer: Text(
+                "x",
+            ),
+            denom: Function(
+                "cos",
+            ),
+        },
+        Text(
+            "x",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=86.3500 h=48.8000 bl=29.4000
+  Function("sin") x=0.0000 y=13.4000 w=33.4000 h=20.0000 bl=16.0000
+  Fraction x=33.4000 y=0.0000 w=41.4000 h=48.8000 bl=29.4000
+    numer:
+      Text("x") x=14.9250 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Function("cos") x=4.0000 y=24.8000 w=33.4000 h=20.0000 bl=16.0000
+  Text("x") x=74.8000 y=13.4000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="29.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">sin</text>
+<text x="48.32" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<line x1="34.40" y1="24.40" x2="73.80" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="37.40" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">cos</text>
+<text x="74.80" y="29.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_glued_both.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_glued_both.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1OVER2
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_greek.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_greek.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: ALPHA OVER BETA
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Text(
+        "ALPHA",
+    ),
+    denom: Text(
+        "BETA",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=76.2500 h=48.8000 bl=29.4000
+  numer:
+    Text("ALPHA") x=4.0000 y=4.0000 w=68.2500 h=20.0000 bl=16.0000
+  denom:
+    Text("BETA") x=10.8250 y=24.8000 w=54.6000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">ALPHA</text>
+<line x1="1.00" y1="24.40" x2="75.25" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="10.82" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">BETA</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_idents.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_idents.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: a OVER b
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Text(
+        "a",
+    ),
+    denom: Text(
+        "b",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+  numer:
+    Text("a") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+  denom:
+    Text("b") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<line x1="1.00" y1="24.40" x2="18.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_in_left_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_in_left_brace.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: LEFT { a OVER b RIGHT }
+honesty: implemented-variant
+
+=== ast ===
+Paren {
+    left: "{",
+    right: "}",
+    body: Fraction {
+        numer: Text(
+            "a",
+        ),
+        denom: Text(
+            "b",
+        ),
+    },
+}
+
+=== layout ===
+Paren("{","}") x=0.0000 y=0.0000 w=36.0700 h=48.8000 bl=29.4000
+  Fraction x=8.2600 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+    numer:
+      Text("a") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Text("b") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M3.78,0.00 Q2.16,0.00 2.16,12.20 Q2.16,24.40 1.08,24.40 Q2.16,24.40 2.16,36.60 Q2.16,48.80 3.78,48.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="12.26" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<line x1="9.26" y1="24.40" x2="26.81" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="12.26" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<path d="M32.29,0.00 Q33.91,0.00 33.91,12.20 Q33.91,24.40 34.99,24.40 Q33.91,24.40 33.91,36.60 Q33.91,48.80 32.29,48.80" fill="none" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/over_infty.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_infty.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 OVER infty
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: MathSymbol(
+        "∞",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=20.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    MathSymbol("∞") x=4.0000 y=24.8000 w=12.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="19.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">∞</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_lower.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 over 2
+honesty: case-insensitive
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_matrix_numer.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_matrix_numer.golden
@@ -1,0 +1,53 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: MATRIX{1 & 2 # 3 & 4} OVER 2
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Matrix {
+        rows: [
+            [
+                Number(
+                    "1",
+                ),
+                Number(
+                    "2",
+                ),
+            ],
+            [
+                Number(
+                    "3",
+                ),
+                Number(
+                    "4",
+                ),
+            ],
+        ],
+        style: Plain,
+    },
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=54.0000 h=74.8000 bl=55.4000
+  numer:
+    Matrix(Plain) x=4.0000 y=4.0000 w=46.0000 h=46.0000 bl=23.0000
+      row0:
+        Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("2") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Number("3") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("4") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=21.5000 y=50.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="35.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="8.00" y="46.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="35.00" y="46.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="1.00" y1="50.40" x2="53.00" y2="50.40" stroke="#000000" stroke-width="0.80"/>
+<text x="21.50" y="66.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_mixed_case.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_mixed_case.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1 Over 2
+honesty: case-insensitive
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_multidigit.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_multidigit.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 123 OVER 456
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "123",
+    ),
+    denom: Number(
+        "456",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=41.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("123") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("456") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">123</text>
+<line x1="1.00" y1="24.40" x2="40.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">456</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_neg.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_neg.golden
@@ -1,0 +1,41 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: -1 OVER -2
+honesty: implemented-variant
+
+=== ast ===
+Row(
+    [
+        Symbol(
+            "-",
+        ),
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Symbol(
+                "-",
+            ),
+        },
+        Number(
+            "2",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=51.0000 h=48.8000 bl=29.4000
+  Symbol("-") x=0.0000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+  Fraction x=16.0000 y=0.0000 w=24.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=6.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Symbol("-") x=4.0000 y=24.8000 w=16.0000 h=20.0000 bl=16.0000
+  Number("2") x=40.0000 y=13.4000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="22.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="17.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="28.00" y="40.80" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">-</text>
+<text x="40.00" y="29.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_nested_matrix_3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_nested_matrix_3.golden
@@ -1,0 +1,168 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: {MATRIX{{1} OVER {2} & {3} OVER {4} # {5} OVER {6} & {7} OVER {8}}} OVER {MATRIX{{9} OVER {10} & {11} OVER {12} # {13} OVER {14} & {15} OVER {16}}}
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Matrix {
+        rows: [
+            [
+                Fraction {
+                    numer: Number(
+                        "1",
+                    ),
+                    denom: Number(
+                        "2",
+                    ),
+                },
+                Fraction {
+                    numer: Number(
+                        "3",
+                    ),
+                    denom: Number(
+                        "4",
+                    ),
+                },
+            ],
+            [
+                Fraction {
+                    numer: Number(
+                        "5",
+                    ),
+                    denom: Number(
+                        "6",
+                    ),
+                },
+                Fraction {
+                    numer: Number(
+                        "7",
+                    ),
+                    denom: Number(
+                        "8",
+                    ),
+                },
+            ],
+        ],
+        style: Plain,
+    },
+    denom: Matrix {
+        rows: [
+            [
+                Fraction {
+                    numer: Number(
+                        "9",
+                    ),
+                    denom: Number(
+                        "10",
+                    ),
+                },
+                Fraction {
+                    numer: Number(
+                        "11",
+                    ),
+                    denom: Number(
+                        "12",
+                    ),
+                },
+            ],
+            [
+                Fraction {
+                    numer: Number(
+                        "13",
+                    ),
+                    denom: Number(
+                        "14",
+                    ),
+                },
+                Fraction {
+                    numer: Number(
+                        "15",
+                    ),
+                    denom: Number(
+                        "16",
+                    ),
+                },
+            ],
+        ],
+        style: Plain,
+    },
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=92.0000 h=216.0000 bl=113.0000
+  numer:
+    Matrix(Plain) x=15.0000 y=4.0000 w=62.0000 h=103.6000 bl=51.8000
+      row0:
+        Fraction x=4.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+        Fraction x=39.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Fraction x=4.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+        Fraction x=39.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Matrix(Plain) x=4.0000 y=108.4000 w=84.0000 h=103.6000 bl=51.8000
+      row0:
+        Fraction x=4.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+        Fraction x=50.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+      row1:
+        Fraction x=4.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("13") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("14") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+        Fraction x=50.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("15") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("16") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="23.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="20.00" y1="28.40" x2="37.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="23.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="58.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="55.00" y1="28.40" x2="72.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="58.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="23.00" y="78.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="20.00" y1="83.20" x2="37.00" y2="83.20" stroke="#000000" stroke-width="0.80"/>
+<text x="23.00" y="99.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="58.00" y="78.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="55.00" y1="83.20" x2="72.00" y2="83.20" stroke="#000000" stroke-width="0.80"/>
+<text x="58.00" y="99.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="1.00" y1="108.00" x2="91.00" y2="108.00" stroke="#000000" stroke-width="0.80"/>
+<text x="17.50" y="128.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="9.00" y1="132.80" x2="37.00" y2="132.80" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="149.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="58.00" y="128.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="55.00" y1="132.80" x2="83.00" y2="132.80" stroke="#000000" stroke-width="0.80"/>
+<text x="58.00" y="149.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="12.00" y="183.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<line x1="9.00" y1="187.60" x2="37.00" y2="187.60" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="204.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="58.00" y="183.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<line x1="55.00" y1="187.60" x2="83.00" y2="187.60" stroke="#000000" stroke-width="0.80"/>
+<text x="58.00" y="204.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_paren_no_left.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_paren_no_left.golden
@@ -1,0 +1,41 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: (x OVER y)
+honesty: implemented-variant
+
+=== ast ===
+Row(
+    [
+        Symbol(
+            "(",
+        ),
+        Fraction {
+            numer: Text(
+                "x",
+            ),
+            denom: Text(
+                "y",
+            ),
+        },
+        Symbol(
+            ")",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=43.5500 h=48.8000 bl=29.4000
+  Symbol("(") x=0.0000 y=13.4000 w=12.0000 h=20.0000 bl=16.0000
+  Fraction x=12.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+    numer:
+      Text("x") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Text("y") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+  Symbol(")") x=31.5500 y=13.4000 w=12.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="6.00" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">(</text>
+<text x="16.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<line x1="13.00" y1="24.40" x2="30.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="16.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="37.55" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">)</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_pi.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_pi.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: pi OVER 2
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: MathSymbol(
+        "π",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    MathSymbol("π") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">π</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_pile.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_pile.golden
@@ -1,0 +1,59 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: PILE{1 OVER 2 # 3 OVER 4} OVER 5
+honesty: pile-layout-as-row
+
+=== ast ===
+Fraction {
+    numer: Pile {
+        rows: [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+        ],
+        align: Center,
+    },
+    denom: Number(
+        "5",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=27.0000 h=132.4000 bl=113.0000
+  numer:
+    Row x=4.0000 y=4.0000 w=19.0000 h=103.6000 bl=51.8000
+      Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      Fraction x=0.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+        numer:
+          Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+        denom:
+          Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("5") x=8.0000 y=108.4000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="8.00" y="24.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="5.00" y1="28.40" x2="22.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="44.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="8.00" y="78.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="5.00" y1="83.20" x2="22.00" y2="83.20" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="99.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="1.00" y1="108.00" x2="26.00" y2="108.00" stroke="#000000" stroke-width="0.80"/>
+<text x="8.00" y="124.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_plus_ungrouped.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_plus_ungrouped.golden
@@ -1,0 +1,51 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: a+b OVER c+d
+honesty: implemented-variant
+
+=== ast ===
+Row(
+    [
+        Text(
+            "a",
+        ),
+        Symbol(
+            "+",
+        ),
+        Fraction {
+            numer: Text(
+                "b",
+            ),
+            denom: Text(
+                "c",
+            ),
+        },
+        Symbol(
+            "+",
+        ),
+        Text(
+            "d",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=74.6500 h=48.8000 bl=29.4000
+  Text("a") x=0.0000 y=13.4000 w=11.5500 h=20.0000 bl=16.0000
+  Symbol("+") x=11.5500 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+  Fraction x=27.5500 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+    numer:
+      Text("b") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Text("c") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+  Symbol("+") x=47.1000 y=13.4000 w=16.0000 h=20.0000 bl=16.0000
+  Text("d") x=63.1000 y=13.4000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="29.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="19.55" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="31.55" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<line x1="28.55" y1="24.40" x2="46.10" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="31.55" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="55.10" y="29.40" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="63.10" y="29.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_root.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_root.golden
@@ -1,0 +1,38 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: ROOT 8 OVER ROOT 2
+honesty: root-aliases-sqrt
+
+=== ast ===
+Fraction {
+    numer: Sqrt {
+        index: None,
+        body: Number(
+            "8",
+        ),
+    },
+    denom: Sqrt {
+        index: None,
+        body: Number(
+            "2",
+        ),
+    },
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=33.0000 h=56.8000 bl=33.4000
+  numer:
+    Sqrt x=4.0000 y=4.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("8") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Sqrt x=4.0000 y=28.8000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("2") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.00,17.40 L6.00,18.40 L12.00,28.00 L15.00,4.00 L29.00,4.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="22.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="1.00" y1="28.40" x2="32.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<path d="M4.00,42.20 L6.00,43.20 L12.00,52.80 L15.00,28.80 L29.00,28.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="46.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_sqrt.golden
@@ -1,0 +1,38 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: SQRT 2 OVER SQRT 3
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Sqrt {
+        index: None,
+        body: Number(
+            "2",
+        ),
+    },
+    denom: Sqrt {
+        index: None,
+        body: Number(
+            "3",
+        ),
+    },
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=33.0000 h=56.8000 bl=33.4000
+  numer:
+    Sqrt x=4.0000 y=4.0000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("2") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Sqrt x=4.0000 y=28.8000 w=25.0000 h=24.0000 bl=18.0000
+      body:
+        Number("3") x=13.0000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M4.00,17.40 L6.00,18.40 L12.00,28.00 L15.00,4.00 L29.00,4.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="22.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="28.40" x2="32.00" y2="28.40" stroke="#000000" stroke-width="0.80"/>
+<path d="M4.00,42.20 L6.00,43.20 L12.00,52.80 L15.00,28.80 L29.00,28.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="46.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_sub.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_sub.golden
@@ -1,0 +1,46 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: x_1 OVER y_1
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Subscript {
+        base: Text(
+            "x",
+        ),
+        sub: Number(
+            "1",
+        ),
+    },
+    denom: Subscript {
+        base: Text(
+            "y",
+        ),
+        sub: Number(
+            "1",
+        ),
+    },
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=27.2500 h=49.6000 bl=29.8000
+  numer:
+    Subscript x=4.0000 y=4.0000 w=19.2500 h=20.4000 bl=16.0000
+      base:
+        Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sub:
+        Number("1") x=11.5500 y=6.4000 w=7.7000 h=14.0000 bl=11.2000
+  denom:
+    Subscript x=4.0000 y=25.2000 w=19.2500 h=20.4000 bl=16.0000
+      base:
+        Text("y") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sub:
+        Number("1") x=11.5500 y=6.4000 w=7.7000 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="15.55" y="21.60" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.80" x2="26.25" y2="24.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="41.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="15.55" y="42.80" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_subsup.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_subsup.golden
@@ -1,0 +1,66 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: x_i^2 OVER y_j^3
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Subscript {
+        base: Text(
+            "x",
+        ),
+        sub: Superscript {
+            base: Text(
+                "i",
+            ),
+            sup: Number(
+                "2",
+            ),
+        },
+    },
+    denom: Subscript {
+        base: Text(
+            "y",
+        ),
+        sub: Superscript {
+            base: Text(
+                "j",
+            ),
+            sup: Number(
+                "3",
+            ),
+        },
+    },
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=33.0250 h=49.6000 bl=29.8000
+  numer:
+    Subscript x=4.0000 y=4.0000 w=25.0250 h=20.4000 bl=16.0000
+      base:
+        Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sub:
+        Superscript x=11.5500 y=6.4000 w=13.4750 h=14.0000 bl=11.2000
+          base:
+            Text("i") x=0.0000 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+          sup:
+            Number("2") x=8.0850 y=0.0000 w=5.3900 h=9.8000 bl=7.8400
+  denom:
+    Subscript x=4.0000 y=25.2000 w=25.0250 h=20.4000 bl=16.0000
+      base:
+        Text("y") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sub:
+        Superscript x=11.5500 y=6.4000 w=13.4750 h=14.0000 bl=11.2000
+          base:
+            Text("j") x=0.0000 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+          sup:
+            Number("3") x=8.0850 y=0.0000 w=5.3900 h=9.8000 bl=7.8400
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="15.55" y="21.60" font-size="14.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>
+<text x="23.64" y="18.24" font-size="9.80" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="24.80" x2="32.03" y2="24.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="41.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="15.55" y="42.80" font-size="14.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">j</text>
+<text x="23.64" y="39.44" font-size="9.80" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_sum.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_sum.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: sum_i a_i OVER n
+honesty: implemented-variant
+
+=== ast ===
+Row(
+    [
+        BigOp {
+            symbol: "∑",
+            sub: Some(
+                Text(
+                    "i",
+                ),
+            ),
+            sup: None,
+        },
+        Fraction {
+            numer: Subscript {
+                base: Text(
+                    "a",
+                ),
+                sub: Text(
+                    "i",
+                ),
+            },
+            denom: Text(
+                "n",
+            ),
+        },
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=60.6350 h=56.8000 bl=29.8000
+  BigOp("∑") x=0.0000 y=11.8000 w=33.0000 h=45.0000 bl=18.0000
+    sub:
+      Text("i") x=7.9575 y=30.0000 w=8.0850 h=14.0000 bl=11.2000
+  Fraction x=33.0000 y=0.0000 w=27.6350 h=49.2000 bl=29.8000
+    numer:
+      Subscript x=4.0000 y=4.0000 w=19.6350 h=20.4000 bl=16.0000
+        base:
+          Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+        sub:
+          Text("i") x=11.5500 y=6.4000 w=8.0850 h=14.0000 bl=11.2000
+    denom:
+      Text("n") x=8.0425 y=25.2000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="35.80" font-size="30.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">∑</text>
+<text x="7.96" y="53.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>
+<text x="37.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="48.55" y="21.60" font-size="14.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>
+<line x1="34.00" y1="24.80" x2="59.64" y2="24.80" stroke="#000000" stroke-width="0.80"/>
+<text x="41.04" y="41.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_sup.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_sup.golden
@@ -1,0 +1,46 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: x^2 OVER y^2
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Superscript {
+        base: Text(
+            "x",
+        ),
+        sup: Number(
+            "2",
+        ),
+    },
+    denom: Superscript {
+        base: Text(
+            "y",
+        ),
+        sup: Number(
+            "2",
+        ),
+    },
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=27.2500 h=48.8000 bl=29.4000
+  numer:
+    Superscript x=4.0000 y=4.0000 w=19.2500 h=20.0000 bl=16.0000
+      base:
+        Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sup:
+        Number("2") x=11.5500 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  denom:
+    Superscript x=4.0000 y=24.8000 w=19.2500 h=20.0000 bl=16.0000
+      base:
+        Text("y") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sup:
+        Number("2") x=11.5500 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="15.55" y="15.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="24.40" x2="26.25" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>
+<text x="15.55" y="36.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_times.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_times.golden
@@ -1,0 +1,51 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: a TIMES b OVER c TIMES d
+honesty: implemented-variant
+
+=== ast ===
+Row(
+    [
+        Text(
+            "a",
+        ),
+        MathSymbol(
+            "×",
+        ),
+        Fraction {
+            numer: Text(
+                "b",
+            ),
+            denom: Text(
+                "c",
+            ),
+        },
+        MathSymbol(
+            "×",
+        ),
+        Text(
+            "d",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=66.6500 h=48.8000 bl=29.4000
+  Text("a") x=0.0000 y=13.4000 w=11.5500 h=20.0000 bl=16.0000
+  MathSymbol("×") x=11.5500 y=13.4000 w=12.0000 h=20.0000 bl=16.0000
+  Fraction x=23.5500 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+    numer:
+      Text("b") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+    denom:
+      Text("c") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+  MathSymbol("×") x=43.1000 y=13.4000 w=12.0000 h=20.0000 bl=16.0000
+  Text("d") x=55.1000 y=13.4000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="29.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="11.55" y="29.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">×</text>
+<text x="27.55" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<line x1="24.55" y1="24.40" x2="42.10" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="27.55" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="43.10" y="29.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">×</text>
+<text x="55.10" y="29.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_triple_nest.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_triple_nest.golden
@@ -1,0 +1,48 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: {{{1 OVER 2} OVER 3} OVER 4}
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Fraction {
+        numer: Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        denom: Number(
+            "3",
+        ),
+    },
+    denom: Number(
+        "4",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=35.0000 h=106.4000 bl=87.0000
+  numer:
+    Fraction x=4.0000 y=4.0000 w=27.0000 h=77.6000 bl=58.2000
+      numer:
+        Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("4") x=12.0000 y=82.4000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="12.00" y="28.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="9.00" y1="32.40" x2="26.00" y2="32.40" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="48.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="5.00" y1="57.20" x2="30.00" y2="57.20" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="73.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="82.00" x2="34.00" y2="82.00" stroke="#000000" stroke-width="0.80"/>
+<text x="12.00" y="98.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>

--- a/src/renderer/equation/fixtures/m09_expand/over_ws_pad.golden
+++ b/src/renderer/equation/fixtures/m09_expand/over_ws_pad.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: 1  OVER  2
+honesty: implemented-variant
+
+=== ast ===
+Fraction {
+    numer: Number(
+        "1",
+    ),
+    denom: Number(
+        "2",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+  numer:
+    Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+  denom:
+    Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/overset_hat.golden
+++ b/src/renderer/equation/fixtures/m09_expand/overset_hat.golden
@@ -1,0 +1,29 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: OVERSET{^}{x}
+honesty: latex-stack
+
+=== ast ===
+Superscript {
+    base: Text(
+        "x",
+    ),
+    sup: Superscript {
+        base: Empty,
+        sup: Empty,
+    },
+}
+
+=== layout ===
+Superscript x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  base:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  sup:
+    Superscript x=11.5500 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+      base:
+        Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+      sup:
+        Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/phantom_x.golden
+++ b/src/renderer/equation/fixtures/m09_expand/phantom_x.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: PHANTOM{x}
+honesty: phantom-space
+
+=== ast ===
+Text(
+    " ",
+)
+
+=== layout ===
+Text(" ") x=0.0000 y=0.0000 w=10.5000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif"> </text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_eight_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_eight_frac.golden
@@ -1,0 +1,144 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{{1} OVER {2} # {2} OVER {3} # {3} OVER {4} # {4} OVER {5} # {5} OVER {6} # {6} OVER {7} # {7} OVER {8} # {8} OVER {9}}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "2",
+            ),
+            denom: Number(
+                "3",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "3",
+            ),
+            denom: Number(
+                "4",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "4",
+            ),
+            denom: Number(
+                "5",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "5",
+            ),
+            denom: Number(
+                "6",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "6",
+            ),
+            denom: Number(
+                "7",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "7",
+            ),
+            denom: Number(
+                "8",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "8",
+            ),
+            denom: Number(
+                "9",
+            ),
+        },
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=19.0000 h=432.4000 bl=216.2000
+  Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=219.2000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=274.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=328.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=383.6000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("8") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("9") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="4.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="79.20" x2="18.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="4.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="134.00" x2="18.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="4.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="1.00" y1="188.80" x2="18.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="4.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="1.00" y1="243.60" x2="18.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="4.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="1.00" y1="298.40" x2="18.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="4.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="1.00" y1="353.20" x2="18.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="4.00" y="403.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="1.00" y1="408.00" x2="18.00" y2="408.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="424.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_empty.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_empty.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{}
+honesty: missing-operand
+
+=== ast ===
+Pile {
+    rows: [],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=0.0000 h=-6.0000 bl=-3.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/pile_five.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_five.golden
@@ -1,0 +1,41 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{a # b # c # d # e}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+        Text(
+            "c",
+        ),
+        Text(
+            "d",
+        ),
+        Text(
+            "e",
+        ),
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=124.0000 bl=62.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("c") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("d") x=0.0000 y=78.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("e") x=0.0000 y=104.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="0.00" y="94.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="0.00" y="120.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_four_matrices.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_four_matrices.golden
@@ -1,0 +1,150 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{MATRIX{1 & 0 # 0 & 1} # PMATRIX{1 & 0 # 0 & 1} # BMATRIX{1 & 0 # 0 & 1} # DMATRIX{1 & 0 # 0 & 1}}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Matrix {
+            rows: [
+                [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+                [
+                    Number(
+                        "0",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ],
+            style: Plain,
+        },
+        Matrix {
+            rows: [
+                [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+                [
+                    Number(
+                        "0",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ],
+            style: Paren,
+        },
+        Matrix {
+            rows: [
+                [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+                [
+                    Number(
+                        "0",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ],
+            style: Bracket,
+        },
+        Matrix {
+            rows: [
+                [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+                [
+                    Number(
+                        "0",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ],
+            style: Vert,
+        },
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=58.0000 h=202.0000 bl=101.0000
+  Matrix(Plain) x=6.0000 y=0.0000 w=46.0000 h=46.0000 bl=23.0000
+    row0:
+      Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("0") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    row1:
+      Number("0") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("1") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  Matrix(Paren) x=0.0000 y=52.0000 w=58.0000 h=46.0000 bl=23.0000
+    row0:
+      Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("0") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    row1:
+      Number("0") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("1") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  Matrix(Bracket) x=0.0000 y=104.0000 w=58.0000 h=46.0000 bl=23.0000
+    row0:
+      Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("0") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    row1:
+      Number("0") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("1") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  Matrix(Vert) x=0.0000 y=156.0000 w=58.0000 h=46.0000 bl=23.0000
+    row0:
+      Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("0") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    row1:
+      Number("0") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("1") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<path d="M5.40,52.00 C0.30,60.28 0.30,89.72 5.40,98.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M52.60,52.00 C57.70,60.28 57.70,89.72 52.60,98.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<path d="M4.20,104.00 L1.80,104.00 L1.80,150.00 L4.20,150.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M53.80,104.00 L56.20,104.00 L56.20,150.00 L53.80,150.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="120.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="120.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="146.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="146.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="3.00" y1="156.00" x2="3.00" y2="202.00" stroke="#000000" stroke-width="0.80"/>
+<line x1="55.00" y1="156.00" x2="55.00" y2="202.00" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="172.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="37.00" y="172.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.00" y="198.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.00" y="198.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_lower.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: pile{a # b}
+honesty: case-insensitive
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_matrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_matrix.golden
@@ -1,0 +1,80 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{MATRIX{1 & 0 # 0 & 1} # MATRIX{0 & 1 # 1 & 0}}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Matrix {
+            rows: [
+                [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+                [
+                    Number(
+                        "0",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+            ],
+            style: Plain,
+        },
+        Matrix {
+            rows: [
+                [
+                    Number(
+                        "0",
+                    ),
+                    Number(
+                        "1",
+                    ),
+                ],
+                [
+                    Number(
+                        "1",
+                    ),
+                    Number(
+                        "0",
+                    ),
+                ],
+            ],
+            style: Plain,
+        },
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=46.0000 h=98.0000 bl=49.0000
+  Matrix(Plain) x=0.0000 y=0.0000 w=46.0000 h=46.0000 bl=23.0000
+    row0:
+      Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("0") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    row1:
+      Number("0") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("1") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  Matrix(Plain) x=0.0000 y=52.0000 w=46.0000 h=46.0000 bl=23.0000
+    row0:
+      Number("0") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("1") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    row1:
+      Number("1") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+      Number("0") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="31.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="31.00" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="4.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="31.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="4.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="31.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE
+honesty: pile-layout-as-row
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/pile_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_over.golden
@@ -1,0 +1,48 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{{1} OVER {2} # {3} OVER {4}}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "3",
+            ),
+            denom: Number(
+                "4",
+            ),
+        },
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=19.0000 h=103.6000 bl=51.8000
+  Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="4.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="79.20" x2="18.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_single.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_single.golden
@@ -1,0 +1,21 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{a}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=10.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>

--- a/src/renderer/equation/fixtures/m09_expand/pile_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pile_sqrt.golden
@@ -1,0 +1,49 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: PILE{SQRT a # SQRT b # SQRT c}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Sqrt {
+            index: None,
+            body: Text(
+                "a",
+            ),
+        },
+        Sqrt {
+            index: None,
+            body: Text(
+                "b",
+            ),
+        },
+        Sqrt {
+            index: None,
+            body: Text(
+                "c",
+            ),
+        },
+    ],
+    align: Center,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=25.5500 h=84.0000 bl=42.0000
+  Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+    body:
+      Text("a") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+  Sqrt x=0.0000 y=30.0000 w=25.5500 h=24.0000 bl=18.0000
+    body:
+      Text("b") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+  Sqrt x=0.0000 y=60.0000 w=25.5500 h=24.0000 bl=18.0000
+    body:
+      Text("c") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<path d="M0.00,43.40 L2.00,44.40 L8.00,54.00 L11.00,30.00 L25.55,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="48.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<path d="M0.00,73.40 L2.00,74.40 L8.00,84.00 L11.00,60.00 L25.55,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="78.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_2x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_2x3.golden
@@ -1,0 +1,54 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{a & b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=86.6500 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=65.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M81.25,0.00 C86.35,8.28 86.35,37.72 81.25,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="65.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_3x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_3x2.golden
@@ -1,0 +1,57 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{a & b # c & d # e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=59.1000 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("e") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,12.96 0.30,59.04 5.40,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.70,0.00 C58.80,12.96 58.80,59.04 53.70,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_3x3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_3x3.golden
@@ -1,0 +1,72 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{a & b & c # d & e & f # g & h & i}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+        [
+            Text(
+                "g",
+            ),
+            Text(
+                "h",
+            ),
+            Text(
+                "i",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=86.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=65.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("d") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("g") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("h") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("i") x=65.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,12.96 0.30,59.04 5.40,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M81.25,0.00 C86.35,12.96 86.35,59.04 81.25,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="65.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">g</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">h</text>
+<text x="65.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_3x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_3x3_over.golden
@@ -1,0 +1,171 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{{21} OVER {22} & {23} OVER {24} & {25} OVER {26} # {27} OVER {28} & {29} OVER {30} & {31} OVER {32} # {33} OVER {34} & {35} OVER {36} & {37} OVER {38}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=142.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,28.51 0.30,129.89 5.40,158.40" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M136.60,0.00 C141.70,28.51 141.70,129.89 136.60,158.40" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="11.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="60.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="57.00" y1="24.40" x2="85.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="106.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="103.00" y1="24.40" x2="131.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_3x7_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_3x7_over.golden
@@ -1,0 +1,363 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{{81} OVER {82} & {83} OVER {84} & {85} OVER {86} & {87} OVER {88} & {89} OVER {90} & {91} OVER {92} & {93} OVER {94} # {95} OVER {96} & {97} OVER {98} & {99} OVER {100} & {101} OVER {102} & {103} OVER {104} & {105} OVER {106} & {107} OVER {108} # {109} OVER {110} & {111} OVER {112} & {113} OVER {114} & {115} OVER {116} & {117} OVER {118} & {119} OVER {120} & {121} OVER {122}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "83",
+                ),
+                denom: Number(
+                    "84",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "85",
+                ),
+                denom: Number(
+                    "86",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "87",
+                ),
+                denom: Number(
+                    "88",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "89",
+                ),
+                denom: Number(
+                    "90",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "91",
+                ),
+                denom: Number(
+                    "92",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "93",
+                ),
+                denom: Number(
+                    "94",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "95",
+                ),
+                denom: Number(
+                    "96",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "97",
+                ),
+                denom: Number(
+                    "98",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "99",
+                ),
+                denom: Number(
+                    "100",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "101",
+                ),
+                denom: Number(
+                    "102",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "103",
+                ),
+                denom: Number(
+                    "104",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "105",
+                ),
+                denom: Number(
+                    "106",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "107",
+                ),
+                denom: Number(
+                    "108",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "109",
+                ),
+                denom: Number(
+                    "110",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "111",
+                ),
+                denom: Number(
+                    "112",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "113",
+                ),
+                denom: Number(
+                    "114",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "115",
+                ),
+                denom: Number(
+                    "116",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "117",
+                ),
+                denom: Number(
+                    "118",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "119",
+                ),
+                denom: Number(
+                    "120",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "121",
+                ),
+                denom: Number(
+                    "122",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=403.0000 h=158.4000 bl=79.2000
+  row0:
+    Fraction x=15.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=72.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("83") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("84") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=129.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("85") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("86") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=186.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("87") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("88") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=243.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("89") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("90") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=300.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("91") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("92") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=357.5000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("93") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("94") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=15.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("95") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("96") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=72.5000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("97") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("98") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=124.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("99") x=9.5000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("100") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=181.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("101") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("102") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=238.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("103") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("104") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=295.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("105") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("106") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=352.0000 y=54.8000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("107") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("108") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("109") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("110") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=67.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("111") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("112") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=124.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("113") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("114") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=181.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("115") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("116") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=238.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("117") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("118") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=295.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("119") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("120") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+    Fraction x=352.0000 y=109.6000 w=41.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("121") x=4.0000 y=4.0000 w=33.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("122") x=4.0000 y=24.8000 w=33.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,28.51 0.30,129.89 5.40,158.40" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M397.60,0.00 C402.70,28.51 402.70,129.89 397.60,158.40" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="19.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="16.50" y1="24.40" x2="44.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>
+<text x="76.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">83</text>
+<line x1="73.50" y1="24.40" x2="101.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="76.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">84</text>
+<text x="133.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">85</text>
+<line x1="130.50" y1="24.40" x2="158.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="133.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">86</text>
+<text x="190.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">87</text>
+<line x1="187.50" y1="24.40" x2="215.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="190.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">88</text>
+<text x="247.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">89</text>
+<line x1="244.50" y1="24.40" x2="272.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="247.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">90</text>
+<text x="304.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">91</text>
+<line x1="301.50" y1="24.40" x2="329.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="304.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">92</text>
+<text x="361.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">93</text>
+<line x1="358.50" y1="24.40" x2="386.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="361.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">94</text>
+<text x="19.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">95</text>
+<line x1="16.50" y1="79.20" x2="44.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">96</text>
+<text x="76.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">97</text>
+<line x1="73.50" y1="79.20" x2="101.50" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="76.50" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">98</text>
+<text x="133.50" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">99</text>
+<line x1="125.00" y1="79.20" x2="164.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="128.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">100</text>
+<text x="185.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">101</text>
+<line x1="182.00" y1="79.20" x2="221.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="185.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">102</text>
+<text x="242.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">103</text>
+<line x1="239.00" y1="79.20" x2="278.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="242.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">104</text>
+<text x="299.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">105</text>
+<line x1="296.00" y1="79.20" x2="335.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="299.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">106</text>
+<text x="356.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">107</text>
+<line x1="353.00" y1="79.20" x2="392.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="356.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">108</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">109</text>
+<line x1="11.00" y1="134.00" x2="50.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">110</text>
+<text x="71.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">111</text>
+<line x1="68.00" y1="134.00" x2="107.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="71.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">112</text>
+<text x="128.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">113</text>
+<line x1="125.00" y1="134.00" x2="164.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="128.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">114</text>
+<text x="185.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">115</text>
+<line x1="182.00" y1="134.00" x2="221.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="185.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">116</text>
+<text x="242.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">117</text>
+<line x1="239.00" y1="134.00" x2="278.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="242.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">118</text>
+<text x="299.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">119</text>
+<line x1="296.00" y1="134.00" x2="335.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="299.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">120</text>
+<text x="356.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">121</text>
+<line x1="353.00" y1="134.00" x2="392.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="356.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">122</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_4x4_mixed.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_4x4_mixed.golden
@@ -1,0 +1,206 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{1 & {1} OVER {3} & SQRT(2) of {7} & d # {2} OVER {2} & SQRT(3) of {6} & d & 8 # SQRT(4) of {5} & d & 11 & {3} OVER {5} # d & 14 & {4} OVER {4} & SQRT(5) of {8}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "3",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Text(
+                "d",
+            ),
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "2",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Text(
+                "d",
+            ),
+            Number(
+                "11",
+            ),
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "5",
+                ),
+            },
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Number(
+                "14",
+            ),
+            Fraction {
+                numer: Number(
+                    "4",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=174.8000 h=213.2000 bl=106.6000
+  row0:
+    Number("1") x=17.8500 y=14.4000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=56.5500 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=95.4000 y=12.4000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=145.6750 y=14.4000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=13.8500 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=52.7000 y=67.2000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=102.9750 y=69.2000 w=11.5500 h=20.0000 bl=16.0000
+    Number("8") x=145.9500 y=69.2000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=10.0000 y=122.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Text("d") x=60.2750 y=124.0000 w=11.5500 h=20.0000 bl=16.0000
+    Number("11") x=97.7500 y=124.0000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=141.9500 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row3:
+    Text("d") x=17.5750 y=178.8000 w=11.5500 h=20.0000 bl=16.0000
+    Number("14") x=55.0500 y=178.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=99.2500 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=138.1000 y=176.8000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,38.38 0.30,174.82 5.40,213.20" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M169.40,0.00 C174.50,38.38 174.50,174.82 169.40,213.20" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="17.85" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="60.55" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="57.55" y1="24.40" x2="74.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.55" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<path d="M97.10,25.80 L99.10,26.80 L105.10,36.40 L108.10,12.40 L122.10,12.40" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="95.40" y="23.60" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="110.10" y="30.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="145.68" y="30.40" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="17.85" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="14.85" y1="79.20" x2="31.85" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="17.85" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<path d="M54.40,80.60 L56.40,81.60 L62.40,91.20 L65.40,67.20 L79.40,67.20" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="52.70" y="78.40" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="67.40" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="102.98" y="85.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="145.95" y="85.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M11.70,135.40 L13.70,136.40 L19.70,146.00 L22.70,122.00 L36.70,122.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="133.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="24.70" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="60.28" y="140.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="97.75" y="140.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="145.95" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="142.95" y1="134.00" x2="159.95" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="145.95" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="17.58" y="194.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="55.05" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="103.25" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="100.25" y1="188.80" x2="117.25" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="103.25" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<path d="M139.80,190.20 L141.80,191.20 L147.80,200.80 L150.80,176.80 L164.80,176.80" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="138.10" y="188.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="152.80" y="194.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_4x4_numbers.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_4x4_numbers.golden
@@ -1,0 +1,110 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{1 & 2 & 3 & 4 # 5 & 6 & 7 & 8 # 9 & 10 & 11 & 12 # 13 & 14 & 15 & 16}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Number(
+                "1",
+            ),
+            Number(
+                "2",
+            ),
+            Number(
+                "3",
+            ),
+            Number(
+                "4",
+            ),
+        ],
+        [
+            Number(
+                "5",
+            ),
+            Number(
+                "6",
+            ),
+            Number(
+                "7",
+            ),
+            Number(
+                "8",
+            ),
+        ],
+        [
+            Number(
+                "9",
+            ),
+            Number(
+                "10",
+            ),
+            Number(
+                "11",
+            ),
+            Number(
+                "12",
+            ),
+        ],
+        [
+            Number(
+                "13",
+            ),
+            Number(
+                "14",
+            ),
+            Number(
+                "15",
+            ),
+            Number(
+                "16",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=156.0000 h=98.0000 bl=49.0000
+  row0:
+    Number("1") x=15.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("2") x=53.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("3") x=91.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("4") x=129.5000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("5") x=15.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("6") x=53.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("7") x=91.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("8") x=129.5000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+  row2:
+    Number("9") x=15.5000 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("10") x=48.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("11") x=86.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("12") x=124.0000 y=52.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Number("13") x=10.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("14") x=48.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("15") x=86.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+    Number("16") x=124.0000 y=78.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,17.64 0.30,80.36 5.40,98.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M150.60,0.00 C155.70,17.64 155.70,80.36 150.60,98.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="15.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="53.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="91.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="129.50" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="15.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="53.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="91.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="129.50" y="42.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="15.50" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="48.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="86.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="124.00" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="10.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="48.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="86.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="124.00" y="94.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_5x5_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_5x5_over.golden
@@ -1,0 +1,433 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{{1} OVER {2} & {3} OVER {4} & {5} OVER {6} & {7} OVER {8} & {9} OVER {10} # {11} OVER {12} & {13} OVER {14} & {15} OVER {16} & {17} OVER {18} & {19} OVER {20} # {21} OVER {22} & {23} OVER {24} & {25} OVER {26} & {27} OVER {28} & {29} OVER {30} # {31} OVER {32} & {33} OVER {34} & {35} OVER {36} & {37} OVER {38} & {39} OVER {40} # {41} OVER {42} & {43} OVER {44} & {45} OVER {46} & {47} OVER {48} & {49} OVER {50}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "9",
+                ),
+                denom: Number(
+                    "10",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "11",
+                ),
+                denom: Number(
+                    "12",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "13",
+                ),
+                denom: Number(
+                    "14",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "15",
+                ),
+                denom: Number(
+                    "16",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "17",
+                ),
+                denom: Number(
+                    "18",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "19",
+                ),
+                denom: Number(
+                    "20",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "21",
+                ),
+                denom: Number(
+                    "22",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "23",
+                ),
+                denom: Number(
+                    "24",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "25",
+                ),
+                denom: Number(
+                    "26",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "27",
+                ),
+                denom: Number(
+                    "28",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "29",
+                ),
+                denom: Number(
+                    "30",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "31",
+                ),
+                denom: Number(
+                    "32",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "33",
+                ),
+                denom: Number(
+                    "34",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "35",
+                ),
+                denom: Number(
+                    "36",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "37",
+                ),
+                denom: Number(
+                    "38",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "39",
+                ),
+                denom: Number(
+                    "40",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=234.0000 h=268.0000 bl=134.0000
+  row0:
+    Fraction x=15.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=61.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=107.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=153.5000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("9") x=9.5000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("10") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("11") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("12") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("13") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("14") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("15") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("16") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("17") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("18") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("19") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("20") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("21") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("22") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("23") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("24") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("25") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("26") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("27") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("28") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("29") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("30") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=10.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("31") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("32") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("33") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("34") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("35") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("36") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("37") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("38") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("39") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("40") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=10.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=148.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=194.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,48.24 0.30,219.76 5.40,268.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M228.60,0.00 C233.70,48.24 233.70,219.76 228.60,268.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="19.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="16.50" y1="24.40" x2="33.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="19.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="65.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="62.50" y1="24.40" x2="79.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="65.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="111.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="108.50" y1="24.40" x2="125.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="111.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="157.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="154.50" y1="24.40" x2="171.50" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="157.50" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="203.50" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<line x1="195.00" y1="24.40" x2="223.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="152.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<line x1="149.00" y1="79.20" x2="177.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="198.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<line x1="195.00" y1="79.20" x2="223.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="152.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<line x1="149.00" y1="134.00" x2="177.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<text x="198.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>
+<line x1="195.00" y1="134.00" x2="223.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">30</text>
+<text x="14.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">31</text>
+<line x1="11.00" y1="188.80" x2="39.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">32</text>
+<text x="60.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">33</text>
+<line x1="57.00" y1="188.80" x2="85.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">34</text>
+<text x="106.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">35</text>
+<line x1="103.00" y1="188.80" x2="131.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">36</text>
+<text x="152.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">37</text>
+<line x1="149.00" y1="188.80" x2="177.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">38</text>
+<text x="198.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">39</text>
+<line x1="195.00" y1="188.80" x2="223.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">40</text>
+<text x="14.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="11.00" y1="243.60" x2="39.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="60.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="57.00" y1="243.60" x2="85.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="106.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="103.00" y1="243.60" x2="131.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="152.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="149.00" y1="243.60" x2="177.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="152.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="198.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="195.00" y1="243.60" x2="223.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="198.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_5x5_sqrt.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_5x5_sqrt.golden
@@ -1,0 +1,483 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{SQRT(2) of {5} & SQRT(3) of {6} & SQRT(4) of {7} & SQRT(5) of {8} & SQRT(6) of {9} # SQRT(7) of {10} & SQRT(8) of {11} & SQRT(9) of {12} & SQRT(10) of {13} & SQRT(11) of {14} # SQRT(12) of {15} & SQRT(13) of {16} & SQRT(14) of {17} & SQRT(15) of {18} & SQRT(16) of {19} # SQRT(17) of {20} & SQRT(18) of {21} & SQRT(19) of {22} & SQRT(20) of {23} & SQRT(21) of {24} # SQRT(22) of {25} & SQRT(23) of {26} & SQRT(24) of {27} & SQRT(25) of {28} & SQRT(26) of {29}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "2",
+                    ),
+                ),
+                body: Number(
+                    "5",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "3",
+                    ),
+                ),
+                body: Number(
+                    "6",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "4",
+                    ),
+                ),
+                body: Number(
+                    "7",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "5",
+                    ),
+                ),
+                body: Number(
+                    "8",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "6",
+                    ),
+                ),
+                body: Number(
+                    "9",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "7",
+                    ),
+                ),
+                body: Number(
+                    "10",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "8",
+                    ),
+                ),
+                body: Number(
+                    "11",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "9",
+                    ),
+                ),
+                body: Number(
+                    "12",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "10",
+                    ),
+                ),
+                body: Number(
+                    "13",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "11",
+                    ),
+                ),
+                body: Number(
+                    "14",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "12",
+                    ),
+                ),
+                body: Number(
+                    "15",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "13",
+                    ),
+                ),
+                body: Number(
+                    "16",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "14",
+                    ),
+                ),
+                body: Number(
+                    "17",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "15",
+                    ),
+                ),
+                body: Number(
+                    "18",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "16",
+                    ),
+                ),
+                body: Number(
+                    "19",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "17",
+                    ),
+                ),
+                body: Number(
+                    "20",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "18",
+                    ),
+                ),
+                body: Number(
+                    "21",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "19",
+                    ),
+                ),
+                body: Number(
+                    "22",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "20",
+                    ),
+                ),
+                body: Number(
+                    "23",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "21",
+                    ),
+                ),
+                body: Number(
+                    "24",
+                ),
+            },
+        ],
+        [
+            Sqrt {
+                index: Some(
+                    Number(
+                        "22",
+                    ),
+                ),
+                body: Number(
+                    "25",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "23",
+                    ),
+                ),
+                body: Number(
+                    "26",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "24",
+                    ),
+                ),
+                body: Number(
+                    "27",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "25",
+                    ),
+                ),
+                body: Number(
+                    "28",
+                ),
+            },
+            Sqrt {
+                index: Some(
+                    Number(
+                        "26",
+                    ),
+                ),
+                body: Number(
+                    "29",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=311.0000 h=144.0000 bl=72.0000
+  row0:
+    Sqrt x=19.3500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("2") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("5") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=80.7500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("6") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=142.1500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("7") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=203.5500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("5") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("8") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+    Sqrt x=264.9500 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+      index:
+        Number("6") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("9") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Sqrt x=13.8500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("7") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("10") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=75.2500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("8") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("11") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=136.6500 y=30.0000 w=37.7000 h=24.0000 bl=18.0000
+      index:
+        Number("9") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      body:
+        Number("12") x=14.7000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("10") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("13") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=30.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("11") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("14") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Sqrt x=10.0000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("12") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("15") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("13") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("16") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("14") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("17") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("15") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("18") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=60.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("16") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("19") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Sqrt x=10.0000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("17") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("20") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("18") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("21") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("19") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("22") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("20") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("23") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=90.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("21") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("24") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Sqrt x=10.0000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("22") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("25") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=71.4000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("23") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("26") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=132.8000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("24") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("27") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=194.2000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("25") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("28") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+    Sqrt x=255.6000 y=120.0000 w=45.4000 h=24.0000 bl=18.0000
+      index:
+        Number("26") x=0.0000 y=0.0000 w=15.4000 h=14.0000 bl=11.2000
+      body:
+        Number("29") x=22.4000 y=2.0000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,25.92 0.30,118.08 5.40,144.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M305.60,0.00 C310.70,25.92 310.70,118.08 305.60,144.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M21.05,13.40 L23.05,14.40 L29.05,24.00 L32.05,0.00 L46.05,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="19.35" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="34.05" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<path d="M82.45,13.40 L84.45,14.40 L90.45,24.00 L93.45,0.00 L107.45,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="80.75" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="95.45" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<path d="M143.85,13.40 L145.85,14.40 L151.85,24.00 L154.85,0.00 L168.85,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="142.15" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="156.85" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<path d="M205.25,13.40 L207.25,14.40 L213.25,24.00 L216.25,0.00 L230.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="203.55" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="218.25" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<path d="M266.65,13.40 L268.65,14.40 L274.65,24.00 L277.65,0.00 L291.65,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="264.95" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="279.65" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<path d="M15.55,43.40 L17.55,44.40 L23.55,54.00 L26.55,30.00 L51.55,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.85" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="28.55" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<path d="M76.95,43.40 L78.95,44.40 L84.95,54.00 L87.95,30.00 L112.95,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="75.25" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="89.95" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<path d="M138.35,43.40 L140.35,44.40 L146.35,54.00 L149.35,30.00 L174.35,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="136.65" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>
+<text x="151.35" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<path d="M203.60,43.40 L205.60,44.40 L211.60,54.00 L214.60,30.00 L239.60,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">10</text>
+<text x="216.60" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<path d="M265.00,43.40 L267.00,44.40 L273.00,54.00 L276.00,30.00 L301.00,30.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="41.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">11</text>
+<text x="278.00" y="48.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<path d="M19.40,73.40 L21.40,74.40 L27.40,84.00 L30.40,60.00 L55.40,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">12</text>
+<text x="32.40" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<path d="M80.80,73.40 L82.80,74.40 L88.80,84.00 L91.80,60.00 L116.80,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">13</text>
+<text x="93.80" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<path d="M142.20,73.40 L144.20,74.40 L150.20,84.00 L153.20,60.00 L178.20,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">14</text>
+<text x="155.20" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<path d="M203.60,73.40 L205.60,74.40 L211.60,84.00 L214.60,60.00 L239.60,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">15</text>
+<text x="216.60" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<path d="M265.00,73.40 L267.00,74.40 L273.00,84.00 L276.00,60.00 L301.00,60.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="71.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">16</text>
+<text x="278.00" y="78.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<path d="M19.40,103.40 L21.40,104.40 L27.40,114.00 L30.40,90.00 L55.40,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">17</text>
+<text x="32.40" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<path d="M80.80,103.40 L82.80,104.40 L88.80,114.00 L91.80,90.00 L116.80,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">18</text>
+<text x="93.80" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<path d="M142.20,103.40 L144.20,104.40 L150.20,114.00 L153.20,90.00 L178.20,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">19</text>
+<text x="155.20" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<path d="M203.60,103.40 L205.60,104.40 L211.60,114.00 L214.60,90.00 L239.60,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">20</text>
+<text x="216.60" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<path d="M265.00,103.40 L267.00,104.40 L273.00,114.00 L276.00,90.00 L301.00,90.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="101.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">21</text>
+<text x="278.00" y="108.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<path d="M19.40,133.40 L21.40,134.40 L27.40,144.00 L30.40,120.00 L55.40,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="10.00" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">22</text>
+<text x="32.40" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<path d="M80.80,133.40 L82.80,134.40 L88.80,144.00 L91.80,120.00 L116.80,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="71.40" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">23</text>
+<text x="93.80" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<path d="M142.20,133.40 L144.20,134.40 L150.20,144.00 L153.20,120.00 L178.20,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="132.80" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">24</text>
+<text x="155.20" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">27</text>
+<path d="M203.60,133.40 L205.60,134.40 L211.60,144.00 L214.60,120.00 L239.60,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="194.20" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">25</text>
+<text x="216.60" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">28</text>
+<path d="M265.00,133.40 L267.00,134.40 L273.00,144.00 L276.00,120.00 L301.00,120.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="255.60" y="131.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">26</text>
+<text x="278.00" y="138.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">29</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_7x3_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_7x3_over.golden
@@ -1,0 +1,375 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{{41} OVER {42} & {43} OVER {44} & {45} OVER {46} # {47} OVER {48} & {49} OVER {50} & {51} OVER {52} # {53} OVER {54} & {55} OVER {56} & {57} OVER {58} # {59} OVER {60} & {61} OVER {62} & {63} OVER {64} # {65} OVER {66} & {67} OVER {68} & {69} OVER {70} # {71} OVER {72} & {73} OVER {74} & {75} OVER {76} # {77} OVER {78} & {79} OVER {80} & {81} OVER {82}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "41",
+                ),
+                denom: Number(
+                    "42",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "43",
+                ),
+                denom: Number(
+                    "44",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "45",
+                ),
+                denom: Number(
+                    "46",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "47",
+                ),
+                denom: Number(
+                    "48",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "49",
+                ),
+                denom: Number(
+                    "50",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "51",
+                ),
+                denom: Number(
+                    "52",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "53",
+                ),
+                denom: Number(
+                    "54",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "55",
+                ),
+                denom: Number(
+                    "56",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "57",
+                ),
+                denom: Number(
+                    "58",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "59",
+                ),
+                denom: Number(
+                    "60",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "61",
+                ),
+                denom: Number(
+                    "62",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "63",
+                ),
+                denom: Number(
+                    "64",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "65",
+                ),
+                denom: Number(
+                    "66",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "67",
+                ),
+                denom: Number(
+                    "68",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "69",
+                ),
+                denom: Number(
+                    "70",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "71",
+                ),
+                denom: Number(
+                    "72",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "73",
+                ),
+                denom: Number(
+                    "74",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "75",
+                ),
+                denom: Number(
+                    "76",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "77",
+                ),
+                denom: Number(
+                    "78",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "79",
+                ),
+                denom: Number(
+                    "80",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "81",
+                ),
+                denom: Number(
+                    "82",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=142.0000 h=377.6000 bl=188.8000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("41") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("42") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("43") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("44") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=0.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("45") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("46") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("47") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("48") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("49") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("50") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=54.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("51") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("52") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row2:
+    Fraction x=10.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("53") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("54") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("55") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("56") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=109.6000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("57") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("58") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row3:
+    Fraction x=10.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("59") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("60") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("61") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("62") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=164.4000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("63") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("64") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row4:
+    Fraction x=10.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("65") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("66") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("67") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("68") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=219.2000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("69") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("70") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row5:
+    Fraction x=10.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("71") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("72") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("73") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("74") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=274.0000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("75") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("76") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+  row6:
+    Fraction x=10.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("77") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("78") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=56.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("79") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("80") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+    Fraction x=102.0000 y=328.8000 w=30.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("81") x=4.0000 y=4.0000 w=22.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("82") x=4.0000 y=24.8000 w=22.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,67.97 0.30,309.63 5.40,377.60" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M136.60,0.00 C141.70,67.97 141.70,309.63 136.60,377.60" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">41</text>
+<line x1="11.00" y1="24.40" x2="39.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">42</text>
+<text x="60.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">43</text>
+<line x1="57.00" y1="24.40" x2="85.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">44</text>
+<text x="106.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">45</text>
+<line x1="103.00" y1="24.40" x2="131.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">46</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">47</text>
+<line x1="11.00" y1="79.20" x2="39.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">48</text>
+<text x="60.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">49</text>
+<line x1="57.00" y1="79.20" x2="85.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">50</text>
+<text x="106.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">51</text>
+<line x1="103.00" y1="79.20" x2="131.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">52</text>
+<text x="14.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">53</text>
+<line x1="11.00" y1="134.00" x2="39.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">54</text>
+<text x="60.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">55</text>
+<line x1="57.00" y1="134.00" x2="85.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">56</text>
+<text x="106.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">57</text>
+<line x1="103.00" y1="134.00" x2="131.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">58</text>
+<text x="14.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">59</text>
+<line x1="11.00" y1="188.80" x2="39.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">60</text>
+<text x="60.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">61</text>
+<line x1="57.00" y1="188.80" x2="85.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">62</text>
+<text x="106.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">63</text>
+<line x1="103.00" y1="188.80" x2="131.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">64</text>
+<text x="14.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">65</text>
+<line x1="11.00" y1="243.60" x2="39.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">66</text>
+<text x="60.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">67</text>
+<line x1="57.00" y1="243.60" x2="85.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">68</text>
+<text x="106.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">69</text>
+<line x1="103.00" y1="243.60" x2="131.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">70</text>
+<text x="14.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">71</text>
+<line x1="11.00" y1="298.40" x2="39.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">72</text>
+<text x="60.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">73</text>
+<line x1="57.00" y1="298.40" x2="85.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">74</text>
+<text x="106.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">75</text>
+<line x1="103.00" y1="298.40" x2="131.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">76</text>
+<text x="14.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">77</text>
+<line x1="11.00" y1="353.20" x2="39.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">78</text>
+<text x="60.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">79</text>
+<line x1="57.00" y1="353.20" x2="85.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="60.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">80</text>
+<text x="106.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">81</text>
+<line x1="103.00" y1="353.20" x2="131.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="106.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">82</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_empty_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_empty_brace.golden
@@ -1,0 +1,20 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{}
+honesty: missing-operand
+
+=== ast ===
+Matrix {
+    rows: [
+        [],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=20.0000 h=20.0000 bl=10.0000
+  row0:
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,3.60 0.30,16.40 5.40,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M14.60,0.00 C19.70,3.60 19.70,16.40 14.60,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_jagged.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_jagged.golden
@@ -1,0 +1,57 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{a # b & c # d & e & f}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+        ],
+        [
+            Text(
+                "b",
+            ),
+            Text(
+                "c",
+            ),
+        ],
+        [
+            Text(
+                "d",
+            ),
+            Text(
+                "e",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=86.6500 h=72.0000 bl=36.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("b") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("c") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  row2:
+    Text("d") x=10.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("e") x=37.5500 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("f") x=65.1000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,12.96 0.30,59.04 5.40,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M81.25,0.00 C86.35,12.96 86.35,59.04 81.25,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="10.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="65.10" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_lower.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: pmatrix{a & b # c & d}
+honesty: case-insensitive
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.70,0.00 C58.80,8.28 58.80,37.72 53.70,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX
+honesty: matrix-no-brace-empty
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_over_all.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_over_all.golden
@@ -1,0 +1,88 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{{1} OVER {2} & {3} OVER {4} # {5} OVER {6} & {7} OVER {8}}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Fraction {
+                numer: Number(
+                    "1",
+                ),
+                denom: Number(
+                    "2",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "3",
+                ),
+                denom: Number(
+                    "4",
+                ),
+            },
+        ],
+        [
+            Fraction {
+                numer: Number(
+                    "5",
+                ),
+                denom: Number(
+                    "6",
+                ),
+            },
+            Fraction {
+                numer: Number(
+                    "7",
+                ),
+                denom: Number(
+                    "8",
+                ),
+            },
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=74.0000 h=103.6000 bl=51.8000
+  row0:
+    Fraction x=10.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=45.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Fraction x=10.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+    Fraction x=45.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,18.65 0.30,84.95 5.40,103.60" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M68.60,0.00 C73.70,18.65 73.70,84.95 68.60,103.60" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="14.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="11.00" y1="24.40" x2="28.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="49.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="46.00" y1="24.40" x2="63.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="49.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="14.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="11.00" y1="79.20" x2="28.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="14.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="49.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="46.00" y1="79.20" x2="63.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="49.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_pile_cell.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_pile_cell.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{PILE{a # b} & 0 # 0 & 1}
+honesty: pile-layout-as-row
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Pile {
+                rows: [
+                    Text(
+                        "a",
+                    ),
+                    Text(
+                        "b",
+                    ),
+                ],
+                align: Center,
+            },
+            Number(
+                "0",
+            ),
+        ],
+        [
+            Number(
+                "0",
+            ),
+            Number(
+                "1",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=58.5500 h=72.0000 bl=36.0000
+  row0:
+    Row x=10.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Number("0") x=37.5500 y=13.0000 w=11.0000 h=20.0000 bl=16.0000
+  row1:
+    Number("0") x=10.2750 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+    Number("1") x=37.5500 y=52.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,12.96 0.30,59.04 5.40,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.15,0.00 C58.25,12.96 58.25,59.04 53.15,72.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="37.55" y="29.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="10.28" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="37.55" y="68.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_spacey.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_spacey.golden
@@ -1,0 +1,44 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{ a  &  b  #  c  &  d }
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=10.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=37.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.70,0.00 C58.80,8.28 58.80,37.72 53.70,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="10.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="37.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_trailing_amp.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_trailing_amp.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{a & b &}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+            Empty,
+        ],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=75.1000 h=20.0000 bl=10.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Empty x=65.1000 y=10.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,3.60 0.30,16.40 5.40,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M69.70,0.00 C74.80,3.60 74.80,16.40 69.70,20.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/pmatrix_trailing_hash.golden
+++ b/src/renderer/equation/fixtures/m09_expand/pmatrix_trailing_hash.golden
@@ -1,0 +1,33 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PMATRIX
+script: PMATRIX{a & b #}
+honesty: implemented-variant
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [],
+    ],
+    style: Paren,
+}
+
+=== layout ===
+Matrix(Paren) x=0.0000 y=0.0000 w=59.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=10.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=37.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+
+=== svg ===
+<path d="M5.40,0.00 C0.30,8.28 0.30,37.72 5.40,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M53.70,0.00 C58.80,8.28 58.80,37.72 53.70,46.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="10.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="37.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/quad_space.golden
+++ b/src/renderer/equation/fixtures/m09_expand/quad_space.golden
@@ -1,0 +1,30 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: a QUAD b
+honesty: latex-space
+
+=== ast ===
+Row(
+    [
+        Text(
+            "a",
+        ),
+        Text(
+            "\u{2003}",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=35.7000 h=20.0000 bl=16.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("\u{2003}") x=11.5500 y=0.0000 w=12.6000 h=20.0000 bl=16.0000
+  Text("b") x=24.1500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="11.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif"> </text>
+<text x="24.15" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/rel_arrow.golden
+++ b/src/renderer/equation/fixtures/m09_expand/rel_arrow.golden
@@ -1,0 +1,31 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: REL -> {f} {g}
+honesty: rel-buildrel
+
+=== ast ===
+Rel {
+    arrow: "→",
+    over: Text(
+        "f",
+    ),
+    under: Some(
+        Text(
+            "g",
+        ),
+    ),
+}
+
+=== layout ===
+Rel x=0.0000 y=0.0000 w=16.0000 h=52.0000 bl=26.0000
+  arrow:
+    MathSymbol("→") x=0.0000 y=16.0000 w=16.0000 h=20.0000 bl=16.0000
+  over:
+    Text("f") x=3.9575 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+  under:
+    Text("g") x=3.9575 y=38.0000 w=8.0850 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="3.96" y="11.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>
+<text x="0.00" y="32.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">→</text>
+<text x="3.96" y="49.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">g</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_bare.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_bare.golden
@@ -1,0 +1,18 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Empty,
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=14.0000 h=4.0000 bl=2.0000
+  body:
+    Empty x=13.0000 y=2.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<path d="M0.00,1.40 L2.00,2.40 L8.00,4.00 L11.00,0.00 L14.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/root_brace_of.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_brace_of.golden
@@ -1,0 +1,28 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT {3} of {x}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_empty_body.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_empty_body.golden
@@ -1,0 +1,18 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT { }
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Empty,
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=14.0000 h=4.0000 bl=2.0000
+  body:
+    Empty x=13.0000 y=2.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<path d="M0.00,1.40 L2.00,2.40 L8.00,4.00 L11.00,0.00 L14.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/root_index_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_index_frac.golden
@@ -1,0 +1,39 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT {1 OVER 2} of {x}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=32.8500 h=24.0000 bl=18.0000
+  index:
+    Fraction x=0.0000 y=0.0000 w=13.3000 h=34.1600 bl=20.5800
+      numer:
+        Number("1") x=2.8000 y=2.8000 w=7.7000 h=14.0000 bl=11.2000
+      denom:
+        Number("2") x=2.8000 y=17.3600 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=20.3000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M7.30,13.40 L9.30,14.40 L15.30,24.00 L18.30,0.00 L32.85,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="2.80" y="14.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="0.70" y1="17.08" x2="12.60" y2="17.08" stroke="#000000" stroke-width="0.56"/>
+<text x="2.80" y="28.56" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="20.30" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_latex_index.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_latex_index.golden
@@ -1,0 +1,28 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT[4]{y}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "4",
+        ),
+    ),
+    body: Text(
+        "y",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("4") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("y") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_lower.golden
@@ -1,0 +1,21 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: root x
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_matrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_matrix.golden
@@ -1,0 +1,48 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT MATRIX{1 & 0 # 0 & 1}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Matrix {
+        rows: [
+            [
+                Number(
+                    "1",
+                ),
+                Number(
+                    "0",
+                ),
+            ],
+            [
+                Number(
+                    "0",
+                ),
+                Number(
+                    "1",
+                ),
+            ],
+        ],
+        style: Plain,
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=60.0000 h=50.0000 bl=25.0000
+  body:
+    Matrix(Plain) x=13.0000 y=2.0000 w=46.0000 h=46.0000 bl=23.0000
+      row0:
+        Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("0") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Number("0") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("1") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,29.00 L2.00,30.00 L8.00,50.00 L11.00,0.00 L60.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="44.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="17.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="44.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_mixed_case.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_mixed_case.golden
@@ -1,0 +1,36 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: RoOt {a+b}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=53.1000 h=24.0000 bl=18.0000
+  body:
+    Row x=13.0000 y=2.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L53.10,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="32.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="40.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_nested.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_nested.golden
@@ -1,0 +1,27 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT ROOT x
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Sqrt {
+        index: None,
+        body: Text(
+            "x",
+        ),
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=39.5500 h=28.0000 bl=20.0000
+  body:
+    Sqrt x=13.0000 y=2.0000 w=25.5500 h=24.0000 bl=18.0000
+      body:
+        Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M-0.00,15.80 L2.00,16.80 L8.00,28.00 L11.00,0.00 L39.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M13.00,15.40 L15.00,16.40 L21.00,26.00 L24.00,2.00 L38.55,2.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="26.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_of_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_of_frac.golden
@@ -1,0 +1,32 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT {a OVER b}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Fraction {
+        numer: Text(
+            "a",
+        ),
+        denom: Text(
+            "b",
+        ),
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=33.5500 h=52.8000 bl=31.4000
+  body:
+    Fraction x=13.0000 y=2.0000 w=19.5500 h=48.8000 bl=29.4000
+      numer:
+        Text("a") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+      denom:
+        Text("b") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M-0.00,30.68 L2.00,31.68 L8.00,52.80 L11.00,0.00 L33.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="22.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<line x1="14.00" y1="26.40" x2="31.55" y2="26.40" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="42.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/root_of_paren_idx.golden
+++ b/src/renderer/equation/fixtures/m09_expand/root_of_paren_idx.golden
@@ -1,0 +1,43 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: ROOT
+script: ROOT(n) of {x+y}
+honesty: root-aliases-sqrt
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Text(
+            "n",
+        ),
+    ),
+    body: Row(
+        [
+            Text(
+                "x",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "y",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=55.1850 h=24.0000 bl=18.0000
+  index:
+    Text("n") x=0.0000 y=0.0000 w=8.0850 h=14.0000 bl=11.2000
+  body:
+    Row x=15.0850 y=2.0000 w=39.1000 h=20.0000 bl=16.0000
+      Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("y") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M2.09,13.40 L4.09,14.40 L10.09,24.00 L13.09,0.00 L55.19,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">n</text>
+<text x="15.09" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="34.64" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="42.64" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_expand/rpile_eight_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/rpile_eight_frac.golden
@@ -1,0 +1,144 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: RPILE{{1} OVER {2} # {2} OVER {3} # {3} OVER {4} # {4} OVER {5} # {5} OVER {6} # {6} OVER {7} # {7} OVER {8} # {8} OVER {9}}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "2",
+            ),
+            denom: Number(
+                "3",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "3",
+            ),
+            denom: Number(
+                "4",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "4",
+            ),
+            denom: Number(
+                "5",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "5",
+            ),
+            denom: Number(
+                "6",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "6",
+            ),
+            denom: Number(
+                "7",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "7",
+            ),
+            denom: Number(
+                "8",
+            ),
+        },
+        Fraction {
+            numer: Number(
+                "8",
+            ),
+            denom: Number(
+                "9",
+            ),
+        },
+    ],
+    align: Right,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=19.0000 h=432.4000 bl=216.2000
+  Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("2") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("3") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=109.6000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=164.4000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("4") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("5") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=219.2000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=274.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("6") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("7") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=328.8000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Fraction x=0.0000 y=383.6000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("8") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("9") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="4.00" y="74.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="1.00" y1="79.20" x2="18.00" y2="79.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="95.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="4.00" y="129.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="1.00" y1="134.00" x2="18.00" y2="134.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="150.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="4.00" y="184.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<line x1="1.00" y1="188.80" x2="18.00" y2="188.80" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="205.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<text x="4.00" y="239.20" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="1.00" y1="243.60" x2="18.00" y2="243.60" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="260.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="4.00" y="294.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<line x1="1.00" y1="298.40" x2="18.00" y2="298.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="314.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<text x="4.00" y="348.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="1.00" y1="353.20" x2="18.00" y2="353.20" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="369.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<text x="4.00" y="403.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>
+<line x1="1.00" y1="408.00" x2="18.00" y2="408.00" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="424.40" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">9</text>

--- a/src/renderer/equation/fixtures/m09_expand/rpile_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/rpile_lower.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: rpile{a # b}
+honesty: case-insensitive
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+    ],
+    align: Right,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=46.0000 bl=23.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/rpile_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/rpile_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: RPILE
+honesty: pile-layout-as-row
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/rpile_over.golden
+++ b/src/renderer/equation/fixtures/m09_expand/rpile_over.golden
@@ -1,0 +1,37 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: RPILE{{1} OVER {2} # x}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        Text(
+            "x",
+        ),
+    ],
+    align: Right,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=19.0000 h=74.8000 bl=37.4000
+  Fraction x=0.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+    numer:
+      Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+    denom:
+      Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+  Text("x") x=7.4500 y=54.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="1.00" y1="24.40" x2="18.00" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="7.45" y="70.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/rpile_three.golden
+++ b/src/renderer/equation/fixtures/m09_expand/rpile_three.golden
@@ -1,0 +1,31 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: PILE
+script: RPILE{a # b # c}
+honesty: pile-layout-as-row
+
+=== ast ===
+Pile {
+    rows: [
+        Text(
+            "a",
+        ),
+        Text(
+            "b",
+        ),
+        Text(
+            "c",
+        ),
+    ],
+    align: Right,
+}
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=11.5500 h=72.0000 bl=36.0000
+  Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+  Text("c") x=0.0000 y=52.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="0.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="0.00" y="68.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>

--- a/src/renderer/equation/fixtures/m09_expand/sladder_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sladder_2x2.golden
@@ -1,0 +1,42 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: SLADDER{a & b # c & d}
+honesty: ladder-fallback-matrix
+
+=== ast ===
+Matrix {
+    rows: [
+        [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        [
+            Text(
+                "c",
+            ),
+            Text(
+                "d",
+            ),
+        ],
+    ],
+    style: Plain,
+}
+
+=== layout ===
+Matrix(Plain) x=0.0000 y=0.0000 w=47.1000 h=46.0000 bl=23.0000
+  row0:
+    Text("a") x=4.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  row1:
+    Text("c") x=4.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+    Text("d") x=31.5500 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="31.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="4.00" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="31.55" y="42.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/sladder_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sladder_no_brace.golden
@@ -1,0 +1,12 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: SLADDER
+honesty: ladder-fallback-matrix
+
+=== ast ===
+Empty
+
+=== layout ===
+Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===

--- a/src/renderer/equation/fixtures/m09_expand/smallmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/smallmatrix_2x2.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: SMALLMATRIX{a & b # c & d}
+honesty: smallmatrix-unimpl-text
+
+=== ast ===
+Row(
+    [
+        Text(
+            "SMALLMATRIX",
+        ),
+        Row(
+            [
+                Text(
+                    "a",
+                ),
+                Space(
+                    Tab,
+                ),
+                Text(
+                    "b",
+                ),
+                Newline,
+                Text(
+                    "c",
+                ),
+                Space(
+                    Tab,
+                ),
+                Text(
+                    "d",
+                ),
+            ],
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=236.3500 h=20.0000 bl=16.0000
+  Text("SMALLMATRIX") x=0.0000 y=0.0000 w=150.1500 h=20.0000 bl=16.0000
+  Row x=150.1500 y=0.0000 w=86.2000 h=20.0000 bl=16.0000
+    Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Space(20.0000) x=11.5500 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Newline x=43.1000 y=16.0000 w=0.0000 h=0.0000 bl=0.0000
+    Text("c") x=43.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Space(20.0000) x=54.6500 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+    Text("d") x=74.6500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">SMALLMATRIX</text>
+<text x="150.15" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="181.70" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="193.25" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="224.80" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/smallmatrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/smallmatrix_no_brace.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: SMALLMATRIX
+honesty: smallmatrix-unimpl-text
+
+=== ast ===
+Text(
+    "SMALLMATRIX",
+)
+
+=== layout ===
+Text("SMALLMATRIX") x=0.0000 y=0.0000 w=150.1500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">SMALLMATRIX</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_bare.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_bare.golden
@@ -1,0 +1,18 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT
+honesty: missing-operand
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Empty,
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=14.0000 h=4.0000 bl=2.0000
+  body:
+    Empty x=13.0000 y=2.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<path d="M0.00,1.40 L2.00,2.40 L8.00,4.00 L11.00,0.00 L14.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_empty_body.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_empty_body.golden
@@ -1,0 +1,18 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT { }
+honesty: missing-operand
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Empty,
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=14.0000 h=4.0000 bl=2.0000
+  body:
+    Empty x=13.0000 y=2.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<path d="M0.00,1.40 L2.00,2.40 L8.00,4.00 L11.00,0.00 L14.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_empty_paren.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_empty_paren.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT() of x
+honesty: missing-operand
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Empty,
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  index:
+    Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_eqalign.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_eqalign.golden
@@ -1,0 +1,45 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: EQALIGN{SQRT x &= y}
+honesty: implemented-variant
+
+=== ast ===
+EqAlign {
+    rows: [
+        (
+            Sqrt {
+                index: None,
+                body: Text(
+                    "x",
+                ),
+            },
+            Row(
+                [
+                    Symbol(
+                        "=",
+                    ),
+                    Text(
+                        "y",
+                    ),
+                ],
+            ),
+        ),
+    ],
+}
+
+=== layout ===
+EqAlign x=0.0000 y=0.0000 w=56.1000 h=24.0000 bl=12.0000
+  row0.left:
+    Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+      body:
+        Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+  row0.right:
+    Row x=28.5500 y=2.0000 w=27.5500 h=20.0000 bl=16.0000
+      Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("y") x=16.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="36.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="44.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">y</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_index_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_index_frac.golden
@@ -1,0 +1,39 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT {1 OVER 2} of {x}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=32.8500 h=24.0000 bl=18.0000
+  index:
+    Fraction x=0.0000 y=0.0000 w=13.3000 h=34.1600 bl=20.5800
+      numer:
+        Number("1") x=2.8000 y=2.8000 w=7.7000 h=14.0000 bl=11.2000
+      denom:
+        Number("2") x=2.8000 y=17.3600 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=20.3000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M7.30,13.40 L9.30,14.40 L15.30,24.00 L18.30,0.00 L32.85,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="2.80" y="14.00" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="0.70" y1="17.08" x2="12.60" y2="17.08" stroke="#000000" stroke-width="0.56"/>
+<text x="2.80" y="28.56" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="20.30" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_index_zero.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_index_zero.golden
@@ -1,0 +1,28 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT(0) of 1
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "0",
+        ),
+    ),
+    body: Number(
+        "1",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=26.7000 h=24.0000 bl=18.0000
+  index:
+    Number("0") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Number("1") x=14.7000 y=2.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L26.70,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_int.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_int.golden
@@ -1,0 +1,52 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT {int_0^1 x dx}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            SubSup {
+                base: MathSymbol(
+                    "∫",
+                ),
+                sub: Number(
+                    "0",
+                ),
+                sup: Number(
+                    "1",
+                ),
+            },
+            Text(
+                "x",
+            ),
+            Text(
+                "dx",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=79.7500 h=58.1200 bl=39.2000
+  body:
+    Row x=13.0000 y=2.0000 w=65.7500 h=54.1200 bl=37.2000
+      SubSup x=0.0000 y=0.0000 w=31.1000 h=54.1200 bl=37.2000
+        base:
+          MathSymbol("∫") x=0.0000 y=2.2000 w=10.4000 h=50.0000 bl=35.0000
+        sub:
+          Number("0") x=5.2000 y=40.1200 w=7.7000 h=14.0000 bl=11.2000
+        sup:
+          Number("1") x=14.4000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+      Text("x") x=31.1000 y=21.2000 w=11.5500 h=20.0000 bl=16.0000
+      Text("dx") x=42.6500 y=21.2000 w=23.1000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,33.87 L2.00,34.87 L8.00,58.12 L11.00,0.00 L79.75,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M13.80,52.20 C23.61,38.40 11.96,20.00 23.00,6.20" fill="none" stroke="#000000" stroke-width="1.20" stroke-linecap="round"/>
+<text x="18.20" y="53.32" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="27.40" y="13.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="44.10" y="39.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="55.65" y="39.20" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">dx</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_latex_empty_idx.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_latex_empty_idx.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT[]{x}
+honesty: missing-operand
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Empty,
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  index:
+    Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_latex_index.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_latex_index.golden
@@ -1,0 +1,28 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT[3]{x}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_long.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_long.golden
@@ -1,0 +1,76 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT {a+b+c+d+e+f}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Row(
+        [
+            Text(
+                "a",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "b",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "c",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "d",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "e",
+            ),
+            Symbol(
+                "+",
+            ),
+            Text(
+                "f",
+            ),
+        ],
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=163.3000 h=24.0000 bl=18.0000
+  body:
+    Row x=13.0000 y=2.0000 w=149.3000 h=20.0000 bl=16.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=11.5500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("b") x=27.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=39.1000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("c") x=55.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=66.6500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("d") x=82.6500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=94.2000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("e") x=110.2000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Symbol("+") x=121.7500 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+      Text("f") x=137.7500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L163.30,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="32.55" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="40.55" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="60.10" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="68.10" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="87.65" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="95.65" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>
+<text x="115.20" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="123.20" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">e</text>
+<text x="142.75" y="18.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">+</text>
+<text x="150.75" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">f</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_lower.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_lower.golden
@@ -1,0 +1,21 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: sqrt x
+honesty: case-insensitive
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_mixed_case.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_mixed_case.golden
@@ -1,0 +1,21 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SqRt x
+honesty: case-insensitive
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=24.0000 bl=18.0000
+  body:
+    Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_nested.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_nested.golden
@@ -1,0 +1,27 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT SQRT x
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Sqrt {
+        index: None,
+        body: Text(
+            "x",
+        ),
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=39.5500 h=28.0000 bl=20.0000
+  body:
+    Sqrt x=13.0000 y=2.0000 w=25.5500 h=24.0000 bl=18.0000
+      body:
+        Text("x") x=13.0000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M-0.00,15.80 L2.00,16.80 L8.00,28.00 L11.00,0.00 L39.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M13.00,15.40 L15.00,16.40 L21.00,26.00 L24.00,2.00 L38.55,2.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="26.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_nested_pmatrix_3.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_nested_pmatrix_3.golden
@@ -1,0 +1,101 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT {3} of {PMATRIX{{1} OVER {2} & {3} OVER {4} # {5} OVER {6} & {7} OVER {8}}}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Matrix {
+        rows: [
+            [
+                Fraction {
+                    numer: Number(
+                        "1",
+                    ),
+                    denom: Number(
+                        "2",
+                    ),
+                },
+                Fraction {
+                    numer: Number(
+                        "3",
+                    ),
+                    denom: Number(
+                        "4",
+                    ),
+                },
+            ],
+            [
+                Fraction {
+                    numer: Number(
+                        "5",
+                    ),
+                    denom: Number(
+                        "6",
+                    ),
+                },
+                Fraction {
+                    numer: Number(
+                        "7",
+                    ),
+                    denom: Number(
+                        "8",
+                    ),
+                },
+            ],
+        ],
+        style: Paren,
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=89.7000 h=107.6000 bl=53.8000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Matrix(Paren) x=14.7000 y=2.0000 w=74.0000 h=103.6000 bl=51.8000
+      row0:
+        Fraction x=10.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+        Fraction x=45.0000 y=0.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("3") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("4") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Fraction x=10.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("5") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("6") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+        Fraction x=45.0000 y=54.8000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("7") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("8") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,63.56 L3.70,64.56 L9.70,107.60 L12.70,0.00 L89.70,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<path d="M20.10,2.00 C15.00,20.65 15.00,86.95 20.10,105.60" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M83.30,2.00 C88.40,20.65 88.40,86.95 83.30,105.60" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="28.70" y="22.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="25.70" y1="26.40" x2="42.70" y2="26.40" stroke="#000000" stroke-width="0.80"/>
+<text x="28.70" y="42.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="63.70" y="22.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<line x1="60.70" y1="26.40" x2="77.70" y2="26.40" stroke="#000000" stroke-width="0.80"/>
+<text x="63.70" y="42.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>
+<text x="28.70" y="76.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">5</text>
+<line x1="25.70" y1="81.20" x2="42.70" y2="81.20" stroke="#000000" stroke-width="0.80"/>
+<text x="28.70" y="97.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">6</text>
+<text x="63.70" y="76.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">7</text>
+<line x1="60.70" y1="81.20" x2="77.70" y2="81.20" stroke="#000000" stroke-width="0.80"/>
+<text x="63.70" y="97.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">8</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_of_frac.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_of_frac.golden
@@ -1,0 +1,32 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT {1 OVER 2}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Fraction {
+        numer: Number(
+            "1",
+        ),
+        denom: Number(
+            "2",
+        ),
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=33.0000 h=52.8000 bl=31.4000
+  body:
+    Fraction x=13.0000 y=2.0000 w=19.0000 h=48.8000 bl=29.4000
+      numer:
+        Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,30.68 L2.00,31.68 L8.00,52.80 L11.00,0.00 L33.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="22.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="14.00" y1="26.40" x2="31.00" y2="26.40" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="42.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_of_matrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_of_matrix.golden
@@ -1,0 +1,48 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT MATRIX{1 & 0 # 0 & 1}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Matrix {
+        rows: [
+            [
+                Number(
+                    "1",
+                ),
+                Number(
+                    "0",
+                ),
+            ],
+            [
+                Number(
+                    "0",
+                ),
+                Number(
+                    "1",
+                ),
+            ],
+        ],
+        style: Plain,
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=60.0000 h=50.0000 bl=25.0000
+  body:
+    Matrix(Plain) x=13.0000 y=2.0000 w=46.0000 h=46.0000 bl=23.0000
+      row0:
+        Number("1") x=4.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("0") x=31.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Number("0") x=4.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("1") x=31.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,29.00 L2.00,30.00 L8.00,50.00 L11.00,0.00 L60.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="17.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="44.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="17.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">0</text>
+<text x="44.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_of_over_chain.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_of_over_chain.golden
@@ -1,0 +1,43 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT {1 OVER 2 OVER 3}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Fraction {
+        numer: Fraction {
+            numer: Number(
+                "1",
+            ),
+            denom: Number(
+                "2",
+            ),
+        },
+        denom: Number(
+            "3",
+        ),
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=41.0000 h=81.6000 bl=60.2000
+  body:
+    Fraction x=13.0000 y=2.0000 w=27.0000 h=77.6000 bl=58.2000
+      numer:
+        Fraction x=4.0000 y=4.0000 w=19.0000 h=48.8000 bl=29.4000
+          numer:
+            Number("1") x=4.0000 y=4.0000 w=11.0000 h=20.0000 bl=16.0000
+          denom:
+            Number("2") x=4.0000 y=24.8000 w=11.0000 h=20.0000 bl=16.0000
+      denom:
+        Number("3") x=8.0000 y=53.6000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,47.96 L2.00,48.96 L8.00,81.60 L11.00,0.00 L41.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="21.00" y="26.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<line x1="18.00" y1="30.40" x2="35.00" y2="30.40" stroke="#000000" stroke-width="0.80"/>
+<text x="21.00" y="46.80" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<line x1="14.00" y1="55.20" x2="39.00" y2="55.20" stroke="#000000" stroke-width="0.80"/>
+<text x="21.00" y="71.60" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_of_pile.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_of_pile.golden
@@ -1,0 +1,32 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT PILE{a # b}
+honesty: pile-layout-as-row
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Pile {
+        rows: [
+            Text(
+                "a",
+            ),
+            Text(
+                "b",
+            ),
+        ],
+        align: Center,
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=25.5500 h=50.0000 bl=25.0000
+  body:
+    Row x=13.0000 y=2.0000 w=11.5500 h=46.0000 bl=23.0000
+      Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      Text("b") x=0.0000 y=26.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,29.00 L2.00,30.00 L8.00,50.00 L11.00,0.00 L25.55,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="13.00" y="44.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_of_pmatrix.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_of_pmatrix.golden
@@ -1,0 +1,50 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT PMATRIX{1 & 2 # 3 & 4}
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Matrix {
+        rows: [
+            [
+                Number(
+                    "1",
+                ),
+                Number(
+                    "2",
+                ),
+            ],
+            [
+                Number(
+                    "3",
+                ),
+                Number(
+                    "4",
+                ),
+            ],
+        ],
+        style: Paren,
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=72.0000 h=50.0000 bl=25.0000
+  body:
+    Matrix(Paren) x=13.0000 y=2.0000 w=58.0000 h=46.0000 bl=23.0000
+      row0:
+        Number("1") x=10.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("2") x=37.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+      row1:
+        Number("3") x=10.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+        Number("4") x=37.0000 y=26.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M0.00,29.00 L2.00,30.00 L8.00,50.00 L11.00,0.00 L72.00,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<path d="M18.40,2.00 C13.30,10.28 13.30,39.72 18.40,48.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<path d="M65.60,2.00 C70.70,10.28 70.70,39.72 65.60,48.00" fill="none" stroke="#000000" stroke-width="0.84" stroke-linecap="round"/>
+<text x="23.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>
+<text x="50.00" y="18.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>
+<text x="23.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="50.00" y="44.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">4</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_paren_no_of.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_paren_no_of.golden
@@ -1,0 +1,28 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT(3) x
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: Some(
+        Number(
+            "3",
+        ),
+    ),
+    body: Text(
+        "x",
+    ),
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=27.2500 h=24.0000 bl=18.0000
+  index:
+    Number("3") x=0.0000 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+  body:
+    Text("x") x=14.7000 y=2.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<path d="M1.70,13.40 L3.70,14.40 L9.70,24.00 L12.70,0.00 L27.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="0.00" y="11.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">3</text>
+<text x="14.70" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/sqrt_sup.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sqrt_sup.golden
@@ -1,0 +1,31 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: SQRT
+script: SQRT x^2
+honesty: implemented-variant
+
+=== ast ===
+Sqrt {
+    index: None,
+    body: Superscript {
+        base: Text(
+            "x",
+        ),
+        sup: Number(
+            "2",
+        ),
+    },
+}
+
+=== layout ===
+Sqrt x=0.0000 y=0.0000 w=33.2500 h=24.0000 bl=18.0000
+  body:
+    Superscript x=13.0000 y=2.0000 w=19.2500 h=20.0000 bl=16.0000
+      base:
+        Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+      sup:
+        Number("2") x=11.5500 y=0.0000 w=7.7000 h=14.0000 bl=11.2000
+
+=== svg ===
+<path d="M0.00,13.40 L2.00,14.40 L8.00,24.00 L11.00,0.00 L33.25,0.00" fill="none" stroke="#000000" stroke-width="0.80"/>
+<text x="13.00" y="18.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>
+<text x="24.55" y="13.20" font-size="14.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/stackrel_star.golden
+++ b/src/renderer/equation/fixtures/m09_expand/stackrel_star.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: STACKREL{*}{=}
+honesty: latex-stack
+
+=== ast ===
+Superscript {
+    base: Symbol(
+        "=",
+    ),
+    sup: Symbol(
+        "*",
+    ),
+}
+
+=== layout ===
+Superscript x=0.0000 y=0.0000 w=24.4000 h=20.0000 bl=16.0000
+  base:
+    Symbol("=") x=0.0000 y=0.0000 w=16.0000 h=20.0000 bl=16.0000
+  sup:
+    Symbol("*") x=16.0000 y=0.0000 w=8.4000 h=14.0000 bl=11.2000
+
+=== svg ===
+<text x="8.00" y="16.00" font-size="20.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">=</text>
+<text x="20.20" y="11.20" font-size="14.00" fill="#000000" text-anchor="middle" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">*</text>

--- a/src/renderer/equation/fixtures/m09_expand/sub_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sub_cmd.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: SUB{i}
+honesty: left-script
+
+=== ast ===
+Text(
+    "i",
+)
+
+=== layout ===
+Text("i") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">i</text>

--- a/src/renderer/equation/fixtures/m09_expand/sup_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/sup_cmd.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: SUP{2}
+honesty: left-script
+
+=== ast ===
+Number(
+    "2",
+)
+
+=== layout ===
+Number("2") x=0.0000 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">2</text>

--- a/src/renderer/equation/fixtures/m09_expand/text_cmd.golden
+++ b/src/renderer/equation/fixtures/m09_expand/text_cmd.golden
@@ -1,0 +1,19 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: TEXT{if}
+honesty: latex-text
+
+=== ast ===
+FontStyle {
+    style: Roman,
+    body: Text(
+        "if",
+    ),
+}
+
+=== layout ===
+FontStyle(Roman) x=0.0000 y=0.0000 w=23.1000 h=20.0000 bl=16.0000
+  Text("if") x=0.0000 y=0.0000 w=23.1000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">if</text>

--- a/src/renderer/equation/fixtures/m09_expand/tfrac_latex.golden
+++ b/src/renderer/equation/fixtures/m09_expand/tfrac_latex.golden
@@ -1,0 +1,26 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: TFRAC{a}{b}
+honesty: latex-frac
+
+=== ast ===
+Fraction {
+    numer: Text(
+        "a",
+    ),
+    denom: Text(
+        "b",
+    ),
+}
+
+=== layout ===
+Fraction x=0.0000 y=0.0000 w=19.5500 h=48.8000 bl=29.4000
+  numer:
+    Text("a") x=4.0000 y=4.0000 w=11.5500 h=20.0000 bl=16.0000
+  denom:
+    Text("b") x=4.0000 y=24.8000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="4.00" y="20.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<line x1="1.00" y1="24.40" x2="18.55" y2="24.40" stroke="#000000" stroke-width="0.80"/>
+<text x="4.00" y="40.80" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>

--- a/src/renderer/equation/fixtures/m09_expand/underset_bar.golden
+++ b/src/renderer/equation/fixtures/m09_expand/underset_bar.golden
@@ -1,0 +1,29 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: OVER
+script: UNDERSET{_}{x}
+honesty: latex-stack
+
+=== ast ===
+Subscript {
+    base: Text(
+        "x",
+    ),
+    sub: Subscript {
+        base: Empty,
+        sub: Empty,
+    },
+}
+
+=== layout ===
+Subscript x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  base:
+    Text("x") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+  sub:
+    Subscript x=11.5500 y=6.4000 w=0.0000 h=0.0000 bl=0.0000
+      base:
+        Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+      sub:
+        Empty x=0.0000 y=0.0000 w=0.0000 h=0.0000 bl=0.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">x</text>

--- a/src/renderer/equation/fixtures/m09_expand/unknown_foobar.golden
+++ b/src/renderer/equation/fixtures/m09_expand/unknown_foobar.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: FOOBAR
+honesty: unknown-command-text
+
+=== ast ===
+Text(
+    "FOOBAR",
+)
+
+=== layout ===
+Text("FOOBAR") x=0.0000 y=0.0000 w=81.9000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">FOOBAR</text>

--- a/src/renderer/equation/fixtures/m09_expand/unknown_xyz.golden
+++ b/src/renderer/equation/fixtures/m09_expand/unknown_xyz.golden
@@ -1,0 +1,25 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: XYZ{1}
+honesty: unknown-command-text
+
+=== ast ===
+Row(
+    [
+        Text(
+            "XYZ",
+        ),
+        Number(
+            "1",
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=51.9500 h=20.0000 bl=16.0000
+  Text("XYZ") x=0.0000 y=0.0000 w=40.9500 h=20.0000 bl=16.0000
+  Number("1") x=40.9500 y=0.0000 w=11.0000 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">XYZ</text>
+<text x="40.95" y="16.00" font-size="20.00" fill="#000000" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">1</text>

--- a/src/renderer/equation/fixtures/m09_expand/vmatrix_2x2.golden
+++ b/src/renderer/equation/fixtures/m09_expand/vmatrix_2x2.golden
@@ -1,0 +1,55 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: VMATRIX{a & b # c & d}
+honesty: vmatrix-unimpl-text
+
+=== ast ===
+Row(
+    [
+        Text(
+            "VMATRIX",
+        ),
+        Row(
+            [
+                Text(
+                    "a",
+                ),
+                Space(
+                    Tab,
+                ),
+                Text(
+                    "b",
+                ),
+                Newline,
+                Text(
+                    "c",
+                ),
+                Space(
+                    Tab,
+                ),
+                Text(
+                    "d",
+                ),
+            ],
+        ),
+    ],
+)
+
+=== layout ===
+Row x=0.0000 y=0.0000 w=181.7500 h=20.0000 bl=16.0000
+  Text("VMATRIX") x=0.0000 y=0.0000 w=95.5500 h=20.0000 bl=16.0000
+  Row x=95.5500 y=0.0000 w=86.2000 h=20.0000 bl=16.0000
+    Text("a") x=0.0000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Space(20.0000) x=11.5500 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+    Text("b") x=31.5500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Newline x=43.1000 y=16.0000 w=0.0000 h=0.0000 bl=0.0000
+    Text("c") x=43.1000 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+    Space(20.0000) x=54.6500 y=0.0000 w=20.0000 h=20.0000 bl=16.0000
+    Text("d") x=74.6500 y=0.0000 w=11.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">VMATRIX</text>
+<text x="95.55" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">a</text>
+<text x="127.10" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">b</text>
+<text x="138.65" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">c</text>
+<text x="170.20" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">d</text>

--- a/src/renderer/equation/fixtures/m09_expand/vmatrix_no_brace.golden
+++ b/src/renderer/equation/fixtures/m09_expand/vmatrix_no_brace.golden
@@ -1,0 +1,15 @@
+# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)
+command: MATRIX
+script: VMATRIX
+honesty: vmatrix-unimpl-text
+
+=== ast ===
+Text(
+    "VMATRIX",
+)
+
+=== layout ===
+Text("VMATRIX") x=0.0000 y=0.0000 w=95.5500 h=20.0000 bl=16.0000
+
+=== svg ===
+<text x="0.00" y="16.00" font-size="20.00" fill="#000000" font-style="italic" font-family="'Latin Modern Math', 'STIX Two Text', 'STIX Two Math', 'Times New Roman', 'Times', serif">VMATRIX</text>

--- a/tests/cases/equation_command_goldens.rs
+++ b/tests/cases/equation_command_goldens.rs
@@ -1,0 +1,428 @@
+//! M09-1 + M09-g: 수식 명령 골든 (변형·예외·미구현 정직 표).
+//!
+//! OVER/SQRT/ROOT/MATRIX/PMATRIX/BMATRIX/DMATRIX/EQALIGN/PILE 의 현재
+//! 파서·레이아웃·SVG 출력을 잠근다. 엔진을 고치거나 디스패치를 리팩터하지
+//! 않는다(M09-2). 미구현·축약 동작도 현행 그대로 고정한다.
+//!
+//! 카탈로그: `src/renderer/equation/fixtures/catalog.tsv`
+//! 골든 갱신: `UPDATE_EQ_GOLDENS=1 cargo test --test <suite> equation_command_goldens`
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use rhwp::renderer::equation::ast::MatrixStyle;
+use rhwp::renderer::equation::layout::{EqLayout, LayoutBox, LayoutKind};
+use rhwp::renderer::equation::parser::parse;
+use rhwp::renderer::equation::svg_render::render_equation_svg;
+
+const FONT_SIZE: f64 = 20.0;
+const COLOR: &str = "#000000";
+const FIXTURE_ROOT: &str = "src/renderer/equation/fixtures";
+const CATALOG_FILE: &str = "catalog.tsv";
+
+/// M09-1 원본 31종 id. 확장 카탈로그가 이 집합을 반드시 포함한다.
+const M09_1_IDS: &[&str] = &[
+    "over_simple",
+    "over_grouped",
+    "over_nested",
+    "over_glued_denom",
+    "over_in_paren",
+    "sqrt_ident",
+    "sqrt_group",
+    "sqrt_index_paren",
+    "sqrt_index_brace",
+    "root_ident",
+    "root_group",
+    "root_index",
+    "matrix_2x2",
+    "matrix_col",
+    "matrix_row",
+    "matrix_no_brace",
+    "pmatrix_2x2",
+    "pmatrix_1x1",
+    "pmatrix_frac",
+    "bmatrix_2x2",
+    "bmatrix_identity",
+    "bmatrix_1x2",
+    "dmatrix_2x2",
+    "dmatrix_col",
+    "dmatrix_1x1",
+    "eqalign_two",
+    "eqalign_one",
+    "eqalign_no_amp",
+    "pile_center",
+    "lpile_left",
+    "rpile_right",
+];
+
+const REQUIRED_COMMANDS: &[&str] = &[
+    "OVER", "SQRT", "ROOT", "MATRIX", "PMATRIX", "BMATRIX", "DMATRIX", "EQALIGN", "PILE",
+];
+
+struct GoldenCase {
+    id: String,
+    dir: String,
+    command: String,
+    honesty: String,
+    script: String,
+}
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_ROOT)
+}
+
+fn catalog_path() -> PathBuf {
+    fixture_root().join(CATALOG_FILE)
+}
+
+fn golden_path(case: &GoldenCase) -> PathBuf {
+    fixture_root()
+        .join(&case.dir)
+        .join(format!("{}.golden", case.id))
+}
+
+fn load_catalog() -> Vec<GoldenCase> {
+    let raw = std::fs::read_to_string(catalog_path())
+        .unwrap_or_else(|e| panic!("read catalog {}: {e}", catalog_path().display()));
+    let mut cases = Vec::new();
+    for (lineno, line) in raw.lines().enumerate() {
+        let line = line.trim_end();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        assert_eq!(
+            cols.len(),
+            5,
+            "catalog.tsv:{}: expected 5 TAB columns, got {}",
+            lineno + 1,
+            cols.len()
+        );
+        cases.push(GoldenCase {
+            id: cols[0].to_string(),
+            dir: cols[1].to_string(),
+            command: cols[2].to_string(),
+            honesty: cols[3].to_string(),
+            script: cols[4].to_string(),
+        });
+    }
+    cases
+}
+
+fn snapshot_of(case: &GoldenCase) -> String {
+    let ast = parse(&case.script);
+    let layout = EqLayout::new(FONT_SIZE).layout(&ast);
+    let svg = render_equation_svg(&layout, COLOR, FONT_SIZE);
+    let mut layout_ir = String::new();
+    dump_layout(&mut layout_ir, &layout, 0);
+    if case.dir == "m09_1" {
+        format!(
+            "# M09-1 equation golden — current-engine lock\n\
+             command: {}\n\
+             script: {}\n\
+             \n\
+             === ast ===\n\
+             {:#?}\n\
+             \n\
+             === layout ===\n\
+             {}\n\
+             === svg ===\n\
+             {}",
+            case.command, case.script, ast, layout_ir, svg
+        )
+    } else {
+        format!(
+            "# M09-g equation golden — current-engine lock (variant/exception/unimplemented honesty)\n\
+             command: {}\n\
+             script: {}\n\
+             honesty: {}\n\
+             \n\
+             === ast ===\n\
+             {:#?}\n\
+             \n\
+             === layout ===\n\
+             {}\n\
+             === svg ===\n\
+             {}",
+            case.command, case.script, case.honesty, ast, layout_ir, svg
+        )
+    }
+    .replace("\r\n", "\n")
+}
+
+fn dump_layout(out: &mut String, lb: &LayoutBox, indent: usize) {
+    let pad = "  ".repeat(indent);
+    let metrics = format!(
+        "x={:.4} y={:.4} w={:.4} h={:.4} bl={:.4}",
+        lb.x, lb.y, lb.width, lb.height, lb.baseline
+    );
+    match &lb.kind {
+        LayoutKind::Row(children) => {
+            let _ = writeln!(out, "{pad}Row {metrics}");
+            for child in children {
+                dump_layout(out, child, indent + 1);
+            }
+        }
+        LayoutKind::Text(text) => {
+            let _ = writeln!(out, "{pad}Text({text:?}) {metrics}");
+        }
+        LayoutKind::Number(text) => {
+            let _ = writeln!(out, "{pad}Number({text:?}) {metrics}");
+        }
+        LayoutKind::Symbol(text) => {
+            let _ = writeln!(out, "{pad}Symbol({text:?}) {metrics}");
+        }
+        LayoutKind::MathSymbol(text) => {
+            let _ = writeln!(out, "{pad}MathSymbol({text:?}) {metrics}");
+        }
+        LayoutKind::Function(text) => {
+            let _ = writeln!(out, "{pad}Function({text:?}) {metrics}");
+        }
+        LayoutKind::Fraction { numer, denom } => {
+            let _ = writeln!(out, "{pad}Fraction {metrics}");
+            let _ = writeln!(out, "{pad}  numer:");
+            dump_layout(out, numer, indent + 2);
+            let _ = writeln!(out, "{pad}  denom:");
+            dump_layout(out, denom, indent + 2);
+        }
+        LayoutKind::Atop { top, bottom } => {
+            let _ = writeln!(out, "{pad}Atop {metrics}");
+            let _ = writeln!(out, "{pad}  top:");
+            dump_layout(out, top, indent + 2);
+            let _ = writeln!(out, "{pad}  bottom:");
+            dump_layout(out, bottom, indent + 2);
+        }
+        LayoutKind::Sqrt { index, body } => {
+            let _ = writeln!(out, "{pad}Sqrt {metrics}");
+            if let Some(index) = index {
+                let _ = writeln!(out, "{pad}  index:");
+                dump_layout(out, index, indent + 2);
+            }
+            let _ = writeln!(out, "{pad}  body:");
+            dump_layout(out, body, indent + 2);
+        }
+        LayoutKind::Superscript { base, sup } => {
+            let _ = writeln!(out, "{pad}Superscript {metrics}");
+            let _ = writeln!(out, "{pad}  base:");
+            dump_layout(out, base, indent + 2);
+            let _ = writeln!(out, "{pad}  sup:");
+            dump_layout(out, sup, indent + 2);
+        }
+        LayoutKind::Subscript { base, sub } => {
+            let _ = writeln!(out, "{pad}Subscript {metrics}");
+            let _ = writeln!(out, "{pad}  base:");
+            dump_layout(out, base, indent + 2);
+            let _ = writeln!(out, "{pad}  sub:");
+            dump_layout(out, sub, indent + 2);
+        }
+        LayoutKind::SubSup { base, sub, sup } => {
+            let _ = writeln!(out, "{pad}SubSup {metrics}");
+            let _ = writeln!(out, "{pad}  base:");
+            dump_layout(out, base, indent + 2);
+            let _ = writeln!(out, "{pad}  sub:");
+            dump_layout(out, sub, indent + 2);
+            let _ = writeln!(out, "{pad}  sup:");
+            dump_layout(out, sup, indent + 2);
+        }
+        LayoutKind::BigOp { symbol, sub, sup } => {
+            let _ = writeln!(out, "{pad}BigOp({symbol:?}) {metrics}");
+            if let Some(sub) = sub {
+                let _ = writeln!(out, "{pad}  sub:");
+                dump_layout(out, sub, indent + 2);
+            }
+            if let Some(sup) = sup {
+                let _ = writeln!(out, "{pad}  sup:");
+                dump_layout(out, sup, indent + 2);
+            }
+        }
+        LayoutKind::Limit { is_upper, sub } => {
+            let _ = writeln!(out, "{pad}Limit(is_upper={is_upper}) {metrics}");
+            if let Some(sub) = sub {
+                let _ = writeln!(out, "{pad}  sub:");
+                dump_layout(out, sub, indent + 2);
+            }
+        }
+        LayoutKind::Matrix { cells, style } => {
+            let style = match style {
+                MatrixStyle::Plain => "Plain",
+                MatrixStyle::Paren => "Paren",
+                MatrixStyle::Bracket => "Bracket",
+                MatrixStyle::Vert => "Vert",
+            };
+            let _ = writeln!(out, "{pad}Matrix({style}) {metrics}");
+            for (row_i, row) in cells.iter().enumerate() {
+                let _ = writeln!(out, "{pad}  row{row_i}:");
+                for cell in row {
+                    dump_layout(out, cell, indent + 2);
+                }
+            }
+        }
+        LayoutKind::Rel { arrow, over, under } => {
+            let _ = writeln!(out, "{pad}Rel {metrics}");
+            let _ = writeln!(out, "{pad}  arrow:");
+            dump_layout(out, arrow, indent + 2);
+            let _ = writeln!(out, "{pad}  over:");
+            dump_layout(out, over, indent + 2);
+            if let Some(under) = under {
+                let _ = writeln!(out, "{pad}  under:");
+                dump_layout(out, under, indent + 2);
+            }
+        }
+        LayoutKind::EqAlign { rows } => {
+            let _ = writeln!(out, "{pad}EqAlign {metrics}");
+            for (row_i, (left, right)) in rows.iter().enumerate() {
+                let _ = writeln!(out, "{pad}  row{row_i}.left:");
+                dump_layout(out, left, indent + 2);
+                let _ = writeln!(out, "{pad}  row{row_i}.right:");
+                dump_layout(out, right, indent + 2);
+            }
+        }
+        LayoutKind::Paren { left, right, body } => {
+            let _ = writeln!(out, "{pad}Paren({left:?},{right:?}) {metrics}");
+            dump_layout(out, body, indent + 1);
+        }
+        LayoutKind::Decoration { kind, body } => {
+            let _ = writeln!(out, "{pad}Decoration({kind:?}) {metrics}");
+            dump_layout(out, body, indent + 1);
+        }
+        LayoutKind::FontStyle { style, body } => {
+            let _ = writeln!(out, "{pad}FontStyle({style:?}) {metrics}");
+            dump_layout(out, body, indent + 1);
+        }
+        LayoutKind::Space(width) => {
+            let _ = writeln!(out, "{pad}Space({width:.4}) {metrics}");
+        }
+        LayoutKind::Newline => {
+            let _ = writeln!(out, "{pad}Newline {metrics}");
+        }
+        LayoutKind::Empty => {
+            let _ = writeln!(out, "{pad}Empty {metrics}");
+        }
+    }
+}
+
+fn update_requested() -> bool {
+    matches!(
+        std::env::var("UPDATE_EQ_GOLDENS").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+fn normalize_lf(s: &str) -> String {
+    s.replace("\r\n", "\n")
+}
+
+#[test]
+fn equation_command_goldens_lock_parse_layout_svg() {
+    let cases = load_catalog();
+    assert!(
+        cases.len() >= 200,
+        "M09-g 카탈로그가 너무 작다 ({}건)",
+        cases.len()
+    );
+
+    let m09_1: Vec<_> = cases.iter().filter(|c| c.dir == "m09_1").collect();
+    assert_eq!(m09_1.len(), 31, "M09-1 원본 31종이 카탈로그에 없다");
+    for id in M09_1_IDS {
+        assert!(
+            cases.iter().any(|c| c.id == *id && c.dir == "m09_1"),
+            "M09-1 id {id} 가 카탈로그에 없다"
+        );
+    }
+    for command in REQUIRED_COMMANDS {
+        assert!(
+            cases.iter().any(|c| c.command == *command),
+            "명령 {command} 골든이 없다"
+        );
+    }
+    let mut ids = cases.iter().map(|c| c.id.as_str()).collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), cases.len(), "골든 id 가 중복된다");
+
+    for dir in ["m09_1", "m09_expand"] {
+        std::fs::create_dir_all(fixture_root().join(dir)).expect("create fixture dir");
+    }
+    let update = update_requested();
+    let mut mismatches = Vec::new();
+
+    for case in &cases {
+        let actual = snapshot_of(case);
+        let path = golden_path(case);
+        if update || !path.exists() {
+            if !update && !path.exists() {
+                mismatches.push(format!(
+                    "{}: 골든 파일 없음 ({}) — UPDATE_EQ_GOLDENS=1 로 생성",
+                    case.id,
+                    path.display()
+                ));
+                continue;
+            }
+            std::fs::write(&path, actual.as_bytes())
+                .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+            continue;
+        }
+        let expected = normalize_lf(
+            &std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display())),
+        );
+        if expected != actual {
+            mismatches.push(format!(
+                "{} ({})\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
+                case.id,
+                path.display()
+            ));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "수식 골든 불일치 {}건 (현행 엔진 잠금. 의도된 변경이면 UPDATE_EQ_GOLDENS=1):\n\n{}",
+        mismatches.len(),
+        mismatches.join("\n\n")
+    );
+}
+
+#[test]
+fn equation_command_goldens_honesty_tags_are_known() {
+    const KNOWN: &[&str] = &[
+        "implemented",
+        "implemented-variant",
+        "root-aliases-sqrt",
+        "pile-layout-as-row",
+        "matrix-no-brace-empty",
+        "missing-operand",
+        "case-insensitive",
+        "atop-vs-over",
+        "latex-frac",
+        "vmatrix-unimpl-text",
+        "smallmatrix-unimpl-text",
+        "ladder-fallback-matrix",
+        "benzene-placeholder",
+        "bigg-size-ignored",
+        "choose-empty-top",
+        "longdiv-simplified-row",
+        "color-passthrough",
+        "unknown-command-text",
+        "cases-related",
+        "rel-buildrel",
+        "phantom-space",
+        "latex-env-partial",
+        "latex-space",
+        "latex-text",
+        "latex-stack",
+        "limit-cmd",
+        "left-script",
+    ];
+    let cases = load_catalog();
+    for case in &cases {
+        assert!(
+            KNOWN.contains(&case.honesty.as_str()),
+            "{}: unknown honesty tag {}",
+            case.id,
+            case.honesty
+        );
+    }
+    let expand = cases.iter().filter(|c| c.dir == "m09_expand").count();
+    assert!(expand >= 160, "확장 골든이 부족하다 ({expand})");
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

MEGA QUEUE M09-g (closes #5453). devel 기준 수식 골든(M09-1 31종)을 변형·예외·미구현 정직 표까지 확장한다.

- 카탈로그 `src/renderer/equation/fixtures/catalog.tsv` — 259건 (M09-1 31 + 확장 228)
- 픽스처 `fixtures/m09_1/*.golden`, `fixtures/m09_expand/*.golden`
- 시험 `tests/cases/equation_command_goldens.rs` — AST·레이아웃 IR·SVG 를 한 파일로 대조
- 정직 태그 설명 `src/renderer/equation/fixtures/README.md`

한컴 정답 오라클이 아니라 **현행 엔진 잠금**이다. 엔진·디스패치를 고치지 않는다(M09-2). 의도된 엔진 변경 시에만 `UPDATE_EQ_GOLDENS=1` 로 갱신한다.

### 현행 동작으로 정직하게 잠근 것

- `ROOT` 는 `SQRT` 와 같은 분기라 AST 가 `Sqrt` 이다.
- `PILE`/`LPILE`/`RPILE` 레이아웃은 전용 kind 없이 `Row` 로 세로 쌓는다.
- 중괄호 없는 `MATRIX`/`EQALIGN`/`PILE` 은 `Empty`.
- `VMATRIX`/`SMALLMATRIX` 는 `is_structure_command` 에 있으나 미분기 → `Text` + 뒤 그룹.
- `LADDER`/`SLADDER` 는 `parse_matrix(Plain)` 폴백.
- `BENZENE` 은 `⌬` 플레이스홀더, `BIGG` 는 크기 무시, `LONGDIV` 는 가로 나열, `CHOOSE` 윗칸 `Empty`.
- 피연산자 누락은 `Empty` 를 끼워 진행한다.

#4056 · planet #5253 은 손대지 않았다. gym 없음.

## 관련 이슈

closes #5453

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test --test regression_suite_027 equation_command_goldens` 통과 (2)
- [ ] `cargo clippy -- -D warnings` — 엔진 미변경, 시험·픽스처만
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (스크립트 단위 골든)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [x] `.claude/agents/`·스킬 변경 없음

분포: OVER 51, SQRT 25, ROOT 14, MATRIX 53, PMATRIX 23, BMATRIX 23, DMATRIX 22, EQALIGN 19, PILE 23 (카탈로그 command 열).

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (시험·픽스처만)
- 재현·측정: 미측정

## 스크린샷

해당 없음.

## 하지 않은 것

- 수식 디스패치 리팩터(M09-2) 없음
- #4056 / planet #5253 수정 없음
- gym / `scripts/visual_sweep.py` 미수정
- 파서·레이아웃·SVG 렌더러 구현 변경 없음
