### PR TITLE
ci: 문서 전용 Proptest fast-pass를 추가한다

### DIFF
--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: proptest-roundtrip-${{ github.workflow }}-${{ github.ref }}
@@ -26,10 +27,72 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  preflight:
+    name: Proptest preflight
+    runs-on: ubuntu-latest
+    outputs:
+      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+    steps:
+      # 문서 전용 devel PR도 `prop roundtrip` check 이름은 남겨야 한다. workflow-level
+      # paths-ignore를 쓰면 required check가 사라질 수 있으므로 job 조건으로 skip한다.
+      - name: Detect mydocs-only devel PR
+        id: detect
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            function setResult(fastPass, reason) {
+              core.setOutput('fast_pass', fastPass ? 'true' : 'false');
+              core.setOutput('reason', reason);
+              core.info(`fast_pass=${fastPass} reason=${reason}`);
+            }
+
+            if (context.eventName !== 'pull_request') {
+              setResult(false, `non-pull-request:${context.eventName}`);
+              return;
+            }
+            const pr = context.payload.pull_request;
+            if (!pr || pr.base.ref !== 'devel') {
+              setResult(false, `non-devel-base:${pr?.base?.ref || 'unknown'}`);
+              return;
+            }
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const mydocsOnly = files.length > 0 && files.every((file) => (
+              file.filename.startsWith('mydocs/')
+              && (!file.previous_filename || file.previous_filename.startsWith('mydocs/'))
+            ));
+            setResult(mydocsOnly, mydocsOnly ? 'mydocs-only-devel-pr' : 'code-or-non-mydocs-change');
+
+      - name: Finalize fast pass
+        id: finalize
+        if: ${{ always() }}
+        env:
+          DETECTED_FAST_PASS: ${{ steps.detect.outputs.fast_pass || 'false' }}
+          DETECTED_REASON: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
+        run: |
+          set -euo pipefail
+          fast_pass='false'
+          reason='preflight-unavailable'
+          if [[ "${DETECTED_FAST_PASS}" == 'true' ]]; then
+            fast_pass='true'
+            reason="${DETECTED_REASON}"
+          elif [[ "${DETECTED_REASON}" != 'preflight-unavailable' ]]; then
+            reason="${DETECTED_REASON}"
+          fi
+          printf 'fast_pass=%s\nreason=%s\n' "${fast_pass}" "${reason}" >> "$GITHUB_OUTPUT"
+
   proptest-roundtrip:
     name: prop roundtrip
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: preflight
+    if: ${{ always() && needs.preflight.result == 'success' && needs.preflight.outputs.fast_pass != 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -28,9 +28,19 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         self.assertTrue(RUNNER.is_file(), "run-prop-roundtrip.mjs 가 없다")
 
     def test_runs_on_pull_request(self) -> None:
-        """PR 마다 도는 always-on job. nightly 전용 퍼지가 아니다."""
+        """PR 마다 preflight를 거치며 nightly 전용 퍼지가 아니다."""
         self.assertIn("pull_request:", self.wf)
         self.assertIn("branches: [main, devel]", self.wf)
+
+    def test_mydocs_only_devel_pr_skips_worker_without_hiding_check(self) -> None:
+        self.assertIn("name: Proptest preflight", self.wf)
+        self.assertIn("pr.base.ref !== 'devel'", self.wf)
+        self.assertIn("file.filename.startsWith('mydocs/')", self.wf)
+        self.assertIn("file.previous_filename.startsWith('mydocs/')", self.wf)
+        self.assertIn("name: prop roundtrip", self.wf)
+        self.assertIn("needs: preflight", self.wf)
+        self.assertIn("needs.preflight.outputs.fast_pass != 'true'", self.wf)
+        self.assertNotRegex(self.wf, r"(?m)^\\s{2,4}paths-ignore:")
 
     def test_is_not_a_long_fuzz(self) -> None:
         self.assertNotIn("cargo-fuzz", self.wf)
@@ -59,6 +69,7 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
 
     def test_read_only_permissions(self) -> None:
         self.assertIn("contents: read", self.wf)
+        self.assertIn("pull-requests: read", self.wf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

- `devel` 대상의 `mydocs/**` 전용 PR에서 Proptest preflight가 fast-pass를 판정합니다.
- `prop roundtrip` required check 이름은 유지하고 worker job을 명시적으로 `skipped` 처리합니다.
- 코드·테스트·workflow 변경, `push`, 수동 실행, 판정 API 실패는 기존처럼 Proptest를 실행합니다.

Closes #5497

## 검증

- `python -m unittest scripts.tests.test_proptest_roundtrip_workflow scripts.tests.test_workflow_contract_wiring`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `node scripts/rust-test-suite-manifest.mjs --generate`
- `node scripts/rust-test-suite-manifest.mjs --check`
- `node scripts/rust-unit-test-tiers.mjs --check`
- `git diff --check`

## 적용 후 확인

- 최신 PR head에서 `Proptest preflight`가 `mydocs-only-devel-pr`를 기록하고 `prop roundtrip`이 명시적으로 skip되는지 확인합니다.
