### PR TITLE
docs(pr): #5455 병합 기록을 분리한다

### DIFF
--- a/mydocs/orders/20260818.md
+++ b/mydocs/orders/20260818.md
@@ -59,3 +59,11 @@ date: 2026-08-18
 - 로컬 통과: suite/unit-tier 정책, fmt, clippy, 전체 nextest **7,153/7,153**, Native Skia lib 58/58·renderer fixture 6/6.
 - 보류: Docker daemon 미기동으로 WASM compose 게이트는 시작 전 차단됐다. daemon 기동 후 재실행하고 원격 CI까지 통과하면 누적 PR을 생성한다.
 - 파생 `tests/suites/unit-test-tiers.json` 변경은 검증 후 정확히 되돌려 커밋에 포함하지 않는다.
+
+## #5454 PR Rust CodeQL 분석 경로 분리
+
+- 이슈 [#5454](https://github.com/edwardkim/rhwp/issues/5454), 기능 PR [#5455](https://github.com/edwardkim/rhwp/pull/5455)는 `30fa47bcf5ab272c915d1852f69386d8d5b5eca1`로 병합됐다.
+- PR 이벤트의 Rust CodeQL은 `.github/codeql/rust-pr.yml`로 `src/**`, `crates/**`, `rhwp-desk/src/**`, `build.rs`만 분석한다. `devel` push와 schedule은 설정 파일 없이 전체 Rust 경로를 계속 분석한다.
+- 원격 CI 기준 Rust job은 15분 13초에서 14분 19초로 54초(5.9%) 단축됐고, 오류 없이 추출한 Rust 파일은 1,376개에서 624개가 됐다. 추출·query 시간이 각각 19초·37초 감소했으며, 전체 CI는 성공 또는 정책상 skip으로 완료됐다.
+- 병합 뒤 `devel`을 `upstream/devel@30fa47bcf5ab272c915d1852f69386d8d5b5eca1`로 fast-forward했고, #5454의 자동 종료와 기능 head 브랜치의 로컬·원격 삭제를 확인했다.
+- 기능 변경과 분리해 오늘할일 및 PR 검증 기록은 docs-only PR에서 보존한다.

--- a/mydocs/pr/archives/pr_5455_review.md
+++ b/mydocs/pr/archives/pr_5455_review.md
@@ -1,0 +1,26 @@
+---
+kind: pr-review
+pr: 5455
+issue: 5454
+status: merged
+merged_at: 2026-08-18T10:27:44Z
+merge_commit: 30fa47bcf5ab272c915d1852f69386d8d5b5eca1
+---
+
+# PR #5455 검증 기록 - PR Rust CodeQL 분석 경로 분리
+
+## 범위
+
+- PR Rust CodeQL 분석만 제품 Rust 경로로 한정했다: `src/**`, `crates/**`, `rhwp-desk/src/**`, `build.rs`.
+- `devel` push와 schedule의 Rust CodeQL은 별도 설정 파일을 사용하지 않아 전체 경로 분석을 유지한다.
+- 분석 job 이름과 required check는 변경하지 않았다.
+
+## 검증 근거
+
+- 로컬: `scripts.tests.test_codeql_workflow` 15건, CodeQL YAML 파싱, `git diff --check`를 통과했다.
+- 원격 CI: 모든 실행 check가 성공 또는 영향 범위에 따른 skip으로 완료됐다.
+- Rust CodeQL job: 기준 15분 13초에서 14분 19초로 54초(5.9%) 단축됐다. 오류 없이 추출한 Rust 파일은 1,376개에서 624개로 줄었고, 추출은 19초, query는 37초 감소했다.
+
+## 결론 및 후속 처리
+
+PR은 `30fa47bcf5ab272c915d1852f69386d8d5b5eca1`로 병합됐다. `Closes #5454`에 따라 이슈가 자동 종료됐으며, 기능 head 브랜치의 로컬·원격 참조를 삭제하고 `devel`을 병합 commit까지 동기화했다.


### PR DESCRIPTION
## 요약

- #5454 / #5455의 PR Rust CodeQL 경로 분리 결과와 실제 CI 측정치를 오늘할일에 기록합니다.
- #5455의 검증 근거, 병합 commit, 이슈 자동 종료 및 브랜치 정리 결과를 archive review 문서로 보존합니다.

## 범위

문서 전용 PR입니다. 제품 코드, CodeQL 설정, CI 동작은 변경하지 않습니다.

## 검증

- cargo fmt --all
- cargo fmt --all -- --check
- node scripts/rust-test-suite-manifest.mjs --generate && node scripts/rust-test-suite-manifest.mjs --check
- node scripts/rust-unit-test-tiers.mjs --check
- git diff --check

파생 tests/generated/regression_suite_*.rs와 tests/suites/manifest.json은 로컬 검사 준비용으로만 재생성했으며 stage하지 않았습니다.
