### PR TITLE
docs(pr): #5473 병합 기록을 분리한다

### DIFF
--- a/mydocs/orders/20260818.md
+++ b/mydocs/orders/20260818.md
@@ -67,3 +67,11 @@ date: 2026-08-18
 - 원격 CI 기준 Rust job은 15분 13초에서 14분 19초로 54초(5.9%) 단축됐고, 오류 없이 추출한 Rust 파일은 1,376개에서 624개가 됐다. 추출·query 시간이 각각 19초·37초 감소했으며, 전체 CI는 성공 또는 정책상 skip으로 완료됐다.
 - 병합 뒤 `devel`을 `upstream/devel@30fa47bcf5ab272c915d1852f69386d8d5b5eca1`로 fast-forward했고, #5454의 자동 종료와 기능 head 브랜치의 로컬·원격 삭제를 확인했다.
 - 기능 변경과 분리해 오늘할일 및 PR 검증 기록은 docs-only PR에서 보존한다.
+
+## #5463 unit-tier inventory CI 파생 전환 완료
+
+- PR #5473에서 추적 대상이던 `tests/suites/unit-test-tiers.json`을 제거하고, 정적 정책만 `tests/suites/unit-test-tier-policy.json`으로 분리했다.
+- inventory는 CI와 로컬 검사 시 소스 및 PR base에서 계산한다. 선택적 진단 출력 `tests/generated/unit-test-tiers.json`은 Git에서 제외해 개발자가 생성하거나 stage할 필요가 없다.
+- 로컬 format·manifest·tier 검사와 script unit test를 통과했고, CI의 Rust CodeQL(13분 45초), test archive 생성(7분 51초), nextest shard, Native Skia 검증이 모두 성공했다.
+- PR #5473은 `2c639ac0da43adabc792bd0649bbeb7ac1490f08`으로 병합했다. #5463은 종료되었고 기능 브랜치의 로컬·원격 참조를 삭제했다.
+- 병합 기록은 `mydocs/pr/archives/pr_5473_review.md`에 보존하며, 본 오늘할일·검토 기록은 문서 전용 후속 PR로 분리한다.

--- a/mydocs/pr/archives/pr_5473_review.md
+++ b/mydocs/pr/archives/pr_5473_review.md
@@ -1,0 +1,31 @@
+---
+kind: pr-review
+pr: 5473
+issue: 5463
+base: devel
+head: codex/5463-derived-unit-tier-inventory
+status: merged
+merged_at: 2026-08-18T11:09:32Z
+merge_commit: 2c639ac0da43adabc792bd0649bbeb7ac1490f08
+---
+
+# PR #5473 검토 기록: unit-tier inventory를 CI 파생 산출물로 분리
+
+## 변경 범위
+
+- 추적하던 `tests/suites/unit-test-tiers.json`을 제거했다.
+- 정적 규칙은 `tests/suites/unit-test-tier-policy.json`으로 분리해 추적한다.
+- 현재 소스와 PR base의 inventory는 CI 및 로컬 검사에서 계산하며, 선택적 진단 산출물은 `tests/generated/unit-test-tiers.json`에 생성하고 Git에서 제외한다.
+- PR 템플릿과 기여·개발·로컬 검증 문서에서 개발자가 inventory를 생성하거나 stage하지 않도록 명확히 했다.
+
+## 검증 근거
+
+- 로컬: `cargo fmt --all`, `cargo fmt --all -- --check`, `node scripts/rust-test-suite-manifest.mjs --check`, `node scripts/rust-unit-test-tiers.mjs --check`, `git diff --check` 통과.
+- 로컬: `node --test scripts/tests/rust-unit-test-tiers.test.mjs` 12건, `node --test scripts/tests/rust-test-suite-manifest.test.mjs` 16건 통과.
+- CI: 2026-08-18 모든 필수 검사가 성공했다. Rust CodeQL은 13분 45초, test archive 생성은 7분 51초였고 regular/slow nextest shard 및 Native Skia 검증도 성공했다.
+
+## 결론 및 후속 처리
+
+- 정적 정책과 매 실행마다 달라지는 inventory를 분리해, 새 회귀 테스트가 추가된 PR 간의 생성 파일 충돌을 제거했다.
+- PR #5473은 `2c639ac0da43adabc792bd0649bbeb7ac1490f08`으로 squash merge되었다.
+- 관련 이슈 #5463은 병합으로 종료되었고, 기능 브랜치 `codex/5463-derived-unit-tier-inventory`는 로컬과 원격에서 삭제했다.


### PR DESCRIPTION
## 목적

PR #5473의 병합 결과를 기능 변경과 분리해 오늘할일 및 PR 검토 기록으로 보존합니다.

## 포함 범위

- `mydocs/orders/20260818.md`: #5463/#5473 완료, 검증, 브랜치 정리 기록
- `mydocs/pr/archives/pr_5473_review.md`: 변경 범위와 로컬·CI 검증 근거

## 검증

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `node scripts/rust-test-suite-manifest.mjs --check`
- `node scripts/rust-unit-test-tiers.mjs --check`
- `git diff --check`

문서 전용 PR입니다.
