### PR TITLE
fix(hwp3): 개체 자리표시자를 8유닛 컨트롤 슬롯으로 세어 U+FFFC 유출을 막는다 (#4957)

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2056,20 +2056,21 @@ fn parse_object_control_char(
         || ch == 16
         || preserve_invisible_anchor_gap
         || (is_control_only_marker && (is_tac_picture_or_shape || is_tac_line));
-    if omit_visible_marker {
-        if preserve_invisible_anchor_gap {
-            utf16_len += 8;
-        }
-    } else {
-        char_offsets.push(utf16_len);
-        // 일반 HWP3의 가시 개체 제어문자는 원본 LineInfo와 CharShape에서 화면
-        // 마커 하나로 좌표가 계산된다. HWP5 저장 시에만 확장 슬롯으로 쓰므로
-        // 여기서 전역으로 8칸을 늘리면 원본 HWP3 도형 문단의 줄 위치가 밀린다.
-        // 실제 암호 HWP3 fixture는 HWP5 변환본의 8-unit control contract를
-        // 사용하므로, 복호화 경로로 한정해 그 슬롯 폭을 보존한다.
-        utf16_len += if *use_password_layout_contract { 8 } else { 1 };
-        text_string.push('\u{FFFC}');
+    if omit_visible_marker && preserve_invisible_anchor_gap {
+        utf16_len += 8;
     }
+    // [#4957] 가시 개체 자리의 슬롯 폭 결정은 **컨트롤이 실제로 생성된 뒤**로 미룬다.
+    //
+    // 종전에는 여기서 `U+FFFC` 를 본문 글자로 밀어 넣고 1유닛만 셌다. 그 문자는 직렬화기
+    // 두 곳(HWP5·HWPX)이 모두 모르는 값이라 리터럴로 기록됐고, 저장본을 한글로 열면 표·
+    // 그림 자리에 원본에 없던 개체 문자가 생겼다. 한글은 같은 HWP3 원본에서 그 자리에
+    // 아무 글자도 내지 않고 8유닛 컨트롤 슬롯만 쓴다(오라클 대조).
+    //
+    // 다만 아래 `controls.push` 는 **조건부**라, 파싱이 개체를 만들지 못한 경로가 있다.
+    // 그때 슬롯만 넓히면 "컨트롤 없는 8유닛 갭"이 생겨 뒤 컨트롤의 슬롯 대응이 밀린다
+    // (미주 표시가 제 오프셋을 잃는다 — #3492 가 지키는 계약).
+    let controls_len_before_object = controls.len();
+    let emit_visible_object_slot = !omit_visible_marker;
 
     if ch == 10 {
         if parsed_is_hypertext {
@@ -2279,6 +2280,31 @@ fn parse_object_control_char(
         ));
     }
     ctrl_data_records.push(None);
+
+    // [#4957] 여기서 슬롯 폭을 확정한다. 위 `controls.push` 가 조건부라, 컨트롤이 실제로
+    // 생겼을 때만 8유닛 슬롯을 세고 가시 글자를 남기지 않는다. 컨트롤이 안 생긴 경로는
+    // 종전 동작(1유닛 + 자리표시 글자)을 그대로 둔다 — 슬롯만 넓히면 "컨트롤 없는 갭" 이
+    // 생겨 뒤 컨트롤의 슬롯 대응이 밀린다(#3492 가 지키는 미주 오프셋 계약).
+    if emit_visible_object_slot {
+        char_offsets.push(utf16_len);
+        // [#4957] 가시 개체는 **자리표시 글자 하나 + 8유닛 슬롯**이다. 암호 HWP3 경로가
+        // 이미 쓰던 계약을 전 경로로 넓힌 것이고, #3504 가 자동번호에 쓴 모양과 같다
+        // (공백 하나 + 8유닛). 글자 인덱스는 그대로라 `char_shapes` 경계가 밀리지 않는다.
+        //
+        // 종전에는 컨트롤이 생겨도 1유닛만 세어, 직렬화기의 자리표시자 판정
+        // (`next_offset >= offset + 8`)이 실패하고 마커가 리터럴로 기록됐다 — 저장본을
+        // 한글로 열면 표·그림 자리에 원본에 없던 개체 문자가 생겼다.
+        //
+        // 컨트롤이 안 생긴 경로는 슬롯을 넓히지 않는다. 넓히면 "컨트롤 없는 8유닛 갭"이
+        // 생겨 뒤 컨트롤의 슬롯 대응이 밀린다(#3492 가 지키는 미주 오프셋 계약).
+        utf16_len += if controls.len() > controls_len_before_object {
+            8
+        } else {
+            1
+        };
+        text_string.push('\u{FFFC}');
+    }
+
     Ok((i, utf16_len, false))
 }
 
@@ -2329,8 +2355,14 @@ fn parse_field_control_char(
                     // 재파싱 때 말미 공백 1칸이 생겼다 (SO-SUEOP 미주 213건).
                     utf16_len += 8;
                 } else {
+                    // [#4957] 새번호(19)·쪽번호 위치(20)·쪽 감추기(21)도 공통 IR 에서는
+                    // **확장 컨트롤 8 코드유닛**이다(직렬화 매핑이 전부 `0x0015`).
+                    // 1 유닛만 세면 자동번호가 겪던 함정이 그대로 재현된다 — 직렬화의
+                    // 자리표시자 판정(`next_offset >= offset + 8`)이 실패해 `U+FFFC` 가
+                    // 리터럴로 기록되고, 저장본을 한글로 열면 원본에 없던 개체 문자가
+                    // 쪽번호 자리에 생긴다(#3504 와 같은 결).
                     text_string.push('\u{FFFC}');
-                    utf16_len += 1;
+                    utf16_len += 8;
                 }
             }
 
@@ -2528,7 +2560,7 @@ fn parse_simple_control_char(
             }
             i += 4;
             char_offsets.push(utf16_len);
-            utf16_len += 1;
+            utf16_len += 8;
             text_string.push('\u{FFFC}');
             let mut overlap = crate::model::control::CharOverlap::default();
             // 스펙 §10.17 표 58: buf[0..6] = 겹칠 글자 hchar array[3]
@@ -2559,7 +2591,7 @@ fn parse_simple_control_char(
             }
             i += 11;
             char_offsets.push(utf16_len);
-            utf16_len += 1;
+            utf16_len += 8;
             text_string.push('\u{FFFC}');
             // 스펙 §10.16 표 57: 필드 이름은 파일 오프셋 2..22 (= 추가로 읽은
             // buf 의 [0..20]). 종전 buf[2..22] 는 이름 앞 2바이트를 유실하고
@@ -2586,7 +2618,7 @@ fn parse_simple_control_char(
             }
             i += 122;
             char_offsets.push(utf16_len);
-            utf16_len += 1;
+            utf16_len += 8;
             text_string.push('\u{FFFC}');
 
             let kw1_bytes = &buf[0..120];
@@ -2614,9 +2646,16 @@ fn parse_simple_control_char(
                 }
             }
             i += 31;
-            char_offsets.push(utf16_len);
-            utf16_len += 1;
-            text_string.push('\u{FFFC}');
+            // [#4957] 개요번호 마커는 본문에 **아무 자취도 남기지 않는다.**
+            //
+            // `fixup_hwp3_outline_fields` 가 이 마커를 소비해 번호 정보를 `ParaShape` 로
+            // 옮긴 뒤 공통 IR 에서 컨트롤을 걷어낸다(#3492). 그런데 자리표시 글자는 `text`
+            // 에 남아 있었고, 짝 컨트롤이 없으니 직렬화기가 그걸 리터럴로 기록했다 —
+            // 저장본을 한글로 열면 원본에 없던 개체 문자가 생긴다.
+            //
+            // 8유닛으로 넓히는 것도 답이 아니다. 컨트롤이 걷힌 뒤 "컨트롤 없는 8유닛 갭"이
+            // 남아 미주 오프셋·char_count 규약이 깨진다(실측 확인). 컨트롤도 글자도 남지
+            // 않는 것이 #3492 계약의 완성형이다.
 
             let kind = (&buf[0..2]).read_u16::<LittleEndian>().unwrap_or(0);
             let shape = buf[2];
@@ -2669,7 +2708,7 @@ fn parse_simple_control_char(
             } else {
                 // unrecognized — fall back to placeholder
                 char_offsets.push(utf16_len);
-                utf16_len += 1;
+                utf16_len += 8;
                 text_string.push('\u{FFFC}');
                 controls.push(crate::model::control::Control::Unknown(
                     crate::model::control::UnknownControl { ctrl_id: ch as u32 },

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -744,18 +744,47 @@ fn serialize_para_text(para: &Paragraph) -> ParaTextResult {
         // 컨트롤이 자동번호인데 공백이 마지막이면 그 공백이 곧 placeholder 다 — 진짜
         // 공백이었다면 그 뒤에 placeholder 가 하나 더 붙어 마지막이 아니게 된다.
         let is_last_text_char = i + 1 == text_chars.len();
-        let is_autonum_placeholder = *ch == ' '
-            && offset == prev_end
-            && ctrl_idx < para.controls.len()
-            // [#3495] 0x0012(자동번호)만 placeholder 공백을 만든다. 두 파서 모두
-            // 그렇다 — parser/body_text.rs 는 ch == 0x0012 일 때만, HWPX section.rs 는
-            // 0x0012 파트일 때만 text 에 공백을 push 한다. 각주·미주(0x0011)는
-            // placeholder 를 만들지 않으므로, 여기 포함하면 미주 앞의 진짜 공백을
-            // placeholder 로 오인해 컨트롤로 덮어쓴다 (SO-SUEOP.hwp 문단 238:
-            // 공백 12개 -> 11개, 뒤 텍스트가 한 칸 당겨짐).
-            && matches!(control_char_code_and_id(&para.controls[ctrl_idx]).0, 0x0012)
-            && next_offset.map_or(is_last_text_char, |n| n >= offset + 8);
-        if is_autonum_placeholder {
+        // 자리표시자 판정 — 종류별 근거는 아래 `match` 팔에 적는다.
+        //
+        // 판정이 `prev_end`·`ctrl_idx` 에 걸려 있어 **갭을 채우기 전과 후에 각각** 묻는다.
+        // 문단 선두에 예약된 갭(구역·단 정의 자리)이 있으면 첫 물음에서는 `prev_end` 가
+        // 아직 0 이라 판정이 실패한다 — 그 자리를 채운 뒤 다시 물어야 자리표시자를 알아본다
+        // (#4957: `secd`·`cold` 를 앞세운 HWP3 첫 문단).
+        //
+        // 두 번째 물음은 `object_only` 로 **U+FFFC 만** 받는다. 공백 자리표시자는 판별자가
+        // 글자가 아니라 `controls[ctrl_idx]` 의 코드(0x0012)뿐인데, 갭을 채우고 나면
+        // `ctrl_idx` 가 다른 컨트롤을 가리킨다 — 그때 다시 물으면 미주 앞의 **진짜 공백**이
+        // 자동번호로 오인돼 먹힌다(#3495 SO-SUEOP 문단 238). `U+FFFC` 는 글자 자체가
+        // 판별자라 이 위험이 없다.
+        let is_placeholder = |prev_end: u32, ctrl_idx: usize, object_only: bool| -> bool {
+            if offset != prev_end
+                || ctrl_idx >= para.controls.len()
+                || !next_offset.map_or(is_last_text_char, |n| n >= offset + 8)
+            {
+                return false;
+            }
+            match *ch {
+                // [#4957] HWP3 가시 개체의 자리표시자는 `U+FFFC` 다. 파서가 그 자리에
+                // **글자 하나 + 8유닛 슬롯**을 두므로(암호 HWP3 경로가 쓰던 계약을 전
+                // 경로로 넓힘) 자동번호 공백과 같은 모양이다 — 여기서 리터럴 대신 컨트롤을
+                // 써야 저장본에 원본에 없던 개체 문자가 남지 않는다(10k 전수 HWP3 28문서
+                // 56경로). 공백과 달리 컨트롤 종류를 가리지 않는다. `U+FFFC` 는 한컴
+                // 원본이 본문에 한 번도 쓰지 않는 글자라(hwp 0/6,579 · hwpx 0/3,418)
+                // 진짜 본문과 헷갈릴 여지가 없다.
+                '\u{FFFC}' => true,
+                // [#3495] 0x0012(자동번호)만 placeholder 공백을 만든다. 두 파서 모두
+                // 그렇다 — parser/body_text.rs 는 ch == 0x0012 일 때만, HWPX section.rs 는
+                // 0x0012 파트일 때만 text 에 공백을 push 한다. 각주·미주(0x0011)는
+                // placeholder 를 만들지 않으므로, 여기 포함하면 미주 앞의 진짜 공백을
+                // placeholder 로 오인해 컨트롤로 덮어쓴다 (SO-SUEOP.hwp 문단 238:
+                // 공백 12개 -> 11개, 뒤 텍스트가 한 칸 당겨짐).
+                ' ' if !object_only => {
+                    matches!(control_char_code_and_id(&para.controls[ctrl_idx]).0, 0x0012)
+                }
+                _ => false,
+            }
+        };
+        if is_placeholder(prev_end, ctrl_idx, false) {
             let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);
             push_extended_ctrl(&mut code_units, ctrl_code, ctrl_id);
             ctrl_idx += 1;
@@ -811,6 +840,17 @@ fn serialize_para_text(para: &Paragraph) -> ParaTextResult {
                 prev_end += 8;
             }
             ctrl_idx += 1;
+        }
+
+        // ③-b 갭을 채우고 나서 자리표시자를 다시 묻는다 — 위 첫 물음은 선두 예약 갭
+        //     때문에 실패했을 수 있다. 여기서 걸리면 `ctrl_idx` 가 갭을 채운 만큼 앞으로
+        //     가 있어, 자리표시자가 **자기 컨트롤**과 짝지어진다(#4957).
+        if is_placeholder(prev_end, ctrl_idx, true) {
+            let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);
+            push_extended_ctrl(&mut code_units, ctrl_code, ctrl_id);
+            ctrl_idx += 1;
+            prev_end = offset + 8;
+            continue;
         }
 
         // ④ 빈 필드(시작==끝)의 FIELD_END — 자기 BEGIN 직후.

--- a/tests/cases/issue_3532_trailing_charshape_boundary.rs
+++ b/tests/cases/issue_3532_trailing_charshape_boundary.rs
@@ -18,12 +18,23 @@ fn issue3532_trailing_boundary_survives_hwpx_roundtrip() {
     let original = parse_document(&bytes).expect("parse hwp3");
 
     // 샘플 전제: 본문 끝 zero-width 경계 + 말미 컨트롤이 공존하는 문단(26).
+    //
+    // [#4957] 경계 좌표는 **글자 수가 아니라 UTF-16 코드유닛 축**이다. 종전에는 이 문단의
+    // 마커(새번호·쪽번호 위치)가 1유닛만 차지해 두 축이 우연히 같았고, 그래서 글자 수로
+    // 비교해도 통과했다. 마커를 확장 컨트롤 8유닛으로 바로잡자 두 축이 갈라진다
+    // (문단 26: 글자 50 · 축 64). 시험이 지키는 계약은 **왕복 뒤 경계가 밀리지 않는가**
+    // 이므로, 전제는 축 끝으로 표현한다.
     let p26 = &original.sections[0].paragraphs[26];
-    let text_units = p26.text.chars().count() as u32;
+    let text_axis_end = p26
+        .char_offsets
+        .last()
+        .zip(p26.text.chars().last())
+        .map(|(offset, last)| offset + last.len_utf16() as u32)
+        .expect("샘플 전제: 문단 26 은 본문이 있다");
     assert!(
         p26.char_shapes
             .last()
-            .is_some_and(|cs| cs.start_pos == text_units),
+            .is_some_and(|cs| cs.start_pos == text_axis_end),
         "샘플 전제: 마지막 경계가 본문 끝(zero-width)이어야 한다"
     );
     assert!(!p26.controls.is_empty(), "샘플 전제: 말미 컨트롤");

--- a/tests/issue_3492_hwp3_outline_marker_leak.rs
+++ b/tests/issue_3492_hwp3_outline_marker_leak.rs
@@ -102,6 +102,17 @@ fn endnote_marks_keep_their_recorded_offset() {
             else {
                 continue;
             };
+            // [#4957] 선두 갭이 있는 문단은 제외한다. 아래 `gap` 은 **문자 사이** 갭만
+            // 찾으므로(`windows(2)`), 첫 문자 앞에 놓인 8유닛 슬롯을 보지 못한다. 그런
+            // 문단에서는 "첫 내부 갭 = 미주 자리" 라는 가정이 성립하지 않는다 — 미주가
+            // 선두 슬롯이고 내부 갭은 다른 개체 것일 수 있다(SO-SUEOP 의 미주+양식
+            // 문단이 그렇다: controls=[Endnote, Form], 축은 미주 0..8 · Form 19..27).
+            //
+            // 이 시험이 지키는 것은 #3492 의 계약 — 앵커 없는 마커가 앞자리를 가로채
+            // 미주를 밀어내지 않는가 — 이고, 그 판정에는 선두 갭 없는 문단으로 충분하다.
+            if paragraph.char_offsets.first().copied().unwrap_or(0) > 0 {
+                continue;
+            }
             // 오프셋에 공백이 있는 문단만 — 미주가 본문 중간에 앵커된 경우다.
             let gap = paragraph
                 .char_offsets

--- a/tests/issue_3495_endnote_space_eaten.rs
+++ b/tests/issue_3495_endnote_space_eaten.rs
@@ -76,6 +76,18 @@ fn convert_roundtrip() -> std::path::PathBuf {
     out
 }
 
+/// [#4957] HWP3 개체 마커(`U+FFFC`)는 본문 글자가 아니므로 비교 축에서 뺀다.
+///
+/// 파서가 개체 자리에 넣는 자리표시자이고, 저장기는 그 자리에 **확장 컨트롤 8유닛**을 쓴다 —
+/// 리터럴 글자로 쓰면 저장본을 한글로 열 때 원본에 없던 개체 문자가 생긴다. 그래서 왕복 뒤
+/// 텍스트에 이 글자가 없는 것이 정상이고, 종전에 남아 있던 쪽이 결함이었다.
+///
+/// 이 시험이 지키는 계약은 **미주 앞의 진짜 공백이 먹히지 않는가** 다. 마커를 뺀 축으로
+/// 비교해도 그 계약은 그대로 검출된다(실측 표본 문단 147: 마커 양옆 공백 두 개가 모두 남는다).
+fn without_object_markers(text: &str) -> String {
+    text.chars().filter(|c| *c != '\u{FFFC}').collect()
+}
+
 /// 미주가 있는 문단의 텍스트가 저장으로 바뀌지 않는다.
 #[test]
 fn saving_keeps_the_space_before_an_endnote() {
@@ -91,6 +103,10 @@ fn saving_keeps_the_space_before_an_endnote() {
 
     assert_eq!(after.len(), before.len(), "저장 후 미주 문단 수가 달라졌다");
     for (i, ((text_a, _), (text_b, _))) in before.iter().zip(after.iter()).enumerate() {
+        let (text_a, text_b) = (
+            without_object_markers(text_a),
+            without_object_markers(text_b),
+        );
         assert_eq!(
             text_a.chars().count(),
             text_b.chars().count(),


### PR DESCRIPTION
Fixes #4957

rhwp 가 저장한 HWP3 문서를 한글로 열면 표·그림·쪽번호 자리에 원본에 없던 개체 문자
`U+FFFC` 가 생긴다. `h2h`·`h2x` 양축에 똑같이 나타나 저장 축이 아니라 **불러오기 축**의
결함이다.

## 근인

HWP3 파서는 개체 자리에 `U+FFFC` 를 본문 글자로 밀어 넣고 **1유닛만** 셌다. 직렬화기의
자리표시자 판정은 `next_offset >= offset + 8`(확장 컨트롤 폭)이라 이 판정이 실패하고,
마커가 리터럴 글자로 기록됐다. #3504 가 자동번호에서 고친 것과 같은 함정이 나머지
컨트롤 종류에 그대로 남아 있었다.

한글은 같은 원본에서 그 자리에 아무 글자도 내지 않고 8유닛 컨트롤 슬롯만 쓴다.
이슈가 의심한 `treat_as_char = ref_pos == 0` 매핑은 무죄다 — 한글도 bit0 을 1 로 읽는다.

## 수정

**파서** (`src/parser/hwp3/mod.rs`)

- 가시 개체(표·그림·도형)와 새번호(19)·쪽번호 위치(20)·쪽 감추기(21) 마커를
  **글자 하나 + 8유닛 슬롯**으로 센다. 글자 인덱스는 그대로라 `char_shapes` 경계가
  밀리지 않는다. 이 셋은 직렬화 매핑이 전부 `0x0015`(확장 컨트롤)인데 파서만 1유닛을
  세고 있었다.
- 개요번호 마커는 본문에 자취를 남기지 않는다. `fixup_hwp3_outline_fields` 가 컨트롤을
  걷어내므로, 8유닛으로 넓히면 "컨트롤 없는 갭"이 남아 미주 오프셋 계약(#3492)이 깨진다.

**HWP5 직렬화기** (`src/serializer/body_text.rs`)

- `U+FFFC` 를 자리표시자로 인식한다.
- 판정이 `prev_end`·`ctrl_idx` 에 걸려 있어 **갭을 채우기 전후 두 번** 묻는다. HWP3 첫
  문단은 `secd`·`cold` 자리가 선두에 예약되므로 첫 물음에서는 `prev_end` 가 0 이라 늘
  실패했다.
- 두 번째 물음은 `U+FFFC` 만 받는다. 공백 자리표시자의 판별자는 글자가 아니라
  `controls[ctrl_idx]` 의 코드뿐인데, 갭을 채우면 그 인덱스가 다른 컨트롤을 가리켜
  미주 앞의 **진짜 공백**이 자동번호로 오인돼 먹힌다(#3495 가 고정한 계약).

## 실측 — 코퍼스 HWP3 38건 전수, 같은 하네스 전후 대조

산출물 바이트를 직접 훑어 셌다(HWP5 는 `HWPTAG_PARA_TEXT` 의 코드유닛, HWPX 는
`Contents/section*.xml`). 기준선은 이 변경 직전 커밋 빌드다.

|      | h2h            | h2x            |
|------|----------------|----------------|
| 전   | 135자 / 28문서 | 135자 / 28문서 |
| 후   | **0 / 0**      | 2자 / 2문서    |

기준선 28문서 135자는 이슈에 적힌 한글 오라클 스윕 수치와 정확히 일치한다 — 서로 다른
두 측정법이 같은 모집단을 짚는다. 최다 유출은 81자·22자 문서였다.

저장소 표본 8건(`hwp3-sample`·`10`·`11`·`13`·`14`·`curve`·`empty-cell`·`pagedef-1915`)도
양축 0 이다.

## 남긴 것 — h2x 잔여 2건은 원인이 다르다

숨은설명(15)·머리말(16)은 HWPX 슬롯 축에 참여하는데 HWP3 파서가 그 자리에 유닛을
배정하지 않는다. 그래서 슬롯 수와 축이 어긋나 문단이 mismatch 경로(텍스트 먼저·컨트롤
몰아쓰기)로 떨어지고 마커가 리터럴로 남는다. 자리표시자 유출이 아니라 **비가시 컨트롤의
축 배정** 결함이고, 고치면 HWP3 전 문서의 `char_count` 계약이 움직이므로 이 PR 에
섞지 않았다.

## 시험 변경 세 건과 근거

- `issue_3492…::endnote_marks_keep_their_recorded_offset` — 선두 갭이 있는 문단을
  제외한다. 갭 탐색이 `windows(2)` 라 첫 문자 앞 슬롯을 보지 못해 "첫 내부 갭 = 미주
  자리" 가정이 성립하지 않는다. #3492 가 지키는 계약(앵커 없는 마커가 앞자리를 가로채지
  않는가)의 판정에는 선두 갭 없는 문단으로 충분하다.
- `issue_3532…` — 샘플 전제를 글자 수에서 **코드유닛 축**으로 정정한다. 종전에는 그 문단의
  마커가 1유닛이라 두 축이 우연히 같았다(50 == 50). 8유닛으로 바로잡자 갈라진다
  (글자 50 · 축 64). 본계약(왕복 뒤 경계가 밀리지 않는가)은 그대로다.
- `issue_3495…` — 비교 축에서 `U+FFFC` 를 뺀다. 이 마커가 왕복 뒤 본문 글자로 남지 않는
  것이 이 PR 이 만든 정상이다. 지키는 계약은 미주 앞의 **진짜 공백**이고, 마커를 뺀
  축으로도 그대로 검출된다(문단 147: 마커 양옆 공백 두 개가 모두 남는다).

## 로컬 검증

**전량 회귀** — `cargo nextest run --workspace --tests --no-fail-fast` (debug 프로파일), 6,915건.
재배치 **직전 기준**(`#5203` 스택 위)에서 돌린 결과다. 6,910 통과 / 5 실패이며 **다섯 건 모두
이 장비의 메모리·페이징 고갈**로 확인했다. 각각 단독 실행에서 통과한다.

| 시험 | 전량 실행 | 단독 실행 |
|---|---|---|
| `issue_1949_giant_cell_render_perf::…without_blowup` | ABORT `0xC0000006` (in-page 오류), 1,831s | PASS **41s** |
| `overflow_cell_baseline::overflow_cell_lines_do_not_grow` | ABORT `0xC0000005`, 2,381s | PASS 364s |
| `ir_field_sweep_baseline::ir_field_sweep_does_not_regress` | ABORT `0xC0000005`, 2,700s | PASS 976s |
| `cfb_writer::tests::test_serialize_real_hwp_files` | FAIL — `std::fs::read_dir` 열거 중 OS 1006 | PASS 480s |
| `issue_2833…::inflated_row_count_does_not_slow_down_parsing` | FAIL — 500ms 벽시계 상한 | PASS 0.35s |

41초짜리가 30분을 넘긴 것과 `STATUS_IN_PAGE_ERROR` 가 같은 실행에서 나온 것이 근거다.
`test_serialize_real_hwp_files` 는 직렬화 단언이 아니라 디렉터리 핸들 무효화로 죽었고,
CFB 시그니처 단언은 하나도 깨지지 않았다.

**정적 검사** — `cargo clippy --all-targets` 변경 파일 지적 없음. 변경 5개 파일 `rustfmt --check`
통과(이 장비 checkout 이 CRLF 라 저장소 전역 `cargo fmt --all -- --check` 는 환경 요인으로
실패한다 — LF 사본으로 파일별 검증했고 전체 판정은 CI 에 맡긴다).
`node scripts/rust-test-suite-manifest.mjs --check` 통과.

**devel 재배치 후** — cherry-pick 이 충돌 없이 붙었고, 이 기준에서 다시 확인했다.

- HWP3·해당 시험 대상 실행 195건 전부 통과
  (`-E 'test(issue_3492) + test(issue_3495) + test(issue3532) + test(hwp3)'`).
- 코퍼스 38건 실측을 devel 기준으로 다시 재어 위 표와 같은 값을 얻었다
  (전 135자/28문서 · 후 h2h 0 · h2x 2자/2문서).

전량 회귀는 재배치 전 기준의 결과이며, devel 기준 전량은 CI 게이트에 의존한다. 같은 checkout 에서
다른 작업이 동시에 빌드 중이라 로컬에서 전량을 다시 돌리면 rustc 가 `STATUS_IN_PAGE_ERROR` 로
죽는다(병렬도를 낮추면 위 대상 실행은 정상 완주한다).
